### PR TITLE
📝 docs: benchmark numbers vs the standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,29 @@ references that omit the trailing semicolon):
 `escape` and `unescape` reproduce `html.escape` and `html.unescape` exactly, so turbohtml is a drop-in replacement on
 hot paths.
 
+## Performance
+
+Measured on CPython 3.14 (release build) against the standard library's `html.escape` / `html.unescape`, via
+`tox -e bench`:
+
+| operation  | input                      | turbohtml | stdlib  | speedup |
+| ---------- | -------------------------- | --------- | ------- | ------- |
+| `escape`   | plain prose, no specials   | 0.35 µs   | 2.23 µs | 6.3×    |
+| `escape`   | typical HTML markup        | 4.49 µs   | 10.5 µs | 2.3×    |
+| `escape`   | special-dense              | 2.99 µs   | 26.5 µs | 8.9×    |
+| `escape`   | non-ASCII prose (UCS-2)    | 0.92 µs   | 1.88 µs | 2.0×    |
+| `escape`   | astral text (UCS-4)        | 2.58 µs   | 2.65 µs | 1.0×    |
+| `unescape` | named references (dense)   | 18.1 µs   | 70.2 µs | 3.9×    |
+| `unescape` | numeric references (dense) | 4.16 µs   | 76.8 µs | 18.5×   |
+| `unescape` | mixed named + numeric      | 8.03 µs   | 35.2 µs | 4.4×    |
+| `unescape` | prose, sparse references   | 3.93 µs   | 3.87 µs | ~1×     |
+| `unescape` | non-ASCII with references  | 9.44 µs   | 35.2 µs | 3.7×    |
+
+`escape` gains the most on text that needs little escaping — the SWAR scan skips eight safe bytes at a time — and
+`unescape` gains the most on entity-heavy input, especially numeric references, where the standard library pays a Python
+function call per match. Where the text is mostly plain, `unescape` ties the standard library, whose regex already
+short-circuits and runs in C. Numbers vary with input and hardware; reproduce them with `tox -e bench`.
+
 ## Documentation
 
 Full documentation, including tutorials, how-to guides, the API reference, and the design rationale, lives at

--- a/docs/changelog/2.doc.rst
+++ b/docs/changelog/2.doc.rst
@@ -1,0 +1,3 @@
+Document the measured ``escape``/``unescape`` speedups over the standard library in the README and the docs, add a
+reproducible benchmark behind ``tox -e bench``, and give the API reference typed signatures with intersphinx links - by
+:user:`gaborbernat`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ exclude_patterns = ["changelog/*"]
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 autodoc_member_order = "bysource"
 nitpicky = True
+always_document_param_types = True
 
 issues_github_path = "tox-dev/turbohtml"
 towncrier_draft_autoversion_mode = "draft"

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -10,6 +10,74 @@ Escaping and unescaping sit on hot paths: HTML output escaping runs on every ren
 every chunk of text an HTML parser emits. ``turbohtml`` implements both in C so they run several times faster than an
 equivalent pure-Python implementation, with no change in behavior.
 
+Measured on CPython 3.14 (a release build, via ``tox -e bench``) against :func:`python:html.escape` and
+:func:`python:html.unescape`:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 12 34 14 14 12
+
+    - - operation
+      - input
+      - turbohtml
+      - stdlib
+      - speedup
+    - - ``escape``
+      - plain prose, no specials
+      - 0.35 µs
+      - 2.23 µs
+      - 6.3x
+    - - ``escape``
+      - typical HTML markup
+      - 4.49 µs
+      - 10.5 µs
+      - 2.3x
+    - - ``escape``
+      - special-dense
+      - 2.99 µs
+      - 26.5 µs
+      - 8.9x
+    - - ``escape``
+      - non-ASCII prose (UCS-2)
+      - 0.92 µs
+      - 1.88 µs
+      - 2.0x
+    - - ``escape``
+      - astral text (UCS-4)
+      - 2.58 µs
+      - 2.65 µs
+      - 1.0x
+    - - ``unescape``
+      - named references (dense)
+      - 18.1 µs
+      - 70.2 µs
+      - 3.9x
+    - - ``unescape``
+      - numeric references (dense)
+      - 4.16 µs
+      - 76.8 µs
+      - 18.5x
+    - - ``unescape``
+      - mixed named + numeric
+      - 8.03 µs
+      - 35.2 µs
+      - 4.4x
+    - - ``unescape``
+      - prose, sparse references
+      - 3.93 µs
+      - 3.87 µs
+      - ~1x
+    - - ``unescape``
+      - non-ASCII with references
+      - 9.44 µs
+      - 35.2 µs
+      - 3.7x
+
+``escape`` gains the most on text that needs little escaping (the SWAR scan skips eight safe bytes at a time);
+``unescape`` gains the most on entity-heavy input, especially numeric references, where the standard library pays a
+Python call per match. On mostly-plain text ``unescape`` ties :func:`python:html.unescape`, whose regex already
+short-circuits and runs in C. Numbers vary with input and hardware; reproduce them with ``tox -e bench``.
+
 Unlike a standard-library accelerator, ``turbohtml`` ships **only** the compiled implementation. :PEP:`399` requires a
 pure-Python fallback only for the standard library; as a third-party package distributing per-interpreter wheels,
 turbohtml has no need for one, which keeps the surface small.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -2,11 +2,6 @@
  Reference
 ###########
 
-.. module:: turbohtml
-
-.. autofunction:: escape
-
-.. autofunction:: unescape
-
-.. autodata:: turbohtml.__version__
-    :no-value:
+.. automodule:: turbohtml
+    :members:
+    :special-members: __version__

--- a/src/turbohtml/__init__.py
+++ b/src/turbohtml/__init__.py
@@ -7,6 +7,7 @@ from importlib.metadata import version
 from ._html import escape, unescape
 
 __version__ = version("turbohtml")
+"""The installed package version."""
 
 __all__ = [
     "__version__",

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Benchmark turbohtml's escape/unescape against the standard library.
+
+Run with ``tox -e bench``. Timing uses the minimum of many trials, which filters
+out scheduler/thermal noise (noise only ever makes a run slower). Pass a substring
+as a positional argument to run only matching cases.
+"""
+
+from __future__ import annotations
+
+import html
+import sys
+import time
+from typing import TYPE_CHECKING
+
+import turbohtml
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+CASES: list[tuple[str, str, str]] = [
+    ("escape", "plain prose, no specials", "the quick brown fox jumps over the lazy dog " * 80),
+    ("escape", "typical HTML markup", '<p>Tom & Jerry said "hi" to <b>O\'Brien</b> & co.</p> ' * 60),
+    ("escape", "special-dense", "<>&\"'" * 500),
+    ("escape", "non-ASCII prose (UCS-2)", "résumé café naïve Москва " * 120),
+    ("escape", "astral text (UCS-4)", "emoji \U0001f600 party \U0001f389 " * 120),
+    ("unescape", "named references (dense)", "&amp;&lt;&gt;&quot;&copy;&mdash;&eacute; " * 60),
+    ("unescape", "numeric references (dense)", "&#62;&#x3e;&#38;&#127881;&#x1F600; " * 60),
+    ("unescape", "mixed named + numeric", "Tom &amp; Jerry &mdash; caf&eacute; &#127881; &lt;b&gt; " * 30),
+    ("unescape", "prose, sparse references", ("the quick brown fox " * 20 + "&amp; ") * 12),
+    ("unescape", "non-ASCII with references", "café &amp; résumé &copy; Москва &mdash; " * 60),
+]
+
+
+def best(func: Callable[[str], str], arg: str) -> float:
+    """Return the fastest per-call time over many trials (noise-resistant)."""
+    inner = 1
+    while True:
+        start = time.perf_counter()
+        for _ in range(inner):
+            func(arg)
+        if time.perf_counter() - start > 0.005:
+            break
+        inner *= 2
+    fastest = float("inf")
+    for _ in range(50):
+        start = time.perf_counter()
+        for _ in range(inner):
+            func(arg)
+        fastest = min(fastest, (time.perf_counter() - start) / inner)
+    return fastest
+
+
+def main() -> None:
+    """Print a turbohtml-vs-stdlib timing table."""
+    selector = sys.argv[1] if len(sys.argv) > 1 else ""
+    print(f"{'operation':10} {'input':28} {'turbohtml':>11} {'stdlib':>10} {'speedup':>8}")
+    for op, name, arg in CASES:
+        if selector and selector not in op and selector not in name:
+            continue
+        turbo = best(getattr(turbohtml, op), arg)
+        stdlib = best(getattr(html, op), arg)
+        print(f"{op:10} {name:28} {turbo * 1e6:8.2f} us {stdlib * 1e6:8.2f} us {stdlib / turbo:6.1f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.toml
+++ b/tox.toml
@@ -91,7 +91,7 @@ commands = [
 
 [env.docs]
 description = "build the documentation"
-package = "editable"  # autodoc imports turbohtml; a normal build, not the coverage one
+package = "wheel"  # co-locate _html.so and _html.pyi so autodoc-typehints finds the stub
 dependency_groups = [ "docs" ]
 commands_pre = []  # drop the instrumented editable install inherited from env_run_base
 commands = [
@@ -132,6 +132,25 @@ commands = [
 description = "run the type checker on the code base"
 dependency_groups = [ "type" ]
 commands = [ [ "ty", "check", "--output-format", "concise", "--error-on-warning", "src", "tests", "tools" ] ]
+
+[env.bench]
+description = "benchmark escape/unescape against the standard library (not run in CI)"
+package = "skip"
+dependency_groups = [ "test" ]
+commands_pre = [
+  [
+    "uv",
+    "pip",
+    "install",
+    "--reinstall",
+    "--no-deps",
+    "--no-build-isolation",
+    "--editable",
+    "{tox_root}",
+    "--config-settings=setup-args=-Dbuildtype=release",
+  ],
+]
+commands = [ [ "python", "{tox_root}{/}tools{/}benchmark.py", { replace = "posargs", extend = true } ] ]
 
 [env.dev]
 description = "dev environment with all dependencies at {envdir}"


### PR DESCRIPTION
The performance claim in the README was qualitative ("several times faster"). This adds the measured numbers so it is concrete: a table in the README and a summary line in the design docs.

On CPython 3.14 with a release build, `escape` runs roughly 2-7x faster than `html.escape` — the larger gain on text that needs little escaping, where the SWAR scan skips eight safe bytes at a time — and `unescape` up to ~4x faster than `html.unescape` on entity-heavy input. On mostly-plain text `unescape` matches the standard library, which already short-circuits, and that tie is shown honestly rather than hidden. 📊

The numbers are flagged as ballpark since they vary with input and hardware.