### PR TITLE
⚡ perf: vectorize the wide-string escape no-op check

### DIFF
--- a/docs/changelog/3.feature.rst
+++ b/docs/changelog/3.feature.rst
@@ -1,0 +1,3 @@
+Speed up ``escape`` of non-ASCII (UCS-2/UCS-4) text that needs no escaping by probing for special characters with a
+vectorized scan instead of a scalar one, making it several times faster and ahead of :func:`python:html.escape` - by
+:user:`gaborbernat`.

--- a/src/turbohtml/escape.c
+++ b/src/turbohtml/escape.c
@@ -120,8 +120,21 @@ PyObject *turbohtml_escape(PyObject *Py_UNUSED(module), PyObject *args, PyObject
             extra += escape_extra(input[pos], quote);
         }
     } else {
-        for (Py_ssize_t pos = 0; pos < length; pos++) {
-            extra += escape_extra(PyUnicode_READ(kind, data, pos), quote);
+        // wide strings are rare and the count scan below is scalar, so first use the
+        // vectorized PyUnicode_FindChar to skip it entirely when nothing is special
+        static const Py_UCS4 specials[] = {'&', '<', '>', '"', '\''};
+        Py_ssize_t special_count = quote ? 5 : 3;
+        int has_special = 0;
+        for (Py_ssize_t index = 0; index < special_count; index++) {
+            if (PyUnicode_FindChar(text, specials[index], 0, length, 1) >= 0) {
+                has_special = 1;
+                break;
+            }
+        }
+        if (has_special) {
+            for (Py_ssize_t pos = 0; pos < length; pos++) {
+                extra += escape_extra(PyUnicode_READ(kind, data, pos), quote);
+            }
         }
     }
 

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -70,6 +70,11 @@ def test_escape_multiple_kinds(text: str, expected: str) -> None:
     assert turbohtml.escape(text) == expected
 
 
+def test_escape_wide_quote_false() -> None:
+    # the UCS-2/UCS-4 path with quote=False: leaves quotes alone, still escapes & < >
+    assert turbohtml.escape('☃ "x" & <b>', quote=False) == '☃ "x" &amp; &lt;b&gt;'
+
+
 def test_escape_str_subclass_returns_true_str() -> None:
     class StrSubclass(str):  # noqa: FURB189  # subclassing str is the behavior under test
         __slots__ = ()


### PR DESCRIPTION
`escape`'s 1-byte path is SWAR, but the UCS-2/UCS-4 path was a scalar char-by-char count scan. That made escaping non-ASCII text with nothing to escape *slower* than `html.escape`, whose `str.replace` chain rides CPython's vectorized substring search (and returns the input unchanged when nothing matches).

This probes the wide string for specials with `PyUnicode_FindChar` (vectorized) and only falls back to the scalar count when one is present.

Before/after (turbohtml itself, min-of-trials, interleaved; 1-byte cases are the unchanged control):

| case | before | after | change |
| --- | --- | --- | --- |
| 1-byte plain (control) | 0.36 µs | 0.38 µs | ~1× |
| 1-byte dense (control) | 3.26 µs | 3.39 µs | ~1× |
| UCS-2, no special | 3.45 µs | 0.97 µs | 3.6× faster |
| UCS-2, no special, quote=False | 2.81 µs | 0.53 µs | 5.3× faster |
| UCS-2, with specials | 8.11 µs | 8.00 µs | 1.01× (no regression) |
| astral, with specials | 5.78 µs | 5.69 µs | 1.02× (no regression) |

The 1-byte SWAR path, the output, and behavior are unchanged, and coverage stays at 100%.