### PR TITLE
👷 ci: publish per-artifact so attestations fit the OIDC lifetime

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,22 +61,33 @@ jobs:
           path: wheelhouse/*.whl
           retention-days: 7
   publish:
-    name: 🚀 Publish to PyPI
+    name: 🚀 Publish ${{ matrix.artifact }}
     needs: [sdist, wheels]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
+    # one job per build artifact: signing every wheel in a single job exceeds the
+    # Sigstore identity lifetime (sigstore.oidc.ExpiredIdentity), so split the upload
+    # so each fresh OIDC token only has to attest its platform's wheels
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact:
+          - dist-sdist
+          - dist-ubuntu-24.04
+          - dist-ubuntu-24.04-arm
+          - dist-macos-15
+          - dist-windows-2025
     environment:
       name: release
       url: https://pypi.org/project/turbohtml
     permissions:
       id-token: write # trusted publishing, no API token stored
     steps:
-      - name: ⬇️ Download all distributions
+      - name: ⬇️ Download ${{ matrix.artifact }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          name: ${{ matrix.artifact }}
           path: dist
-          pattern: dist-*
-          merge-multiple: true
       - name: 🚀 Publish
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:

--- a/docs/changelog/4.packaging.rst
+++ b/docs/changelog/4.packaging.rst
@@ -1,0 +1,3 @@
+Publish each wheel artifact in its own job so PEP 740 attestations finish within the Sigstore signing identity's
+lifetime, fixing the ``sigstore.oidc.ExpiredIdentity`` failure that blocked the first PyPI upload - by
+:user:`gaborbernat`.


### PR DESCRIPTION
The `0.1.0` release publish failed with `sigstore.oidc.ExpiredIdentity`. With `attestations: true`, the single publish job signs **every** wheel through Sigstore, and the full per-interpreter matrix produces ~50 wheels (3.10–3.15 + free-threaded × Linux/Linux-ARM/macOS/Windows, manylinux + musllinux). Signing them all took longer than the Sigstore signing identity's ~10-minute lifetime, so it expired before the upload and nothing reached PyPI. (It worked for pure-Python projects like `tox` because they have a single wheel.)

This splits the publish into one job per build artifact, each with its own fresh OIDC token, so no job signs more than a platform's worth of wheels (≤16) — comfortably within the identity window. Attestations stay enabled, and `skip-existing` keeps the disjoint uploads safe.