### PR TITLE
Fix links: gaborbernat -> tox-dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ readable, maintainable code in equal measure.
 ## Quick start
 
 ```console
-git clone https://github.com/gaborbernat/turbohtml
+git clone https://github.com/tox-dev/turbohtml
 cd turbohtml
 uvx --with tox-uv tox r -e 3.14   # build, test, and check coverage
 ```

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -13,7 +13,7 @@ turbohtml uses `tox <https://tox.wiki>`_ with `tox-uv <https://github.com/tox-de
 
 .. code-block:: console
 
-    $ git clone --recurse-submodules https://github.com/gaborbernat/turbohtml
+    $ git clone --recurse-submodules https://github.com/tox-dev/turbohtml
     $ cd turbohtml
     $ uvx --with tox-uv tox r -e 3.14   # build, test, and check coverage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,9 @@ dynamic = [
   "version",
 ]
 urls.Documentation = "https://turbohtml.readthedocs.io"
-urls.Homepage = "https://github.com/gaborbernat/turbohtml"
-urls.Source = "https://github.com/gaborbernat/turbohtml"
-urls.Tracker = "https://github.com/gaborbernat/turbohtml/issues"
+urls.Homepage = "https://github.com/tox-dev/turbohtml"
+urls.Source = "https://github.com/tox-dev/turbohtml"
+urls.Tracker = "https://github.com/tox-dev/turbohtml/issues"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
<!-- Thank you for your contribution!

See the development docs for how to set up and run the checks:
https://turbohtml.readthedocs.io/en/latest/development.html -->

- [ ] ran the linter to address style issues (`tox -e fix`)
- [ ] wrote descriptive pull request text
- [ ] ensured there are test(s) validating the fix, keeping coverage at 100%
- [ ] added a news fragment in the `docs/changelog` folder
- [ ] updated/extended the documentation

The links point to the fork, not the upstream.
