### PR TITLE
⚡ perf: SIMD escape scan and span-hopping unescape

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "tools/html5lib-python"]
 	path = tools/html5lib-python
 	url = https://github.com/html5lib/html5lib-python
+[submodule "tools/bench-data/war-and-peace"]
+	path = tools/bench-data/war-and-peace
+	url = https://github.com/GITenberg/War-and-Peace_2600
+	shallow = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ readable, maintainable code in equal measure.
 ```console
 git clone https://github.com/tox-dev/turbohtml
 cd turbohtml
+git submodule update --init tests/html5lib-tests   # conformance data for the test suite
 uvx --with tox-uv tox r -e 3.14   # build, test, and check coverage
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # turbohtml
 
+[![PyPI](https://img.shields.io/pypi/v/turbohtml)](https://pypi.org/project/turbohtml/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/turbohtml.svg)](https://pypi.org/project/turbohtml/)
+[![Downloads](https://static.pepy.tech/badge/turbohtml/month)](https://pepy.tech/project/turbohtml)
+[![Documentation status](https://readthedocs.org/projects/turbohtml/badge/?version=latest)](https://turbohtml.readthedocs.io/en/latest/?badge=latest)
+[![check](https://github.com/tox-dev/turbohtml/actions/workflows/check.yaml/badge.svg)](https://github.com/tox-dev/turbohtml/actions/workflows/check.yaml)
+
 A fast, fully typed HTML toolkit for Python, powered by a C-accelerated core. `turbohtml` provides spec-correct HTML
 escaping and unescaping that match the standard library byte for byte, and a WHATWG-conformant streaming tokenizer — all
 several times faster than their pure-Python counterparts and ready for the free-threaded build.
@@ -71,23 +77,23 @@ submodules. Reproduce with `tox -e bench`:
 
 | operation  | input                        | turbohtml | stdlib  | speedup |
 | ---------- | ---------------------------- | --------- | ------- | ------- |
-| `escape`   | tiny plain (64 B)            | 0.04 µs   | 0.14 µs | 3.6×    |
-| `escape`   | medium markup (4 KiB)        | 2.54 µs   | 8.17 µs | 3.2×    |
-| `escape`   | no-op prose (4 MiB)          | 0.12 ms   | 2.80 ms | 23.3×   |
-| `escape`   | book text (3 MiB)            | 0.71 ms   | 3.12 ms | 4.4×    |
-| `escape`   | book HTML (4 MiB)            | 1.38 ms   | 5.06 ms | 3.7×    |
-| `escape`   | spec HTML, dense (4 MiB)     | 5.31 ms   | 13.7 ms | 2.6×    |
-| `escape`   | UCS-2 plain (4 MiB)          | 0.74 ms   | 2.67 ms | 3.6×    |
-| `escape`   | UCS-2 markup (4 MiB)         | 3.73 ms   | 11.7 ms | 3.1×    |
-| `escape`   | UCS-4 plain (4 MiB)          | 1.52 ms   | 6.09 ms | 4.0×    |
-| `escape`   | UCS-4 markup (4 MiB)         | 4.64 ms   | 21.4 ms | 4.6×    |
-| `unescape` | tiny plain (64 B)            | 0.02 µs   | 0.03 µs | 1.4×    |
-| `unescape` | medium dense refs (4 KiB)    | 14.8 µs   | 74.4 µs | 5.0×    |
-| `unescape` | numeric refs (4 KiB)         | 5.11 µs   | 83.0 µs | 16.2×   |
-| `unescape` | book HTML, real refs (4 MiB) | 2.90 ms   | 9.24 ms | 3.2×    |
-| `unescape` | escaped book HTML (5 MiB)    | 6.10 ms   | 22.2 ms | 3.6×    |
-| `unescape` | dense refs (4 MiB)           | 17.0 ms   | 80.4 ms | 4.7×    |
-| `unescape` | UCS-2 refs (4 MiB)           | 5.55 ms   | 20.7 ms | 3.7×    |
+| `escape`   | tiny plain (64 B)            | 0.04 µs   | 0.11 µs | 2.9×    |
+| `escape`   | medium markup (4 KiB)        | 2.38 µs   | 8.09 µs | 3.4×    |
+| `escape`   | no-op prose (4 MiB)          | 0.12 ms   | 2.66 ms | 22.2×   |
+| `escape`   | book text (3 MiB)            | 0.72 ms   | 2.80 ms | 3.9×    |
+| `escape`   | book HTML (4 MiB)            | 1.35 ms   | 4.88 ms | 3.6×    |
+| `escape`   | spec HTML, dense (4 MiB)     | 5.27 ms   | 13.3 ms | 2.5×    |
+| `escape`   | UCS-2 plain (4 MiB)          | 0.74 ms   | 2.60 ms | 3.5×    |
+| `escape`   | UCS-2 markup (4 MiB)         | 3.44 ms   | 11.5 ms | 3.3×    |
+| `escape`   | UCS-4 plain (4 MiB)          | 0.97 ms   | 5.58 ms | 5.8×    |
+| `escape`   | UCS-4 markup (4 MiB)         | 4.08 ms   | 20.3 ms | 5.0×    |
+| `unescape` | tiny plain (64 B)            | 0.02 µs   | 0.03 µs | 1.3×    |
+| `unescape` | medium dense refs (4 KiB)    | 8.57 µs   | 72.5 µs | 8.5×    |
+| `unescape` | numeric refs (4 KiB)         | 5.24 µs   | 81.1 µs | 15.5×   |
+| `unescape` | book HTML, real refs (4 MiB) | 2.80 ms   | 8.96 ms | 3.2×    |
+| `unescape` | escaped book HTML (5 MiB)    | 2.10 ms   | 21.2 ms | 10.1×   |
+| `unescape` | dense refs (4 MiB)           | 10.4 ms   | 78.5 ms | 7.6×    |
+| `unescape` | UCS-2 refs (4 MiB)           | 2.78 ms   | 19.4 ms | 7.0×    |
 
 `escape` gains the most on text that needs little escaping — the SIMD scan classifies sixteen bytes at a time and copies
 clean stretches wholesale — and `unescape` gains the most on entity-heavy input, where the standard library pays a
@@ -96,21 +102,24 @@ special-dense markup, where both sides spend their time writing replacements. Nu
 reproduce them with `tox -e bench`.
 
 `tokenize` is compared against the standard library's `html.parser.HTMLParser` (driven with no-op handlers) and
-html5lib's pure-Python tokenizer, over synthetic cases and html5lib's benchmark corpus of real documents (a slice of the
-WHATWG spec source plus web-platform-tests pages of varied sizes):
+html5lib's pure-Python tokenizer, over synthetic cases, html5lib's benchmark corpus of real documents (a slice of the
+WHATWG spec source plus web-platform-tests pages of varied sizes), and two multi-megabyte specifications:
 
-| input                  | turbohtml | `html.parser` | speedup | html5lib | speedup |
-| ---------------------- | --------- | ------------- | ------- | -------- | ------- |
-| typical markup         | 31.9 µs   | 438 µs        | 13.7×   | 836 µs   | 26×     |
-| text-heavy prose       | 0.87 µs   | 2.9 µs        | 3.3×    | 148 µs   | 171×    |
-| attribute-heavy        | 26.1 µs   | 353 µs        | 13.5×   | 960 µs   | 37×     |
-| script-heavy           | 12.5 µs   | 173 µs        | 13.8×   | 529 µs   | 42×     |
-| entity-heavy           | 33.6 µs   | 219 µs        | 6.5×    | 1283 µs  | 38×     |
-| wpt page (0.6 kB)      | 1.7 µs    | 19.2 µs       | 11.0×   | 54 µs    | 31×     |
-| wpt page (9.6 kB)      | 37.3 µs   | 428 µs        | 11.5×   | 1402 µs  | 38×     |
-| wpt page (92 kB)       | 483 µs    | 4432 µs       | 9.2×    | 9410 µs  | 20×     |
-| wpt page, CJK (124 kB) | 685 µs    | 9047 µs       | 13.2×   | 23136 µs | 34×     |
-| whatwg spec (235 kB)   | 805 µs    | 7954 µs       | 9.9×    | 20328 µs | 25×     |
+| input                       | turbohtml | `html.parser` | speedup | html5lib | speedup |
+| --------------------------- | --------- | ------------- | ------- | -------- | ------- |
+| typical markup              | 30.3 µs   | 449 µs        | 14.8×   | 840 µs   | 28×     |
+| text-heavy prose            | 0.55 µs   | 2.9 µs        | 5.3×    | 149 µs   | 273×    |
+| attribute-heavy             | 24.7 µs   | 330 µs        | 13.3×   | 837 µs   | 34×     |
+| script-heavy                | 13.0 µs   | 162 µs        | 12.5×   | 526 µs   | 41×     |
+| entity-heavy                | 22.3 µs   | 205 µs        | 9.2×    | 1246 µs  | 56×     |
+| wpt page (0.6 kB)           | 1.6 µs    | 18.2 µs       | 11.4×   | 49 µs    | 31×     |
+| wpt page (4 kB)             | 15.0 µs   | 176 µs        | 11.8×   | 434 µs   | 29×     |
+| wpt page (9.6 kB)           | 34.9 µs   | 376 µs        | 10.8×   | 1190 µs  | 34×     |
+| wpt page (92 kB)            | 348 µs    | 4250 µs       | 12.2×   | 9311 µs  | 27×     |
+| wpt page, CJK (124 kB)      | 626 µs    | 8926 µs       | 14.3×   | 22844 µs | 37×     |
+| whatwg spec (235 kB)        | 701 µs    | 7838 µs       | 11.2×   | 20409 µs | 29×     |
+| ecmascript spec (3 MB)      | 7.08 ms   | 57.9 ms       | 8.2×    | 192 ms   | 27×     |
+| whatwg spec source (7.9 MB) | 37.0 ms   | 399 ms        | 10.8×   | 907 ms   | 25×     |
 
 The state machine is stamped per input storage width (the CPython stringlib trick) and, like html5ever, bulk-scans plain
 text runs instead of dispatching per character, so ASCII documents stay one byte per character end to end. Run scanning

--- a/README.md
+++ b/README.md
@@ -64,26 +64,36 @@ For incremental input, `Tokenizer.feed()` returns the tokens completed by each c
 
 ## Performance
 
-Measured on CPython 3.14 (release build) against the standard library's `html.escape` / `html.unescape`, via
-`tox -e bench`:
+Measured with [pyperf](https://pyperf.readthedocs.io) on CPython 3.14 (release build, Apple M-series) against the
+standard library's `html.escape` / `html.unescape`. The multi-MiB inputs stream well past the CPU caches; the book and
+spec cases are real documents (Project Gutenberg's *War and Peace*, the WHATWG HTML spec source) pulled in as git
+submodules. Reproduce with `tox -e bench`:
 
-| operation  | input                      | turbohtml | stdlib  | speedup |
-| ---------- | -------------------------- | --------- | ------- | ------- |
-| `escape`   | plain prose, no specials   | 0.35 µs   | 2.23 µs | 6.3×    |
-| `escape`   | typical HTML markup        | 4.49 µs   | 10.5 µs | 2.3×    |
-| `escape`   | special-dense              | 2.99 µs   | 26.5 µs | 8.9×    |
-| `escape`   | non-ASCII prose (UCS-2)    | 0.92 µs   | 1.88 µs | 2.0×    |
-| `escape`   | astral text (UCS-4)        | 2.58 µs   | 2.65 µs | 1.0×    |
-| `unescape` | named references (dense)   | 18.1 µs   | 70.2 µs | 3.9×    |
-| `unescape` | numeric references (dense) | 4.16 µs   | 76.8 µs | 18.5×   |
-| `unescape` | mixed named + numeric      | 8.03 µs   | 35.2 µs | 4.4×    |
-| `unescape` | prose, sparse references   | 3.93 µs   | 3.87 µs | ~1×     |
-| `unescape` | non-ASCII with references  | 9.44 µs   | 35.2 µs | 3.7×    |
+| operation  | input                        | turbohtml | stdlib  | speedup |
+| ---------- | ---------------------------- | --------- | ------- | ------- |
+| `escape`   | tiny plain (64 B)            | 0.04 µs   | 0.14 µs | 3.6×    |
+| `escape`   | medium markup (4 KiB)        | 2.54 µs   | 8.17 µs | 3.2×    |
+| `escape`   | no-op prose (4 MiB)          | 0.12 ms   | 2.80 ms | 23.3×   |
+| `escape`   | book text (3 MiB)            | 0.71 ms   | 3.12 ms | 4.4×    |
+| `escape`   | book HTML (4 MiB)            | 1.38 ms   | 5.06 ms | 3.7×    |
+| `escape`   | spec HTML, dense (4 MiB)     | 5.31 ms   | 13.7 ms | 2.6×    |
+| `escape`   | UCS-2 plain (4 MiB)          | 0.74 ms   | 2.67 ms | 3.6×    |
+| `escape`   | UCS-2 markup (4 MiB)         | 3.73 ms   | 11.7 ms | 3.1×    |
+| `escape`   | UCS-4 plain (4 MiB)          | 1.52 ms   | 6.09 ms | 4.0×    |
+| `escape`   | UCS-4 markup (4 MiB)         | 4.64 ms   | 21.4 ms | 4.6×    |
+| `unescape` | tiny plain (64 B)            | 0.02 µs   | 0.03 µs | 1.4×    |
+| `unescape` | medium dense refs (4 KiB)    | 14.8 µs   | 74.4 µs | 5.0×    |
+| `unescape` | numeric refs (4 KiB)         | 5.11 µs   | 83.0 µs | 16.2×   |
+| `unescape` | book HTML, real refs (4 MiB) | 2.90 ms   | 9.24 ms | 3.2×    |
+| `unescape` | escaped book HTML (5 MiB)    | 6.10 ms   | 22.2 ms | 3.6×    |
+| `unescape` | dense refs (4 MiB)           | 17.0 ms   | 80.4 ms | 4.7×    |
+| `unescape` | UCS-2 refs (4 MiB)           | 5.55 ms   | 20.7 ms | 3.7×    |
 
-`escape` gains the most on text that needs little escaping — the SWAR scan skips eight safe bytes at a time — and
-`unescape` gains the most on entity-heavy input, especially numeric references, where the standard library pays a Python
-function call per match. Where the text is mostly plain, `unescape` ties the standard library, whose regex already
-short-circuits and runs in C. Numbers vary with input and hardware; reproduce them with `tox -e bench`.
+`escape` gains the most on text that needs little escaping — the SIMD scan classifies sixteen bytes at a time and copies
+clean stretches wholesale — and `unescape` gains the most on entity-heavy input, where the standard library pays a
+Python function call per match. The gap is narrowest on tiny strings, where call overhead dominates, and on
+special-dense markup, where both sides spend their time writing replacements. Numbers vary with input and hardware;
+reproduce them with `tox -e bench`.
 
 `tokenize` is compared against the standard library's `html.parser.HTMLParser` (driven with no-op handlers) and
 html5lib's pure-Python tokenizer, over synthetic cases and html5lib's benchmark corpus of real documents (a slice of the

--- a/docs/changelog/7.feature.rst
+++ b/docs/changelog/7.feature.rst
@@ -1,0 +1,11 @@
+Speed up ``escape`` and ``unescape`` across the board. ``escape``: one-byte strings are classified sixteen bytes at a
+time with NEON / SSE2 (a SWAR word elsewhere) — on NEON a single low-nibble table lookup matches all five specials at
+once — the sizing pass accumulates growth branchlessly, the writing pass copies clean stretches wholesale and rewrites
+only the positions a match bitmask singles out, and UCS-2 / UCS-4 text is probed for all special characters in a single
+SWAR pass instead of one ``PyUnicode_FindChar`` sweep per character (UCS-4 with a four-lane NEON vector). ``unescape``:
+the scan hops between ``&`` occurrences and bulk-copies the clean spans instead of funnelling every character through a
+per-code-point emit, output staging stays at the input's width until a reference actually widens it, and the entities
+``html.escape`` emits resolve with one comparison instead of the full binary search — unescaping escaped real HTML runs
+about three times faster than via the general lookup path alone. The benchmark now uses `pyperf
+<https://pyperf.readthedocs.io>`_ with multi-MiB real documents referenced as pinned git submodules under
+``tools/bench-data`` - by :user:`gaborbernat`.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -13,16 +13,20 @@ turbohtml uses `tox <https://tox.wiki>`_ with `tox-uv <https://github.com/tox-de
 
 .. code-block:: console
 
-    $ git clone --recurse-submodules https://github.com/tox-dev/turbohtml
+    $ git clone https://github.com/tox-dev/turbohtml
     $ cd turbohtml
+    $ git submodule update --init tests/html5lib-tests   # conformance data for the test suite
     $ uvx --with tox-uv tox r -e 3.14   # build, test, and check coverage
 
-The ``--recurse-submodules`` flag fetches the ``html5lib-tests`` conformance suite used by one of the tests; if you
-already cloned without it, run ``git submodule update --init``.
+The ``tests/html5lib-tests`` submodule holds the conformance suite used by one of the tests. Do not initialize all
+submodules indiscriminately: the ``tools/bench-data`` submodules reference multi-MiB real documents (pinned upstream
+commits, nothing copied into this repository) used only by ``tox r -e bench``; fetch them on demand with ``git submodule
+update --init --depth 1 tools/bench-data/whatwg-html tools/bench-data/war-and-peace``.
 
 ``tox r -e 3.14`` builds the extension, runs the test suite, and **fails unless both Python and C coverage are 100%**
 (line and branch). Other environments: ``type`` (`ty <https://github.com/astral-sh/ty>`_), ``docs`` (Sphinx), ``fix``
-(`pre-commit <https://pre-commit.com>`_), ``pkg_meta`` (wheel/sdist metadata), and ``regen`` (regenerate the entity
+(`pre-commit <https://pre-commit.com>`_), ``pkg_meta`` (wheel/sdist metadata), ``bench`` (`pyperf
+<https://pyperf.readthedocs.io>`_ comparison against the standard library), and ``regen`` (regenerate the entity
 tables).
 
 ****************
@@ -36,7 +40,7 @@ tables).
         _html.pyi            # type stub for the C extension
         py.typed             # PEP 561 marker
         turbohtml.h          # internal header shared by the C sources
-        escape.c             # html.escape implementation (SWAR)
+        escape.c             # html.escape implementation (SIMD / SWAR)
         unescape.c           # html.unescape implementation (entity tables)
         _htmlmodule.c        # module definition; wires escape.c + unescape.c
         html_entities.h      # generated tables (do not edit)
@@ -67,9 +71,14 @@ matrix.
 **No pure-Python fallback.** :PEP:`399` requires a pure-Python fallback only for standard-library modules. As a
 third-party package distributing per-interpreter wheels, turbohtml ships only the compiled implementation.
 
-**SWAR for escape.** ``escape`` confirms most strings need no escaping, so it scans one-byte strings eight bytes at a
-time using the `bit-twiddling "has-zero" trick <https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord>`_,
-falling back to a scalar scan for UCS-2 / UCS-4 (see :PEP:`393` for the representations).
+**SIMD / SWAR for escape.** ``escape`` confirms most strings need no escaping, so it classifies one-byte strings sixteen
+bytes at a time: on NEON a single low-nibble table lookup plus one comparison matches all five specials at once (each
+has a unique low nibble — the PSHUFB trick used by pulldown-cmark), on x86-64 SSE2 compares per special, and elsewhere a
+SWAR word applies the `bit-twiddling "has-zero" trick
+<https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord>`_. The sizing pass accumulates the growth of all
+matches branchlessly, and the writing pass copies clean stretches wholesale, rewriting only the positions a match
+bitmask singles out. UCS-2 / UCS-4 strings (see :PEP:`393` for the representations) are probed for all five special
+characters in one SWAR pass over a 64-bit word.
 
 **Free-threading ready.** The module has no mutable state (immutable ``str`` inputs, read-only tables), so it declares
 ``Py_MOD_GIL_NOT_USED`` and per-interpreter GIL support on interpreters that support them. See the `free-threading

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -27,88 +27,88 @@ git submodules. Reproduce with ``tox -e bench``:
     - - ``escape``
       - tiny plain (64 B)
       - 0.04 µs
-      - 0.14 µs
-      - 3.6x
+      - 0.11 µs
+      - 2.9x
     - - ``escape``
       - medium markup (4 KiB)
-      - 2.54 µs
-      - 8.17 µs
-      - 3.2x
+      - 2.38 µs
+      - 8.09 µs
+      - 3.4x
     - - ``escape``
       - no-op prose (4 MiB)
       - 0.12 ms
-      - 2.80 ms
-      - 23.3x
+      - 2.66 ms
+      - 22.2x
     - - ``escape``
       - book text (3 MiB)
-      - 0.71 ms
-      - 3.12 ms
-      - 4.4x
+      - 0.72 ms
+      - 2.80 ms
+      - 3.9x
     - - ``escape``
       - book HTML (4 MiB)
-      - 1.38 ms
-      - 5.06 ms
-      - 3.7x
+      - 1.35 ms
+      - 4.88 ms
+      - 3.6x
     - - ``escape``
       - spec HTML, dense (4 MiB)
-      - 5.31 ms
-      - 13.7 ms
-      - 2.6x
+      - 5.27 ms
+      - 13.3 ms
+      - 2.5x
     - - ``escape``
       - UCS-2 plain (4 MiB)
       - 0.74 ms
-      - 2.67 ms
-      - 3.6x
+      - 2.60 ms
+      - 3.5x
     - - ``escape``
       - UCS-2 markup (4 MiB)
-      - 3.73 ms
-      - 11.7 ms
-      - 3.1x
+      - 3.44 ms
+      - 11.5 ms
+      - 3.3x
     - - ``escape``
       - UCS-4 plain (4 MiB)
-      - 1.52 ms
-      - 6.09 ms
-      - 4.0x
+      - 0.97 ms
+      - 5.58 ms
+      - 5.8x
     - - ``escape``
       - UCS-4 markup (4 MiB)
-      - 4.64 ms
-      - 21.4 ms
-      - 4.6x
+      - 4.08 ms
+      - 20.3 ms
+      - 5.0x
     - - ``unescape``
       - tiny plain (64 B)
       - 0.02 µs
       - 0.03 µs
-      - 1.4x
+      - 1.3x
     - - ``unescape``
       - medium dense refs (4 KiB)
-      - 14.8 µs
-      - 74.4 µs
-      - 5.0x
+      - 8.57 µs
+      - 72.5 µs
+      - 8.5x
     - - ``unescape``
       - numeric refs (4 KiB)
-      - 5.11 µs
-      - 83.0 µs
-      - 16.2x
+      - 5.24 µs
+      - 81.1 µs
+      - 15.5x
     - - ``unescape``
       - book HTML, real refs (4 MiB)
-      - 2.90 ms
-      - 9.24 ms
+      - 2.80 ms
+      - 8.96 ms
       - 3.2x
     - - ``unescape``
       - escaped book HTML (5 MiB)
-      - 6.10 ms
-      - 22.2 ms
-      - 3.6x
+      - 2.10 ms
+      - 21.2 ms
+      - 10.1x
     - - ``unescape``
       - dense refs (4 MiB)
-      - 17.0 ms
-      - 80.4 ms
-      - 4.7x
+      - 10.4 ms
+      - 78.5 ms
+      - 7.6x
     - - ``unescape``
       - UCS-2 refs (4 MiB)
-      - 5.55 ms
-      - 20.7 ms
-      - 3.7x
+      - 2.78 ms
+      - 19.4 ms
+      - 7.0x
 
 ``escape`` gains the most on text that needs little escaping (the SIMD scan classifies sixteen bytes at a time and
 copies clean stretches wholesale); ``unescape`` gains the most on entity-heavy input, where the standard library pays a
@@ -202,69 +202,87 @@ of the WHATWG spec source plus web-platform-tests pages of varied sizes):
       - html5lib
       - speedup
     - - typical markup
-      - 47.3 µs
-      - 451 µs
-      - 9.5x
-      - 850 µs
-      - 18x
+      - 30.3 µs
+      - 449 µs
+      - 14.8x
+      - 840 µs
+      - 27.7x
     - - text-heavy prose
-      - 4.5 µs
-      - 2.9 µs
-      - 0.7x
-      - 150 µs
-      - 33x
+      - 0.55 µs
+      - 2.92 µs
+      - 5.3x
+      - 149 µs
+      - 273x
     - - attribute-heavy
-      - 33.5 µs
-      - 315 µs
-      - 9.4x
-      - 846 µs
-      - 25x
+      - 24.7 µs
+      - 330 µs
+      - 13.3x
+      - 837 µs
+      - 33.8x
     - - script-heavy
-      - 18.0 µs
-      - 165 µs
-      - 9.1x
-      - 513 µs
-      - 28x
+      - 13.0 µs
+      - 162 µs
+      - 12.5x
+      - 526 µs
+      - 40.5x
     - - entity-heavy
-      - 34.0 µs
-      - 199 µs
-      - 5.9x
-      - 1240 µs
-      - 36x
-    - - wpt page (0.6 kB)
-      - 2.5 µs
-      - 18.7 µs
-      - 7.5x
-      - 50 µs
-      - 20x
-    - - wpt page (9.6 kB)
-      - 47.7 µs
-      - 380 µs
-      - 8.0x
-      - 1208 µs
-      - 25x
-    - - wpt page (92 kB)
-      - 552 µs
-      - 4178 µs
-      - 7.6x
-      - 9185 µs
-      - 17x
-    - - wpt page, CJK (124 kB)
-      - 890 µs
-      - 9067 µs
-      - 10.2x
-      - 23293 µs
-      - 26x
+      - 22.3 µs
+      - 205 µs
+      - 9.2x
+      - 1246 µs
+      - 55.8x
+    - - wpt tiny (0.6 kB)
+      - 1.60 µs
+      - 18.2 µs
+      - 11.4x
+      - 49 µs
+      - 30.9x
+    - - wpt small (4 kB)
+      - 15.0 µs
+      - 176 µs
+      - 11.8x
+      - 434 µs
+      - 29.0x
+    - - wpt medium (9.6 kB)
+      - 34.9 µs
+      - 376 µs
+      - 10.8x
+      - 1190 µs
+      - 34.1x
+    - - wpt large (92 kB)
+      - 348 µs
+      - 4250 µs
+      - 12.2x
+      - 9311 µs
+      - 26.7x
+    - - wpt CJK (124 kB)
+      - 626 µs
+      - 8926 µs
+      - 14.3x
+      - 22844 µs
+      - 36.5x
     - - whatwg spec (235 kB)
-      - 1167 µs
-      - 8010 µs
-      - 6.9x
-      - 20481 µs
-      - 18x
+      - 701 µs
+      - 7838 µs
+      - 11.2x
+      - 20409 µs
+      - 29.1x
+    - - ecmascript spec (3 MB)
+      - 7.08 ms
+      - 57.9 ms
+      - 8.2x
+      - 192 ms
+      - 27.1x
+    - - whatwg spec source (7.9 MB)
+      - 37.0 ms
+      - 399 ms
+      - 10.8x
+      - 907 ms
+      - 24.5x
 
-The one case the standard library wins — a document that is almost entirely a single text node — is where its regex
-performs one C scan and never really tokenizes; everywhere markup actually appears, the state machine is 5–10x faster.
-Numbers vary with input and hardware; reproduce them with ``tox -e bench``.
+The closest case is a document that is almost entirely a single text node, where the standard library's regex performs
+one C scan and never really tokenizes; everywhere markup actually appears, the state machine is 8-15x faster. Numbers
+vary with input and hardware; reproduce them with ``tox -e bench``.
 
 ****************
  Free-threading

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -10,8 +10,10 @@ Escaping and unescaping sit on hot paths: HTML output escaping runs on every ren
 every chunk of text an HTML parser emits. ``turbohtml`` implements both in C so they run several times faster than an
 equivalent pure-Python implementation, with no change in behavior.
 
-Measured on CPython 3.14 (a release build, via ``tox -e bench``) against :func:`python:html.escape` and
-:func:`python:html.unescape`:
+Measured with `pyperf <https://pyperf.readthedocs.io>`_ on CPython 3.14 (a release build, Apple M-series) against
+:func:`python:html.escape` and :func:`python:html.unescape`. The multi-MiB inputs stream well past the CPU caches; the
+book and spec cases are real documents (Project Gutenberg's *War and Peace*, the WHATWG HTML spec source) referenced as
+git submodules. Reproduce with ``tox -e bench``:
 
 .. list-table::
     :header-rows: 1
@@ -23,77 +25,117 @@ Measured on CPython 3.14 (a release build, via ``tox -e bench``) against :func:`
       - stdlib
       - speedup
     - - ``escape``
-      - plain prose, no specials
-      - 0.35 µs
-      - 2.23 µs
-      - 6.3x
+      - tiny plain (64 B)
+      - 0.04 µs
+      - 0.14 µs
+      - 3.6x
     - - ``escape``
-      - typical HTML markup
-      - 4.49 µs
-      - 10.5 µs
-      - 2.3x
+      - medium markup (4 KiB)
+      - 2.54 µs
+      - 8.17 µs
+      - 3.2x
     - - ``escape``
-      - special-dense
-      - 2.99 µs
-      - 26.5 µs
-      - 8.9x
+      - no-op prose (4 MiB)
+      - 0.12 ms
+      - 2.80 ms
+      - 23.3x
     - - ``escape``
-      - non-ASCII prose (UCS-2)
-      - 0.92 µs
-      - 1.88 µs
-      - 2.0x
-    - - ``escape``
-      - astral text (UCS-4)
-      - 2.58 µs
-      - 2.65 µs
-      - 1.0x
-    - - ``unescape``
-      - named references (dense)
-      - 18.1 µs
-      - 70.2 µs
-      - 3.9x
-    - - ``unescape``
-      - numeric references (dense)
-      - 4.16 µs
-      - 76.8 µs
-      - 18.5x
-    - - ``unescape``
-      - mixed named + numeric
-      - 8.03 µs
-      - 35.2 µs
+      - book text (3 MiB)
+      - 0.71 ms
+      - 3.12 ms
       - 4.4x
+    - - ``escape``
+      - book HTML (4 MiB)
+      - 1.38 ms
+      - 5.06 ms
+      - 3.7x
+    - - ``escape``
+      - spec HTML, dense (4 MiB)
+      - 5.31 ms
+      - 13.7 ms
+      - 2.6x
+    - - ``escape``
+      - UCS-2 plain (4 MiB)
+      - 0.74 ms
+      - 2.67 ms
+      - 3.6x
+    - - ``escape``
+      - UCS-2 markup (4 MiB)
+      - 3.73 ms
+      - 11.7 ms
+      - 3.1x
+    - - ``escape``
+      - UCS-4 plain (4 MiB)
+      - 1.52 ms
+      - 6.09 ms
+      - 4.0x
+    - - ``escape``
+      - UCS-4 markup (4 MiB)
+      - 4.64 ms
+      - 21.4 ms
+      - 4.6x
     - - ``unescape``
-      - prose, sparse references
-      - 3.93 µs
-      - 3.87 µs
-      - ~1x
+      - tiny plain (64 B)
+      - 0.02 µs
+      - 0.03 µs
+      - 1.4x
     - - ``unescape``
-      - non-ASCII with references
-      - 9.44 µs
-      - 35.2 µs
+      - medium dense refs (4 KiB)
+      - 14.8 µs
+      - 74.4 µs
+      - 5.0x
+    - - ``unescape``
+      - numeric refs (4 KiB)
+      - 5.11 µs
+      - 83.0 µs
+      - 16.2x
+    - - ``unescape``
+      - book HTML, real refs (4 MiB)
+      - 2.90 ms
+      - 9.24 ms
+      - 3.2x
+    - - ``unescape``
+      - escaped book HTML (5 MiB)
+      - 6.10 ms
+      - 22.2 ms
+      - 3.6x
+    - - ``unescape``
+      - dense refs (4 MiB)
+      - 17.0 ms
+      - 80.4 ms
+      - 4.7x
+    - - ``unescape``
+      - UCS-2 refs (4 MiB)
+      - 5.55 ms
+      - 20.7 ms
       - 3.7x
 
-``escape`` gains the most on text that needs little escaping (the SWAR scan skips eight safe bytes at a time);
-``unescape`` gains the most on entity-heavy input, especially numeric references, where the standard library pays a
-Python call per match. On mostly-plain text ``unescape`` ties :func:`python:html.unescape`, whose regex already
-short-circuits and runs in C. Numbers vary with input and hardware; reproduce them with ``tox -e bench``.
+``escape`` gains the most on text that needs little escaping (the SIMD scan classifies sixteen bytes at a time and
+copies clean stretches wholesale); ``unescape`` gains the most on entity-heavy input, where the standard library pays a
+Python call per match. The gap is narrowest on tiny strings, where call overhead dominates, and on special-dense markup,
+where both sides spend their time writing replacements. Numbers vary with input and hardware; reproduce them with ``tox
+-e bench``.
 
 Unlike a standard-library accelerator, ``turbohtml`` ships **only** the compiled implementation. :PEP:`399` requires a
 pure-Python fallback only for the standard library; as a third-party package distributing per-interpreter wheels,
 turbohtml has no need for one, which keeps the surface small.
 
-*************************
- Word-at-a-time scanning
-*************************
+**************************
+ Block-at-a-time scanning
+**************************
 
 ``escape`` spends most of its time confirming that a string contains nothing that needs escaping. For one-byte strings
-it scans eight bytes at a time using SWAR ("SIMD within a register"): it loads eight bytes into a 64-bit integer and
-tests every lane for ``&``, ``<``, ``>`` and the quotes with the `has-zero bit trick
-<https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord>`_, advancing eight bytes whenever none match. When
-nothing needs escaping the input is returned unchanged. Wider (UCS-2 / UCS-4) strings — see :PEP:`393` for CPython's
-string representations — fall back to a straightforward scalar scan. This needs the `PyUnicode buffer API
-<https://docs.python.org/3/c-api/unicode.html>`_, which is why turbohtml cannot use the :ref:`Limited API
-<python:stable>`.
+it classifies sixteen bytes at a time with SIMD (on arm64 NEON a single low-nibble table lookup plus one comparison
+matches all five specials at once; on x86-64 SSE2 compares per special; elsewhere a 64-bit SWAR word applies the
+`has-zero bit trick <https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord>`_). The sizing pass turns each
+comparison directly into that special's output growth and sums the block branchlessly; the writing pass converts the
+comparisons into a position bitmask so clean stretches are copied wholesale and only the matched bytes are rewritten.
+When nothing needs escaping the input is returned unchanged. Wider (UCS-2 / UCS-4) strings — see :PEP:`393` for
+CPython's string representations — pack four / two code points into a 64-bit SWAR word and probe all five special
+characters in a single pass. ``unescape`` works the same way in reverse: it hops between ``&`` occurrences (``memchr``
+on one-byte text) and bulk-copies the clean spans between references instead of inspecting every character. This needs
+the `PyUnicode buffer API <https://docs.python.org/3/c-api/unicode.html>`_, which is why turbohtml cannot use the
+:ref:`Limited API <python:stable>`.
 
 *******************************
  Matching the standard library

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,9 @@ project(
 # Freeze the git-derived version into the sdist so wheels built from it need no git history.
 meson.add_dist_script('tools/generate_version.py', '--write', 'src/turbohtml/_version.py', '--meson-dist')
 
+# Keep the development-only submodule corpora out of the sdist regardless of local checkout state.
+meson.add_dist_script('tools/prune_dist.py')
+
 py = import('python').find_installation(pure: false)
 
 py.extension_module(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ urls.Tracker = "https://github.com/tox-dev/turbohtml/issues"
 
 [dependency-groups]
 dev = [
+  { include-group = "bench" },
   { include-group = "coverage" },
   { include-group = "docs" },
   { include-group = "fix" },
@@ -153,6 +154,7 @@ lint.per-file-ignores."tests/**/*.py" = [
 ]
 lint.per-file-ignores."tools/**/*.py" = [
   "INP001", # no implicit namespace
+  "S311",   # benchmark data is pseudo-random on purpose, nothing cryptographic
   "S404",   # generate_version.py shells out to git to derive the version
   "S603",   # fixed git subcommands, not external input
   "S607",   # git is resolved from PATH

--- a/src/turbohtml/charref.c
+++ b/src/turbohtml/charref.c
@@ -22,6 +22,35 @@ static int cmp_name(const char *left, Py_ssize_t left_len, const char *right, un
 }
 
 const html5_entity *charref_find_entity(const char *name, Py_ssize_t len) {
+    /* the names html.escape emits dominate real input, so try them with one
+       comparison each before paying for the ~11-round binary search */
+    switch (name[0]) {
+    case 'a':
+        if (len == 4 && memcmp(name, "amp;", 4) == 0) {
+            return &html5_entities[HTML5_INDEX_AMP];
+        }
+        if (len == 5 && memcmp(name, "apos;", 5) == 0) {
+            return &html5_entities[HTML5_INDEX_APOS];
+        }
+        break;
+    case 'g':
+        if (len == 3 && memcmp(name, "gt;", 3) == 0) {
+            return &html5_entities[HTML5_INDEX_GT];
+        }
+        break;
+    case 'l':
+        if (len == 3 && memcmp(name, "lt;", 3) == 0) {
+            return &html5_entities[HTML5_INDEX_LT];
+        }
+        break;
+    case 'q':
+        if (len == 5 && memcmp(name, "quot;", 5) == 0) {
+            return &html5_entities[HTML5_INDEX_QUOT];
+        }
+        break;
+    default:
+        break;
+    }
     int low = 0, high = html5_count - 1;
     while (low <= high) {
         int mid = (low + high) >> 1;

--- a/src/turbohtml/escape.c
+++ b/src/turbohtml/escape.c
@@ -1,35 +1,30 @@
 /* HTML escaping.
 
-   Most strings contain nothing that needs escaping, so the 1-byte path scans a
-   word (eight bytes) at a time with a SWAR has-zero test and skips all eight
-   whenever none is special; that is why escape() can return the input untouched
-   without inspecting most bytes one by one. UCS-2 / UCS-4 strings are rare here
-   and use a plain scalar scan. */
+   Most strings contain nothing that needs escaping, so escape() runs two
+   passes: a counting pass that sizes the result (and proves a no-op when the
+   count is zero), and a writing pass. The 1-byte path works sixteen bytes per
+   step with NEON / SSE2 where available (a SWAR word elsewhere): the counting
+   pass accumulates per-special growth branchlessly, and the writing pass turns
+   the comparison result into a position bitmask so untouched stretches are
+   copied wholesale and only actual specials are rewritten. UCS-2 / UCS-4 test
+   a 64-bit word holding four / two code points with SWAR, so all specials are
+   matched in one pass instead of one PyUnicode_FindChar() sweep per special. */
 
 #include "turbohtml.h"
 
 #include <stdint.h>
 #include <string.h>
 
-#define SWAR_ONES 0x0101010101010101ULL
-#define SWAR_HIGHS 0x8080808080808080ULL
-#define SWAR_WORD 8
-
-static inline uint64_t swar_haszero(uint64_t word) {
-    return (word - SWAR_ONES) & ~word & SWAR_HIGHS;
+#if defined(_MSC_VER)
+#include <intrin.h>
+static inline int ctz64(uint64_t value) {
+    unsigned long index;
+    _BitScanForward64(&index, value);
+    return (int)index;
 }
-
-static inline uint64_t swar_hasbyte(uint64_t word, uint8_t byte) {
-    return swar_haszero(word ^ (SWAR_ONES * byte));
-}
-
-static inline uint64_t swar_specials(uint64_t word, int quote) {
-    uint64_t mask = swar_hasbyte(word, '&') | swar_hasbyte(word, '<') | swar_hasbyte(word, '>');
-    if (quote) {
-        mask |= swar_hasbyte(word, '"') | swar_hasbyte(word, '\'');
-    }
-    return mask;
-}
+#else
+#define ctz64(value) __builtin_ctzll(value)
+#endif
 
 static inline Py_ssize_t escape_extra(Py_UCS4 character, int quote) {
     switch (character) {
@@ -45,6 +40,192 @@ static inline Py_ssize_t escape_extra(Py_UCS4 character, int quote) {
     default:
         return 0;
     }
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+#include <arm_neon.h>
+
+#define BLOCK_BYTES 16
+
+/* Every special has a unique low nibble ('"' 0x22, '&' 0x26, '\'' 0x27, '<'
+   0x3C, '>' 0x3E), so one table lookup on the low nibble plus one comparison
+   classifies a whole block (the PSHUFB trick from pulldown-cmark). Index 0
+   holds 0x7F, which no byte with a zero low nibble equals, so it never
+   produces a false match. The growth tables map the same nibbles to how many
+   characters that special's replacement adds (&amp; adds 4, &lt;/&gt; add 3,
+   &quot;/&#x27; add 5). */
+static const uint8_t NIBBLE_SPECIALS[2][16] = {
+    {0x7F, 0, 0, 0, 0, 0, '&', 0, 0, 0, 0, 0, '<', 0, '>', 0},
+    {0x7F, 0, '"', 0, 0, 0, '&', '\'', 0, 0, 0, 0, '<', 0, '>', 0},
+};
+static const uint8_t NIBBLE_GROWTH[2][16] = {
+    {0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 3, 0, 3, 0},
+    {0, 0, 5, 0, 0, 0, 4, 5, 0, 0, 0, 0, 3, 0, 3, 0},
+};
+
+/* How many characters of growth escaping this block adds, all lanes at once:
+   the match mask selects each lane's growth, summed horizontally. */
+static inline Py_ssize_t block_extra(const uint8_t *block, int quote) {
+    uint8x16_t bytes = vld1q_u8(block);
+    uint8x16_t nibbles = vandq_u8(bytes, vdupq_n_u8(0x0F));
+    uint8x16_t matches = vceqq_u8(bytes, vqtbl1q_u8(vld1q_u8(NIBBLE_SPECIALS[quote]), nibbles));
+    uint8x16_t growth = vqtbl1q_u8(vld1q_u8(NIBBLE_GROWTH[quote]), nibbles);
+    return (Py_ssize_t)vaddvq_u8(vandq_u8(matches, growth));
+}
+
+/* Four mask bits per byte (the narrowing-shift trick: NEON has no movemask);
+   SPECIAL_INDEX / SPECIAL_CLEAR below hide the per-arch mask layout. */
+static inline uint64_t block_special_mask(const uint8_t *block, int quote) {
+    uint8x16_t bytes = vld1q_u8(block);
+    uint8x16_t nibbles = vandq_u8(bytes, vdupq_n_u8(0x0F));
+    uint8x16_t hits = vceqq_u8(bytes, vqtbl1q_u8(vld1q_u8(NIBBLE_SPECIALS[quote]), nibbles));
+    return vget_lane_u64(vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(hits), 4)), 0);
+}
+
+#define SPECIAL_INDEX(mask) (ctz64(mask) >> 2)
+#define SPECIAL_CLEAR(mask, index) ((mask) & ~(0xFULL << ((index) * 4)))
+
+/* Wide sizing scan: UCS-4 tests four code points per vector (UCS-2 stays on
+   the SWAR probes; both an eight-lane step and a 64-bit vector test measured
+   no better than SWAR on real and dense inputs). */
+#define UCS2_STEP UCS2_LANES
+#define UCS4_STEP 4
+#define word_has_special16 swar_word_has_special16
+
+static inline int word_has_special32(const uint32_t *block, int quote) {
+    uint32x4_t lanes = vld1q_u32(block);
+    uint32x4_t hits = vorrq_u32(vorrq_u32(vceqq_u32(lanes, vdupq_n_u32('&')), vceqq_u32(lanes, vdupq_n_u32('<'))),
+                                vceqq_u32(lanes, vdupq_n_u32('>')));
+    if (quote) {
+        hits = vorrq_u32(hits, vorrq_u32(vceqq_u32(lanes, vdupq_n_u32('"')), vceqq_u32(lanes, vdupq_n_u32('\''))));
+    }
+    return vmaxvq_u32(hits) != 0;
+}
+
+#elif defined(__SSE2__) || defined(_M_X64)
+
+#include <emmintrin.h>
+
+#define BLOCK_BYTES 16
+
+/* How many characters of growth escaping this block adds, all lanes at once:
+   each comparison yields 0xFF per match, masked down to that special's growth
+   (&amp; adds 4, &lt;/&gt; add 3, &quot;/&#x27; add 5), summed horizontally. */
+static inline Py_ssize_t block_extra(const uint8_t *block, int quote) {
+    __m128i bytes = _mm_loadu_si128((const __m128i *)block);
+    __m128i extras = _mm_and_si128(_mm_cmpeq_epi8(bytes, _mm_set1_epi8('&')), _mm_set1_epi8(4));
+    extras = _mm_add_epi8(extras, _mm_and_si128(_mm_cmpeq_epi8(bytes, _mm_set1_epi8('<')), _mm_set1_epi8(3)));
+    extras = _mm_add_epi8(extras, _mm_and_si128(_mm_cmpeq_epi8(bytes, _mm_set1_epi8('>')), _mm_set1_epi8(3)));
+    if (quote) {
+        extras = _mm_add_epi8(extras, _mm_and_si128(_mm_cmpeq_epi8(bytes, _mm_set1_epi8('"')), _mm_set1_epi8(5)));
+        extras = _mm_add_epi8(extras, _mm_and_si128(_mm_cmpeq_epi8(bytes, _mm_set1_epi8('\'')), _mm_set1_epi8(5)));
+    }
+    __m128i sums = _mm_sad_epu8(extras, _mm_setzero_si128());
+    return (Py_ssize_t)(_mm_cvtsi128_si32(sums) + _mm_extract_epi16(sums, 4));
+}
+
+/* One mask bit per byte; SPECIAL_INDEX / SPECIAL_CLEAR hide the layout. */
+static inline uint64_t block_special_mask(const uint8_t *block, int quote) {
+    __m128i bytes = _mm_loadu_si128((const __m128i *)block);
+    __m128i hits =
+        _mm_or_si128(_mm_or_si128(_mm_cmpeq_epi8(bytes, _mm_set1_epi8('&')), _mm_cmpeq_epi8(bytes, _mm_set1_epi8('<'))),
+                     _mm_cmpeq_epi8(bytes, _mm_set1_epi8('>')));
+    if (quote) {
+        hits = _mm_or_si128(
+            hits, _mm_or_si128(_mm_cmpeq_epi8(bytes, _mm_set1_epi8('"')), _mm_cmpeq_epi8(bytes, _mm_set1_epi8('\''))));
+    }
+    return (uint64_t)(unsigned)_mm_movemask_epi8(hits);
+}
+
+#define SPECIAL_INDEX(mask) ctz64(mask)
+#define SPECIAL_CLEAR(mask, index) ((mask) & ((mask) - 1))
+
+/* Wide sizing scan: vector variants are unvalidated on this project's
+   benchmark hardware, so x86 keeps the portable SWAR probes. */
+#define UCS2_STEP UCS2_LANES
+#define UCS4_STEP UCS4_LANES
+#define word_has_special16 swar_word_has_special16
+#define word_has_special32 swar_word_has_special32
+
+#else
+
+#define BLOCK_BYTES 8
+
+#define SWAR_ONES 0x0101010101010101ULL
+#define SWAR_HIGHS 0x8080808080808080ULL
+
+static inline uint64_t swar_hasbyte(uint64_t word, uint8_t byte) {
+    uint64_t lanes = word ^ (SWAR_ONES * byte);
+    return (lanes - SWAR_ONES) & ~lanes & SWAR_HIGHS;
+}
+
+/* The has-byte mask sets only each matching lane's high bit, so shifting it to
+   the lanes' low bits and multiplying by ones sums the lanes into the top byte. */
+static inline Py_ssize_t swar_count(uint64_t mask) {
+    return (Py_ssize_t)((((mask) >> 7) * SWAR_ONES) >> 56);
+}
+
+/* How many characters of growth escaping this block adds, all lanes at once
+   (&amp; adds 4, &lt;/&gt; add 3, &quot;/&#x27; add 5). */
+static inline Py_ssize_t block_extra(const uint8_t *block, int quote) {
+    uint64_t word;
+    memcpy(&word, block, sizeof(word));
+    Py_ssize_t extra = 4 * swar_count(swar_hasbyte(word, '&')) + 3 * swar_count(swar_hasbyte(word, '<')) +
+                       3 * swar_count(swar_hasbyte(word, '>'));
+    if (quote) {
+        extra += 5 * swar_count(swar_hasbyte(word, '"')) + 5 * swar_count(swar_hasbyte(word, '\''));
+    }
+    return extra;
+}
+
+/* One mask bit per byte, in each lane's high bit; SPECIAL_INDEX / SPECIAL_CLEAR
+   hide the layout. */
+static inline uint64_t block_special_mask(const uint8_t *block, int quote) {
+    uint64_t word;
+    memcpy(&word, block, sizeof(word));
+    uint64_t mask = swar_hasbyte(word, '&') | swar_hasbyte(word, '<') | swar_hasbyte(word, '>');
+    if (quote) {
+        mask |= swar_hasbyte(word, '"') | swar_hasbyte(word, '\'');
+    }
+    return mask;
+}
+
+#define SPECIAL_INDEX(mask) (ctz64(mask) >> 3)
+#define SPECIAL_CLEAR(mask, index) ((mask) & ((mask) - 1))
+
+/* Wide sizing scan: no vectors here, fall back to the SWAR word probes. */
+#define UCS2_STEP UCS2_LANES
+#define UCS4_STEP UCS4_LANES
+#define word_has_special16 swar_word_has_special16
+#define word_has_special32 swar_word_has_special32
+
+#endif
+
+/* The wide write phase keeps the fine-grained SWAR probes from turbohtml.h on
+   every arch: one special poisons only four / two code points into the scalar
+   rewrite, where a full SIMD step would poison eight / four. The wide sizing
+   scan uses the per-arch UCS2_STEP / UCS4_STEP tests above instead, because
+   its dirty-window cost is one escape_extra per lane regardless of width. */
+
+static inline int swar_word_has_special16(const uint16_t *block, int quote) {
+    uint64_t word;
+    memcpy(&word, block, sizeof(word));
+    uint64_t mask = swar_haslane16(word, '&') | swar_haslane16(word, '<') | swar_haslane16(word, '>');
+    if (quote) {
+        mask |= swar_haslane16(word, '"') | swar_haslane16(word, '\'');
+    }
+    return mask != 0;
+}
+
+static inline int swar_word_has_special32(const uint32_t *block, int quote) {
+    uint64_t word;
+    memcpy(&word, block, sizeof(word));
+    uint64_t mask = swar_haslane32(word, '&') | swar_haslane32(word, '<') | swar_haslane32(word, '>');
+    if (quote) {
+        mask |= swar_haslane32(word, '"') | swar_haslane32(word, '\'');
+    }
+    return mask != 0;
 }
 
 static inline Py_ssize_t write_escaped(int kind, void *data, Py_ssize_t offset, Py_UCS4 character, int quote) {
@@ -104,37 +285,40 @@ PyObject *turbohtml_escape(PyObject *Py_UNUSED(module), PyObject *args, PyObject
     if (kind == PyUnicode_1BYTE_KIND) {
         const uint8_t *input = (const uint8_t *)data;
         Py_ssize_t pos = 0;
-        while (pos + SWAR_WORD <= length) {
-            uint64_t word;
-            memcpy(&word, input + pos, SWAR_WORD);
-            if (swar_specials(word, quote) == 0) {
-                pos += SWAR_WORD;
-                continue;
+        while (pos + BLOCK_BYTES <= length) {
+            extra += block_extra(input + pos, quote);
+            pos += BLOCK_BYTES;
+        }
+        for (; pos < length; pos++) {
+            extra += escape_extra(input[pos], quote);
+        }
+    } else if (kind == PyUnicode_2BYTE_KIND) {
+        const uint16_t *input = (const uint16_t *)data;
+        Py_ssize_t pos = 0;
+        while (pos + UCS2_STEP <= length) {
+            if (word_has_special16(input + pos, quote)) {
+                for (int lane = 0; lane < UCS2_STEP; lane++) {
+                    extra += escape_extra(input[pos + lane], quote);
+                }
             }
-            for (int lane = 0; lane < SWAR_WORD; lane++) {
-                extra += escape_extra(input[pos + lane], quote);
-            }
-            pos += SWAR_WORD;
+            pos += UCS2_STEP;
         }
         for (; pos < length; pos++) {
             extra += escape_extra(input[pos], quote);
         }
     } else {
-        // wide strings are rare and the count scan below is scalar, so first use the
-        // vectorized PyUnicode_FindChar to skip it entirely when nothing is special
-        static const Py_UCS4 specials[] = {'&', '<', '>', '"', '\''};
-        Py_ssize_t special_count = quote ? 5 : 3;
-        int has_special = 0;
-        for (Py_ssize_t index = 0; index < special_count; index++) {
-            if (PyUnicode_FindChar(text, specials[index], 0, length, 1) >= 0) {
-                has_special = 1;
-                break;
+        const uint32_t *input = (const uint32_t *)data;
+        Py_ssize_t pos = 0;
+        while (pos + UCS4_STEP <= length) {
+            if (word_has_special32(input + pos, quote)) {
+                for (int lane = 0; lane < UCS4_STEP; lane++) {
+                    extra += escape_extra(input[pos + lane], quote);
+                }
             }
+            pos += UCS4_STEP;
         }
-        if (has_special) {
-            for (Py_ssize_t pos = 0; pos < length; pos++) {
-                extra += escape_extra(PyUnicode_READ(kind, data, pos), quote);
-            }
+        for (; pos < length; pos++) {
+            extra += escape_extra(input[pos], quote);
         }
     }
 
@@ -143,6 +327,8 @@ PyObject *turbohtml_escape(PyObject *Py_UNUSED(module), PyObject *args, PyObject
         return PyUnicode_FromObject(text);
     }
 
+    /* maxchar comes from the input and escapes are ASCII, so the output kind
+       always matches the input kind and clean blocks can be copied bytewise */
     Py_UCS4 maxchar = PyUnicode_MAX_CHAR_VALUE(text);
     PyObject *out = PyUnicode_New(length + extra, maxchar);
     if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -153,30 +339,74 @@ PyObject *turbohtml_escape(PyObject *Py_UNUSED(module), PyObject *args, PyObject
     Py_ssize_t written = 0;
 
     if (kind == PyUnicode_1BYTE_KIND) {
-        /* a 1-byte input gains only ASCII escapes, so the result stays 1-byte */
         const uint8_t *input = (const uint8_t *)data;
         uint8_t *output = (uint8_t *)out_data;
         Py_ssize_t pos = 0;
-        while (pos + SWAR_WORD <= length) {
-            uint64_t word;
-            memcpy(&word, input + pos, SWAR_WORD);
-            if (swar_specials(word, quote) == 0) {
-                memcpy(output + written, input + pos, SWAR_WORD);
-                written += SWAR_WORD;
-                pos += SWAR_WORD;
-                continue;
+        while (pos + BLOCK_BYTES <= length) {
+            uint64_t mask = block_special_mask(input + pos, quote);
+            if (mask == 0) {
+                memcpy(output + written, input + pos, BLOCK_BYTES);
+                written += BLOCK_BYTES;
+            } else {
+                /* copy the gap before each special wholesale, rewrite the
+                   special, then copy whatever trails the last one; the gap
+                   checks keep special-dense input from paying for empty copies */
+                Py_ssize_t prev = 0;
+                do {
+                    Py_ssize_t index = SPECIAL_INDEX(mask);
+                    if (index > prev) {
+                        memcpy(output + written, input + pos + prev, (size_t)(index - prev));
+                        written += index - prev;
+                    }
+                    written += write_escaped(out_kind, out_data, written, input[pos + index], quote);
+                    mask = SPECIAL_CLEAR(mask, index);
+                    prev = index + 1;
+                } while (mask != 0);
+                if (BLOCK_BYTES > prev) {
+                    memcpy(output + written, input + pos + prev, (size_t)(BLOCK_BYTES - prev));
+                    written += BLOCK_BYTES - prev;
+                }
             }
-            for (int lane = 0; lane < SWAR_WORD; lane++) {
-                written += write_escaped(out_kind, out_data, written, input[pos + lane], quote);
+            pos += BLOCK_BYTES;
+        }
+        for (; pos < length; pos++) {
+            written += write_escaped(out_kind, out_data, written, input[pos], quote);
+        }
+    } else if (kind == PyUnicode_2BYTE_KIND) {
+        const uint16_t *input = (const uint16_t *)data;
+        uint16_t *output = (uint16_t *)out_data;
+        Py_ssize_t pos = 0;
+        while (pos + UCS2_LANES <= length) {
+            if (swar_word_has_special16(input + pos, quote)) {
+                for (int lane = 0; lane < UCS2_LANES; lane++) {
+                    written += write_escaped(out_kind, out_data, written, input[pos + lane], quote);
+                }
+            } else {
+                memcpy(output + written, input + pos, UCS2_LANES * sizeof(uint16_t));
+                written += UCS2_LANES;
             }
-            pos += SWAR_WORD;
+            pos += UCS2_LANES;
         }
         for (; pos < length; pos++) {
             written += write_escaped(out_kind, out_data, written, input[pos], quote);
         }
     } else {
-        for (Py_ssize_t pos = 0; pos < length; pos++) {
-            written += write_escaped(out_kind, out_data, written, PyUnicode_READ(kind, data, pos), quote);
+        const uint32_t *input = (const uint32_t *)data;
+        uint32_t *output = (uint32_t *)out_data;
+        Py_ssize_t pos = 0;
+        while (pos + UCS4_LANES <= length) {
+            if (swar_word_has_special32(input + pos, quote)) {
+                for (int lane = 0; lane < UCS4_LANES; lane++) {
+                    written += write_escaped(out_kind, out_data, written, input[pos + lane], quote);
+                }
+            } else {
+                memcpy(output + written, input + pos, UCS4_LANES * sizeof(uint32_t));
+                written += UCS4_LANES;
+            }
+            pos += UCS4_LANES;
+        }
+        for (; pos < length; pos++) {
+            written += write_escaped(out_kind, out_data, written, input[pos], quote);
         }
     }
     return out;

--- a/src/turbohtml/html_entities.h
+++ b/src/turbohtml/html_entities.h
@@ -9,6 +9,11 @@ typedef struct {
 } html5_entity;
 
 #define HTML5_MAX_NAME_LEN 32
+#define HTML5_INDEX_AMP 657
+#define HTML5_INDEX_APOS 688
+#define HTML5_INDEX_GT 1135
+#define HTML5_INDEX_LT 1390
+#define HTML5_INDEX_QUOT 1754
 static const int html5_count = 2231;
 static const html5_entity html5_entities[] = {
     {"AElig", 5u, 198u, 0u},

--- a/src/turbohtml/turbohtml.h
+++ b/src/turbohtml/turbohtml.h
@@ -10,6 +10,8 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include <stdint.h>
+
 /* Implemented in escape.c. Signature matches METH_VARARGS | METH_KEYWORDS. */
 PyObject *turbohtml_escape(PyObject *module, PyObject *args, PyObject *kwds);
 
@@ -20,5 +22,25 @@ PyObject *turbohtml_unescape(PyObject *module, PyObject *arg);
    conformance hook _tokenize_states matches METH_VARARGS. */
 PyObject *turbohtml_tokenize(PyObject *module, PyObject *arg);
 PyObject *turbohtml_tokenize_states(PyObject *module, PyObject *args);
+
+/* SWAR lane probes over a 64-bit word holding four UCS-2 / two UCS-4 code
+   points. The has-zero test is exact as an existence test: the subtraction can
+   only borrow across a lane when that lane itself is zero, so the mask is
+   nonzero iff some lane equals the searched value. Lane positions inside the
+   mask depend on byte order, so callers treat a nonzero mask as "somewhere in
+   these lanes" and resolve the exact index with a scalar scan. */
+
+#define UCS2_LANES 4
+#define UCS4_LANES 2
+
+static inline uint64_t swar_haslane16(uint64_t word, uint16_t value) {
+    uint64_t lanes = word ^ (0x0001000100010001ULL * value);
+    return (lanes - 0x0001000100010001ULL) & ~lanes & 0x8000800080008000ULL;
+}
+
+static inline uint64_t swar_haslane32(uint64_t word, uint32_t value) {
+    uint64_t lanes = word ^ (0x0000000100000001ULL * value);
+    return (lanes - 0x0000000100000001ULL) & ~lanes & 0x8000000080000000ULL;
+}
 
 #endif /* TURBOHTML_H */

--- a/src/turbohtml/unescape.c
+++ b/src/turbohtml/unescape.c
@@ -1,15 +1,19 @@
 /* HTML unescaping.
 
-   unescape() makes a single pass over the input, resolving numeric and named
-   character references per the HTML5 rules. Named references use binary search
-   over the generated table, with longest-prefix matching for references that
-   omit the trailing semicolon; numeric references apply the spec's correction
-   tables. The output is built into a Py_UCS4 buffer because unescape never
-   lengthens the text, so the input length is a safe upper bound. */
+   unescape() hops between '&' occurrences (memchr for 1-byte text), bulk-copies
+   the clean spans in between, and resolves numeric and named character
+   references per the HTML5 rules at each stop. Named references use binary
+   search over the generated table, with longest-prefix matching for references
+   that omit the trailing semicolon; numeric references apply the spec's
+   correction tables. The output staging starts at the input's width (so clean
+   spans are plain memcpy) and widens to Py_UCS4 only when a reference produces
+   a wider character (e.g. "&#127881;" in ASCII text); unescape never lengthens
+   the text, so the input length is a safe upper bound for the staging. */
 
 #include "turbohtml.h"
 
 #include <stdint.h>
+#include <string.h>
 
 #include "charref.h"
 
@@ -30,18 +34,134 @@ static inline int is_name_char(Py_UCS4 character) {
     }
 }
 
-static inline void emit(Py_UCS4 *out, Py_ssize_t *count, Py_UCS4 *maxchar, Py_UCS4 character) {
-    out[*count] = character;
-    if (character > *maxchar) {
-        *maxchar = character;
+/* The output is staged in one buffer of length * 4 bytes. One-byte input
+   starts in narrow mode, where the staging holds bytes (so clean spans move
+   with plain memcpy) and switches to wide Py_UCS4 staging only when a
+   reference produces a character above 0xFF; the switch widens the staged
+   prefix in place, back to front, which is safe because slot 4 * i never
+   overlaps unread byte j <= i. UCS-2 / UCS-4 input starts wide. "seen"
+   accumulates an OR of every wide-mode code point instead of an exact
+   maximum: PyUnicode_New only bins maxchar at 0x7F / 0xFF / 0xFFFF, OR never
+   crosses one of those bins unless a character did, and the OR has no
+   per-call branch. Values above 0xFFFF are clamped to 0x10FFFF before use. */
+typedef struct {
+    uint8_t *narrow; /* the staging buffer seen as bytes; valid while !is_wide */
+    Py_UCS4 *wide;   /* the same buffer seen as code points; valid once is_wide */
+    Py_ssize_t count;
+    Py_UCS4 seen;
+    int is_wide;
+} sink_t;
+
+static void sink_widen(sink_t *sink) {
+    for (Py_ssize_t index = sink->count - 1; index >= 0; index--) {
+        Py_UCS4 character = sink->narrow[index]; /* read before the slot is overwritten (index 0 overlaps) */
+        sink->wide[index] = character;
+        sink->seen |= character;
     }
-    (*count)++;
+    sink->is_wide = 1;
+}
+
+static inline void emit(sink_t *sink, Py_UCS4 character) {
+    if (!sink->is_wide) {
+        if (character <= 0xFF) {
+            sink->narrow[sink->count++] = (uint8_t)character;
+            return;
+        }
+        sink_widen(sink);
+    }
+    sink->wide[sink->count] = character;
+    sink->seen |= character;
+    sink->count++;
+}
+
+static Py_ssize_t find_amp(int kind, const void *data, Py_ssize_t from, Py_ssize_t length) {
+    if (kind == PyUnicode_1BYTE_KIND) {
+        const uint8_t *input = (const uint8_t *)data;
+        /* in reference-dense text the next '&' is a handful of characters away,
+           so probe inline first; memchr's call cost only pays off on long spans */
+        Py_ssize_t probe_end = from + 16 < length ? from + 16 : length;
+        for (Py_ssize_t pos = from; pos < probe_end; pos++) {
+            if (input[pos] == '&') {
+                return pos;
+            }
+        }
+        if (probe_end == length) {
+            return -1;
+        }
+        const uint8_t *hit = memchr(input + probe_end, '&', (size_t)(length - probe_end));
+        return hit == NULL ? -1 : (Py_ssize_t)(hit - input);
+    }
+    if (kind == PyUnicode_2BYTE_KIND) {
+        const uint16_t *input = (const uint16_t *)data;
+        Py_ssize_t pos = from;
+        while (pos + UCS2_LANES <= length) {
+            uint64_t word;
+            memcpy(&word, input + pos, sizeof(word));
+            if (swar_haslane16(word, '&') != 0) {
+                break; /* the scalar loop below pins down which lane it is */
+            }
+            pos += UCS2_LANES;
+        }
+        for (; pos < length; pos++) {
+            if (input[pos] == '&') {
+                return pos;
+            }
+        }
+        return -1;
+    }
+    const uint32_t *input = (const uint32_t *)data;
+    Py_ssize_t pos = from;
+    while (pos + UCS4_LANES <= length) {
+        uint64_t word;
+        memcpy(&word, input + pos, sizeof(word));
+        if (swar_haslane32(word, '&') != 0) {
+            break; /* the scalar loop below pins down which lane it is */
+        }
+        pos += UCS4_LANES;
+    }
+    for (; pos < length; pos++) {
+        if (input[pos] == '&') {
+            return pos;
+        }
+    }
+    return -1;
+}
+
+static void copy_span(int kind, const void *data, Py_ssize_t from, Py_ssize_t to, sink_t *sink) {
+    if (kind == PyUnicode_1BYTE_KIND && !sink->is_wide) {
+        /* narrow staging matches the input width, so the span is one memcpy */
+        memcpy(sink->narrow + sink->count, (const uint8_t *)data + from, (size_t)(to - from));
+        sink->count += to - from;
+        return;
+    }
+    Py_UCS4 *dest = sink->wide + sink->count;
+    Py_UCS4 bits = 0;
+    if (kind == PyUnicode_1BYTE_KIND) {
+        const uint8_t *input = (const uint8_t *)data;
+        for (Py_ssize_t pos = from; pos < to; pos++) {
+            dest[pos - from] = input[pos];
+            bits |= input[pos];
+        }
+    } else if (kind == PyUnicode_2BYTE_KIND) {
+        const uint16_t *input = (const uint16_t *)data;
+        for (Py_ssize_t pos = from; pos < to; pos++) {
+            dest[pos - from] = input[pos];
+            bits |= input[pos];
+        }
+    } else {
+        const uint32_t *input = (const uint32_t *)data;
+        for (Py_ssize_t pos = from; pos < to; pos++) {
+            dest[pos - from] = input[pos];
+            bits |= input[pos];
+        }
+    }
+    sink->count += to - from;
+    sink->seen |= bits;
 }
 
 /* Returns the number of input characters consumed (including '&'), or 0 when no
    reference matches so the caller can emit a literal '&' and move on. */
-static Py_ssize_t parse_charref(int kind, const void *data, Py_ssize_t length, Py_ssize_t amp_index, Py_UCS4 *out,
-                                Py_ssize_t *count, Py_UCS4 *maxchar) {
+static Py_ssize_t parse_charref(int kind, const void *data, Py_ssize_t length, Py_ssize_t amp_index, sink_t *sink) {
     Py_ssize_t pos = amp_index + 1;
     if (pos >= length) {
         return 0;
@@ -90,13 +210,13 @@ static Py_ssize_t parse_charref(int kind, const void *data, Py_ssize_t length, P
 
         Py_UCS4 replacement;
         if (!overflow && charref_find_invalid(num, &replacement)) {
-            emit(out, count, maxchar, replacement);
+            emit(sink, replacement);
         } else if ((num >= 0xD800 && num <= 0xDFFF) || num > 0x10FFFF) {
-            emit(out, count, maxchar, 0xFFFD);
+            emit(sink, 0xFFFD);
         } else if (charref_is_invalid_codepoint(num)) {
             /* the spec maps these to the empty string, so emit nothing */
         } else {
-            emit(out, count, maxchar, num);
+            emit(sink, num);
         }
         return cursor - amp_index;
     }
@@ -140,22 +260,22 @@ static Py_ssize_t parse_charref(int kind, const void *data, Py_ssize_t length, P
     }
 
     if (entity == NULL) {
-        emit(out, count, maxchar, '&');
+        emit(sink, '&');
         for (int index = 0; index < name_len; index++) {
-            emit(out, count, maxchar, name_chars[index]);
+            emit(sink, name_chars[index]);
         }
         if (semicolon) {
-            emit(out, count, maxchar, ';');
+            emit(sink, ';');
         }
         return cursor - amp_index;
     }
 
-    emit(out, count, maxchar, entity->cp0);
+    emit(sink, entity->cp0);
     if (entity->cp1) {
-        emit(out, count, maxchar, entity->cp1);
+        emit(sink, entity->cp1);
     }
     for (int index = match_len; index < token_len; index++) {
-        emit(out, count, maxchar, (index < name_len) ? name_chars[index] : (Py_UCS4)';');
+        emit(sink, (index < name_len) ? name_chars[index] : (Py_UCS4)';');
     }
     return cursor - amp_index;
 }
@@ -169,7 +289,8 @@ PyObject *turbohtml_unescape(PyObject *Py_UNUSED(module), PyObject *arg) {
     int kind = PyUnicode_KIND(arg);
     const void *data = PyUnicode_DATA(arg);
 
-    if (PyUnicode_FindChar(arg, '&', 0, length, 1) < 0) {
+    Py_ssize_t amp = find_amp(kind, data, 0, length);
+    if (amp < 0) {
         return Py_NewRef(arg); /* without a '&' there is nothing to resolve; keep the original object */
     }
 
@@ -180,34 +301,66 @@ PyObject *turbohtml_unescape(PyObject *Py_UNUSED(module), PyObject *arg) {
     if (out == NULL) {              /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return PyErr_NoMemory();    /* GCOVR_EXCL_LINE */
     }
-    Py_ssize_t count = 0;
-    Py_UCS4 maxchar = 0;
+    sink_t sink = {(uint8_t *)out, out, 0, 0, kind != PyUnicode_1BYTE_KIND};
     Py_ssize_t pos = 0;
-    while (pos < length) {
-        Py_UCS4 character = PyUnicode_READ(kind, data, pos);
-        if (character != '&') {
-            emit(out, &count, &maxchar, character);
-            pos++;
+    while (1) {
+        if (amp > pos) {
+            copy_span(kind, data, pos, amp, &sink);
+        }
+        Py_ssize_t consumed = parse_charref(kind, data, length, amp, &sink);
+        if (consumed == 0) {
+            emit(&sink, '&');
+            pos = amp + 1;
+        } else {
+            pos = amp + consumed;
+        }
+        if (pos >= length) {
+            break;
+        }
+        /* references often sit back-to-back, so probe before paying for a search call */
+        if (PyUnicode_READ(kind, data, pos) == '&') {
+            amp = pos;
             continue;
         }
-        Py_ssize_t consumed = parse_charref(kind, data, length, pos, out, &count, &maxchar);
-        if (consumed == 0) {
-            emit(out, &count, &maxchar, '&');
-            pos++;
-        } else {
-            pos += consumed;
+        amp = find_amp(kind, data, pos + 1, length);
+        if (amp < 0) {
+            copy_span(kind, data, pos, length, &sink);
+            break;
         }
     }
 
-    PyObject *result = PyUnicode_New(count, maxchar);
+    Py_ssize_t count = sink.count;
+    Py_UCS4 seen = sink.seen;
+    if (!sink.is_wide) {
+        for (Py_ssize_t index = 0; index < count; index++) {
+            seen |= sink.narrow[index];
+        }
+    }
+    /* the OR accumulator can exceed 0x10FFFF only when an astral character was
+       emitted, and everything above 0xFFFF lands in the same PyUnicode_New bin */
+    PyObject *result = PyUnicode_New(count, seen > 0xFFFF ? 0x10FFFF : seen);
     if (result == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         PyMem_Free(out);  /* GCOVR_EXCL_LINE */
         return NULL;      /* GCOVR_EXCL_LINE */
     }
-    int result_kind = PyUnicode_KIND(result);
     void *result_data = PyUnicode_DATA(result);
-    for (Py_ssize_t index = 0; index < count; index++) {
-        PyUnicode_WRITE(result_kind, result_data, index, out[index]);
+    switch (PyUnicode_KIND(result)) {
+    case PyUnicode_1BYTE_KIND:
+        /* a 1-byte result implies narrow staging: wide mode is entered only by
+           a >0xFF character or by wide input, whose >0xFF characters survive
+           (references consume ASCII only), and either forces a wider result */
+        memcpy(result_data, sink.narrow, (size_t)count);
+        break;
+    case PyUnicode_2BYTE_KIND: {
+        uint16_t *dest = (uint16_t *)result_data;
+        for (Py_ssize_t index = 0; index < count; index++) {
+            dest[index] = (uint16_t)sink.wide[index];
+        }
+        break;
+    }
+    default:
+        memcpy(result_data, sink.wide, (size_t)count * sizeof(Py_UCS4));
+        break;
     }
     PyMem_Free(out);
     return result;

--- a/tests/test_escape.py
+++ b/tests/test_escape.py
@@ -31,13 +31,23 @@ def test_escape_quote_default_true() -> None:
         pytest.param("x" * 100, id="long-ascii"),
         pytest.param("caf\xe9 r\xe9sum\xe9", id="latin1"),
         pytest.param("☃ snowman", id="ucs2"),
+        pytest.param("☃" * 100, id="long-ucs2"),
         pytest.param("\U0001f600 emoji", id="astral"),
+        pytest.param("\U0001f600" * 100, id="long-astral"),
     ],
 )
 def test_escape_no_specials_returns_equal(text: str) -> None:
     assert turbohtml.escape(text) == text
 
 
+@pytest.mark.parametrize(
+    "marker",
+    [
+        pytest.param("", id="ascii"),
+        pytest.param("☃", id="ucs2"),
+        pytest.param("\U0001f600", id="ucs4"),
+    ],
+)
 @pytest.mark.parametrize("pad", range(20))
 @pytest.mark.parametrize(
     ("char", "rep"),
@@ -49,8 +59,8 @@ def test_escape_no_specials_returns_equal(text: str) -> None:
         pytest.param("'", "&#x27;", id="apos"),
     ],
 )
-def test_escape_special_at_every_offset(pad: int, char: str, rep: str) -> None:
-    head, tail = "a" * pad, "b" * pad
+def test_escape_special_at_every_offset(marker: str, pad: int, char: str, rep: str) -> None:
+    head, tail = f"{marker}{'a' * pad}", "b" * pad
     assert turbohtml.escape(f"{head}{char}{tail}") == f"{head}{rep}{tail}"
 
 
@@ -73,6 +83,26 @@ def test_escape_multiple_kinds(text: str, expected: str) -> None:
 def test_escape_wide_quote_false() -> None:
     # the UCS-2/UCS-4 path with quote=False: leaves quotes alone, still escapes & < >
     assert turbohtml.escape('☃ "x" & <b>', quote=False) == '☃ "x" &amp; &lt;b&gt;'
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        pytest.param("", id="ascii"),
+        pytest.param("☃", id="ucs2"),
+        pytest.param("\U0001f600", id="ucs4"),
+    ],
+)
+def test_escape_quote_false_skips_full_blocks(marker: str) -> None:
+    # quotes spread over whole blocks must be skipped with quote=False while & is still escaped
+    body = "'a\"b" * 10
+    assert turbohtml.escape(f"{marker}{body}&", quote=False) == f"{marker}{body}&amp;"
+
+
+def test_escape_wide_lookalike_codepoints() -> None:
+    # wide code points whose individual bytes match specials ('&' is 0x26, '<' is 0x3c) must stay untouched
+    assert turbohtml.escape("☦㰼Ħ&") == "☦㰼Ħ&amp;"
+    assert turbohtml.escape("\U0001f626\U0001f63c&") == "\U0001f626\U0001f63c&amp;"
 
 
 def test_escape_str_subclass_returns_true_str() -> None:

--- a/tests/test_unescape.py
+++ b/tests/test_unescape.py
@@ -65,6 +65,11 @@ def test_unescape_no_reference_returns_input() -> None:
     [
         pytest.param("☃ &amp; &#62; &copy; x", "☃ & > \xa9 x", id="ucs2"),
         pytest.param("\U0001f600&amp;&#x41;&notin;", "\U0001f600&A∉", id="astral"),
+        pytest.param("\U0001f600 &amp; tail", "\U0001f600 & tail", id="astral-trailing-text"),
+        pytest.param("☃ snowman waits patiently &amp; melts", "☃ snowman waits patiently & melts", id="ucs2-late-ref"),
+        pytest.param(
+            "\U0001f600 emoji party &gt; goes on late", "\U0001f600 emoji party > goes on late", id="ucs4-late-ref"
+        ),
     ],
 )
 def test_unescape_multiple_kinds(text: str, expected: str) -> None:

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -181,7 +181,8 @@ def build_cases() -> list[tuple[str, str, str]]:
     rng = random.Random(0)
     book_text = corpus("war-and-peace/2600.txt", LARGE)
     book_html = corpus("war-and-peace/2600-h/2600-h.htm", LARGE)
-    spec_html = large_text(*LARGE_FILES[1][1:])[:LARGE]
+    # byte-slice and decode latin-1 like corpus() so the case stays a 1-byte string
+    spec_html = large_text(*LARGE_FILES[1][1:]).encode()[:LARGE].decode("latin-1")
     return [
         ("escape", "tiny plain (64 B)", prose_of(rng, ASCII_WORDS, TINY)),
         ("escape", "medium markup (4 KiB)", markup_of(rng, ASCII_WORDS, MEDIUM)),

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -10,7 +10,11 @@ process then prints a speedup table
 against the standard library and, for tokenize, html5lib's pure-Python
 tokenizer.
 
-Besides the synthetic cases, tokenize also runs over html5lib's benchmark
+The escape/unescape inputs span tiny strings (call overhead) and multi-MiB
+documents streaming well past the CPU caches: real corpora (Project
+Gutenberg's War and Peace from the tools/bench-data submodule and the WHATWG
+HTML spec source) plus seeded pseudo-random UCS-2/UCS-4 text, since large real
+wide-kind documents are scarce. tokenize also runs over html5lib's benchmark
 corpus (the tools/html5lib-python submodule) — a slice of the WHATWG HTML spec
 source plus a size-weighted sample of web-platform-tests pages, 0.6 kB to
 234 kB — and two multi-megabyte real documents (the ECMAScript specification
@@ -22,6 +26,7 @@ from __future__ import annotations
 
 import html
 import os
+import random
 import urllib.request
 from html.parser import HTMLParser
 from pathlib import Path
@@ -75,18 +80,130 @@ def large_text(filename: str, url: str) -> str:
     return target.read_text(encoding="utf-8")
 
 
-CASES: list[tuple[str, str, str]] = [
-    ("escape", "plain prose, no specials", "the quick brown fox jumps over the lazy dog " * 80),
-    ("escape", "typical HTML markup", '<p>Tom & Jerry said "hi" to <b>O\'Brien</b> & co.</p> ' * 60),
-    ("escape", "special-dense", "<>&\"'" * 500),
-    ("escape", "non-ASCII prose (UCS-2)", "résumé café naïve Москва " * 120),
-    ("escape", "astral text (UCS-4)", "emoji \U0001f600 party \U0001f389 " * 120),
-    ("unescape", "named references (dense)", "&amp;&lt;&gt;&quot;&copy;&mdash;&eacute; " * 60),
-    ("unescape", "numeric references (dense)", "&#62;&#x3e;&#38;&#127881;&#x1F600; " * 60),
-    ("unescape", "mixed named + numeric", "Tom &amp; Jerry &mdash; caf&eacute; &#127881; &lt;b&gt; " * 30),
-    ("unescape", "prose, sparse references", ("the quick brown fox " * 20 + "&amp; ") * 12),
-    ("unescape", "non-ASCII with references", "café &amp; résumé &copy; Москва &mdash; " * 60),
-]
+DATA_DIR = Path(__file__).resolve().parent / "bench-data"
+
+ASCII_WORDS = (
+    "the",
+    "quick",
+    "brown",
+    "fox",
+    "jumps",
+    "over",
+    "lazy",
+    "dogs",
+    "while",
+    "zealous",
+    "wizards",
+    "vex",
+    "sphinx",
+    "judges",
+    "of",
+    "black",
+    "quartz",
+    "monoliths",
+)
+UCS2_WORDS = (*ASCII_WORDS, "résumé", "café", "naïve", "Москва", "über", "façade", "πλάτων", "Ω")
+UCS4_WORDS = (*UCS2_WORDS, "😀", "🎉", "🚀", "🐍")
+REFERENCES = ("&amp;", "&lt;", "&gt;", "&quot;", "&#x27;", "&copy;", "&mdash;", "&eacute;", "&#62;", "&#127881;")
+NUMERIC_REFERENCES = ("&#62;", "&#x3e;", "&#38;", "&#127881;", "&#x1F600;")
+
+TINY = 64
+MEDIUM = 4 * 2**10
+LARGE = 4 * 2**20
+# unique generated prefix tiled up to LARGE: cache pressure comes from the address
+# footprint of the full string, not from the content repeating every 64 KiB
+CHUNK = 64 * 2**10
+
+
+def corpus(relative: str, size: int) -> str:
+    """
+    Load a slice of a vendored real-world document.
+
+    Decoded as latin-1 so the result is always a 1-byte unicode object exercising
+    the byte path regardless of any UTF-8 multibyte sequences in the file (the
+    bytes are preserved verbatim; mojibake is irrelevant to throughput).
+    """
+    path = DATA_DIR / relative
+    if not path.exists():
+        msg = f"{path} is missing; run: git submodule update --init --depth 1 tools/bench-data/war-and-peace"
+        raise FileNotFoundError(msg)
+    return path.read_bytes()[:size].decode("latin-1")
+
+
+def prose_of(rng: random.Random, vocabulary: tuple[str, ...], size: int) -> str:
+    """Build at least ``size`` characters of word soup with nothing to escape."""
+    pieces: list[str] = []
+    total = 0
+    while total < size:
+        word = rng.choice(vocabulary)
+        pieces.append(word)
+        total += len(word) + 1
+    return " ".join(pieces)
+
+
+def markup_of(rng: random.Random, vocabulary: tuple[str, ...], size: int) -> str:
+    """Build at least ``size`` characters of HTML-looking text rich in characters escape() rewrites."""
+    pieces: list[str] = []
+    total = 0
+    while total < size:
+        tag = rng.choice(("p", "div", "span", "em", "li"))
+        body = " ".join(rng.choice(vocabulary) for _ in range(rng.randint(4, 12)))
+        piece = f'<{tag} class="{rng.choice(vocabulary)}">{body} & {rng.choice(vocabulary)}\'s</{tag}>\n'
+        pieces.append(piece)
+        total += len(piece)
+    return "".join(pieces)
+
+
+def references_of(
+    rng: random.Random, vocabulary: tuple[str, ...], gap: int, size: int, references: tuple[str, ...] = REFERENCES
+) -> str:
+    """Build at least ``size`` characters of prose with a character reference after every ``gap`` words."""
+    pieces: list[str] = []
+    total = 0
+    while total < size:
+        for _ in range(gap):
+            word = rng.choice(vocabulary)
+            pieces.append(word)
+            total += len(word) + 1
+        reference = rng.choice(references)
+        pieces.append(reference)
+        total += len(reference) + 1
+    return " ".join(pieces)
+
+
+def tile(chunk: str, size: int) -> str:
+    """Repeat ``chunk`` up to exactly ``size`` characters."""
+    return (chunk * (size // len(chunk) + 1))[:size]
+
+
+def build_cases() -> list[tuple[str, str, str]]:
+    """Return the (operation, case name, input) escape/unescape matrix."""
+    rng = random.Random(0)
+    book_text = corpus("war-and-peace/2600.txt", LARGE)
+    book_html = corpus("war-and-peace/2600-h/2600-h.htm", LARGE)
+    spec_html = large_text(*LARGE_FILES[1][1:])[:LARGE]
+    return [
+        ("escape", "tiny plain (64 B)", prose_of(rng, ASCII_WORDS, TINY)),
+        ("escape", "medium markup (4 KiB)", markup_of(rng, ASCII_WORDS, MEDIUM)),
+        ("escape", "no-op prose (4 MiB)", tile(prose_of(rng, ASCII_WORDS, CHUNK), LARGE)),
+        ("escape", "book text (3 MiB)", book_text),
+        ("escape", "book HTML (4 MiB)", book_html),
+        ("escape", "spec HTML, dense (4 MiB)", spec_html),
+        ("escape", "UCS-2 plain (4 MiB)", tile(prose_of(rng, UCS2_WORDS, CHUNK), LARGE)),
+        ("escape", "UCS-2 markup (4 MiB)", tile(markup_of(rng, UCS2_WORDS, CHUNK), LARGE)),
+        ("escape", "UCS-4 plain (4 MiB)", tile(prose_of(rng, UCS4_WORDS, CHUNK), LARGE)),
+        ("escape", "UCS-4 markup (4 MiB)", tile(markup_of(rng, UCS4_WORDS, CHUNK), LARGE)),
+        ("unescape", "tiny plain (64 B)", prose_of(rng, ASCII_WORDS, TINY)),
+        ("unescape", "medium dense refs (4 KiB)", references_of(rng, ASCII_WORDS, 1, MEDIUM)),
+        ("unescape", "numeric refs (4 KiB)", references_of(rng, ASCII_WORDS, 1, MEDIUM, NUMERIC_REFERENCES)),
+        ("unescape", "book HTML, real refs (4 MiB)", book_html),
+        ("unescape", "escaped book HTML (5 MiB)", html.escape(book_html)),
+        ("unescape", "dense refs (4 MiB)", tile(references_of(rng, ASCII_WORDS, 1, CHUNK), LARGE)),
+        ("unescape", "UCS-2 refs (4 MiB)", tile(references_of(rng, UCS2_WORDS, 10, CHUNK), LARGE)),
+    ]
+
+
+CASES: list[tuple[str, str, str]] = build_cases()
 
 TOKENIZE_CASES: list[tuple[str, str]] = [
     (

--- a/tools/generate_html_entities.py
+++ b/tools/generate_html_entities.py
@@ -48,11 +48,18 @@ def generate(out_path: Path) -> None:
         raise SystemExit(msg)
     max_name_len = max(len(name) for name in html5)
 
+    ordered = sorted(html5)
     named = [
         f'    {{"{name}", {len(name)}u, {ord(value[0])}u, {ord(value[1]) if len(value) == 2 else 0}u}},'
-        for name in sorted(html5)
+        for name in ordered
         for value in (html5[name],)
     ]
+    # the names html.escape emits dominate real input; expose their indices so
+    # unescape can check them with one comparison before the binary search
+    escape_defines = "".join(
+        f"#define HTML5_INDEX_{name.rstrip(';').upper()} {ordered.index(name)}\n"
+        for name in ("amp;", "apos;", "gt;", "lt;", "quot;")
+    )
     charrefs = [f"    {{{num}u, {ord(_invalid_charrefs[num])}u}}," for num in sorted(_invalid_charrefs)]
     codepoints = sorted(_invalid_codepoints)
     codepoint_lines = "\n".join(
@@ -70,6 +77,7 @@ def generate(out_path: Path) -> None:
         "    Py_UCS4 cp1; /* second code point, or 0 when the value is one char */\n"
         "} html5_entity;\n\n"
         f"#define HTML5_MAX_NAME_LEN {max_name_len}\n"
+        f"{escape_defines}"
         f"static const int html5_count = {len(named)};\n"
         "static const html5_entity html5_entities[] = {\n"
         f"{chr(10).join(named)}\n"

--- a/tools/prune_dist.py
+++ b/tools/prune_dist.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+Drop the vendored git submodules from the sdist staging tree.
+
+Meson dist archives initialized submodules, so without this the sdist content
+would depend on which submodules happen to be checked out locally; the corpora
+(conformance data and benchmark documents) are development-only either way.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+if __name__ == "__main__":
+    root = Path(os.environ["MESON_DIST_ROOT"])
+    for relative in ("tests/html5lib-tests", "tools/bench-data", "tools/html5lib-python"):
+        shutil.rmtree(root / relative, ignore_errors=True)


### PR DESCRIPTION
The benchmark made the hot paths look better than they were: its inputs fit in L1 cache and were synthetic, so the cost of scanning real documents never showed up. Under that surface, `escape` tested one SWAR word per step and probed wide (UCS-2/UCS-4) text with one `PyUnicode_FindChar` sweep per special character, while `unescape` funnelled every character through a per-code-point emit into a UCS4 staging buffer and paid an ~11-round binary search for every named reference. ⚡

`escape` now classifies sixteen bytes per step: NEON resolves all five specials with a single low-nibble table lookup (the `PSHUFB` trick from `pulldown-cmark` — each special has a unique low nibble), SSE2 compares per special, and other targets keep the SWAR word. The sizing pass accumulates growth branchlessly, the writing pass converts matches into a position bitmask so clean stretches move as single copies, and wide strings probe all specials in one pass (UCS-4 with a four-lane vector). `unescape` hops between `&` occurrences (`memchr` plus an inline probe), bulk-copies the spans, stages at the input's width until a reference actually widens the result, and resolves the entities `html.escape` emits with one comparison — a fast path that lives in the shared `charref_find_entity`, so the tokenizer's character-reference state gets it too. Every step was gated with `pyperf compare_to` against the previous build; variants that measured neutral or regressive (32-byte unrolling, wide UCS-2 vectors, LTO) were dropped.

Measured at full rigor on Apple M-series against the standard library: the no-op `escape` scan of 4 MiB runs 22×, real book text 3.9×, unescaping escaped real HTML 10.1× (2.97× of which is the entity fast path), reference-dense text 7.6×, and the tokenizer's entity-heavy case improves from 6.5× to 9.2× through the shared fast path. 📊

The benchmark now measures multi-MiB real documents: Project Gutenberg's *War and Peace* as a pinned shallow submodule under `tools/bench-data`, and the WHATWG spec source through the pinned cached download mechanism the tokenizer benchmarks introduced. A `meson dist` script prunes all submodule content from the sdist regardless of local checkout state, and the README gains the same shields as the other tox-dev projects plus revalidated numbers for all three operations.