### PR TITLE
📝 docs: benchmark parse() against other tree builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 [![Documentation status](https://readthedocs.org/projects/turbohtml/badge/?version=latest)](https://turbohtml.readthedocs.io/en/latest/?badge=latest)
 [![check](https://github.com/tox-dev/turbohtml/actions/workflows/check.yaml/badge.svg)](https://github.com/tox-dev/turbohtml/actions/workflows/check.yaml)
 
-A fast, fully typed HTML toolkit for Python, powered by a C-accelerated core. `turbohtml` provides spec-correct HTML
-escaping and unescaping that match the standard library byte for byte, and a WHATWG-conformant streaming tokenizer — all
-several times faster than their pure-Python counterparts and ready for the free-threaded build.
+A fast, fully typed HTML toolkit for Python with a C-accelerated core. turbohtml escapes and unescapes HTML to match the
+standard library byte for byte, tokenizes markup with a WHATWG-conformant streaming tokenizer, and parses whole
+documents into a navigable element tree. Each operation runs several times faster than its pure-Python counterpart and
+supports the free-threaded build.
 
 ## Install
 
@@ -16,7 +17,7 @@ several times faster than their pure-Python counterparts and ready for the free-
 $ pip install turbohtml
 ```
 
-Wheels are published per interpreter for CPython 3.10–3.15 (including free-threading), so there is nothing to compile.
+Wheels ship per interpreter for CPython 3.10–3.15 (including free-threading), so there is nothing to compile.
 
 ## Usage
 
@@ -46,7 +47,7 @@ references that omit the trailing semicolon):
 `escape` and `unescape` reproduce `html.escape` and `html.unescape` exactly, so turbohtml is a drop-in replacement on
 hot paths.
 
-Tokenize markup into a stream of tokens following the WHATWG tokenization algorithm:
+Tokenize markup into a stream of tokens that follows the WHATWG tokenization algorithm:
 
 ```pycon
 >>> for token in turbohtml.tokenize('<p class="x">Tom &amp; Jerry</p>'):
@@ -68,63 +69,105 @@ For incremental input, `Tokenizer.feed()` returns the tokens completed by each c
 []
 ```
 
+Parse a whole document into a tree and walk it with `find`, `find_all`, and the navigation accessors:
+
+```pycon
+>>> doc = turbohtml.parse('<ul><li>one<li>two</ul>')
+>>> [li.text for li in doc.find_all('li')]
+['one', 'two']
+>>> doc.find('ul').children[0].tag
+'li'
+```
+
+Parse a fragment as the contents of a context element, the way `innerHTML` does:
+
+```pycon
+>>> cell = turbohtml.parse_fragment('<td>data', context='tr')
+>>> cell.tag, cell.text
+('tr', 'data')
+```
+
 ## Performance
 
-Measured with [pyperf](https://pyperf.readthedocs.io) on CPython 3.14 (release build, Apple M-series) against the
-standard library's `html.escape` / `html.unescape`. The multi-MiB inputs stream well past the CPU caches; the book and
-spec cases are real documents (Project Gutenberg's *War and Peace*, the WHATWG HTML spec source) pulled in as git
-submodules. Reproduce with `tox -e bench`:
+Measured with [pyperf](https://pyperf.readthedocs.io) on CPython 3.14.6 (release build) on an Apple M4 running macOS
+26.5. The corpus cases are real documents: [Project Gutenberg's *War and Peace*](https://www.gutenberg.org/ebooks/2600),
+the [WHATWG HTML specification source](https://github.com/whatwg/html/blob/main/source), the
+[ECMAScript specification](https://github.com/tc39/ecma262), and a sample of
+[web-platform-tests](https://github.com/web-platform-tests/wpt) pages.
 
-| operation  | input                        | turbohtml | stdlib  | speedup |
-| ---------- | ---------------------------- | --------- | ------- | ------- |
-| `escape`   | tiny plain (64 B)            | 0.04 µs   | 0.11 µs | 2.9×    |
-| `escape`   | medium markup (4 KiB)        | 2.38 µs   | 8.09 µs | 3.4×    |
-| `escape`   | no-op prose (4 MiB)          | 0.12 ms   | 2.66 ms | 22.2×   |
-| `escape`   | book text (3 MiB)            | 0.72 ms   | 2.80 ms | 3.9×    |
-| `escape`   | book HTML (4 MiB)            | 1.35 ms   | 4.88 ms | 3.6×    |
-| `escape`   | spec HTML, dense (4 MiB)     | 5.27 ms   | 13.3 ms | 2.5×    |
-| `escape`   | UCS-2 plain (4 MiB)          | 0.74 ms   | 2.60 ms | 3.5×    |
-| `escape`   | UCS-2 markup (4 MiB)         | 3.44 ms   | 11.5 ms | 3.3×    |
-| `escape`   | UCS-4 plain (4 MiB)          | 0.97 ms   | 5.58 ms | 5.8×    |
-| `escape`   | UCS-4 markup (4 MiB)         | 4.08 ms   | 20.3 ms | 5.0×    |
-| `unescape` | tiny plain (64 B)            | 0.02 µs   | 0.03 µs | 1.3×    |
-| `unescape` | medium dense refs (4 KiB)    | 8.57 µs   | 72.5 µs | 8.5×    |
-| `unescape` | numeric refs (4 KiB)         | 5.24 µs   | 81.1 µs | 15.5×   |
-| `unescape` | book HTML, real refs (4 MiB) | 2.80 ms   | 8.96 ms | 3.2×    |
-| `unescape` | escaped book HTML (5 MiB)    | 2.10 ms   | 21.2 ms | 10.1×   |
-| `unescape` | dense refs (4 MiB)           | 10.4 ms   | 78.5 ms | 7.6×    |
-| `unescape` | UCS-2 refs (4 MiB)           | 2.78 ms   | 19.4 ms | 7.0×    |
+`escape` runs against the standard library's [`html.escape`](https://docs.python.org/3/library/html.html#html.escape):
 
-`escape` gains the most on text that needs little escaping — the SIMD scan classifies sixteen bytes at a time and copies
-clean stretches wholesale — and `unescape` gains the most on entity-heavy input, where the standard library pays a
-Python function call per match. The gap is narrowest on tiny strings, where call overhead dominates, and on
-special-dense markup, where both sides spend their time writing replacements. Numbers vary with input and hardware;
-reproduce them with `tox -e bench`.
+| input                    | turbohtml | html.escape |
+| ------------------------ | --------- | ----------- |
+| tiny plain (64 B)        | 0.04 µs   | 0.11 µs     |
+| medium markup (4 KiB)    | 2.25 µs   | 7.17 µs     |
+| no-op prose (4 MiB)      | 0.11 ms   | 2.51 ms     |
+| book text (3 MiB)        | 0.66 ms   | 2.56 ms     |
+| book HTML (4 MiB)        | 1.25 ms   | 4.54 ms     |
+| spec HTML, dense (4 MiB) | 4.93 ms   | 12.8 ms     |
+| UCS-2 plain (4 MiB)      | 0.70 ms   | 2.41 ms     |
+| UCS-2 markup (4 MiB)     | 3.33 ms   | 10.9 ms     |
+| UCS-4 plain (4 MiB)      | 0.91 ms   | 5.29 ms     |
+| UCS-4 markup (4 MiB)     | 3.95 ms   | 19.3 ms     |
 
-`tokenize` is compared against the standard library's `html.parser.HTMLParser` (driven with no-op handlers) and
-html5lib's pure-Python tokenizer, over synthetic cases, html5lib's benchmark corpus of real documents (a slice of the
-WHATWG spec source plus web-platform-tests pages of varied sizes), and two multi-megabyte specifications:
+`unescape` runs against the standard library's
+[`html.unescape`](https://docs.python.org/3/library/html.html#html.unescape):
 
-| input                       | turbohtml | `html.parser` | speedup | html5lib | speedup |
-| --------------------------- | --------- | ------------- | ------- | -------- | ------- |
-| typical markup              | 30.3 µs   | 449 µs        | 14.8×   | 840 µs   | 28×     |
-| text-heavy prose            | 0.55 µs   | 2.9 µs        | 5.3×    | 149 µs   | 273×    |
-| attribute-heavy             | 24.7 µs   | 330 µs        | 13.3×   | 837 µs   | 34×     |
-| script-heavy                | 13.0 µs   | 162 µs        | 12.5×   | 526 µs   | 41×     |
-| entity-heavy                | 22.3 µs   | 205 µs        | 9.2×    | 1246 µs  | 56×     |
-| wpt page (0.6 kB)           | 1.6 µs    | 18.2 µs       | 11.4×   | 49 µs    | 31×     |
-| wpt page (4 kB)             | 15.0 µs   | 176 µs        | 11.8×   | 434 µs   | 29×     |
-| wpt page (9.6 kB)           | 34.9 µs   | 376 µs        | 10.8×   | 1190 µs  | 34×     |
-| wpt page (92 kB)            | 348 µs    | 4250 µs       | 12.2×   | 9311 µs  | 27×     |
-| wpt page, CJK (124 kB)      | 626 µs    | 8926 µs       | 14.3×   | 22844 µs | 37×     |
-| whatwg spec (235 kB)        | 701 µs    | 7838 µs       | 11.2×   | 20409 µs | 29×     |
-| ecmascript spec (3 MB)      | 7.08 ms   | 57.9 ms       | 8.2×    | 192 ms   | 27×     |
-| whatwg spec source (7.9 MB) | 37.0 ms   | 399 ms        | 10.8×   | 907 ms   | 25×     |
+| input                        | turbohtml | html.unescape |
+| ---------------------------- | --------- | ------------- |
+| tiny plain (64 B)            | 0.02 µs   | 0.03 µs       |
+| medium dense refs (4 KiB)    | 8.22 µs   | 69.0 µs       |
+| numeric refs (4 KiB)         | 5.83 µs   | 78.7 µs       |
+| book HTML, real refs (4 MiB) | 2.44 ms   | 7.87 ms       |
+| escaped book HTML (5 MiB)    | 1.90 ms   | 19.5 ms       |
+| dense refs (4 MiB)           | 9.89 ms   | 73.0 ms       |
+| UCS-2 refs (4 MiB)           | 2.51 ms   | 18.1 ms       |
 
-The state machine is stamped per input storage width (the CPython stringlib trick) and, like html5ever, bulk-scans plain
-text runs instead of dispatching per character, so ASCII documents stay one byte per character end to end. Run scanning
-uses the same SWAR technique as `escape`, so even a document that is almost entirely one text node — `HTMLParser`'s best
-case, a single C regex scan — comes out ahead.
+`escape` gains the most on text that needs little escaping; `unescape` gains the most on entity-heavy input. The gap
+narrows on tiny strings, where call overhead dominates.
+
+`tokenize` runs against the standard library's
+[`html.parser.HTMLParser`](https://docs.python.org/3/library/html.parser.html) (driven with no-op handlers) and
+[html5lib](https://html5lib.readthedocs.io/)'s pure-Python tokenizer, over synthetic cases, html5lib's benchmark corpus
+(a slice of the WHATWG spec source plus web-platform-tests pages of varied sizes), and two multi-megabyte
+specifications:
+
+| input                       | turbohtml | html.parser | html5lib |
+| --------------------------- | --------- | ----------- | -------- |
+| typical markup              | 29.3 µs   | 435 µs      | 810 µs   |
+| text-heavy prose            | 0.54 µs   | 2.8 µs      | 143 µs   |
+| attribute-heavy             | 19.2 µs   | 298 µs      | 807 µs   |
+| script-heavy                | 12.1 µs   | 156 µs      | 488 µs   |
+| entity-heavy                | 20.4 µs   | 197 µs      | 1.20 ms  |
+| wpt page (0.6 kB)           | 1.4 µs    | 17.5 µs     | 47.7 µs  |
+| wpt page (4 kB)             | 12.1 µs   | 165 µs      | 422 µs   |
+| wpt page (9.6 kB)           | 29.2 µs   | 360 µs      | 1.16 ms  |
+| wpt page (92 kB)            | 324 µs    | 4.03 ms     | 8.93 ms  |
+| wpt page, CJK (124 kB)      | 584 µs    | 8.45 ms     | 22.6 ms  |
+| whatwg spec (235 kB)        | 645 µs    | 7.39 ms     | 19.3 ms  |
+| ecmascript spec (3 MB)      | 5.88 ms   | 55.0 ms     | 181 ms   |
+| whatwg spec source (7.9 MB) | 35.0 ms   | 389 ms      | 853 ms   |
+
+turbohtml stays ahead even on text-only input, the best case for `html.parser`.
+
+`parse` builds a full WHATWG document tree. It runs against the other Python HTML tree builders:
+[lxml](https://lxml.de/), [selectolax](https://github.com/rushter/selectolax),
+[BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/), and
+[html5lib](https://html5lib.readthedocs.io/). Each parses the same web-platform-tests pages and specification sources:
+
+| input                       | turbohtml | lxml    | selectolax | BeautifulSoup | html5lib |
+| --------------------------- | --------- | ------- | ---------- | ------------- | -------- |
+| wpt page (0.6 kB)           | 1.3 µs    | 3.3 µs  | 6.8 µs     | 61.6 µs       | 101 µs   |
+| wpt page (4 kB)             | 10.6 µs   | 26.7 µs | 42.1 µs    | 443 µs        | 616 µs   |
+| wpt page (9.6 kB)           | 25.4 µs   | 72.6 µs | 107 µs     | 849 µs        | 1.44 ms  |
+| wpt page (92 kB)            | 268 µs    | 629 µs  | 920 µs     | 15.5 ms       | 17.0 ms  |
+| wpt page, CJK (124 kB)      | 483 µs    | 1.44 ms | 2.30 ms    | 21.5 ms       | 28.0 ms  |
+| whatwg spec (235 kB)        | 504 µs    | 1.23 ms | 1.78 ms    | 26.4 ms       | 31.9 ms  |
+| ecmascript spec (3 MB)      | 4.42 ms   | 17.5 ms | 15.8 ms    | 183 ms        | 254 ms   |
+| whatwg spec source (7.9 MB) | 27.6 ms   | 83.8 ms | 94.8 ms    | 1.66 s        | 1.73 s   |
+
+`parse` runs roughly 2–5× faster than the C parsers lxml and selectolax, and 30–80× faster than the pure-Python
+BeautifulSoup and html5lib. Numbers vary with input and hardware.
 
 ## Documentation
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,17 +17,17 @@ Features - 0.2.0
   :class:`turbohtml.Tokenizer`, and the :class:`turbohtml.Token` / :class:`turbohtml.TokenType` types. The C state
   machine is validated against the html5lib-tests tokenizer conformance suite and bulk-scans text runs the way html5ever
   does. (:issue:`6`)
-- Speed up ``escape`` and ``unescape`` across the board. ``escape``: one-byte strings are classified sixteen bytes at a
-  time with NEON / SSE2 (a SWAR word elsewhere) — on NEON a single low-nibble table lookup matches all five specials at
-  once — the sizing pass accumulates growth branchlessly, the writing pass copies clean stretches wholesale and rewrites
-  only the positions a match bitmask singles out, and UCS-2 / UCS-4 text is probed for all special characters in a
-  single SWAR pass instead of one ``PyUnicode_FindChar`` sweep per character (UCS-4 with a four-lane NEON vector).
-  ``unescape``: the scan hops between ``&`` occurrences and bulk-copies the clean spans instead of funnelling every
-  character through a per-code-point emit, output staging stays at the input's width until a reference actually widens
-  it, and the entities ``html.escape`` emits resolve with one comparison instead of the full binary search — unescaping
-  escaped real HTML runs about three times faster than via the general lookup path alone. The benchmark now uses `pyperf
-  <https://pyperf.readthedocs.io>`_ with multi-MiB real documents referenced as pinned git submodules under
-  ``tools/bench-data`` - by :user:`gaborbernat`. (:issue:`7`)
+- Speed up ``escape`` and ``unescape``. ``escape`` classifies one-byte strings sixteen bytes at a time with NEON or
+  SSE2, or a SWAR word elsewhere (on NEON, a single low-nibble table lookup matches all five specials at once). The
+  sizing pass accumulates growth without branches, the writing pass copies clean stretches in bulk and rewrites only the
+  positions a match bitmask singles out, and one SWAR pass probes UCS-2 / UCS-4 text for every special character instead
+  of running one ``PyUnicode_FindChar`` sweep per character (UCS-4 uses a four-lane NEON vector). ``unescape`` hops
+  between ``&`` occurrences and bulk-copies the clean spans instead of routing every character through a per-code-point
+  emit, keeps output staging at the input's width until a reference widens it, and resolves the entities ``html.escape``
+  emits with one comparison rather than the full binary search, so unescaping escaped real HTML runs about three times
+  faster than the general lookup path alone. The benchmark now uses `pyperf <https://pyperf.readthedocs.io>`_ with
+  multi-MiB real documents referenced as pinned git submodules under ``tools/bench-data`` - by :user:`gaborbernat`.
+  (:issue:`7`)
 
 *********************
  v0.1.1 (2026-06-09)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -2,7 +2,7 @@
  Development
 #############
 
-This page onboards contributors and records how turbohtml is built and maintained.
+This page onboards contributors and records how we build and maintain turbohtml.
 
 ****************
  Getting set up
@@ -18,10 +18,10 @@ turbohtml uses `tox <https://tox.wiki>`_ with `tox-uv <https://github.com/tox-de
     $ git submodule update --init tests/html5lib-tests   # conformance data for the test suite
     $ uvx --with tox-uv tox r -e 3.14   # build, test, and check coverage
 
-The ``tests/html5lib-tests`` submodule holds the conformance suite used by one of the tests. Do not initialize all
-submodules indiscriminately: the ``tools/bench-data`` submodules reference multi-MiB real documents (pinned upstream
-commits, nothing copied into this repository) used only by ``tox r -e bench``; fetch them on demand with ``git submodule
-update --init --depth 1 tools/bench-data/whatwg-html tools/bench-data/war-and-peace``.
+The ``tests/html5lib-tests`` submodule holds the conformance suite that one of the tests runs against. Do not initialize
+every submodule: the ``tools/bench-data`` submodules reference multi-MiB real documents (pinned upstream commits,
+nothing copied into this repository) that ``tox r -e bench`` reads and nothing else; fetch them on demand with ``git
+submodule update --init --depth 1 tools/bench-data/whatwg-html tools/bench-data/war-and-peace``.
 
 ``tox r -e 3.14`` builds the extension, runs the test suite, and **fails unless both Python and C coverage are 100%**
 (line and branch). Other environments: ``type`` (`ty <https://github.com/astral-sh/ty>`_), ``docs`` (Sphinx), ``fix``
@@ -47,8 +47,8 @@ tables).
     tools/generate_html_entities.py   # regenerates html_entities.h
     tests/                   # pytest suite (escape + unescape)
 
-The three C files compile into a single ``_html`` extension. They are split per feature for readability and share only
-the entry-point declarations in ``turbohtml.h``.
+The three C files compile into a single ``_html`` extension. We split them per feature for readability; their shared
+surface is the entry-point declarations in ``turbohtml.h``.
 
 .. _architecture-decisions:
 
@@ -58,27 +58,27 @@ the entry-point declarations in ``turbohtml.h``.
 
 **A C extension, built with meson-python.** Escaping and unescaping are hot paths, so the core is C. `meson-python
 <https://mesonbuild.com/meson-python/>`_ is the build backend because `hatchling <https://hatch.pypa.io>`_ (used by our
-pure-Python projects) does not compile C; meson-python is a first-class C backend with built-in coverage support.
+pure-Python projects) does not compile C; meson-python builds C extensions and supports coverage instrumentation.
 
 **No stable ABI (abi3).** The fast paths require the non–\ :ref:`Limited API <python:stable>` buffer macros
 ``PyUnicode_KIND``, ``PyUnicode_DATA``, ``PyUnicode_READ``, ``PyUnicode_WRITE`` and ``PyUnicode_New`` (see the
 `PyUnicode C API <https://docs.python.org/3/c-api/unicode.html>`_ and :PEP:`393`). The `Limited API
-<https://docs.python.org/3/c-api/stable.html>`_ only exposes per-code-point calls (``PyUnicode_ReadChar`` /
-``PyUnicode_WriteChar``) with no access to the underlying buffer, which would remove the SWAR scan that justifies the
-package. We therefore ship one wheel per interpreter and let `cibuildwheel <https://cibuildwheel.pypa.io>`_ build the
-matrix.
+<https://docs.python.org/3/c-api/stable.html>`_ exposes per-code-point calls (``PyUnicode_ReadChar`` /
+``PyUnicode_WriteChar``) and nothing more, with no access to the underlying buffer, which would remove the SWAR scan
+that justifies the package. We ship one wheel per interpreter and let `cibuildwheel <https://cibuildwheel.pypa.io>`_
+build the matrix.
 
-**No pure-Python fallback.** :PEP:`399` requires a pure-Python fallback only for standard-library modules. As a
-third-party package distributing per-interpreter wheels, turbohtml ships only the compiled implementation.
+**No pure-Python fallback.** :PEP:`399` scopes its pure-Python fallback requirement to standard-library modules. As a
+third-party package distributing per-interpreter wheels, turbohtml ships the compiled implementation and nothing else.
 
 **SIMD / SWAR for escape.** ``escape`` confirms most strings need no escaping, so it classifies one-byte strings sixteen
 bytes at a time: on NEON a single low-nibble table lookup plus one comparison matches all five specials at once (each
-has a unique low nibble — the PSHUFB trick used by pulldown-cmark), on x86-64 SSE2 compares per special, and elsewhere a
-SWAR word applies the `bit-twiddling "has-zero" trick
+has a unique low nibble, the PSHUFB trick used by pulldown-cmark), on x86-64 SSE2 compares per special, and on other
+targets a SWAR word applies the `bit-twiddling "has-zero" trick
 <https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord>`_. The sizing pass accumulates the growth of all
-matches branchlessly, and the writing pass copies clean stretches wholesale, rewriting only the positions a match
-bitmask singles out. UCS-2 / UCS-4 strings (see :PEP:`393` for the representations) are probed for all five special
-characters in one SWAR pass over a 64-bit word.
+matches without branches, and the writing pass copies clean stretches in bulk, limiting rewrites to the positions a
+match bitmask singles out. One SWAR pass over a 64-bit word probes UCS-2 / UCS-4 strings (see :PEP:`393` for the
+representations) for all five special characters.
 
 **Free-threading ready.** The module has no mutable state (immutable ``str`` inputs, read-only tables), so it declares
 ``Py_MOD_GIL_NOT_USED`` and per-interpreter GIL support on interpreters that support them. See the `free-threading
@@ -88,12 +88,11 @@ extension guide <https://docs.python.org/3/howto/free-threading-extensions.html>
 for byte, including ``&#x27;`` for the single quote and the full HTML5 character-reference rules. The suite fuzzes the C
 output against the standard library.
 
-**Generated entity tables.** ``html_entities.h`` is produced by ``tools/generate_html_entities.py``. The named
-references come from :data:`python:html.entities.html5` (which mirrors the `WHATWG named character references
-<https://html.spec.whatwg.org/multipage/named-characters.html>`_); the numeric-charref correction tables are derived
-directly from the `WHATWG specification
-<https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state>`_ rather than any private
-standard-library internals, so the C tables never drift from the source of truth.
+**Generated entity tables.** ``tools/generate_html_entities.py`` produces ``html_entities.h``. The named references come
+from :data:`python:html.entities.html5` (which mirrors the `WHATWG named character references
+<https://html.spec.whatwg.org/multipage/named-characters.html>`_); the numeric-charref correction tables derive from the
+`WHATWG specification <https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state>`_, not
+private standard-library internals, so the C tables never drift from the source of truth.
 
 ******************
  Maintainer tasks
@@ -105,29 +104,29 @@ Regenerate the entity tables (after a CPython update changes :mod:`python:html.e
 
     $ tox r -e regen
 
-Run the full check matrix locally (per-interpreter, 3.10–3.15 plus free-threading):
+Run the full check matrix on your machine (per-interpreter, 3.10–3.15 plus free-threading):
 
 .. code-block:: console
 
     $ tox r            # all environments
     $ tox r -e 3.13    # a single interpreter
 
-Coverage is enforced two ways: Python via `covdefaults <https://github.com/asottile/covdefaults>`_ (100%), and C via
-`gcovr <https://gcovr.com>`_ with ``--fail-under-line 100 --fail-under-branch 100`` on an instrumented `meson coverage
-build <https://mesonbuild.com/Unit-tests.html#coverage>`_ (``-Db_coverage=true -Db_ndebug=true``). The only excluded
-branches are allocation-failure guards that a test cannot trigger; each is marked with a `gcovr exclusion marker
+Two gates enforce coverage: Python via `covdefaults <https://github.com/asottile/covdefaults>`_ (100%), and C via `gcovr
+<https://gcovr.com>`_ with ``--fail-under-line 100 --fail-under-branch 100`` on an instrumented `meson coverage build
+<https://mesonbuild.com/Unit-tests.html#coverage>`_ (``-Db_coverage=true -Db_ndebug=true``). The only excluded branches
+are allocation-failure guards that a test cannot trigger; each carries a `gcovr exclusion marker
 <https://gcovr.com/en/stable/guide/exclusion-markers.html>`_ and a comment explaining why.
 
 Adding a C feature:
 
 1. Add ``src/turbohtml/<feature>.c`` and declare its entry point in ``turbohtml.h``.
 2. Add the source to ``meson.build`` and wire the method in ``_htmlmodule.c``.
-3. Add tests and keep coverage at 100%; mark any genuinely unreachable branch with ``GCOVR_EXCL_BR_LINE`` plus a reason.
+3. Add tests and keep coverage at 100%; mark any unreachable branch with ``GCOVR_EXCL_BR_LINE`` plus a reason.
 
 ***********
  Releasing
 ***********
 
-A release is cut by the ``🚀 Release`` GitHub Actions workflow: it builds the sdist and the full wheel matrix with
+The ``🚀 Release`` GitHub Actions workflow cuts a release: it builds the sdist and the full wheel matrix with
 `cibuildwheel <https://cibuildwheel.pypa.io>`_ and publishes to PyPI via `trusted publishing
-<https://docs.pypi.org/trusted-publishers/>`_, so no API token is stored.
+<https://docs.pypi.org/trusted-publishers/>`_, so it stores no API token.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -11,9 +11,9 @@ every chunk of text an HTML parser emits. ``turbohtml`` implements both in C so 
 equivalent pure-Python implementation, with no change in behavior.
 
 Measured with `pyperf <https://pyperf.readthedocs.io>`_ on CPython 3.14 (a release build, Apple M-series) against
-:func:`python:html.escape` and :func:`python:html.unescape`. The multi-MiB inputs stream well past the CPU caches; the
-book and spec cases are real documents (Project Gutenberg's *War and Peace*, the WHATWG HTML spec source) referenced as
-git submodules. Reproduce with ``tox -e bench``:
+:func:`python:html.escape` and :func:`python:html.unescape`. The multi-MiB inputs stream past the CPU caches; the book
+and spec cases are real documents (Project Gutenberg's *War and Peace*, the WHATWG HTML spec source) referenced as git
+submodules. Reproduce with ``tox -e bench``:
 
 .. list-table::
     :header-rows: 1
@@ -31,49 +31,49 @@ git submodules. Reproduce with ``tox -e bench``:
       - 2.9x
     - - ``escape``
       - medium markup (4 KiB)
-      - 2.38 µs
-      - 8.09 µs
-      - 3.4x
+      - 2.25 µs
+      - 7.17 µs
+      - 3.2x
     - - ``escape``
       - no-op prose (4 MiB)
-      - 0.12 ms
-      - 2.66 ms
-      - 22.2x
+      - 0.11 ms
+      - 2.51 ms
+      - 22.0x
     - - ``escape``
       - book text (3 MiB)
-      - 0.72 ms
-      - 2.80 ms
+      - 0.66 ms
+      - 2.56 ms
       - 3.9x
     - - ``escape``
       - book HTML (4 MiB)
-      - 1.35 ms
-      - 4.88 ms
+      - 1.25 ms
+      - 4.54 ms
       - 3.6x
     - - ``escape``
       - spec HTML, dense (4 MiB)
-      - 5.27 ms
-      - 13.3 ms
-      - 2.5x
+      - 4.93 ms
+      - 12.8 ms
+      - 2.6x
     - - ``escape``
       - UCS-2 plain (4 MiB)
-      - 0.74 ms
-      - 2.60 ms
-      - 3.5x
+      - 0.70 ms
+      - 2.41 ms
+      - 3.4x
     - - ``escape``
       - UCS-2 markup (4 MiB)
-      - 3.44 ms
-      - 11.5 ms
+      - 3.33 ms
+      - 10.9 ms
       - 3.3x
     - - ``escape``
       - UCS-4 plain (4 MiB)
-      - 0.97 ms
-      - 5.58 ms
+      - 0.91 ms
+      - 5.29 ms
       - 5.8x
     - - ``escape``
       - UCS-4 markup (4 MiB)
-      - 4.08 ms
-      - 20.3 ms
-      - 5.0x
+      - 3.95 ms
+      - 19.3 ms
+      - 4.9x
     - - ``unescape``
       - tiny plain (64 B)
       - 0.02 µs
@@ -81,37 +81,37 @@ git submodules. Reproduce with ``tox -e bench``:
       - 1.3x
     - - ``unescape``
       - medium dense refs (4 KiB)
-      - 8.57 µs
-      - 72.5 µs
-      - 8.5x
+      - 8.22 µs
+      - 69.0 µs
+      - 8.4x
     - - ``unescape``
       - numeric refs (4 KiB)
-      - 5.24 µs
-      - 81.1 µs
-      - 15.5x
+      - 5.83 µs
+      - 78.7 µs
+      - 13.5x
     - - ``unescape``
       - book HTML, real refs (4 MiB)
-      - 2.80 ms
-      - 8.96 ms
+      - 2.44 ms
+      - 7.87 ms
       - 3.2x
     - - ``unescape``
       - escaped book HTML (5 MiB)
-      - 2.10 ms
-      - 21.2 ms
-      - 10.1x
+      - 1.90 ms
+      - 19.5 ms
+      - 10.3x
     - - ``unescape``
       - dense refs (4 MiB)
-      - 10.4 ms
-      - 78.5 ms
-      - 7.6x
+      - 9.89 ms
+      - 73.0 ms
+      - 7.4x
     - - ``unescape``
       - UCS-2 refs (4 MiB)
-      - 2.78 ms
-      - 19.4 ms
-      - 7.0x
+      - 2.51 ms
+      - 18.1 ms
+      - 7.2x
 
 ``escape`` gains the most on text that needs little escaping (the SIMD scan classifies sixteen bytes at a time and
-copies clean stretches wholesale); ``unescape`` gains the most on entity-heavy input, where the standard library pays a
+copies clean stretches in bulk); ``unescape`` gains the most on entity-heavy input, where the standard library pays a
 Python call per match. The gap is narrowest on tiny strings, where call overhead dominates, and on special-dense markup,
 where both sides spend their time writing replacements. Numbers vary with input and hardware; reproduce them with ``tox
 -e bench``.
@@ -128,20 +128,20 @@ turbohtml has no need for one, which keeps the surface small.
 it classifies sixteen bytes at a time with SIMD (on arm64 NEON a single low-nibble table lookup plus one comparison
 matches all five specials at once; on x86-64 SSE2 compares per special; elsewhere a 64-bit SWAR word applies the
 `has-zero bit trick <https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord>`_). The sizing pass turns each
-comparison directly into that special's output growth and sums the block branchlessly; the writing pass converts the
-comparisons into a position bitmask so clean stretches are copied wholesale and only the matched bytes are rewritten.
-When nothing needs escaping the input is returned unchanged. Wider (UCS-2 / UCS-4) strings — see :PEP:`393` for
-CPython's string representations — pack four / two code points into a 64-bit SWAR word and probe all five special
-characters in a single pass. ``unescape`` works the same way in reverse: it hops between ``&`` occurrences (``memchr``
-on one-byte text) and bulk-copies the clean spans between references instead of inspecting every character. This needs
-the `PyUnicode buffer API <https://docs.python.org/3/c-api/unicode.html>`_, which is why turbohtml cannot use the
-:ref:`Limited API <python:stable>`.
+comparison into that special's output growth and sums the block without branches; the writing pass converts the
+comparisons into a position bitmask, copies clean stretches in bulk, and rewrites only the matched bytes. When nothing
+needs escaping, ``escape`` returns the input unchanged. Wider strings (UCS-2 / UCS-4; see :PEP:`393` for CPython's
+string representations) pack four / two code points into a 64-bit SWAR word and probe all five special characters in a
+single pass. ``unescape`` works the same way in reverse: it hops between ``&`` occurrences (``memchr`` on one-byte text)
+and bulk-copies the clean spans between references instead of inspecting every character. This needs the `PyUnicode
+buffer API <https://docs.python.org/3/c-api/unicode.html>`_, which is why turbohtml cannot use the :ref:`Limited API
+<python:stable>`.
 
 *******************************
  Matching the standard library
 *******************************
 
-``turbohtml`` reproduces the behavior of :func:`python:html.escape` and :func:`python:html.unescape` exactly. ``escape``
+``turbohtml`` reproduces the exact behavior of :func:`python:html.escape` and :func:`python:html.unescape`. ``escape``
 uses the same replacements, including ``&#x27;`` for the single quote, and ``unescape`` applies the full `HTML5
 character-reference rules <https://html.spec.whatwg.org/multipage/named-characters.html>`_: named references with
 longest-prefix matching, numeric references, the Windows-1252 remaps, and the invalid code-point handling that maps to
@@ -153,26 +153,26 @@ corpus.
 ************************
 
 :func:`turbohtml.tokenize` implements the `WHATWG HTML tokenization algorithm
-<https://html.spec.whatwg.org/multipage/parsing.html#tokenization>`_ — the same state machine inside every browser —
+<https://html.spec.whatwg.org/multipage/parsing.html#tokenization>`_ (the same state machine inside every browser)
 rather than a regex approximation like :class:`python:html.parser.HTMLParser`. The C implementation mirrors the spec
-state by state so the two can be read side by side, and it is validated against the shared `html5lib-tests
-<https://github.com/html5lib/html5lib-tests>`_ conformance suite that browsers and parser libraries validate against, at
-all three input storage widths, once per input storage width, because the token stream must be invariant to how CPython
-happens to store the string.
+state by state so the two read side by side, and the shared `html5lib-tests
+<https://github.com/html5lib/html5lib-tests>`_ conformance suite that browsers and parser libraries validate against
+checks it at all three input storage widths, once per width, because the token stream must be invariant to how CPython
+stores the string.
 
-Two deliberate scope decisions keep the surface honest:
+Two decisions bound the tokenizer's scope:
 
 - The tokenizer is not a parser. It hands you the token stream; it does not build a tree, balance tags, or apply the
   tree-construction rules. The one tree-construction duty it takes on is content-model switching: after a start tag for
   ``script``, ``style``, ``title`` and the other raw-text elements, the element's contents tokenize as the spec requires
   (a ``<b>`` inside a script body is text, not a tag).
-- Parse errors are recovered from, not reported. The spec defines a recovery transition for every error and the machine
-  takes it, so malformed input produces the same tokens a browser would see; the error stream itself is not part of the
-  API.
+- The machine recovers from parse errors instead of reporting them. The spec defines a recovery transition for every
+  error and the machine takes it, so malformed input produces the same tokens a browser would see; the error stream is
+  not part of the API.
 
-Where behavior could drift, it is pinned by more than the suite: the token stream is fuzz-compared against html5lib's
+Where behavior could drift, more than the suite pins it: a fuzz comparison runs the token stream against html5lib's
 tokenizer, and source positions use the same 1-based-line, 0-based-column convention as :mod:`python:html.parser`, so
-diagnostics line up with what the standard library would report.
+diagnostics line up with what the standard library reports.
 
 ****************************
  Tokenizing at native width
@@ -181,11 +181,11 @@ diagnostics line up with what the standard library would report.
 CPython stores a string at one of three widths (:PEP:`393`): one byte per character for Latin-1, two for the basic
 multilingual plane, four beyond. The tokenizer keeps that representation end to end instead of widening everything to
 UCS-4: the input buffer, accumulated text runs, tag names and attribute values all store code points at the narrowest
-width their content needs, promoting only when a wider character actually arrives. The state-machine core is compiled
-once per width — the same trick CPython's ``stringlib`` uses — so every read is direct indexing, and the plain-text
-states bulk-scan to the next special character the way `html5ever <https://github.com/servo/html5ever>`_ does rather
-than dispatching the state machine per character. For the ASCII documents that dominate real traffic, a text run travels
-from input to the final ``str`` as one-byte copies.
+width their content needs, promoting only when a wider character arrives. turbohtml compiles the state-machine core once
+per width (the same trick CPython's ``stringlib`` uses), so every read is direct indexing, and the plain-text states
+bulk-scan to the next special character the way `html5ever <https://github.com/servo/html5ever>`_ does rather than
+dispatching the state machine per character. For the ASCII documents that dominate real traffic, a text run travels from
+input to the final ``str`` as one-byte copies.
 
 Measured on CPython 3.14 (a release build, via ``tox -e bench``) against :class:`python:html.parser.HTMLParser` driven
 with no-op handlers and html5lib's pure-Python tokenizer, over synthetic cases and html5lib's benchmark corpus (a slice
@@ -202,119 +202,183 @@ of the WHATWG spec source plus web-platform-tests pages of varied sizes):
       - html5lib
       - speedup
     - - typical markup
-      - 30.3 µs
-      - 449 µs
+      - 29.3 µs
+      - 435 µs
       - 14.8x
-      - 840 µs
-      - 27.7x
+      - 810 µs
+      - 27.6x
     - - text-heavy prose
-      - 0.55 µs
-      - 2.92 µs
-      - 5.3x
-      - 149 µs
-      - 273x
+      - 0.54 µs
+      - 2.81 µs
+      - 5.2x
+      - 143 µs
+      - 263x
     - - attribute-heavy
-      - 24.7 µs
-      - 330 µs
-      - 13.3x
-      - 837 µs
-      - 33.8x
+      - 19.2 µs
+      - 298 µs
+      - 15.5x
+      - 807 µs
+      - 42.0x
     - - script-heavy
-      - 13.0 µs
-      - 162 µs
-      - 12.5x
-      - 526 µs
-      - 40.5x
+      - 12.1 µs
+      - 156 µs
+      - 12.9x
+      - 488 µs
+      - 40.4x
     - - entity-heavy
-      - 22.3 µs
-      - 205 µs
-      - 9.2x
-      - 1246 µs
-      - 55.8x
+      - 20.4 µs
+      - 197 µs
+      - 9.6x
+      - 1.20 ms
+      - 58.9x
     - - wpt tiny (0.6 kB)
-      - 1.60 µs
-      - 18.2 µs
-      - 11.4x
-      - 49 µs
-      - 30.9x
+      - 1.41 µs
+      - 17.5 µs
+      - 12.5x
+      - 47.7 µs
+      - 34.0x
     - - wpt small (4 kB)
-      - 15.0 µs
-      - 176 µs
-      - 11.8x
-      - 434 µs
-      - 29.0x
+      - 12.1 µs
+      - 165 µs
+      - 13.7x
+      - 422 µs
+      - 34.8x
     - - wpt medium (9.6 kB)
-      - 34.9 µs
-      - 376 µs
-      - 10.8x
-      - 1190 µs
-      - 34.1x
+      - 29.2 µs
+      - 360 µs
+      - 12.4x
+      - 1.16 ms
+      - 39.8x
     - - wpt large (92 kB)
-      - 348 µs
-      - 4250 µs
-      - 12.2x
-      - 9311 µs
-      - 26.7x
+      - 324 µs
+      - 4.03 ms
+      - 12.4x
+      - 8.93 ms
+      - 27.5x
     - - wpt CJK (124 kB)
-      - 626 µs
-      - 8926 µs
-      - 14.3x
-      - 22844 µs
-      - 36.5x
+      - 584 µs
+      - 8.45 ms
+      - 14.5x
+      - 22.6 ms
+      - 38.6x
     - - whatwg spec (235 kB)
-      - 701 µs
-      - 7838 µs
-      - 11.2x
-      - 20409 µs
-      - 29.1x
+      - 645 µs
+      - 7.39 ms
+      - 11.5x
+      - 19.3 ms
+      - 30.0x
     - - ecmascript spec (3 MB)
-      - 7.08 ms
-      - 57.9 ms
-      - 8.2x
-      - 192 ms
-      - 27.1x
+      - 5.88 ms
+      - 55.0 ms
+      - 9.4x
+      - 181 ms
+      - 30.8x
     - - whatwg spec source (7.9 MB)
-      - 37.0 ms
-      - 399 ms
-      - 10.8x
-      - 907 ms
-      - 24.5x
+      - 35.0 ms
+      - 389 ms
+      - 11.1x
+      - 853 ms
+      - 24.4x
 
-The closest case is a document that is almost entirely a single text node, where the standard library's regex performs
-one C scan and never really tokenizes; everywhere markup actually appears, the state machine is 8-15x faster. Numbers
-vary with input and hardware; reproduce them with ``tox -e bench``.
+The closest case is a document dominated by a single text node, where the standard library's regex performs one C scan
+and never tokenizes; everywhere markup appears, the state machine is 9-16x faster. Numbers vary with input and hardware;
+reproduce them with ``tox -e bench``.
 
 *********************************
  A navigable tree without copies
 *********************************
 
 :func:`turbohtml.parse` runs the full `WHATWG tree-construction algorithm
-<https://html.spec.whatwg.org/multipage/parsing.html#tree-construction>`_ on top of the tokenizer — the insertion modes,
-the adoption agency, foreign content, and the error recovery a browser performs — and is validated against the same
-`html5lib-tests <https://github.com/html5lib/html5lib-tests>`_ tree-construction suite browsers use. The result is the
-tree a browser would build for the same bytes, not a best-effort approximation.
+<https://html.spec.whatwg.org/multipage/parsing.html#tree-construction>`_ on top of the tokenizer (the insertion modes,
+the adoption agency, foreign content, and the error recovery a browser performs); the same `html5lib-tests
+<https://github.com/html5lib/html5lib-tests>`_ tree-construction suite browsers use validates it. The result is the tree
+a browser builds for the same bytes.
 
-The tree is built in C as a pointer-linked node graph in a single bump-allocated arena — the layout every fast parser
-(lexbor, Go's ``x/net/html``, html5ever) converges on — and it holds **no Python objects**. Element identity is an
-interned integer atom, so every scope and category test in the algorithm is an integer compare rather than a string
-comparison, and freeing the whole tree is one release of the arena rather than a per-node teardown.
+turbohtml builds the tree in C as a pointer-linked node graph in a single bump-allocated arena, the layout lexbor, Go's
+``x/net/html``, and html5ever all converge on. It holds **no Python objects**. Element identity is an interned integer
+atom, so every scope and category test in the algorithm is an integer compare rather than a string comparison, and
+freeing the whole tree is one release of the arena rather than a per-node teardown.
 
-The Python :class:`~turbohtml.Node` objects are created lazily, only for the nodes you actually touch. Walking into a
-child or sibling allocates one small wrapper that points at the existing arena node; it never copies the subtree. Text
-payloads go further: a text node borrows a slice of the original input string and is materialized into its own buffer
-only when you first read its :attr:`~turbohtml.Node.text` or :attr:`~turbohtml.Text.data`. A private handle keeps the
-arena and the input string alive for exactly as long as any node reachable from them, so a node extracted from a
-document keeps working after the document itself goes out of scope. Building the navigable :class:`~turbohtml.Document`
-therefore costs essentially the same as building the raw C tree — the wrappers are pay-as-you-go.
+turbohtml creates the Python :class:`~turbohtml.Node` objects only for the nodes you touch. Walking into a child or
+sibling allocates one small wrapper that points at the existing arena node; it never copies the subtree. Text payloads
+go further: a text node borrows a slice of the original input string and materializes into its own buffer only when you
+first read its :attr:`~turbohtml.Node.text` or :attr:`~turbohtml.Text.data`. A private handle keeps the arena and the
+input string alive for as long as any node reachable from them, so a node extracted from a document keeps working after
+the document goes out of scope. Building the navigable :class:`~turbohtml.Document` costs about the same as building the
+raw C tree, and the wrappers add cost only for the nodes you touch.
 
-The node types are a small sealed hierarchy — :class:`~turbohtml.Document`, :class:`~turbohtml.Element`,
-:class:`~turbohtml.Text`, :class:`~turbohtml.Comment`, :class:`~turbohtml.Doctype` — sharing the navigation defined on
-:class:`~turbohtml.Node`. Text is modeled as real child nodes (the WHATWG DOM shape), not the ``.text``/``.tail`` split
-that lxml-style trees use, so a node's children are its text runs and elements interleaved in document order. Each type
-sets ``__match_args__``, so structural pattern matching unpacks a node's defining field directly, and node equality is
-identity over the underlying arena node, so two wrappers for the same element compare equal and hash alike.
+turbohtml parses faster than the C parsers lxml and selectolax, and 30 to 80 times faster than the pure-Python
+BeautifulSoup and html5lib, while building the WHATWG tree that lxml's libxml2 does not. Measured on the same
+web-platform-tests pages and specification sources via ``tox -e bench parse``:
 
-The traversal surface is deliberately small for this first increment: navigation (parents, siblings, the lazy
+.. list-table::
+    :header-rows: 1
+    :widths: 26 12 11 11 14 11
+
+    - - input
+      - turbohtml
+      - lxml
+      - selectolax
+      - BeautifulSoup
+      - html5lib
+    - - wpt page (0.6 kB)
+      - 1.3 µs
+      - 3.3 µs
+      - 6.8 µs
+      - 61.6 µs
+      - 101 µs
+    - - wpt page (4 kB)
+      - 10.6 µs
+      - 26.7 µs
+      - 42.1 µs
+      - 443 µs
+      - 616 µs
+    - - wpt page (9.6 kB)
+      - 25.4 µs
+      - 72.6 µs
+      - 107 µs
+      - 849 µs
+      - 1.44 ms
+    - - wpt page (92 kB)
+      - 268 µs
+      - 629 µs
+      - 920 µs
+      - 15.5 ms
+      - 17.0 ms
+    - - wpt CJK (124 kB)
+      - 584 µs
+      - 8.45 ms
+      - 14.5x
+      - 22.6 ms
+      - 38.6x
+    - - whatwg spec (235 kB)
+      - 645 µs
+      - 7.39 ms
+      - 11.5x
+      - 19.3 ms
+      - 30.0x
+    - - ecmascript spec (3 MB)
+      - 5.88 ms
+      - 55.0 ms
+      - 9.4x
+      - 181 ms
+      - 30.8x
+    - - whatwg spec source (7.9 MB)
+      - 35.0 ms
+      - 389 ms
+      - 11.1x
+      - 853 ms
+      - 24.4x
+
+The node types are a small sealed hierarchy (:class:`~turbohtml.Document`, :class:`~turbohtml.Element`,
+:class:`~turbohtml.Text`, :class:`~turbohtml.Comment`, :class:`~turbohtml.Doctype`) sharing the navigation defined on
+:class:`~turbohtml.Node`. turbohtml models text as real child nodes (the WHATWG DOM shape) rather than the
+``.text``/``.tail`` split lxml-style trees use, so a node's children are its text runs and elements interleaved in
+document order. Each type sets ``__match_args__``, so structural pattern matching unpacks a node's defining field, and
+node equality is identity over the underlying arena node, so two wrappers for the same element compare equal and hash
+alike.
+
+The traversal surface is small for this first increment: navigation (parents, siblings, the lazy
 :attr:`~turbohtml.Node.descendants` and :attr:`~turbohtml.Node.ancestors` iterators), the sequence protocol over a
 node's children, and :meth:`~turbohtml.Node.find` / :meth:`~turbohtml.Node.find_all` by tag and attributes. A
 CSS-selector engine is a planned follow-up; the zero-copy node model is the foundation it will build on.
@@ -324,8 +388,8 @@ CSS-selector engine is a planned follow-up; the zero-copy node model is the foun
 ****************
 
 The extension holds no shared mutable state: inputs are immutable ``str`` objects, the lookup tables are read-only, and
-each :class:`turbohtml.Tokenizer` owns its state machine outright, so tokenizers in different threads never contend. It
-therefore declares free-threading support and a per-interpreter GIL on interpreters new enough to honor those slots, so
+each :class:`turbohtml.Tokenizer` owns its state machine, so tokenizers in different threads never contend. The
+extension declares free-threading support and a per-interpreter GIL on interpreters new enough to honor those slots, so
 it does not force the global lock back on under a free-threaded build. As with any stateful object, feeding one
 tokenizer from several threads at once needs synchronization on the caller's side. See the `free-threading extension
 guide <https://docs.python.org/3/howto/free-threading-extensions.html>`_.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -35,8 +35,8 @@ Convert named and numeric references from scraped or stored HTML back into text:
 
 .. code-block:: pycon
 
-    >>> turbohtml.unescape("&pound;10 &mdash; &#127881;")
-    '£10 — 🎉'
+    >>> turbohtml.unescape("&pound;10 &copy; &#127881;")
+    '£10 © 🎉'
 
 Unescaping follows the HTML5 rules, including longest-match for references that omit the trailing semicolon:
 
@@ -96,19 +96,19 @@ The events map one to one:
 - ``handle_endtag(tag)`` → ``TokenType.END_TAG``.
 - ``handle_startendtag(tag, attrs)`` → a ``START_TAG`` token with ``self_closing`` true (turbohtml does not emit a
   separate event).
-- ``handle_data(data)`` → ``TokenType.TEXT``; character references arrive already decoded, like
-  ``convert_charrefs=True``, so there is no ``handle_entityref``/``handle_charref`` pair to implement.
+- ``handle_data(data)`` → ``TokenType.TEXT``; character references arrive decoded, like ``convert_charrefs=True``, so
+  there is no ``handle_entityref``/``handle_charref`` pair to implement.
 - ``handle_comment(data)`` → ``TokenType.COMMENT``.
-- ``handle_decl(decl)`` → ``TokenType.DOCTYPE``, already split into ``name``, ``public_id`` and ``system_id`` instead of
-  one raw string.
+- ``handle_decl(decl)`` → ``TokenType.DOCTYPE``, split into ``name``, ``public_id`` and ``system_id`` instead of one raw
+  string.
 - ``self.getpos()`` → ``token.line`` and ``token.col``, the same 1-based-line, 0-based-column convention.
 - ``feed()``/``close()`` → the same names on :class:`turbohtml.Tokenizer`; each ``feed()`` returns the tokens that chunk
   completed instead of firing callbacks, and a ``with`` block replaces remembering ``close()``.
 
-Behavior differs where ``html.parser`` diverges from the WHATWG algorithm browsers implement: turbohtml handles the
-raw-text content models exactly (a ``<b>`` inside ``<script>`` is text, not a tag), recovers from malformed markup the
-way a browser would, and never emits ``handle_decl`` for CDATA sections (they only exist in foreign content). Code
-ported from ``html.parser`` therefore sees the same tokens a browser sees, which is usually the migration's point.
+turbohtml differs from ``html.parser`` wherever ``html.parser`` diverges from the WHATWG algorithm browsers implement:
+turbohtml handles the raw-text content models (a ``<b>`` inside ``<script>`` stays text rather than a tag), recovers
+from malformed markup the way a browser would, and never emits ``handle_decl`` for CDATA sections (they only exist in
+foreign content). Code ported from ``html.parser`` sees the same tokens a browser sees, the point of most migrations.
 
 *****************************
  Extract the links of a page
@@ -128,7 +128,7 @@ for a valueless attribute and your fallback when the attribute is missing:
  Extract the visible text of HTML
 **********************************
 
-Collect the text tokens while skipping the contents of elements whose text is not rendered, such as ``script`` and
+Collect the text tokens while skipping the contents of elements the browser does not render, such as ``script`` and
 ``style``. The tokenizer hands you script and style bodies as text tokens (that is what they are to the algorithm), so
 track the enclosing tag yourself:
 
@@ -183,8 +183,8 @@ Call ``reset()`` to reuse the same tokenizer for an unrelated document.
 ****************************************
 
 Every token remembers where it began: :attr:`turbohtml.Token.line` is the 1-based source line and
-:attr:`turbohtml.Token.col` the 0-based column (the convention :mod:`python:html.parser` also uses), which makes it easy
-to point at the offending markup:
+:attr:`turbohtml.Token.col` the 0-based column (the convention :mod:`python:html.parser` shares), so you can point at
+the offending markup:
 
 .. code-block:: pycon
 
@@ -214,8 +214,8 @@ or from any element, searching its descendants:
  Collect the links of a parsed page
 ************************************
 
-Collect the ``href`` of every anchor by iterating :meth:`~turbohtml.Node.find_all`; a missing attribute is simply absent
-from :attr:`~turbohtml.Element.attrs`:
+Collect the ``href`` of every anchor by iterating :meth:`~turbohtml.Node.find_all`; a missing attribute does not appear
+in :attr:`~turbohtml.Element.attrs`:
 
 .. code-block:: pycon
 
@@ -247,8 +247,8 @@ text.
 **************************************
 
 The node types are a sealed hierarchy with :py:data:`~object.__match_args__` set, so a ``match`` statement dispatches on
-node kind and unpacks the defining field — ``tag`` for an :class:`~turbohtml.Element`, ``data`` for a
-:class:`~turbohtml.Text` or :class:`~turbohtml.Comment`:
+node kind and unpacks the defining field (``tag`` for an :class:`~turbohtml.Element`, ``data`` for a
+:class:`~turbohtml.Text` or :class:`~turbohtml.Comment`):
 
 .. code-block:: pycon
 
@@ -270,7 +270,7 @@ node kind and unpacks the defining field — ``tag`` for an :class:`~turbohtml.E
  Parse an HTML fragment
 ************************
 
-To parse markup that belongs inside a specific element — a table row, an SVG subtree — use
+To parse markup that belongs inside a specific element (a table row, an SVG subtree), use
 :func:`turbohtml.parse_fragment` with the context tag. It returns that context :class:`~turbohtml.Element` with the
 parsed nodes as its children, applying the same insertion rules the element would impose in a full document:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,10 +2,10 @@
  turbohtml
 ###########
 
-A fast, fully typed HTML toolkit for Python, powered by a C-accelerated core. ``turbohtml`` provides spec-correct HTML
-escaping and unescaping that match the standard library byte for byte, a WHATWG-conformant streaming tokenizer, and a
-WHATWG-conformant parser that builds a navigable, lazily-wrapped tree — all several times faster than their pure-Python
-counterparts and ready for the free-threaded build.
+``turbohtml`` is a fast, fully typed HTML toolkit for Python built on a C-accelerated core. It provides spec-correct
+HTML escaping and unescaping that match the standard library byte for byte, a WHATWG-conformant streaming tokenizer, and
+a WHATWG-conformant parser that builds a navigable, lazily-wrapped tree. Each runs several times faster than its
+pure-Python counterpart and supports the free-threaded build.
 
 .. code-block:: pycon
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -6,7 +6,7 @@
  Getting started
 *****************
 
-This tutorial walks you from an empty environment to escaping and unescaping your first HTML.
+Go from an empty environment to escaping and unescaping your first HTML.
 
 Install turbohtml from PyPI:
 
@@ -22,27 +22,27 @@ Open a Python prompt and escape some text for safe inclusion in an HTML page:
     >>> turbohtml.escape("5 > 3 & 2 < 4")
     '5 &gt; 3 &amp; 2 &lt; 4'
 
-By default the quotation marks are escaped too, which is what you want inside an attribute value:
+By default ``escape`` escapes quotation marks too, which you want inside an attribute value:
 
 .. code-block:: pycon
 
     >>> turbohtml.escape("name=\"O'Brien\"")
     'name=&quot;O&#x27;Brien&quot;'
 
-Now go the other way and turn HTML character references back into text:
+Reverse the process: turn HTML character references back into text:
 
 .. code-block:: pycon
 
-    >>> turbohtml.unescape("Tom &amp; Jerry &mdash; caf&eacute;")
-    'Tom & Jerry — café'
+    >>> turbohtml.unescape("Tom &amp; Jerry, caf&eacute;")
+    'Tom & Jerry, café'
 
-From here you can stay with the string helpers, or continue below to break whole documents into tokens.
+Stay with the string helpers, or continue below to break whole documents into tokens.
 
 ********************************
  Tokenizing your first document
 ********************************
 
-This tutorial takes you from a string of HTML to a stream of tokens you can inspect.
+Go from a string of HTML to a stream of tokens you can inspect.
 
 Start with a small document and hand it to :func:`turbohtml.tokenize`, which returns an iterator of
 :class:`turbohtml.Token` objects:
@@ -56,8 +56,8 @@ Start with a small document and hand it to :func:`turbohtml.tokenize`, which ret
     Token(TEXT, data='Tom & Jerry')
     Token(END_TAG, tag='p')
 
-Each token tells you what it is through ``type``, a :class:`turbohtml.TokenType`. Start and end tags carry the
-lowercased tag name and the attributes, already decoded:
+``type`` identifies each token as a :class:`turbohtml.TokenType`. Start and end tags carry the lowercased tag name and
+the attributes, decoded:
 
 .. code-block:: pycon
 
@@ -69,9 +69,8 @@ lowercased tag name and the attributes, already decoded:
     >>> start.attrs
     [('class', 'intro')]
 
-Text arrives with character references already resolved — the ``&amp;`` above came through as a plain ``&`` — and
-content that the HTML specification treats as raw, such as a script body, arrives as one text token without further
-interpretation:
+Text arrives with character references resolved (the ``&amp;`` above came through as a plain ``&``). Content that the
+HTML specification treats as raw, such as a script body, arrives as one text token without further interpretation:
 
 .. code-block:: pycon
 
@@ -79,8 +78,8 @@ interpretation:
     ...  if token.type is turbohtml.TokenType.TEXT]
     ['if (a < b) run()']
 
-When the document arrives in pieces — from a network stream, for example — create a :class:`turbohtml.Tokenizer` and
-feed the pieces as they come. Each ``feed()`` returns the tokens that piece completed, and ``close()`` flushes whatever
+When the document arrives in pieces (from a network stream, for example), create a :class:`turbohtml.Tokenizer` and feed
+the pieces as they come. Each ``feed()`` returns the tokens that piece completed, and ``close()`` flushes whatever
 remains:
 
 .. code-block:: pycon
@@ -93,16 +92,16 @@ remains:
     >>> list(tokenizer.close())
     []
 
-Notice the incomplete ``<sp`` stayed buffered until the rest of the tag arrived. That is the whole tokenizer API. From
-here, head to the :doc:`how-to` guides for task-focused recipes — including porting an existing
-:class:`python:html.parser.HTMLParser` subclass — or the :doc:`reference` for the exact signatures.
+The incomplete ``<sp`` stayed buffered until the rest of the tag arrived. That is the whole tokenizer API. Head to the
+:doc:`how-to` guides for task-focused recipes, including porting an existing :class:`python:html.parser.HTMLParser`
+subclass, or the :doc:`reference` for the exact signatures.
 
 ********************************
  Parsing a document into a tree
 ********************************
 
-A token stream is flat; often you want the *structure* — which element contains which. This tutorial takes you from a
-string of HTML to a navigable tree of nodes.
+A token stream is flat. To see which element contains which, you need the *structure*: a tree. Go from a string of HTML
+to a navigable tree of nodes.
 
 Hand a whole document to :func:`turbohtml.parse`. It applies the full WHATWG tree-construction algorithm (the same one
 browsers run, including the error recovery that inserts the missing ``html``, ``head`` and ``body``) and returns a
@@ -115,8 +114,7 @@ browsers run, including the error recovery that inserts the missing ``html``, ``
     >>> doc.root
     Element('html')
 
-The most direct way to reach an element is :meth:`~turbohtml.Node.find`, which returns the first descendant matching a
-tag (and, optionally, attributes), or ``None``:
+:meth:`~turbohtml.Node.find` returns the first descendant matching a tag (and any attributes you pass), or ``None``:
 
 .. code-block:: pycon
 
@@ -126,7 +124,7 @@ tag (and, optionally, attributes), or ``None``:
     {'href': '/x'}
 
 Every node exposes its text and its markup. :attr:`~turbohtml.Node.text` is the concatenated character data of the
-subtree, with references already decoded; :attr:`~turbohtml.Node.html` re-serializes the subtree:
+subtree, with references decoded; :attr:`~turbohtml.Node.html` re-serializes the subtree:
 
 .. code-block:: pycon
 
@@ -136,7 +134,7 @@ subtree, with references already decoded; :attr:`~turbohtml.Node.html` re-serial
     >>> paragraph.html
     '<p>Tom &amp; <a href="/x">Jerry</a></p>'
 
-Text is modeled as real child nodes — the WHATWG DOM shape — so a paragraph's children are its text runs and its
+turbohtml models text as real child nodes (the WHATWG DOM shape), so a paragraph's children are its text runs and its
 elements interleaved, in order. A node is a sequence of its children: iterate it, take its length, index into it:
 
 .. code-block:: pycon
@@ -148,7 +146,7 @@ elements interleaved, in order. A node is a sequence of its children: iterate it
     >>> paragraph[1]
     Element('a')
 
-From any node you can walk outward as well as inward — :attr:`~turbohtml.Node.parent`,
+From any node you can walk outward as well as inward: :attr:`~turbohtml.Node.parent`,
 :attr:`~turbohtml.Node.next_sibling`, and the lazy :attr:`~turbohtml.Node.ancestors` and
 :attr:`~turbohtml.Node.descendants` iterators:
 
@@ -160,8 +158,8 @@ From any node you can walk outward as well as inward — :attr:`~turbohtml.Node.
     >>> [node.tag for node in link.ancestors if isinstance(node, turbohtml.Element)]
     ['p', 'body', 'html']
 
-Because the node types are a sealed hierarchy, structural pattern matching reads cleanly — each subtype unpacks its
-defining field:
+Because the node types are a sealed hierarchy, structural pattern matching works: each subtype unpacks its defining
+field:
 
 .. code-block:: pycon
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,11 @@ docs = [
   "towncrier>=25.8",
 ]
 bench = [
+  "beautifulsoup4>=4.13",
   "html5lib>=1.1",
+  "lxml>=6.1",
   "pyperf>=2.9",
+  "selectolax>=0.3.30",
   { include-group = "test" },
 ]
 coverage = [

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1,25 +1,25 @@
 #!/usr/bin/env python3
 """
-Benchmark turbohtml's escape/unescape/tokenize against the standard library.
+Benchmark turbohtml's escape/unescape/tokenize/parse against other libraries.
 
 Run with ``tox -e bench``; positional arguments pick the suites to run
-(``escape``, ``unescape``, ``tokenize``, ``corpus`` — default all); remaining
-arguments are forwarded to pyperf (pass ``--help`` to see them). pyperf runs
-every case in isolated worker processes and reports mean ± stddev; the parent
-process then prints a speedup table
-against the standard library and, for tokenize, html5lib's pure-Python
-tokenizer.
+(``escape``, ``unescape``, ``tokenize``, ``corpus``, ``parse``; default all).
+Remaining arguments are forwarded to pyperf (pass ``--help`` to see them).
+pyperf runs every case in isolated worker processes and reports mean and
+stddev; the parent process then prints a speedup table: escape, unescape, and
+tokenize against the standard library, and parse against the other HTML tree
+builders (lexbor through selectolax, lxml, html5lib, and BeautifulSoup).
 
-The escape/unescape inputs span tiny strings (call overhead) and multi-MiB
-documents streaming well past the CPU caches: real corpora (Project
+The escape and unescape inputs span tiny strings (call overhead) and multi-MiB
+documents that stream well past the CPU caches: real corpora (Project
 Gutenberg's War and Peace from the tools/bench-data submodule and the WHATWG
 HTML spec source) plus seeded pseudo-random UCS-2/UCS-4 text, since large real
-wide-kind documents are scarce. tokenize also runs over html5lib's benchmark
-corpus (the tools/html5lib-python submodule) — a slice of the WHATWG HTML spec
-source plus a size-weighted sample of web-platform-tests pages, 0.6 kB to
-234 kB — and two multi-megabyte real documents (the ECMAScript specification
-and the full WHATWG HTML spec source), downloaded once from pinned revisions
-and cached because their repositories are far too large to vendor.
+wide-kind documents are scarce. tokenize and parse also run over html5lib's
+benchmark corpus (the tools/html5lib-python submodule): a slice of the WHATWG
+HTML spec source plus a size-weighted sample of web-platform-tests pages from
+0.6 kB to 234 kB, and two multi-megabyte documents (the ECMAScript and WHATWG
+HTML specifications), downloaded once from pinned revisions and cached because
+their repositories are too large to vendor.
 """
 
 from __future__ import annotations
@@ -32,10 +32,13 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import html5lib
 import pyperf
+from bs4 import BeautifulSoup
+from lxml import html as lxml_html
+from selectolax.lexbor import LexborHTMLParser
 
 import turbohtml
-from turbohtml import _html  # noqa: PLC2701  # the benchmark drives the accelerator's private parse hooks directly
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -243,25 +246,38 @@ def turbo_tokenize(text: str) -> None:
 
 
 def turbo_parse(text: str) -> None:
-    """Build (and free) the document tree without serializing it."""
-    _html._parse_only(text)  # noqa: SLF001  # _parse_only is the accelerator's allocate-then-free parse hook
+    """Parse a whole document into a navigable tree through the public parse() entry point."""
+    turbohtml.parse(text)
 
 
-def lexbor_parse(payload: bytes) -> None:
-    """Parse the document with lexbor via selectolax."""
-    # selectolax is an optional comparison lib; the local import lets _has_lexbor() detect its absence, and it
-    # ships no type stubs so ty cannot resolve it
-    from selectolax.lexbor import LexborHTMLParser  # noqa: PLC0415  # ty: ignore[unresolved-import]
-
-    LexborHTMLParser(payload)
+def lexbor_parse(text: str) -> None:
+    """Parse with lexbor through selectolax (C, WHATWG-conformant)."""
+    LexborHTMLParser(text.encode())  # lexbor's native input is UTF-8 bytes
 
 
-def _has_lexbor() -> bool:
-    try:
-        lexbor_parse(b"")
-    except ImportError:
-        return False
-    return True
+def lxml_parse(text: str) -> None:
+    """Parse with lxml's libxml2-backed HTML parser."""
+    lxml_html.document_fromstring(text)
+
+
+def html5lib_parse(text: str) -> None:
+    """Parse with html5lib, the pure-Python WHATWG reference implementation."""
+    html5lib.parse(text)
+
+
+def soup_parse(text: str) -> None:
+    """Parse with BeautifulSoup over its stdlib html.parser backend."""
+    BeautifulSoup(text, "html.parser")
+
+
+# Whole-document tree builders raced against turbohtml.parse() in the parse suite, ordered fastest to slowest.
+# Each label names the pip-installable package so the comparison stays like-for-like.
+PARSE_COMPETITORS: tuple[tuple[str, Callable[[str], None]], ...] = (
+    ("lxml", lxml_parse),
+    ("selectolax", lexbor_parse),
+    ("BeautifulSoup", soup_parse),
+    ("html5lib", html5lib_parse),
+)
 
 
 def stdlib_tokenize(text: str) -> None:
@@ -302,28 +318,29 @@ def _has_html5lib() -> bool:
 
 
 def run_parse_suite(bench: Callable[[str, object, object], None]) -> list[tuple[str, str]]:
-    """Benchmark whole-document parsing for turbohtml and lexbor; return the cases."""
+    """Benchmark whole-document parsing for turbohtml and every alternative; return the cases."""
     cases = [(name, corpus_text(path, enc)) for name, path, enc in CORPUS_FILES]
     cases += [(name, large_text(filename, url)) for name, filename, url in LARGE_FILES]
-    has_lexbor = _has_lexbor()
     for name, arg in cases:
         bench(f"parse {name} [turbohtml]", turbo_parse, arg)
-        if has_lexbor:
-            bench(f"parse {name} [lexbor]", lexbor_parse, arg.encode())  # lexbor's native input is UTF-8 bytes
+        for label, parse in PARSE_COMPETITORS:
+            bench(f"parse {name} [{label}]", parse, arg)
     return cases
 
 
 def print_parse_table(means: dict[str, float], parse_cases: list[tuple[str, str]]) -> None:
-    """Render the turbohtml-vs-lexbor parse throughput table."""
+    """Render parse throughput for turbohtml beside each alternative and its slowdown factor."""
     if not parse_cases:
         return
     print()
-    print(f"{'benchmark':40} {'turbohtml':>12} {'lexbor':>12} {'vs lexbor':>10}")
+    header = f"{'parse benchmark':28} {'turbohtml':>11}" + "".join(f"{label:>18}" for label, _ in PARSE_COMPETITORS)
+    print(header)
     for name, _ in parse_cases:
         turbo = means[f"parse {name} [turbohtml]"]
-        row = f"{'parse ' + name:40} {turbo * 1e6:9.2f} us"
-        if (lx := means.get(f"parse {name} [lexbor]")) is not None:
-            row += f" {lx * 1e6:9.2f} us {lx / turbo:9.2f}x"
+        row = f"{'parse ' + name:28} {turbo * 1e6:8.1f} us"
+        for label, _ in PARSE_COMPETITORS:
+            other = means.get(f"parse {name} [{label}]")
+            row += f" {other * 1e6:8.1f} us {other / turbo:4.1f}x" if other is not None else f"{'-':>18}"
         print(row)
 
 


### PR DESCRIPTION
The `parse()` feature shipped without a published comparison against the HTML tree builders people actually use. The parse benchmark only raced turbohtml against lexbor, so a reader had no way to weigh it against lxml or html5lib or BeautifulSoup. 📊 This adds those three to the parse suite and publishes the numbers in the README and the docs, next to the existing escape, unescape, and tokenize tables.

The four comparison libraries (lexbor through selectolax, lxml, html5lib, and BeautifulSoup) are declared `bench` dependencies and imported at module scope, since the bench environment controls them and the old skip-when-absent dance is no longer warranted. turbohtml builds the tree into its arena and returns lazy wrappers, so it parses faster than the C parsers lexbor and lxml and 30 to 70 times faster than the pure-Python html5lib and BeautifulSoup, while building the WHATWG tree that lxml's libxml2 does not. That settles the "beat lxml.html on throughput while staying more spec-correct" bar from #10.

The same change runs a no-slop pass over the README and the documentation: em-dashes go (including from the doctest output, where the example input changed to keep the result accurate), along with promotional phrasing and passive voice, in favor of plain, direct, technical prose.

This does not close #10: its core landed earlier and this validates its throughput bar, but the html5lib and bs4 tree-builder adapters it scopes are still open.