### PR TITLE
🐛 fix: detection and URL-scheme bugs found running competitors' test suites

### DIFF
--- a/src/turbohtml/bleach_compat.py
+++ b/src/turbohtml/bleach_compat.py
@@ -81,10 +81,11 @@ def _convert_attributes(
 def _per_tag_filter(
     predicates: dict[str, Callable[[str, str, str], bool]],
 ) -> Callable[[str, str, str], str | None]:
-    """Fold per-tag bleach predicates into one value-rewriting filter that leaves other tags' attributes alone."""
+    """Fold per-tag bleach predicates into one value-rewriting filter, with the ``"*"`` predicate as the fallback."""
 
     def attribute_filter(tag: str, name: str, value: str) -> str | None:
-        predicate = predicates.get(tag)
+        # a tag-specific predicate wins; otherwise the "*" predicate applies, so a wildcard callable does not fail open
+        predicate = predicates.get(tag) or predicates.get("*")
         if predicate is None:
             return value
         return value if predicate(tag, name, value) else None

--- a/src/turbohtml/linkify.c
+++ b/src/turbohtml/linkify.c
@@ -259,20 +259,27 @@ static int match_url(int kind, const void *data, Py_ssize_t colon, Py_ssize_t st
     if (scheme_start < 0 || blocked_on_left(kind, data, scheme_start)) {
         return 0;
     }
-    /* skip an optional userinfo prefix (user[:password]@) so http://user:pass@host links the whole URL, not the email
-     */
+    /* Most URLs have no userinfo, so scan the host directly and only hunt for a
+       user[:password]@ prefix when that host fails or is followed by ':' or '@';
+       the common case stays a single host scan. The last '@' before the path wins,
+       so http://user:pass@host links the host, not the embedded email. */
     Py_ssize_t host_start = colon + 3;
-    for (Py_ssize_t scan = host_start; scan < len; scan++) {
-        Py_UCS4 c = READ(scan);
-        if (c == '@') {
-            host_start = scan + 1;
-            break;
+    Py_ssize_t host_end = scan_host(kind, data, host_start, len, 0);
+    if (host_end < 0 || (host_end < len && (READ(host_end) == ':' || READ(host_end) == '@'))) {
+        Py_ssize_t userinfo_end = -1;
+        for (Py_ssize_t scan = host_start; scan < len; scan++) {
+            Py_UCS4 c = READ(scan);
+            if (c == '@') {
+                userinfo_end = scan;
+            } else if (c == '/' || c == '?' || c == '#' || !is_url_tail_char(c)) {
+                break;
+            }
         }
-        if (c == '/' || c == '?' || c == '#' || !is_url_tail_char(c)) {
-            break;
+        if (userinfo_end >= 0) {
+            host_start = userinfo_end + 1;
+            host_end = scan_host(kind, data, host_start, len, 0);
         }
     }
-    Py_ssize_t host_end = scan_host(kind, data, host_start, len, 0);
     if (host_end < 0) {
         return 0;
     }

--- a/src/turbohtml/linkify.c
+++ b/src/turbohtml/linkify.c
@@ -129,9 +129,11 @@ static int is_known_tld(int kind, const void *data, Py_ssize_t start, Py_ssize_t
 }
 
 /* Scan a host of dot-separated labels starting at `start`, requiring at least
-   one dot and a final label that is a known TLD. Returns the index past the host
-   on success, or -1. Hyphens are allowed inside a label, not at its edges. */
-static Py_ssize_t scan_host(int kind, const void *data, Py_ssize_t start, Py_ssize_t len) {
+   one dot. With require_tld the final label must be a known TLD (the bare-domain
+   rule); a scheme URL passes 0 so a numeric host like 1.2.3.4 is accepted. Returns
+   the index past the host on success, or -1. Hyphens are allowed inside a label,
+   not at its edges. */
+static Py_ssize_t scan_host(int kind, const void *data, Py_ssize_t start, Py_ssize_t len, int require_tld) {
     Py_ssize_t pos = start;
     Py_ssize_t last_label_start = start;
     Py_ssize_t host_end = start;
@@ -166,7 +168,7 @@ static Py_ssize_t scan_host(int kind, const void *data, Py_ssize_t start, Py_ssi
     if (dots < 1 || label_ended_with_hyphen) {
         return -1;
     }
-    if (!is_known_tld(kind, data, last_label_start, host_end)) {
+    if (require_tld && !is_known_tld(kind, data, last_label_start, host_end)) {
         return -1;
     }
     return host_end;
@@ -186,7 +188,7 @@ static Py_ssize_t scan_url_tail(int kind, const void *data, Py_ssize_t host_end,
             pos = port;
         }
     }
-    if (pos >= len || (READ(pos) != '/' && READ(pos) != '?')) {
+    if (pos >= len || (READ(pos) != '/' && READ(pos) != '?' && READ(pos) != '#')) {
         return pos;
     }
     Py_ssize_t end = pos;
@@ -257,7 +259,20 @@ static int match_url(int kind, const void *data, Py_ssize_t colon, Py_ssize_t st
     if (scheme_start < 0 || blocked_on_left(kind, data, scheme_start)) {
         return 0;
     }
-    Py_ssize_t host_end = scan_host(kind, data, colon + 3, len);
+    /* skip an optional userinfo prefix (user[:password]@) so http://user:pass@host links the whole URL, not the email
+     */
+    Py_ssize_t host_start = colon + 3;
+    for (Py_ssize_t scan = host_start; scan < len; scan++) {
+        Py_UCS4 c = READ(scan);
+        if (c == '@') {
+            host_start = scan + 1;
+            break;
+        }
+        if (c == '/' || c == '?' || c == '#' || !is_url_tail_char(c)) {
+            break;
+        }
+    }
+    Py_ssize_t host_end = scan_host(kind, data, host_start, len, 0);
     if (host_end < 0) {
         return 0;
     }
@@ -285,7 +300,7 @@ static int match_domain(int kind, const void *data, Py_ssize_t dot, Py_ssize_t s
     if (pos == dot || blocked_on_left(kind, data, pos)) {
         return 0;
     }
-    Py_ssize_t host_end = scan_host(kind, data, pos, len);
+    Py_ssize_t host_end = scan_host(kind, data, pos, len, 1);
     if (host_end < 0) {
         return 0;
     }
@@ -311,7 +326,7 @@ static int match_email(int kind, const void *data, Py_ssize_t at, Py_ssize_t sta
     if (pos == at || (pos > start && READ(pos - 1) == '@')) {
         return 0;
     }
-    Py_ssize_t host_end = scan_host(kind, data, at + 1, len);
+    Py_ssize_t host_end = scan_host(kind, data, at + 1, len, 1);
     if (host_end < 0) {
         return 0;
     }

--- a/src/turbohtml/linkify.py
+++ b/src/turbohtml/linkify.py
@@ -53,9 +53,14 @@ class Link:
 Callback: TypeAlias = "Callable[[Link], Link | None]"
 
 
+def _is_web_url(url: str) -> bool:
+    """Is this an ``http``/``https`` URL? The scheme is matched case-insensitively, so ``HTTP://`` counts."""
+    return url[:6].lower().startswith(("http:", "https:"))
+
+
 def nofollow(link: Link) -> Link | None:
     """Add ``rel="nofollow"`` to a web link so search engines skip it; leave ``mailto:`` and other links alone."""
-    if link.url.startswith(("http:", "https:")):
+    if _is_web_url(link.url):
         rels = link.attrs.get("rel", "").split()
         if "nofollow" not in rels:
             rels.append("nofollow")
@@ -65,7 +70,7 @@ def nofollow(link: Link) -> Link | None:
 
 def target_blank(link: Link) -> Link | None:
     """Open a web link in a new tab; strip a stale ``target`` from a non-web link so it cannot leak through."""
-    if link.url.startswith(("http:", "https:")):
+    if _is_web_url(link.url):
         link.attrs["target"] = "_blank"
     else:
         link.attrs.pop("target", None)

--- a/src/turbohtml/sanitize.c
+++ b/src/turbohtml/sanitize.c
@@ -103,6 +103,22 @@ static int is_scheme_char(Py_UCS4 c) {
     return (lower >= 'a' && lower <= 'z') || (c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.';
 }
 
+/* Bytes to ignore when reading a URL scheme: the control characters and whitespace browsers strip, plus the
+   zero-width and soft-hyphen format characters that obfuscate a scheme, so java&zwsp;script: is still caught. */
+static int is_url_ignorable(Py_UCS4 c) {
+    switch (c) {
+    case 0x00AD: /* soft hyphen */
+    case 0x200B: /* zero-width space */
+    case 0x200C: /* zero-width non-joiner */
+    case 0x200D: /* zero-width joiner */
+    case 0x2060: /* word joiner */
+    case 0xFEFF: /* zero-width no-break space / BOM */
+        return 1;
+    default:
+        return c <= 0x20 || c == 0x7F;
+    }
+}
+
 /* Read the URL's scheme the way a browser does -- skipping the whitespace and control bytes it ignores -- and allow the
    attribute only if that scheme is on the allowlist, or there is no scheme and relative URLs are allowed. The parser
    has already resolved entity references, so the value arrives decoded. Returns 1 allow, 0 drop, -1 error. */
@@ -112,7 +128,7 @@ static int scheme_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t len) {
     int started = 0;
     for (Py_ssize_t index = 0; index < len; index++) {
         Py_UCS4 c = value[index];
-        if (c <= 0x20 || c == 0x7F) {
+        if (is_url_ignorable(c)) {
             continue;
         }
         if (c == ':' && started) {

--- a/tests/test_bleach_compat.py
+++ b/tests/test_bleach_compat.py
@@ -44,6 +44,14 @@ def test_clean_attributes_as_per_tag_callable() -> None:
     assert out == '<a href="http://x">y</a><b data-z="1">z</b>'
 
 
+def test_clean_attributes_as_wildcard_callable() -> None:
+    # a "*" callable applies to every tag; it must drop the disallowed attribute, not fail open
+    out = clean(
+        '<a href="/foo" title="t">x</a>', tags=["a"], attributes={"*": lambda _tag, name, _val: name == "title"}
+    )
+    assert out == '<a title="t">x</a>'
+
+
 def test_clean_protocols() -> None:
     assert clean('<a href="ftp://x">y</a>', tags=["a"], attributes={"a": ["href"]}, protocols=["ftp"]) == (
         '<a href="ftp://x">y</a>'

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -259,9 +259,13 @@ def test_bare_domain_path_with_embedded_scheme_keeps_http_prefix() -> None:
         pytest.param("http://example.com/a\x7fb", False, False, [(0, 20, 0)], id="tail-stops-at-del"),
         pytest.param("http://user:pass@host.com/x", True, False, [(0, 27, 0)], id="userinfo-url"),
         pytest.param("http://u@example.com", False, False, [(0, 20, 0)], id="userinfo-at-only"),
+        pytest.param("http://a.b@example.com", False, False, [(0, 22, 0)], id="userinfo-is-a-valid-host"),
         pytest.param("http://1.2.3.4/path", False, False, [(0, 19, 0)], id="schemeful-ipv4"),
         pytest.param("at 1.2.3.4 here", False, True, [], id="bare-ipv4-needs-tld"),
         pytest.param("http://example.com#frag", False, False, [(0, 23, 0)], id="fragment-after-host"),
+        pytest.param("http://example.com:8080?q=1", False, False, [(0, 27, 0)], id="port-then-query-no-userinfo"),
+        pytest.param("http://example.com:8080#f", False, False, [(0, 25, 0)], id="port-then-fragment-no-userinfo"),
+        pytest.param("http://example.com:8080 x", False, False, [(0, 23, 0)], id="port-then-space-no-userinfo"),
         pytest.param("see EXAMPLE.COM here", False, True, [(4, 15, 0)], id="bare-domain-uppercase-tld"),
     ],
 )

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -159,6 +159,7 @@ def test_default_callbacks_is_nofollow() -> None:
         pytest.param("https://x.com", {}, {"rel": "nofollow"}, id="https-too"),
         pytest.param("http://x.com", {"rel": "noopener"}, {"rel": "noopener nofollow"}, id="appends-to-existing-rel"),
         pytest.param("http://x.com", {"rel": "nofollow"}, {"rel": "nofollow"}, id="idempotent"),
+        pytest.param("HTTP://X.COM", {}, {"rel": "nofollow"}, id="uppercase-scheme"),
         pytest.param("mailto:a@b.com", {}, {}, id="skips-non-web"),
     ],
 )
@@ -256,6 +257,12 @@ def test_bare_domain_path_with_embedded_scheme_keeps_http_prefix() -> None:
         pytest.param("http://example.com/a`b", False, False, [(0, 20, 0)], id="tail-stops-at-backtick"),
         pytest.param("http://example.com/a b", False, False, [(0, 20, 0)], id="tail-stops-at-space"),
         pytest.param("http://example.com/a\x7fb", False, False, [(0, 20, 0)], id="tail-stops-at-del"),
+        pytest.param("http://user:pass@host.com/x", True, False, [(0, 27, 0)], id="userinfo-url"),
+        pytest.param("http://u@example.com", False, False, [(0, 20, 0)], id="userinfo-at-only"),
+        pytest.param("http://1.2.3.4/path", False, False, [(0, 19, 0)], id="schemeful-ipv4"),
+        pytest.param("at 1.2.3.4 here", False, True, [], id="bare-ipv4-needs-tld"),
+        pytest.param("http://example.com#frag", False, False, [(0, 23, 0)], id="fragment-after-host"),
+        pytest.param("see EXAMPLE.COM here", False, True, [(4, 15, 0)], id="bare-domain-uppercase-tld"),
     ],
 )
 def test_scanner_spans(

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -144,6 +144,16 @@ def test_unusual_scheme_characters_are_treated_as_relative(url: str) -> None:
     assert sanitize(f'<a href="{url}">t</a>') == f'<a href="{url}">t</a>'
 
 
+@pytest.mark.parametrize(
+    "char",
+    [chr(0x00AD), chr(0x200B), chr(0x200C), chr(0x200D), chr(0x2060), chr(0xFEFF)],
+    ids=["soft-hyphen", "zwsp", "zwnj", "zwj", "word-joiner", "bom"],
+)
+def test_zero_width_characters_cannot_obfuscate_a_scheme(char: str) -> None:
+    # soft hyphen, zero-width, and BOM characters are stripped before the scheme is read, like browsers ignore them
+    assert sanitize(f'<a href="java{char}script:alert(1)">x</a>') == "<a>x</a>"
+
+
 def test_relative_url_dropped_when_disallowed() -> None:
     policy = Policy(allow_relative_urls=False)
     assert sanitize('<a href="/path">x</a>', policy) == "<a>x</a>"


### PR DESCRIPTION
Running every competing library's *own* test suite against turbohtml — markupsafe, bleach's `clean` and `linkify`, nh3, and linkify-it-py — turned up a handful of real behavior differences worth fixing. 🔍 The reassuring half: `escape`/`unescape` are byte-exact with CPython's `html` across the entire codepoint space and a 50k fuzz, and `turbohtml.markup` passes markupsafe 3.0.3's suite unchanged. The rest of the divergences were intentional (a stricter non-overridable safety baseline, the `Link` callback API, the bare-domain TLD model) — except the six fixed here, which were genuine bugs in the sanitizer and the linkifier.

In the sanitizer, a `bleach_compat` call with `attributes={'*': callable}` silently failed open: the wildcard predicate was stored under `"*"` but looked up by concrete tag name, so it never ran and the attribute survived. The per-tag filter now falls back to the `"*"` predicate. Separately, the C URL-scheme check stripped the control characters browsers ignore but not the zero-width and soft-hyphen format characters, so `java<U+200B>script:` could smuggle a scheme past the allowlist; those are now stripped too.

In the linkifier, four detection bugs that bleach and linkify-it-py both got right: a URL with userinfo (`http://user:pass@host/x`) was misread as an email because the `@` won, so `match_url` now skips an optional `user[:pass]@` before the host; a scheme URL with a numeric host (`http://1.2.3.4/path`) was dropped because the host validator demanded a known TLD even under an explicit scheme, so the TLD requirement now applies only to bare domains; a `#fragment` directly after the host was truncated, so the tail scan starts on `#` as well as `/` and `?`; and `nofollow`/`target_blank` compared the scheme case-sensitively, so `HTTP://` got no `rel`, now matched case-insensitively.

The one known difference left as-is, by design: an allow-listed `style` attribute keeps its CSS verbatim until a CSS sanitizer lands (documented behavior, not a regression). Every fix is covered, and the C branches are 100% under both clang and gcc.