### PR TITLE
⚡ perf: faster serialize and data-state scan

### DIFF
--- a/docs/changelog/73.feature.rst
+++ b/docs/changelog/73.feature.rst
@@ -1,6 +1,6 @@
 Serialize a parsed document back to HTML up to 1.6 times faster: the writer scans each text run for the next character
 that needs escaping two code points at a time with the same SWAR lane probes :func:`~turbohtml.escape` uses, recovers
 each special's position straight from the lane mask, and reserves the whole-document buffer up front so the output grows
-in a single allocation instead of a dozen reallocations.
-The 1-byte data-state tokenizer scan now also runs straight through newlines in one vector sweep, folding line and
-column tracking in afterwards, so prose-heavy documents parse a few percent faster.
+in a single allocation instead of a dozen reallocations. The 1-byte data-state tokenizer scan now also runs straight
+through newlines in one vector sweep, folding line and column tracking in afterwards, so prose-heavy documents parse a
+few percent faster.

--- a/docs/changelog/73.feature.rst
+++ b/docs/changelog/73.feature.rst
@@ -1,5 +1,6 @@
-Serialize a parsed document back to HTML up to 1.4 times faster: the writer scans each text run for the next character
-that needs escaping two code points at a time with the same SWAR lane probes :func:`~turbohtml.escape` uses, and
-reserves the whole-document buffer up front so the output grows in a single allocation instead of a dozen reallocations.
+Serialize a parsed document back to HTML up to 1.6 times faster: the writer scans each text run for the next character
+that needs escaping two code points at a time with the same SWAR lane probes :func:`~turbohtml.escape` uses, recovers
+each special's position straight from the lane mask, and reserves the whole-document buffer up front so the output grows
+in a single allocation instead of a dozen reallocations.
 The 1-byte data-state tokenizer scan now also runs straight through newlines in one vector sweep, folding line and
 column tracking in afterwards, so prose-heavy documents parse a few percent faster.

--- a/docs/changelog/73.feature.rst
+++ b/docs/changelog/73.feature.rst
@@ -1,0 +1,5 @@
+Serialize a parsed document back to HTML up to 1.4 times faster: the writer scans each text run for the next character
+that needs escaping two code points at a time with the same SWAR lane probes :func:`~turbohtml.escape` uses, and
+reserves the whole-document buffer up front so the output grows in a single allocation instead of a dozen reallocations.
+The 1-byte data-state tokenizer scan now also runs straight through newlines in one vector sweep, folding line and
+column tracking in afterwards, so prose-heavy documents parse a few percent faster.

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -394,9 +394,10 @@ than BeautifulSoup.
 *************
 
 Serializing a parsed document back to HTML: turbohtml's :attr:`~turbohtml.Node.html`, lxml's ``tostring``, selectolax's
-``html``, and BeautifulSoup's ``decode``. turbohtml scans each text run for the next character that needs escaping and
-bulk-copies the clean spans, so it serializes two to four times faster than lxml and selectolax and about forty times
-faster than BeautifulSoup.
+``html``, and BeautifulSoup's ``decode``. turbohtml scans each text run for the next character that needs escaping --
+two code points at a time with the same SWAR lane probes :func:`~turbohtml.escape` uses -- and bulk-copies the clean
+spans, reserving the whole-document buffer up front so the output grows in one allocation. It serializes three to five
+times faster than lxml, three times faster than selectolax, and about fifty times faster than BeautifulSoup.
 
 .. list-table::
     :header-rows: 1
@@ -408,20 +409,20 @@ faster than BeautifulSoup.
       - selectolax
       - BeautifulSoup
     - - wpt page (4 kB)
-      - 4.7 µs
-      - 18.5 µs
+      - 4.1 µs
+      - 18.6 µs
       - 12.4 µs
-      - 198 µs
+      - 197 µs
     - - wpt page (9.6 kB)
-      - 13.0 µs
-      - 50.6 µs
-      - 29.7 µs
-      - 475 µs
+      - 10.5 µs
+      - 50.9 µs
+      - 30.0 µs
+      - 474 µs
     - - wpt page (92 kB)
-      - 151 µs
-      - 383 µs
-      - 337 µs
-      - 5.95 ms
+      - 115 µs
+      - 381 µs
+      - 341 µs
+      - 5.96 ms
 
 **********
  Building

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -396,8 +396,9 @@ than BeautifulSoup.
 Serializing a parsed document back to HTML: turbohtml's :attr:`~turbohtml.Node.html`, lxml's ``tostring``, selectolax's
 ``html``, and BeautifulSoup's ``decode``. turbohtml scans each text run for the next character that needs escaping --
 two code points at a time with the same SWAR lane probes :func:`~turbohtml.escape` uses -- and bulk-copies the clean
-spans, reserving the whole-document buffer up front so the output grows in one allocation. It serializes three to five
-times faster than lxml, three times faster than selectolax, and about fifty times faster than BeautifulSoup.
+spans, recovering each special's position from the lane mask, and reserves the whole-document buffer up front so the
+output grows in one allocation. It serializes three to six times faster than lxml, over three times faster than
+selectolax, and fifty to sixty times faster than BeautifulSoup.
 
 .. list-table::
     :header-rows: 1
@@ -409,20 +410,20 @@ times faster than lxml, three times faster than selectolax, and about fifty time
       - selectolax
       - BeautifulSoup
     - - wpt page (4 kB)
-      - 4.1 µs
-      - 18.6 µs
-      - 12.4 µs
-      - 197 µs
+      - 3.7 µs
+      - 19.1 µs
+      - 12.6 µs
+      - 204 µs
     - - wpt page (9.6 kB)
-      - 10.5 µs
-      - 50.9 µs
-      - 30.0 µs
-      - 474 µs
+      - 9.5 µs
+      - 53.2 µs
+      - 30.6 µs
+      - 481 µs
     - - wpt page (92 kB)
-      - 115 µs
-      - 381 µs
-      - 341 µs
-      - 5.96 ms
+      - 105 µs
+      - 385 µs
+      - 339 µs
+      - 6.30 ms
 
 **********
  Building

--- a/src/turbohtml/tokenizer_sm.c
+++ b/src/turbohtml/tokenizer_sm.c
@@ -614,11 +614,14 @@ static void text_begin_mark(th_tokenizer *self) {
 
 /* ----------------------------------------------------------------- run */
 
-/* Append input[pos..stop), a run guaranteed free of newlines, to the text
-   buffer in one step. The plain-text states scan ahead for their next special
-   character and move whole runs here instead of dispatching per character
-   (html5ever and lexbor take the same fast path). */
-static void text_append_run(th_tokenizer *self, Py_ssize_t stop) {
+/* Append input[pos..stop) to the text buffer in one step, advancing the
+   line/column counters by the run's newline structure. The plain-text states
+   scan ahead for their next special character and move whole runs here instead
+   of dispatching per character (html5ever and lexbor take the same fast path).
+   newlines is how many '\n' the run holds and col the column the run leaves the
+   cursor at (characters after its last newline); a newline-free run passes 0/0
+   and only advances the column by its length. */
+static void text_append_run_lc(th_tokenizer *self, Py_ssize_t stop, Py_ssize_t newlines, Py_ssize_t col) {
     Py_ssize_t count = stop - self->pos;
     text_begin(self);
     if (self->text.len == 0 && (self->slice_len == 0 || self->pos == self->slice_start + self->slice_len)) {
@@ -632,7 +635,18 @@ static void text_append_run(th_tokenizer *self, Py_ssize_t stop) {
         copy_input_range(self, self->pos, count);
     }
     self->pos = stop;
-    self->col += count;
+    if (newlines > 0) {
+        self->line += newlines;
+        self->col = col;
+    } else {
+        self->col += count;
+    }
+}
+
+/* Append a run guaranteed free of newlines (every plain-text state but DATA,
+   whose scan stops at every newline). */
+static void text_append_run(th_tokenizer *self, Py_ssize_t stop) {
+    text_append_run_lc(self, stop, 0, 0);
 }
 
 static void init_markup(th_tokenizer *self, enum th_kind kind) {
@@ -752,6 +766,69 @@ static Py_ssize_t scan_stops_ucs1(const th_tokenizer *self, Py_ssize_t index, Py
     while (index < len && !((data[index] == s1) | (data[index] == s2) | (data[index] == s3) | (data[index] == s4))) {
         index++;
     }
+    return index;
+}
+
+/* The DATA-state text scan: find the next '&' or '<' from index on while folding
+   in line/column tracking, so a multi-line prose run between tags is one vector
+   sweep rather than one scan per wrapped line. *out_newlines receives how many
+   newlines the run [index, return) holds, and *out_last_nl the index of its last
+   newline (-1 when none), from which the caller derives the ending column. The
+   per-block newline count is a SIMD population count; the last newline alone
+   needs a position, found by a short backward scan bounded by the final line. */
+static Py_ssize_t scan_data_ucs1(const th_tokenizer *self, Py_ssize_t index, Py_ssize_t *out_newlines,
+                                 Py_ssize_t *out_last_nl) {
+    const Py_UCS1 *data = (const Py_UCS1 *)self->input.data;
+    Py_ssize_t len = self->input.len;
+    Py_ssize_t newlines = 0;
+#if defined(TH_SCAN_NEON)
+    uint8x16_t amp = vdupq_n_u8('&'), lt = vdupq_n_u8('<'), nlv = vdupq_n_u8('\n');
+    while (index + 16 <= len) {
+        uint8x16_t block = vld1q_u8(data + index);
+        if (vmaxvq_u8(vorrq_u8(vceqq_u8(block, amp), vceqq_u8(block, lt)))) {
+            break;
+        }
+        newlines += vaddvq_u8(vshrq_n_u8(vceqq_u8(block, nlv), 7)); /* 0xFF >> 7 == 1 per match */
+        index += 16;
+    }
+#elif defined(TH_SCAN_SSE2)
+    __m128i amp = _mm_set1_epi8('&'), lt = _mm_set1_epi8('<'), nlv = _mm_set1_epi8('\n');
+    while (index + 16 <= len) {
+        __m128i block = _mm_loadu_si128((const __m128i *)(data + index));
+        if (_mm_movemask_epi8(_mm_or_si128(_mm_cmpeq_epi8(block, amp), _mm_cmpeq_epi8(block, lt)))) {
+            break;
+        }
+        newlines += __builtin_popcount((unsigned)_mm_movemask_epi8(_mm_cmpeq_epi8(block, nlv)));
+        index += 16;
+    }
+#else
+    uint64_t amp = TH_ONES * '&', lt = TH_ONES * '<', nlv = TH_ONES * '\n';
+    while (index + 8 <= len) {
+        uint64_t word;
+        memcpy(&word, data + index, sizeof(word));
+        if (TH_HASZERO(word ^ amp) | TH_HASZERO(word ^ lt)) {
+            break;
+        }
+        newlines += (Py_ssize_t)(((TH_HASZERO(word ^ nlv) >> 7) * TH_ONES) >> 56);
+        index += 8;
+    }
+#endif
+    while (index < len && data[index] != '&' && data[index] != '<') {
+        newlines += data[index] == '\n';
+        index++;
+    }
+    *out_newlines = newlines;
+    /* newlines > 0 guarantees a '\n' lies in [start, index), so the backward walk
+       is bounded by that newline and needs no explicit start guard (the same
+       guaranteed-terminator pattern th_node_doctype_ids uses). */
+    Py_ssize_t last_nl = -1;
+    if (newlines > 0) {
+        last_nl = index - 1;
+        while (data[last_nl] != '\n') {
+            last_nl--;
+        }
+    }
+    *out_last_nl = last_nl;
     return index;
 }
 

--- a/src/turbohtml/tokenizer_sm.c
+++ b/src/turbohtml/tokenizer_sm.c
@@ -798,7 +798,11 @@ static Py_ssize_t scan_data_ucs1(const th_tokenizer *self, Py_ssize_t index, Py_
         if (_mm_movemask_epi8(_mm_or_si128(_mm_cmpeq_epi8(block, amp), _mm_cmpeq_epi8(block, lt)))) {
             break;
         }
-        newlines += __builtin_popcount((unsigned)_mm_movemask_epi8(_mm_cmpeq_epi8(block, nlv)));
+        /* sum one-per-newline across the lanes with SAD (escape.c's reduction), so
+           the count needs no popcount intrinsic MSVC lacks */
+        __m128i ones = _mm_and_si128(_mm_cmpeq_epi8(block, nlv), _mm_set1_epi8(1));
+        __m128i sums = _mm_sad_epu8(ones, _mm_setzero_si128());
+        newlines += _mm_cvtsi128_si32(sums) + _mm_extract_epi16(sums, 4);
         index += 16;
     }
 #else

--- a/src/turbohtml/tokenizer_sm_run.h
+++ b/src/turbohtml/tokenizer_sm_run.h
@@ -208,11 +208,28 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
             if (at_eof) {
                 EOF_FLUSH();
             }
+#if TH_UCS1
+            /* '\n' is ordinary text in DATA — the only per-newline work is
+               line/column tracking, so a single SIMD pass runs straight through
+               newlines to the next markup (a paragraph between tags becomes one
+               sweep, not one per wrapped line) and folds the newline count and
+               last-newline column in along the way. The wider widths keep the
+               generic newline-stopping scan: they are rarer and the dedicated
+               1-byte pass is where real documents live. */
+            if (ch != '&' && ch != '<') {
+                Py_ssize_t newlines;
+                Py_ssize_t last_nl;
+                Py_ssize_t stop = scan_data_ucs1(self, self->pos, &newlines, &last_nl);
+                text_append_run_lc(self, stop, newlines, last_nl < 0 ? 0 : stop - last_nl - 1);
+                continue;
+            }
+#else
             if (ch != '&' && ch != '<' && ch != '\n') {
                 Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '&', '<', '\n', '\n');
                 text_append_run(self, stop);
                 continue;
             }
+#endif
             if (ch == '&') {
                 text_begin(self);
                 text_materialize(self);
@@ -224,6 +241,15 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
                 self->col += consumed;
                 continue;
             }
+#if TH_UCS1
+            /* the run branch consumed every character but '&' and '<', and '&' is
+               handled above, so ch is '<' here: open a tag with no further test
+               (the wider widths still fall through a bare-newline text_push) */
+            MARK();
+            CONSUME();
+            self->state = ST_TAG_OPEN;
+            continue;
+#else
             if (ch == '<') {
                 MARK();
                 CONSUME();
@@ -233,6 +259,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
             text_push(self, ch);
             CONSUME();
             continue;
+#endif
 
         case ST_RCDATA:
             if (at_eof) {

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -13,6 +13,7 @@
 #include "treebuilder.h"
 
 #include "ascii.h"
+#include "turbohtml.h" /* SWAR lane probes for the serializer's clean-run scan */
 
 #include <string.h>
 

--- a/src/turbohtml/treebuilder_serialize.h
+++ b/src/turbohtml/treebuilder_serialize.h
@@ -276,31 +276,34 @@ enum th_formatter {
     TH_FMT_NAMED,   /* HTML named entities for every character that has one */
 };
 
-/* Whether a character must be rewritten under the formatter. NAMED rewrites any
-   character with a named reference (the ASCII ones are exactly & " < >, so the
-   table is only consulted past 0x7F); the others escape the structural set, with
-   WHATWG also folding the quote and no-break space the spec calls for. */
-static int sbuf_text_special(Py_UCS4 character, int in_attr, int formatter) {
-    if (formatter == TH_FMT_NAMED) {
-        if (character < 0x80) {
-            return character == '&' || character == '"' || character == '<' || character == '>';
-        }
-        return th_entity_name(character) != NULL;
+/* Whether a character has a named reference under the NAMED formatter. The ASCII
+   ones are exactly & " < >, so the generated table is only consulted past 0x7F. */
+static int sbuf_named_special(Py_UCS4 character) {
+    if (character < 0x80) {
+        return character == '&' || character == '"' || character == '<' || character == '>';
     }
-    int escape_angle = formatter == TH_FMT_MINIMAL || !in_attr;
-    if (character == '&') {
-        return 1;
-    }
-    if ((character == '<' || character == '>') && escape_angle) {
-        return 1;
-    }
-    if (character == '"' && in_attr) {
-        return formatter == TH_FMT_WHATWG;
-    }
-    return character == 0xA0 && formatter == TH_FMT_WHATWG;
+    return th_entity_name(character) != NULL;
 }
 
-/* Emit the replacement for a character sbuf_text_special flagged. */
+/* The WHATWG/MINIMAL special set tested over a 64-bit word of two UCS-4 code
+   points: & always, < > when angle brackets escape (text, or any MINIMAL), " in
+   a WHATWG attribute value, and the no-break space WHATWG folds. Each probe sets
+   the matching lane's high bit; a nonzero result means a special is in the pair. */
+static inline uint64_t sbuf_special_mask(uint64_t word, int escape_angle, int escape_quote, int escape_nbsp) {
+    uint64_t mask = swar_haslane32(word, '&');
+    if (escape_angle) {
+        mask |= swar_haslane32(word, '<') | swar_haslane32(word, '>');
+    }
+    if (escape_quote) {
+        mask |= swar_haslane32(word, '"');
+    }
+    if (escape_nbsp) {
+        mask |= swar_haslane32(word, 0xA0);
+    }
+    return mask;
+}
+
+/* Emit the replacement for a flagged character. */
 static void sbuf_put_special(sbuf *out, Py_UCS4 character, int formatter) {
     const char *name = formatter == TH_FMT_NAMED ? th_entity_name(character) : NULL;
     if (name != NULL) {
@@ -320,52 +323,73 @@ static void sbuf_put_special(sbuf *out, Py_UCS4 character, int formatter) {
     }
 }
 
-/* Append text under one formatter, bulk-copying each run with nothing to escape
-   and rewriting only the flagged characters in between. The tree stores text as
-   UCS-4, so the clean-run scan tests two code points per 64-bit word with the
-   same SWAR lane probes escape.c uses, hopping over long unescaped spans (which
-   dominate real documents) instead of re-classifying every character. NAMED
-   consults a table past 0x7F, so it keeps the scalar scan; WHATWG and MINIMAL
-   have a fixed special set (& plus < > " 0xA0 as the context selects) that the
-   probes resolve directly. */
-static void sbuf_put_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t len, int in_attr, int formatter) {
-    int swar = formatter != TH_FMT_NAMED;
-    int escape_angle = formatter == TH_FMT_MINIMAL || !in_attr;
-    int escape_quote = in_attr && formatter == TH_FMT_WHATWG;
-    int escape_nbsp = formatter == TH_FMT_WHATWG;
+/* Append NAMED-formatter text: bulk-copy each run with no named reference and
+   rewrite the rest. NAMED consults a table past 0x7F, so it stays scalar. */
+static void sbuf_put_named_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t len) {
     Py_ssize_t index = 0;
     while (index < len) {
         Py_ssize_t start = index;
-        if (swar) {
-            while (index + UCS4_LANES <= len) {
-                uint64_t word;
-                memcpy(&word, &text[index], sizeof(word));
-                uint64_t mask = swar_haslane32(word, '&');
-                if (escape_angle) {
-                    mask |= swar_haslane32(word, '<') | swar_haslane32(word, '>');
-                }
-                if (escape_quote) {
-                    mask |= swar_haslane32(word, '"');
-                }
-                if (escape_nbsp) {
-                    mask |= swar_haslane32(word, 0xA0);
-                }
-                if (mask != 0) {
-                    break;
-                }
-                index += UCS4_LANES;
-            }
-        }
-        while (index < len && !sbuf_text_special(text[index], in_attr, formatter)) {
+        while (index < len && !sbuf_named_special(text[index])) {
             index++;
         }
         if (index > start) {
             sbuf_put_run(out, &text[start], index - start);
         }
         if (index < len) {
-            sbuf_put_special(out, text[index], formatter);
+            sbuf_put_special(out, text[index], TH_FMT_NAMED);
             index++;
         }
+    }
+}
+
+/* Append text under the WHATWG or MINIMAL formatter, bulk-copying each run with
+   nothing to escape and rewriting only the specials between. The tree stores
+   text as UCS-4, so the clean-run scan tests two code points per 64-bit word
+   with the same SWAR lane probes escape.c uses, hopping over the long unescaped
+   spans real documents are made of instead of classifying every character. When
+   a pair holds a special, its exact code point is recovered from the lane mask
+   over a word built low-lane-first, so the position is independent of byte order
+   and of which character class matched. */
+static void sbuf_put_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t len, int in_attr, int formatter) {
+    if (formatter == TH_FMT_NAMED) {
+        sbuf_put_named_text(out, text, len);
+        return;
+    }
+    int escape_angle = formatter == TH_FMT_MINIMAL || !in_attr;
+    int escape_quote = in_attr && formatter == TH_FMT_WHATWG;
+    int escape_nbsp = formatter == TH_FMT_WHATWG;
+    Py_ssize_t index = 0;
+    while (index < len) {
+        Py_ssize_t start = index;
+        Py_ssize_t special = -1;
+        while (index + UCS4_LANES <= len) {
+            uint64_t word;
+            memcpy(&word, &text[index], sizeof(word));
+            if (sbuf_special_mask(word, escape_angle, escape_quote, escape_nbsp) != 0) {
+                uint64_t ordered = (uint64_t)text[index] | ((uint64_t)text[index + 1] << 32);
+                uint64_t omask = sbuf_special_mask(ordered, escape_angle, escape_quote, escape_nbsp);
+                special = index + (Py_ssize_t)((omask & 0x80000000ULL) == 0);
+                break;
+            }
+            index += UCS4_LANES;
+        }
+        if (special < 0 && index < len) {
+            /* one code point trails the last full pair; pad with a non-special
+               lane so the same mask probe classifies it without a buffer overread */
+            uint64_t word = (uint64_t)text[index];
+            if (sbuf_special_mask(word, escape_angle, escape_quote, escape_nbsp) != 0) {
+                special = index;
+            }
+        }
+        Py_ssize_t stop = special < 0 ? len : special;
+        if (stop > start) {
+            sbuf_put_run(out, &text[start], stop - start);
+        }
+        if (special < 0) {
+            break;
+        }
+        sbuf_put_special(out, text[special], formatter);
+        index = special + 1;
     }
 }
 

--- a/src/turbohtml/treebuilder_serialize.h
+++ b/src/turbohtml/treebuilder_serialize.h
@@ -294,8 +294,8 @@ static int sbuf_text_special(Py_UCS4 character, int in_attr, int formatter) {
     if ((character == '<' || character == '>') && escape_angle) {
         return 1;
     }
-    if (character == '"' && in_attr && formatter == TH_FMT_WHATWG) {
-        return 1;
+    if (character == '"' && in_attr) {
+        return formatter == TH_FMT_WHATWG;
     }
     return character == 0xA0 && formatter == TH_FMT_WHATWG;
 }
@@ -321,11 +321,41 @@ static void sbuf_put_special(sbuf *out, Py_UCS4 character, int formatter) {
 }
 
 /* Append text under one formatter, bulk-copying each run with nothing to escape
-   and rewriting only the flagged characters in between. */
+   and rewriting only the flagged characters in between. The tree stores text as
+   UCS-4, so the clean-run scan tests two code points per 64-bit word with the
+   same SWAR lane probes escape.c uses, hopping over long unescaped spans (which
+   dominate real documents) instead of re-classifying every character. NAMED
+   consults a table past 0x7F, so it keeps the scalar scan; WHATWG and MINIMAL
+   have a fixed special set (& plus < > " 0xA0 as the context selects) that the
+   probes resolve directly. */
 static void sbuf_put_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t len, int in_attr, int formatter) {
+    int swar = formatter != TH_FMT_NAMED;
+    int escape_angle = formatter == TH_FMT_MINIMAL || !in_attr;
+    int escape_quote = in_attr && formatter == TH_FMT_WHATWG;
+    int escape_nbsp = formatter == TH_FMT_WHATWG;
     Py_ssize_t index = 0;
     while (index < len) {
         Py_ssize_t start = index;
+        if (swar) {
+            while (index + UCS4_LANES <= len) {
+                uint64_t word;
+                memcpy(&word, &text[index], sizeof(word));
+                uint64_t mask = swar_haslane32(word, '&');
+                if (escape_angle) {
+                    mask |= swar_haslane32(word, '<') | swar_haslane32(word, '>');
+                }
+                if (escape_quote) {
+                    mask |= swar_haslane32(word, '"');
+                }
+                if (escape_nbsp) {
+                    mask |= swar_haslane32(word, 0xA0);
+                }
+                if (mask != 0) {
+                    break;
+                }
+                index += UCS4_LANES;
+            }
+        }
         while (index < len && !sbuf_text_special(text[index], in_attr, formatter)) {
             index++;
         }
@@ -631,8 +661,22 @@ Py_UCS4 *th_node_text(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
     return sbuf_finish(&out, out_len);
 }
 
+/* When serializing a whole parsed document, the output length tracks the input
+   length closely, so reserve it up front. That turns the buffer's geometric
+   doubling (about ten reallocs and ~2x the output in memmoves for a 235 kB page)
+   into a single allocation. A subtree serialize keeps the default growth, since
+   the input length would wildly over-reserve. */
+static void sbuf_presize_for_root(sbuf *out, th_tree *tree, th_node *node) {
+    if (node == th_tree_document(tree)) {
+        /* reserving the input length is a no-op for an empty or programmatic
+           tree (length 0), so no separate guard is needed */
+        sbuf_reserve(out, tree->length);
+    }
+}
+
 Py_UCS4 *th_node_html(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
     sbuf out = {NULL, 0, 0, 0};
+    sbuf_presize_for_root(&out, tree, node);
     serialize_compact(&out, tree, node, TH_FMT_WHATWG);
     return sbuf_finish(&out, out_len);
 }
@@ -648,6 +692,7 @@ Py_UCS4 *th_node_inner_html(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
 Py_UCS4 *th_node_serialize(th_tree *tree, th_node *node, int formatter, const Py_UCS4 *indent, Py_ssize_t indent_len,
                            Py_ssize_t *out_len) {
     sbuf out = {NULL, 0, 0, 0};
+    sbuf_presize_for_root(&out, tree, node);
     if (indent == NULL) {
         serialize_compact(&out, tree, node, formatter);
     } else {


### PR DESCRIPTION
Serializing a parsed document and parsing prose-heavy markup were leaving speed on the table that the escape path had already shown how to reclaim. Profiling both over the wpt and WHATWG-spec corpora put serialize's time almost entirely in the text-escaping writer and parse's in the tokenizer's per-character data state. ⚡

The serializer scanned each text run for the next escapable character one code point at a time. Tree text is stored as UCS-4, so it now probes two code points per machine word with the same `swar_haslane32` lane tests `escape.c` uses and bulk-copies the clean spans between specials; the `NAMED` formatter keeps the scalar scan since it consults an entity table past `0x7F`. Whole-document output also reserves the buffer to the input length up front, so a 235 kB page grows in one allocation instead of a dozen geometric reallocations. The corpus serializes 1.2x to 1.4x faster, widening the lead to three to five times over `lxml`, three times over `selectolax`, and about fifty times over `BeautifulSoup`.

The 1-byte data state stopped its vector scan at every newline only to keep the line and column counters current, restarting the sweep on each wrapped line. It now runs straight through newlines in a single pass, counting them with a SIMD population count and resolving the final column with a short backward walk, so prose-heavy documents tokenize a few percent faster. 🚀 The wider code-point widths, which real documents rarely hit, keep the original newline-stopping scan.

Every number in `docs/performance.rst` for the serialize suite was refreshed from `tox -e bench`. The C coverage gate stays at 100% line and branch.