### PR TITLE
🐛 fix(linkify): keep underscore in host labels

### DIFF
--- a/docs/changelog/34.bugfix.rst
+++ b/docs/changelog/34.bugfix.rst
@@ -1,0 +1,4 @@
+Keep the underscore in a host label when linkifying. ``turbohtml.linkify`` stopped scanning a host at ``_``, so a URL
+like ``https://cdn_1.example.org/x`` lost its ``cdn_`` label and scheme and was rewritten to an anchor pointing at a
+different host (``http://1.example.org/x``) that never appeared in the input. Underscore is an RFC 3986 unreserved
+character, valid anywhere in a reg-name host (``_dmarc``, ``cdn_1``), so the whole URL is now linked as written.

--- a/src/turbohtml/linkify.c
+++ b/src/turbohtml/linkify.c
@@ -34,10 +34,12 @@ static inline int is_ascii_digit(Py_UCS4 c) {
     return c >= '0' && c <= '9';
 }
 
-/* A host label character: ASCII alphanumeric, or any non-ASCII code point so an
-   internationalized domain stays in one piece (the IRI case). */
+/* A host label character: ASCII alphanumeric, underscore (an RFC 3986 unreserved
+   character, valid anywhere in a reg-name host, as in ``_dmarc``/``cdn_1``), or
+   any non-ASCII code point so an internationalized domain stays in one piece (the
+   IRI case). */
 static inline int is_label_char(Py_UCS4 c) {
-    return is_ascii_alpha(c) || is_ascii_digit(c) || c >= 0x80;
+    return is_ascii_alpha(c) || is_ascii_digit(c) || c == '_' || c >= 0x80;
 }
 
 /* Email local-part atext, per the addr-spec dot-atom plus the characters real

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -66,6 +66,16 @@ def _no_callbacks() -> list[Callback]:
             'trailing dot <a href="http://example.com">http://example.com</a>. end',
             id="trailing-dot-trimmed",
         ),
+        pytest.param(
+            "https://cdn_1.example.org/x",
+            '<a href="https://cdn_1.example.org/x">https://cdn_1.example.org/x</a>',
+            id="underscore-in-host-label-kept",
+        ),
+        pytest.param(
+            "http://_dmarc.example.com/",
+            '<a href="http://_dmarc.example.com/">http://_dmarc.example.com/</a>',
+            id="underscore-leading-host-label-kept",
+        ),
     ],
 )
 def test_linkify_plain(text: str, expected: str) -> None:
@@ -267,6 +277,10 @@ def test_bare_domain_path_with_embedded_scheme_keeps_http_prefix() -> None:
         pytest.param("http://example.com:8080#f", False, False, [(0, 25, 0)], id="port-then-fragment-no-userinfo"),
         pytest.param("http://example.com:8080 x", False, False, [(0, 23, 0)], id="port-then-space-no-userinfo"),
         pytest.param("see EXAMPLE.COM here", False, True, [(4, 15, 0)], id="bare-domain-uppercase-tld"),
+        pytest.param("https://cdn_1.example.org/x", False, False, [(0, 27, 0)], id="underscore-in-scheme-host"),
+        pytest.param("http://_dmarc.example.com/", False, False, [(0, 26, 0)], id="underscore-leading-scheme-host"),
+        pytest.param("cdn_1.example.org/x", False, True, [(0, 19, 0)], id="underscore-in-bare-host"),
+        pytest.param("_dmarc.example.com here", False, True, [(0, 18, 0)], id="underscore-leading-bare-host"),
     ],
 )
 def test_scanner_spans(


### PR DESCRIPTION
`turbohtml.linkify` stopped scanning a host at an underscore, so a URL such as `https://cdn_1.example.org/x` was mangled: the leading `https://cdn_` fell back to plain text, the schemeless remainder `1.example.org/x` was re-scanned as a bare domain, and an anchor was fabricated pointing at `http://1.example.org/x`. 🔐 That target host and scheme never appear in the input, which is both a correctness and a security concern given how common underscore subdomains are (`_dmarc`, `_dkim`, `cdn_1`).

Underscore is an RFC 3986 unreserved character (`unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"`) and is valid anywhere in a reg-name host, including a label's leading position. The fix treats `_` as a host-label character in the C scan, so the whole URL is linked exactly as it appears in the text. ✨

The change is a one-condition addition to a branchless inline predicate on the host-scan hot path, so no benchmark regression is expected. Closes #34.