### PR TITLE
🐛 fix(serialize): emit frame as a void element

### DIFF
--- a/docs/changelog/33.bugfix.rst
+++ b/docs/changelog/33.bugfix.rst
@@ -1,0 +1,3 @@
+Serialize ``frame`` as a void element, emitting only its start tag. The WHATWG fragment-serialization algorithm lists
+``frame`` among the void elements that take no end tag, so ``turbohtml.parse('<frameset><frame>').serialize()`` no longer
+appends a spurious ``</frame>``.

--- a/docs/changelog/33.bugfix.rst
+++ b/docs/changelog/33.bugfix.rst
@@ -1,3 +1,3 @@
 Serialize ``frame`` as a void element, emitting only its start tag. The WHATWG fragment-serialization algorithm lists
-``frame`` among the void elements that take no end tag, so ``turbohtml.parse('<frameset><frame>').serialize()`` no longer
-appends a spurious ``</frame>``.
+``frame`` among the void elements that take no end tag, so ``turbohtml.parse('<frameset><frame>').serialize()`` no
+longer appends a spurious ``</frame>``.

--- a/src/turbohtml/treebuilder_serialize.h
+++ b/src/turbohtml/treebuilder_serialize.h
@@ -409,6 +409,16 @@ static int is_rawtext_element(const th_node *node) {
     return (node->tag_flags & TH_TAG_RAWTEXT) && node->atom != TH_TAG_NOSCRIPT;
 }
 
+/* The WHATWG fragment-serialization void set extends the parser's void elements
+   with `frame`: it is emitted as a start tag only, never an end tag. `frame` is
+   absent from is_void_atom because, unlike a true void element, it is a normal
+   open element during parsing (in frameset mode it is inserted childless), so
+   widening is_void_atom would wrongly make a stray in-body <frame> swallow no
+   following content. */
+static int is_serialize_void_atom(uint16_t atom) {
+    return atom == TH_TAG_FRAME || is_void_atom(atom);
+}
+
 /* The doctype name length: build_doctype_text stores "name" optionally followed
    by ` "public" "system"`, but HTML serialization emits only the name. */
 static Py_ssize_t doctype_name_len(const th_node *node) {
@@ -465,7 +475,7 @@ static void serialize_compact(sbuf *out, th_tree *tree, th_node *node, int forma
     switch (node->type) { /* GCOVR_EXCL_BR_LINE: th_node_type is exhaustive; the implicit default is unreachable */
     case TH_NODE_ELEMENT: {
         ser_open_tag(out, tree, node, formatter);
-        if (node->ns == TH_NS_HTML && is_void_atom(node->atom)) {
+        if (node->ns == TH_NS_HTML && is_serialize_void_atom(node->atom)) {
             break; /* void elements have no children or end tag */
         }
         if (ser_needs_leading_newline(tree, node)) {
@@ -538,7 +548,7 @@ static void serialize_pretty(sbuf *out, th_tree *tree, th_node *node, const ser_
     switch (node->type) { /* GCOVR_EXCL_BR_LINE: th_node_type is exhaustive; the implicit default is unreachable */
     case TH_NODE_ELEMENT: {
         ser_open_tag(out, tree, node, opts->formatter);
-        if (node->ns == TH_NS_HTML && is_void_atom(node->atom)) {
+        if (node->ns == TH_NS_HTML && is_serialize_void_atom(node->atom)) {
             break;
         }
         int raw = is_rawtext_element(node);

--- a/tests/test_tree_format.py
+++ b/tests/test_tree_format.py
@@ -112,6 +112,7 @@ def test_formatter_serialize(html: str, selector: str, formatter: Formatter, exp
         pytest.param("<div><p>x</p></div>", "div", 0, "<div>\n<p>\nx\n</p>\n</div>", id="zero-newlines-no-indent"),
         pytest.param("<div></div>", "div", 2, "<div></div>", id="empty-element-one-line"),
         pytest.param("<p><br></p>", "p", 2, "<p>\n  <br>\n</p>", id="void-element"),
+        pytest.param("<frameset><frame>", "frameset", 2, "<frameset>\n  <frame>\n</frameset>", id="void-frame"),
         pytest.param("<div><pre>\n\nkeep</pre></div>", "div", 2, "<div>\n  <pre>\n\nkeep</pre>\n</div>", id="raw-pre"),
         pytest.param(
             "<div><script>a<b</script></div>", "div", 2, "<div>\n  <script>a<b</script>\n</div>", id="raw-script"

--- a/tests/test_tree_serialize.py
+++ b/tests/test_tree_serialize.py
@@ -35,6 +35,7 @@ def test_text_concatenates_descendant_character_data(
         pytest.param("<p class='a b'>x</p>", "p", '<p class="a b">x</p>', id="attribute-quoting"),
         pytest.param("<input disabled>", "input", '<input disabled="">', id="void-no-end-tag"),
         pytest.param("<br>", "br", "<br>", id="void-br"),
+        pytest.param("<frameset><frame>", "frameset", "<frameset><frame></frameset>", id="void-frame"),
         pytest.param("<p>a<b>c</b>d</p>", "p", "<p>a<b>c</b>d</p>", id="nested"),
         pytest.param("<style>a > b { x }</style>", "style", "<style>a > b { x }</style>", id="rawtext-style"),
         pytest.param("<script>1 < 2 && 3</script>", "script", "<script>1 < 2 && 3</script>", id="rawtext-script"),


### PR DESCRIPTION
`turbohtml.parse('<frameset><frame>').serialize()` appended a stray `</frame>`. The WHATWG fragment-serialization algorithm lists `frame` among the void elements that take only a start tag, so the closing tag is non-conformant output and breaks parse/serialize round-trips for documents with frames. 🧩

The serializer reused the parser's `is_void_atom`, which deliberately omits `frame`: during parsing `frame` is a normal open element (only frameset mode inserts it childless), and adding it there would make a stray in-body `<frame>` wrongly swallow no following content. The fix keeps the parser set untouched and introduces a serializer-local `is_serialize_void_atom` that adds `frame` for output only, applied in both the compact and pretty paths.

Fixes #33