### PR TITLE
🐛 fix(treebuilder): ignore stray end tag before <html>

### DIFF
--- a/docs/changelog/35.bugfix.rst
+++ b/docs/changelog/35.bugfix.rst
@@ -1,0 +1,4 @@
+Ignore a stray end tag in the "before html" insertion mode instead of opening ``<html>`` on it.
+``parse("</x><!--c-->")`` now keeps the comment as a Document-level child before ``<html>``, matching the WHATWG
+tree-construction rule that "any other end tag" before ``<html>`` is a parse error that is ignored without creating the
+``html`` element. Previously the ignored end tag prematurely opened ``<html>``, nesting the following comment inside it.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2201,6 +2201,13 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 mode = M_BEFORE_HEAD;
                 break;
             }
+            if (tok->kind == TH_END_TAG) {
+                uint16_t end_atom = tok_atom(tok);
+                if (end_atom != TH_TAG_HEAD && end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML &&
+                    end_atom != TH_TAG_BR) {
+                    break; /* any other end tag before html is a parse error and ignored */
+                }
+            }
             {
                 th_node *html = insert_implicit(tree, "html", TH_TAG_HTML, TH_TAG_SPECIAL | TH_TAG_SCOPING);
                 if (html != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -311,6 +311,38 @@ def test_document_paths(html: str, needle: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "html",
+    [
+        pytest.param("</x><!--c-->", id="stray-unknown-end-tag"),
+        pytest.param("</div><!--c-->", id="stray-known-end-tag"),
+    ],
+)
+def test_before_html_ignored_end_tag_keeps_comment_at_document_level(html: str) -> None:
+    # in "before html", an "any other end tag" is ignored without opening <html>, so a
+    # following comment stays a Document-level child before <html> rather than nested inside it
+    assert _doc(html) == "| <!-- c -->\n| <html>\n|   <head>\n|   <body>"
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        pytest.param("</head>x", id="head"),
+        pytest.param("</body>x", id="body"),
+        pytest.param("</html>x", id="html"),
+    ],
+)
+def test_before_html_allowed_end_tag_opens_html(html: str) -> None:
+    # head/body/html/br end tags in "before html" act as "anything else": they open
+    # <html> and are reprocessed, so following text lands in the body
+    assert _doc(html) == '| <html>\n|   <head>\n|   <body>\n|     "x"'
+
+
+def test_before_html_end_br_synthesizes_br() -> None:
+    # </br> in "before html" also acts as "anything else" and is later turned into a <br>
+    assert _doc("</br>x") == '| <html>\n|   <head>\n|   <body>\n|     <br>\n|     "x"'
+
+
+@pytest.mark.parametrize(
     ("html", "context", "needle"),
     [
         pytest.param("</li>x", "div", '| "x"', id="end-li-no-scope"),


### PR DESCRIPTION
In the WHATWG "before html" insertion mode, an end tag other than `head`, `body`, `html`, or `br` is "any other end tag": a parse error that the tree builder must ignore without creating the `html` element. turbohtml instead fell through to the "anything else" branch, opening `<html>` on the stray end tag. A following comment then landed as the first child of `<html>` (before `<head>`) rather than as the Document-level sibling before `<html>` the spec calls for, so `parse("</x><!--c-->")` diverged from html5lib. 🌳

The fix mirrors the handling the adjacent "before head" mode already uses: in "before html", ignore any end tag whose name is not `head`/`body`/`html`/`br`, and leave those four to act as "anything else" (open `<html>` and reprocess). The control cases `<!--c-->` and `<!--c-->x` were already correct, confirming the divergence was specific to the preceding ignored end tag.

Closes #35.