### PR TITLE
🐛 fix(sanitizer): drop URL attr when a duplicate scheme is unsafe

### DIFF
--- a/docs/changelog/38.bugfix.rst
+++ b/docs/changelog/38.bugfix.rst
@@ -1,0 +1,5 @@
+Drop a URL attribute entirely when a duplicate of it carries a disallowed scheme. ``Sanitizer`` checked each ``href``
+value in isolation and removed a rejected one by name, which deleted the first (benign) occurrence and left the
+dangerous duplicate as the lone attribute, so ``<a href='http://ok' href='javascript:alert(1)'>`` survived sanitizing
+with a live ``javascript:`` link. Every occurrence of a URL attribute whose value fails the scheme policy is now
+removed, closing the duplicate-attribute desync and restoring ``sanitize(sanitize(x)) == sanitize(x)``.

--- a/src/turbohtml/sanitize.c
+++ b/src/turbohtml/sanitize.c
@@ -240,7 +240,18 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             if (ok < 0) {  /* GCOVR_EXCL_BR_LINE: scheme_allowed only fails on allocation failure */
                 return -1; /* GCOVR_EXCL_LINE */
             }
-            drop = !ok;
+            if (!ok) {
+                /* A duplicate URL attribute desyncs the per-value scheme check from the
+                   single value a re-parsing browser keeps (WHATWG keeps the first): dropping
+                   only this occurrence deletes the first match by name, which may be a benign
+                   sibling, leaving the disallowed value as the lone attribute. Drop every
+                   occurrence of the name so no disallowed scheme survives, then rescan from
+                   the start because removing an earlier slot shifts the rest down. */
+                while (th_node_attr_del(s->tree, element, name, name_len)) {
+                }
+                index = 0;
+                continue;
+            }
         }
         if (drop) {
             th_node_attr_del(s->tree, element, name, name_len);

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -127,6 +127,24 @@ def test_every_url_attribute_is_scheme_checked(attr: str) -> None:
     assert sanitize(f'<x {attr}="javascript:alert(1)">t</x>', policy) == "<x>t</x>"
 
 
+@pytest.mark.parametrize(
+    "html",
+    [
+        pytest.param("<a href='http://ok' href='javascript:alert(1)'>x</a>", id="bad-scheme-second"),
+        pytest.param("<a href='javascript:alert(1)' href='http://ok'>x</a>", id="bad-scheme-first"),
+    ],
+)
+def test_duplicate_url_attribute_with_bad_scheme_drops_all(html: str) -> None:
+    # a duplicate href keeps only one value in the serialized output; if either value fails the
+    # scheme policy the whole attribute is dropped, so no disallowed scheme can survive the desync
+    assert sanitize(html, Policy.relaxed()) == "<a>x</a>"
+
+
+def test_duplicate_url_attribute_all_allowed_is_kept() -> None:
+    out = sanitize("<a href='http://a' href='http://b'>x</a>", Policy.relaxed())
+    assert out == '<a href="http://a" href="http://b" rel="noopener noreferrer">x</a>'
+
+
 def test_non_url_attribute_value_is_not_scheme_checked() -> None:
     policy = _allow_all({"x"}, {"title"})
     assert sanitize('<x title="javascript:not-a-url">t</x>', policy) == '<x title="javascript:not-a-url">t</x>'

--- a/tests/test_sanitizer_security.py
+++ b/tests/test_sanitizer_security.py
@@ -80,6 +80,10 @@ XSS_CORPUS = [
     pytest.param("<b><i></b></i><img src=x onerror=alert(1)>", id="misnested-adoption"),
     pytest.param('<a href="javascript:alert(1)" onmouseover=alert(2)>x</a>', id="js-url-plus-handler"),
     pytest.param("<p title='\"><img src=x onerror=alert(1)>'>safe</p>", id="attr-value-breakout"),
+    pytest.param("<a href='http://ok' href='javascript:alert(1)'>x</a>", id="dup-href-js-second"),
+    pytest.param("<a href='javascript:alert(1)' href='http://ok'>x</a>", id="dup-href-js-first"),
+    pytest.param("<a href='http://ok' href='data:text/html,<script>alert(1)</script>'>x</a>", id="dup-href-data"),
+    pytest.param('<a href="http://ok" href="vbscript:msgbox(1)">x</a>', id="dup-href-vbscript"),
 ]
 
 _MODES = [


### PR DESCRIPTION
`Sanitizer(Policy.relaxed())` let a dangerous URL scheme survive on `<a href>` whenever the tag carried a **duplicate** `href` — a benign allowed-scheme value followed by a disallowed one. 🔓 The sanitizer checked each value in isolation and removed the rejected one with `th_node_attr_del`, which deletes the **first** match by name. For `<a href='http://ok' href='javascript:alert(1)'>` that deleted the benign value and left the dangerous one as the lone `href`, so the output carried a live `javascript:` (or `data:`/`vbscript:`) link. It also broke the round-trip invariant: `sanitize(x)` emitted the dangerous output but `sanitize(sanitize(x))` stripped it.

The fix removes **every** occurrence of a URL attribute name as soon as any of its values fails the scheme policy, then rescans from the start because deleting an earlier slot shifts the rest down (a naive `continue` could skip a later `on*` handler that slid into an unscanned index). Duplicates whose values are all allowed are left untouched, so a re-parsing browser still keeps the benign first value.

Added the duplicate-`href` vectors (`javascript:`/`data:`/`vbscript:`, both value orderings) to the security corpus, so they are now asserted inert and idempotent across every policy disposition. Closes #38.