### PR TITLE
🐛 fix(tokenizer): drop duplicate attribute names per WHATWG

### DIFF
--- a/docs/changelog/45.bugfix.rst
+++ b/docs/changelog/45.bugfix.rst
@@ -1,0 +1,3 @@
+Discard a duplicate attribute name during tokenization, keeping the first occurrence as the WHATWG specification
+requires, so ``<a href=x href=y>`` now carries a single ``href`` of ``x`` in the token, the parsed tree, and the
+serialized output.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -121,7 +121,9 @@ Two decisions bound the tokenizer's scope:
   (a ``<b>`` inside a script body is text, not a tag).
 - The machine recovers from parse errors instead of reporting them. The spec defines a recovery transition for every
   error and the machine takes it, so malformed input produces the same tokens a browser would see; the error stream is
-  not part of the API.
+  not part of the API. A duplicate attribute name is one such recovery: the spec keeps the first occurrence and drops
+  the rest at tokenization, so ``<a href=x href=y>`` carries a single ``href`` of ``x`` everywhere it is observed — in
+  the token, the parsed tree, and the serialized output alike.
 
 Where behavior could drift, more than the suite pins it: a fuzz comparison runs the token stream against html5lib's
 tokenizer, and source positions use the same 1-based-line, 0-based-column convention as :mod:`python:html.parser`, so

--- a/src/turbohtml/token_type.c
+++ b/src/turbohtml/token_type.c
@@ -177,8 +177,9 @@ static PyObject *token_get_tag(PyObject *self, void *Py_UNUSED(closure)) {
     Py_RETURN_NONE;
 }
 
-/* Build the attribute list, keeping the first occurrence of each name (the spec
-   discards later duplicates) and mapping a valueless attribute to None. */
+/* Build the attribute list (the tokenizer already dropped duplicate names, so
+   the first occurrence is the only one left), mapping a valueless attribute to
+   None. */
 static PyObject *token_get_attrs(PyObject *self, void *Py_UNUSED(closure)) {
     const th_token *record = &((TokenObject *)self)->record;
     if (!is_tag(record)) {
@@ -190,18 +191,6 @@ static PyObject *token_get_attrs(PyObject *self, void *Py_UNUSED(closure)) {
     }
     for (Py_ssize_t index = 0; index < record->attr_count; index++) {
         const th_attr *attr = &record->attrs[index];
-        int duplicate = 0;
-        for (Py_ssize_t prior_index = 0; prior_index < index; prior_index++) {
-            const th_attr *prior = &record->attrs[prior_index];
-            if (prior->name.len == attr->name.len && prior->name.kind == attr->name.kind &&
-                memcmp(prior->name.data, attr->name.data, (size_t)(attr->name.len * attr->name.kind)) == 0) {
-                duplicate = 1;
-                break;
-            }
-        }
-        if (duplicate) {
-            continue;
-        }
         PyObject *name = buf_to_str(&attr->name);
         PyObject *value = attr->has_value ? buf_to_str(&attr->value) : Py_NewRef(Py_None);
         if (name == NULL || value == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */

--- a/src/turbohtml/tokenizer_sm.c
+++ b/src/turbohtml/tokenizer_sm.c
@@ -573,6 +573,32 @@ static void new_attr(th_tokenizer *self) {
     self->attr = attr;
 }
 
+/* Two attribute names are the same when they hold identical code points;
+   minimal-kind storage means equal content always shares a width, so the kind
+   guard both keeps the memcmp well-defined and rejects same-length-different-width
+   names that cannot be equal. */
+static int attr_name_dup(const th_attr *a, const th_attr *b) {
+    return a->name.len == b->name.len && a->name.kind == b->name.kind &&
+           memcmp(a->name.data, b->name.data, (size_t)(a->name.len * a->name.kind)) == 0;
+}
+
+/* Per WHATWG, on leaving the attribute name state: if the token already carries
+   an attribute with this exact name it is a duplicate-attribute parse error and
+   the new attribute is dropped, so the first occurrence wins. The dropped slot's
+   value is routed to the oom sink so the value states keep writing into valid
+   storage. */
+static void finish_attr_name(th_tokenizer *self) {
+    th_token *tok = &self->tok;
+    Py_ssize_t cur = tok->attr_count - 1;
+    for (Py_ssize_t index = 0; index < cur; index++) {
+        if (attr_name_dup(&tok->attrs[index], &tok->attrs[cur])) {
+            tok->attr_count = cur;
+            self->attr = &self->oom_attr;
+            return;
+        }
+    }
+}
+
 /* When a start tag is emitted, remember its name for appropriate-end-tag
    checks; spec discards attributes on end tags but we keep the structure. */
 static void remember_start_tag(th_tokenizer *self) {

--- a/src/turbohtml/tokenizer_sm_run.h
+++ b/src/turbohtml/tokenizer_sm_run.h
@@ -858,10 +858,12 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
 
         case ST_ATTR_NAME:
             if (at_eof || is_space(ch) || ch == '/' || ch == '>') {
+                finish_attr_name(self);
                 self->state = ST_AFTER_ATTR_NAME;
                 continue;
             }
             if (ch == '=') {
+                finish_attr_name(self);
                 CONSUME();
                 self->state = ST_BEFORE_ATTR_VALUE;
                 continue;

--- a/src/turbohtml/tokenizer_type.c
+++ b/src/turbohtml/tokenizer_type.c
@@ -334,10 +334,7 @@ static PyObject *record_as_test_tuple(const th_tokenizer *sm, const th_token *re
                 Py_DECREF(attrs); /* GCOVR_EXCL_LINE: allocation-failure path */
                 return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
             }
-            if (PyDict_Contains(attrs, key) == 1) { /* duplicate: keep the first */
-                Py_DECREF(key);
-                continue;
-            }
+            /* the tokenizer already dropped duplicate attribute names, so each key is unique */
             PyObject *value = PyUnicode_FromKindAndData(attr->value.kind, attr->value.data, attr->value.len);
             /* allocation failure cannot be forced from a test */
             if (value == NULL || PyDict_SetItem(attrs, key, value) < 0) { /* GCOVR_EXCL_BR_LINE */

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -128,21 +128,26 @@ def test_every_url_attribute_is_scheme_checked(attr: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "html",
+    ("html", "expected"),
     [
-        pytest.param("<a href='http://ok' href='javascript:alert(1)'>x</a>", id="bad-scheme-second"),
-        pytest.param("<a href='javascript:alert(1)' href='http://ok'>x</a>", id="bad-scheme-first"),
+        pytest.param(
+            "<a href='http://ok' href='javascript:alert(1)'>x</a>",
+            '<a href="http://ok" rel="noopener noreferrer">x</a>',
+            id="safe-first-survives",
+        ),
+        pytest.param("<a href='javascript:alert(1)' href='http://ok'>x</a>", "<a>x</a>", id="unsafe-first-dropped"),
     ],
 )
-def test_duplicate_url_attribute_with_bad_scheme_drops_all(html: str) -> None:
-    # a duplicate href keeps only one value in the serialized output; if either value fails the
-    # scheme policy the whole attribute is dropped, so no disallowed scheme can survive the desync
-    assert sanitize(html, Policy.relaxed()) == "<a>x</a>"
+def test_duplicate_url_attribute_collapses_to_first(html: str, expected: str) -> None:
+    # the tokenizer drops a duplicate attribute name, keeping the first occurrence (WHATWG), so the
+    # sanitizer only ever sees one href: a safe first value survives the scheme check, an unsafe one
+    # is dropped, and no disallowed scheme can reach the output.
+    assert sanitize(html, Policy.relaxed()) == expected
 
 
-def test_duplicate_url_attribute_all_allowed_is_kept() -> None:
+def test_duplicate_url_attribute_keeps_only_the_first() -> None:
     out = sanitize("<a href='http://a' href='http://b'>x</a>", Policy.relaxed())
-    assert out == '<a href="http://a" href="http://b" rel="noopener noreferrer">x</a>'
+    assert out == '<a href="http://a" rel="noopener noreferrer">x</a>'
 
 
 def test_non_url_attribute_value_is_not_scheme_checked() -> None:

--- a/tests/test_tree_attrs.py
+++ b/tests/test_tree_attrs.py
@@ -132,3 +132,31 @@ def test_attrs_supports_mapping_protocol(find: Callable[[str, str], Element]) ->
     assert attrs.get("missing") is None
     assert "class" in attrs
     assert "missing" not in attrs
+
+
+@pytest.mark.parametrize(
+    ("html", "tag", "attrs", "markup"),
+    [
+        pytest.param(
+            '<a href="1" href="2" href="3">x</a>',
+            "a",
+            {"href": "1"},
+            '<a href="1">x</a>',
+            id="repeated-value-first-wins",
+        ),
+        pytest.param(
+            "<p id=first id=second>z</p>", "p", {"id": "first"}, '<p id="first">z</p>', id="unquoted-first-wins"
+        ),
+        pytest.param(
+            "<span data-x data-x>w</span>", "span", {"data-x": None}, '<span data-x="">w</span>', id="valueless"
+        ),
+    ],
+)
+def test_duplicate_attributes_drop_to_first(
+    find: Callable[[str, str], Element], html: str, tag: str, attrs: dict[str, str | None], markup: str
+) -> None:
+    # WHATWG discards a later duplicate attribute name during tokenization, so the tree keeps
+    # only the first occurrence (in storage, not just a view) and serializes a single copy.
+    element = find(html, tag)
+    assert dict(element.attrs) == attrs
+    assert element.html == markup


### PR DESCRIPTION
A start tag that repeated an attribute name, like `<a href=x href=y>`, kept every copy in the tokenizer's attribute array. The token's Python views collapsed them on access, but the tree builder and serializer read the raw array, so a parsed and reserialized tag still carried the duplicates, and different access paths disagreed on which value won (`closes #45`).

The WHATWG tokenizer discards a duplicate at the moment it leaves the attribute-name state, keeping the first occurrence. 🎯 Doing the same here, at the source, means every consumer downstream — the token, the parsed tree, and the serialized output — sees a single attribute, and the redundant deduplication passes that had grown up in `token_get_attrs` and the `tokenize()` dict build are no longer needed.

This supersedes the sanitizer-level handling from #104, which guarded against a duplicate URL attribute desyncing the scheme check. That defense stays in place as belt-and-suspenders (a sanitizer should never assume its input was deduplicated), but it now only ever sees one attribute, so its two duplicate-scenario tests move to the spec-correct outcome: a safe first `href` survives the scheme check and an unsafe first `href` is dropped on its own merits. The #38 security angle remains covered by #104.