### PR TITLE
🐛 fix(treebuilder): adjust MathML definitionURL attribute name

### DIFF
--- a/docs/changelog/41.bugfix.rst
+++ b/docs/changelog/41.bugfix.rst
@@ -1,0 +1,5 @@
+Apply the WHATWG "adjust MathML attributes" step so a MathML ``definitionurl`` attribute is cased to ``definitionURL``
+in the parsed tree and every serialization, not only the ``#document`` debug format. ``parse_fragment("<math
+definitionURL=x></math>", "body")`` now reports ``definitionURL`` in ``Element.attrs`` and ``inner_html``, matching
+html5lib. Attribute lookups on foreign (MathML/SVG) elements stay case-insensitive, so ``math.attrs["definitionURL"]``
+and ``math.attrs["definitionurl"]`` both resolve.

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -799,16 +799,7 @@ static char *attr_key_utf8(PyObject *key, Py_ssize_t *out_len) {
 
 /* The index of the attribute named name in node, or -1 when it has none. */
 static Py_ssize_t find_attr_index(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len) {
-    uint32_t atom = th_attr_lookup(tree, name, name_len);
-    if (atom == UINT32_MAX) {
-        return -1;
-    }
-    for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-        if (node->attrs[index].name_atom == atom) {
-            return index;
-        }
-    }
-    return -1;
+    return th_node_attr_find(tree, node, name, name_len);
 }
 
 /* The live mutable view of an element's attributes: a mapping name -> value over

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -540,12 +540,11 @@ int th_node_attr_set(th_tree *tree, th_node *node, const char *name, Py_ssize_t 
         }
         memcpy(owned, value, (size_t)value_len * sizeof(Py_UCS4));
     }
-    for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-        if (node->attrs[index].name_atom == atom) {
-            node->attrs[index].value = owned;
-            node->attrs[index].value_len = has_value ? value_len : 0;
-            return 0;
-        }
+    Py_ssize_t existing = th_node_attr_find(tree, node, name, name_len);
+    if (existing >= 0) {
+        node->attrs[existing].value = owned;
+        node->attrs[existing].value_len = has_value ? value_len : 0;
+        return 0;
     }
     th_node_attr *grown = arena_alloc(tree, (node->attr_count + 1) * (Py_ssize_t)sizeof(th_node_attr));
     if (grown == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -580,21 +579,47 @@ int th_node_set_data(th_tree *tree, th_node *node, const Py_UCS4 *data, Py_ssize
 
 /* Remove the attribute with this name, shifting the rest down. Returns 1 when one
    was removed, 0 when the element had no such attribute. */
-int th_node_attr_del(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len) {
+Py_ssize_t th_node_attr_find(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len) {
     uint32_t atom = th_attr_lookup(tree, name, name_len);
-    if (atom == UINT32_MAX) {
-        return 0;
-    }
-    for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-        if (node->attrs[index].name_atom == atom) {
-            for (Py_ssize_t shift = index; shift + 1 < node->attr_count; shift++) {
-                node->attrs[shift] = node->attrs[shift + 1];
+    if (atom != UINT32_MAX) {
+        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
+            if (node->attrs[index].name_atom == atom) {
+                return index;
             }
-            node->attr_count--;
-            return 1;
         }
     }
-    return 0;
+    /* A foreign element can store a case-adjusted attribute name (definitionURL)
+       whose atom differs from the lowercased probe, so match case-insensitively
+       against the stored names; the probe is already lowercased by the caller. */
+    if (node->ns != TH_NS_HTML) {
+        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
+            Py_ssize_t stored_len;
+            const char *stored = th_attr_name(tree, node->attrs[index].name_atom, &stored_len);
+            if (stored_len != name_len) {
+                continue;
+            }
+            Py_ssize_t offset = 0;
+            while (offset < name_len && lower_ascii((Py_UCS4)(unsigned char)stored[offset]) == (Py_UCS4)name[offset]) {
+                offset++;
+            }
+            if (offset == name_len) {
+                return index;
+            }
+        }
+    }
+    return -1;
+}
+
+int th_node_attr_del(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len) {
+    Py_ssize_t index = th_node_attr_find(tree, node, name, name_len);
+    if (index < 0) {
+        return 0;
+    }
+    for (Py_ssize_t shift = index; shift + 1 < node->attr_count; shift++) {
+        node->attrs[shift] = node->attrs[shift + 1];
+    }
+    node->attr_count--;
+    return 1;
 }
 
 static void node_append(th_node *parent, th_node *child) {

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -107,6 +107,11 @@ int th_tree_set_attr(th_tree *tree, th_node *node, Py_ssize_t index, const char 
 int th_node_attr_set(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len, const Py_UCS4 *value,
                      Py_ssize_t value_len, int has_value);
 
+/* The index of node's attribute named `name` (UTF-8, caller-lowercased), or -1.
+   Foreign elements can store a case-adjusted name (e.g. MathML definitionURL), so
+   a missed atom match falls back to a case-insensitive scan for non-HTML nodes. */
+Py_ssize_t th_node_attr_find(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len);
+
 /* Remove the named attribute; returns 1 if one was removed, else 0. */
 int th_node_attr_del(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len);
 

--- a/src/turbohtml/treebuilder_foreign.h
+++ b/src/turbohtml/treebuilder_foreign.h
@@ -265,6 +265,19 @@ static th_node *insert_foreign(th_tree *tree, const th_token *token, uint8_t ns)
                   (ns == TH_NS_SVG &&
                    (node->atom == TH_TAG_FOREIGNOBJECT || node->atom == TH_TAG_DESC || node->atom == TH_TAG_TITLE));
     node->tag_flags = special ? TH_TAG_SPECIAL : 0;
+    /* "adjust MathML attributes": definitionurl -> definitionURL. Done here, at
+       construction, so the cased name lands in the tree (node.attrs) and every
+       serializer emits it, not only the #document debug format. */
+    if (ns == TH_NS_MATHML) {
+        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
+            Py_ssize_t name_len;
+            const char *name = th_attr_name(tree, node->attrs[index].name_atom, &name_len);
+            const char *mixed = foreign_adjust_attr(name, name_len, ns);
+            if (mixed != NULL) {
+                node->attrs[index].name_atom = intern_attr_dynamic(tree, mixed, (Py_ssize_t)strlen(mixed));
+            }
+        }
+    }
     if (ns == TH_NS_SVG && node->text != NULL) { /* GCOVR_EXCL_BR_LINE: an SVG element always has a tag name */
         char lower[MAX_SVG_NAME];
         if (node->text_len < (Py_ssize_t)sizeof(lower)) { /* GCOVR_EXCL_BR_LINE: SVG names are under 64 chars */

--- a/tests/test_tree_attrs.py
+++ b/tests/test_tree_attrs.py
@@ -160,3 +160,28 @@ def test_duplicate_attributes_drop_to_first(
     element = find(html, tag)
     assert dict(element.attrs) == attrs
     assert element.html == markup
+
+
+def test_mathml_definitionurl_attribute_name_is_cased(find: Callable[[str, str], Element]) -> None:
+    # WHATWG "adjust MathML attributes": definitionurl -> definitionURL, applied at construction
+    # so the cased name lands in the tree and serialization, not only the #document debug format
+    math = find("<math definitionURL='x'></math>", "math")
+    assert dict(math.attrs) == {"definitionURL": "x"}
+    assert math.html == '<math definitionURL="x"></math>'
+    assert math.attrs["definitionURL"] == "x"
+    assert math.attrs.get("definitionurl") == "x"  # foreign lookup stays case-insensitive
+    assert "nope" not in math.attrs  # length mismatch in the foreign scan
+    assert "abcdefghijklm" not in math.attrs  # same length as definitionURL, different name
+
+
+def test_mathml_definitionurl_can_be_set_and_deleted_by_either_case(find: Callable[[str, str], Element]) -> None:
+    math = find("<math definitionURL='x'></math>", "math")
+    math.attrs["definitionURL"] = "y"  # updates the existing slot, no duplicate
+    assert math.html == '<math definitionURL="y"></math>'
+    del math.attrs["definitionurl"]
+    assert math.html == "<math></math>"
+
+
+def test_svg_definitionurl_attribute_stays_lowercase(find: Callable[[str, str], Element]) -> None:
+    # definitionurl is only in the MathML adjust table, so on an SVG element it stays as written
+    assert dict(find("<svg definitionURL='x'></svg>", "svg").attrs) == {"definitionurl": "x"}

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -134,6 +134,8 @@ _LONG_NAME = "z" * 130
         pytest.param("<svg><![CDATA[Ω]]></svg>", '"Ω"', id="cdata-foreign-ucs2"),
         pytest.param("<svg><![CDATA[\U0001f600]]></svg>", '"\U0001f600"', id="cdata-foreign-ucs4"),
         pytest.param("<math><mi mathvariant=bold>x</mi></math>", 'mathvariant="bold"', id="mathml-attribute-adjust"),
+        pytest.param("<math definitionurl=x></math>", 'definitionURL="x"', id="mathml-definitionurl-cased"),
+        pytest.param("<svg definitionurl=x></svg>", 'definitionurl="x"', id="svg-definitionurl-stays-lower"),
         pytest.param("<svg viewBox='0 0 1 1'>x</svg>", 'viewBox="0 0 1 1"', id="svg-camelcase-attribute"),
         pytest.param("<svg><foreignObject>x</foreignObject></svg>", "<svg foreignObject>", id="svg-camelcase-tag"),
         pytest.param(


### PR DESCRIPTION
The WHATWG "adjust MathML attributes" step renames `definitionurl` to `definitionURL` when a MathML element is created (its only mapping). turbohtml stored the lowercased name and only restored the casing in the `#document` debug serializer, so `Element.attrs` and `inner_html` both showed `definitionurl`, diverging from html5lib (the spec oracle). 🔧

The fix applies the adjustment at **construction**, mirroring the existing SVG element-name adjustment in `insert_foreign`, so the cased name lands in the tree and flows through every serializer (`inner_html`, `.html`, and `#document`). Because the attribute-lookup API lowercases probes and matches by interned atom, a cased stored name would otherwise be unreachable (`math.attrs["definitionURL"]` would `KeyError` despite showing in `repr`). To keep lookups working, `find`/`set`/`delete` now route through a shared `th_node_attr_find` that falls back to a case-insensitive scan for foreign (MathML/SVG) elements, while HTML elements stay on the fast atom path. So `math.attrs["definitionURL"]` and `math.attrs["definitionurl"]` both resolve, and setting/deleting by either case updates the single existing slot.

SVG `definitionurl` is left lowercase (it is only in the MathML adjust table), matching the conformance suite. Closes #41.