### PR TITLE
🐛 fix(treebuilder): synthesize head/body for html fragments

### DIFF
--- a/docs/changelog/42.bugfix.rst
+++ b/docs/changelog/42.bugfix.rst
@@ -1,0 +1,5 @@
+Synthesize the implicit ``head`` and ``body`` for a ``parse_fragment(context="html")`` fragment at end of input. An
+html-context fragment starts in the "before head" insertion mode, so the WHATWG missing-element rules run on EOF and a
+``head`` and ``body`` are always present even when no token forces them: ``""`` now yields an empty ``head`` and
+``body``, ``"<title>t</title>"`` yields ``head`` plus an empty ``body``, and a leading comment is kept before the
+synthesized pair.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -3711,19 +3711,13 @@ static th_node *make_named(th_tree *tree, const char *name, Py_ssize_t len, uint
     return node;
 }
 
-/* At EOF a document always has html, head and body (the missing-element rules of
-   the early insertion modes), so synthesize any the parse left out. */
-static void finalize_document(th_tree *tree) {
-    th_node *html = child_with_atom(tree->document, TH_TAG_HTML);
-    if (html == NULL) {
-        html = make_named(tree, "html", 4, TH_TAG_HTML, TH_TAG_SPECIAL | TH_TAG_SCOPING);
-        if (html == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-            return;         /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
-        }
-        node_append(tree->document, html);
-    }
+/* At EOF the early insertion modes give an html element a head and a body unless a
+   frameset took the body's place; synthesize whichever the parse left out. The html
+   element is the document's <html> child or, for an html-context fragment, the
+   fragment root that stands in for it. */
+static void ensure_head_body(th_tree *tree, th_node *html) {
     if (child_with_atom(html, TH_TAG_FRAMESET) != NULL) {
-        return; /* a frameset document has no body */
+        return; /* a frameset takes the place of the body */
     }
     th_node *head = child_with_atom(html, TH_TAG_HEAD);
     if (head == NULL) {
@@ -3741,6 +3735,20 @@ static void finalize_document(th_tree *tree) {
         }
         node_append(html, body);
     }
+}
+
+/* At EOF a document always has html, head and body (the missing-element rules of
+   the early insertion modes), so synthesize any the parse left out. */
+static void finalize_document(th_tree *tree) {
+    th_node *html = child_with_atom(tree->document, TH_TAG_HTML);
+    if (html == NULL) {
+        html = make_named(tree, "html", 4, TH_TAG_HTML, TH_TAG_SPECIAL | TH_TAG_SCOPING);
+        if (html == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return;         /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
+        }
+        node_append(tree->document, html);
+    }
+    ensure_head_body(tree, html);
 }
 
 th_tree *th_tree_parse(int kind, const void *data, Py_ssize_t length) {
@@ -3898,6 +3906,13 @@ th_tree *th_tree_parse_fragment(int kind, const void *data, Py_ssize_t length, c
     setup_input(tree, sm, kind, data, length);
     run(tree, sm, ctx_ns == TH_NS_HTML ? fragment_mode(ctx_atom) : M_IN_BODY);
     th_tok_free(sm);
+
+    /* an html-context fragment starts in "before head"; at EOF the same
+       missing-element rules a document runs synthesize the head and body, with
+       the fragment root standing in for the <html> element */
+    if (ctx_atom == TH_TAG_HTML) {
+        ensure_head_body(tree, tree->fragment_root);
+    }
 
     if (tree->failed) {     /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         th_tree_free(tree); /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -370,6 +370,11 @@ def test_before_html_end_br_synthesizes_br() -> None:
         pytest.param("", "title", "", id="empty-fragment-serializes-empty"),
         pytest.param("x", "a" * 40, '"x"', id="context-name-longer-than-buffer"),
         pytest.param("<br>", "svg", "<br>", id="breakout-stops-at-fragment-root"),
+        # an html-context fragment starts in "before head" and synthesizes the
+        # implicit head and body at EOF even when no token forces them (issue #42)
+        pytest.param("", "html", "| <head>\n| <body>", id="html-fragment-empty-synthesizes-head-body"),
+        pytest.param("<title>t</title>", "html", '|     "t"\n| <body>', id="html-fragment-head-only-adds-body"),
+        pytest.param("<!--c-->", "html", "| <!-- c -->\n| <head>\n| <body>", id="html-fragment-comment-then-head-body"),
     ],
 )
 def test_fragment_paths(html: str, context: str, needle: str) -> None:


### PR DESCRIPTION
`parse_fragment(context="html")` dropped the implicit `head` and `body` that a conformant parser always produces. An empty fragment came back empty, `"<title>t</title>"` produced a `head` with no `body`, and a comment-only fragment kept neither — diverging from the WHATWG tree-construction algorithm and the html5lib reference. 🌳

An html-context fragment starts in the "before head" insertion mode, so on end of input the missing-element rules walk before-head → in-head → after-head → in-body and materialize both a `head` and a `body` whether or not any token forced them. A document already does this in `finalize_document`; this extracts that step into a shared `ensure_head_body` and runs it on the fragment root when the context is `html`, keeping the frameset guard so a `<frameset>` still takes the body's place. Only the html context starts in before-head, so every other fragment context is untouched.

So `""` now yields an empty `head` and `body`, `"<title>t</title>"` yields a populated `head` and an empty `body`, and a leading comment is preserved before the synthesized pair.

Fixes #42