### PR TITLE
🐛 fix(treebuilder): restore table mode after fostered rawtext

### DIFF
--- a/docs/changelog/44.bugfix.rst
+++ b/docs/changelog/44.bugfix.rst
@@ -1,0 +1,5 @@
+Return to the "in table" insertion mode after a RCDATA/RAWTEXT element (``textarea``, ``title``, ``xmp``) is
+foster-parented out of a ``<table>``. The element was processed under the in-body rules, which saved "in body" as the
+original insertion mode, so closing it dropped the following ``<tr>``/``<td>`` and pushed trailing text straight into
+the table. The saved mode now follows the active table mode, so ``parse("<table><textarea></textarea><tr><td>x")``
+builds the expected ``table > tbody > tr > td`` structure, matching html5lib.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2944,7 +2944,10 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                         tree->drop_newline = 1; /* a leading LF in a textarea is ignored */
                     }
                     th_tok_switch(sm, (enum th_initial_state)model);
-                    original_mode = M_IN_BODY;
+                    /* when fostered out of a table the in-body rules run but the real insertion
+                       mode is still the table mode, so the text mode must return there, not to
+                       in body, or the table's later rows would be dropped */
+                    original_mode = foster_pending ? foster_return : M_IN_BODY;
                     mode = M_TEXT;
                     break;
                 }

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -322,6 +322,17 @@ def test_document_paths(html: str, needle: str) -> None:
     assert needle in _doc(html)
 
 
+@pytest.mark.parametrize("element", ["textarea", "title", "xmp"])
+def test_rawtext_in_table_restores_table_mode(element: str) -> None:
+    # a fostered RCDATA/RAWTEXT element's end tag must return to "in table", not "in body",
+    # or the following rows are dropped and trailing text lands directly in the table
+    doc = _doc(f"<table><{element}></{element}><tr><td>x")
+    assert doc == (
+        f"| <html>\n|   <head>\n|   <body>\n|     <{element}>\n|     <table>\n"
+        '|       <tbody>\n|         <tr>\n|           <td>\n|             "x"'
+    )
+
+
 @pytest.mark.parametrize(
     "html",
     [


### PR DESCRIPTION
A RCDATA/RAWTEXT element (`textarea`, `title`, `xmp`) inside a `<table>` is foster-parented and, per the spec, processed using the in-body rules. turbohtml modeled that by switching to the in-body insertion mode before reprocessing, so when in-body opened the text mode it saved **in body** as the original insertion mode. Closing the element then restored in body instead of the table mode, and the following `<tr>`/`<td>` were silently dropped while trailing text landed directly in `<table>`, corrupting all later table structure. 🧩

Fostering applies the in-body *rules* without actually changing the insertion mode, so the text mode must return to the table. When the element is fostered (`foster_pending` is set), the saved original insertion mode now follows the active table mode (`foster_return`) rather than a hardcoded in body. `style`/`script` are unaffected — they take the explicit in-table path and never foster.

`parse("<table><textarea></textarea><tr><td>x")` now builds `table > tbody > tr > td > "x"`, matching html5lib, lexbor, and selectolax; the same holds for `title` and `xmp`. Closes #44.