### PR TITLE
🐛 fix(parse): keep head mode on redundant html/duplicate head

### DIFF
--- a/docs/changelog/46.bugfix.rst
+++ b/docs/changelog/46.bugfix.rst
@@ -1,0 +1,5 @@
+Keep head-only elements in ``<head>`` after a redundant ``<html>`` or duplicate ``<head>`` start tag. Such a tag in the
+"before head"/"in head" insertion modes prematurely left head mode, so a following ``style``, ``meta``, ``link``,
+``base``, or ``title`` was inserted into ``<body>``. Per the WHATWG tree-construction algorithm a redundant ``<html>``
+start tag merges its attributes onto the open ``<html>`` without changing the mode, and a duplicate ``<head>`` start tag
+is an ignored parse error; both now leave subsequent head content in ``<head>``.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2259,6 +2259,15 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 }
                 tree->text_offset += ws; /* the whitespace prefix is dropped, not moved */
             }
+            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
+                /* a redundant html start tag is processed via the in-body rules
+                   (merge attributes onto the open html), leaving the mode intact */
+                if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
+                    stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+                    merge_attrs(tree, tree->open[0], tok);
+                }
+                break;
+            }
             if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HEAD) {
                 th_node *head = insert_element(tree, tok);
                 if (head != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
@@ -2306,6 +2315,18 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
             if (tok->kind == TH_START_TAG) {
                 uint8_t flags = tok->tag_flags;
                 uint16_t atom = tok->atom;
+                if (atom == TH_TAG_HTML) {
+                    /* a redundant html start tag merges attributes via the in-body
+                       rules; the head insertion mode is left untouched */
+                    if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
+                        stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+                        merge_attrs(tree, tree->open[0], tok);
+                    }
+                    break;
+                }
+                if (atom == TH_TAG_HEAD) {
+                    break; /* a duplicate head start tag is a parse error, ignored */
+                }
                 /* only the head's own raw-text/RCDATA elements switch to text
                    mode here; textarea/xmp/iframe/etc belong in the body */
                 if (atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT || atom == TH_TAG_NOFRAMES) {

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -319,6 +319,14 @@ _LONG_NAME = "z" * 130
         pytest.param("<svg><desc><svg></br>y", "desc", id="end-br-breakout-stops-at-html-integration"),
         pytest.param("<p " + _LONG_NAME + "=1 m=2>x", "z" * 40, id="attr-name-fills-sort-buffer"),
         pytest.param("<svg " + _LONG_NAME + "=1 m=2>y</svg>", "z" * 40, id="foreign-attr-name-fills-sort-buffer"),
+        # a redundant <html> start tag before/in head keeps the head insertion
+        # mode, so following head-only content stays in <head> (issue #46)
+        pytest.param("<html><html><style>x", "<head>\n|     <style>", id="redundant-html-in-head-keeps-style"),
+        pytest.param("<html><html><meta>", "<head>\n|     <meta>", id="redundant-html-before-head-keeps-meta"),
+        pytest.param("<html a><html b>", '|   a=""\n|   b=""', id="redundant-html-merges-attributes"),
+        # a duplicate <head> start tag is an ignored parse error, not a mode change
+        pytest.param("<head><head><meta>", "<head>\n|     <meta>", id="duplicate-head-keeps-meta"),
+        pytest.param("<head><head><title>t", "<head>\n|     <title>", id="duplicate-head-keeps-title"),
     ],
 )
 def test_document_paths(html: str, needle: str) -> None:


### PR DESCRIPTION
A redundant ``<html>`` start tag in the "before head"/"in head" insertion modes, or a duplicate ``<head>`` in "in head", prematurely left head mode: turbohtml fell through to the anything-else path that pops ``<head>`` and advances to "after head". A following head-only element — ``style``, ``meta``, ``link``, ``base``, ``title`` — then landed in ``<body>`` instead of ``<head>``. 🧩 So ``<html><html><style>x`` put the style in the body, diverging from html5lib, lexbor, and the spec.

The WHATWG tree-construction algorithm handles a redundant ``<html>`` start tag with the in-body rules — merge its attributes onto the already-open ``<html>`` and leave the insertion mode untouched — and treats a duplicate ``<head>`` start tag as a parse error that is ignored. Both branches now do exactly that, mirroring the existing "after head" redundant-``<html>`` handling, so subsequent head content stays in ``<head>`` and stray ``<html>`` attributes still merge.

Fixes #46