### PR TITLE
🐛 fix(treebuilder): honor foreign scope in adoption agency

### DIFF
--- a/docs/changelog/47.bugfix.rst
+++ b/docs/changelog/47.bugfix.rst
@@ -1,0 +1,5 @@
+Treat the MathML and SVG integration points (``mi``, ``mo``, ``mn``, ``ms``, ``mtext``, ``foreignObject``, ``desc``,
+``title``) as scope boundaries in the adoption agency's in-scope check. A formatting end tag separated from the current
+node by one of these foreign elements wrongly ran the adoption agency, splitting the foreign subtree out to ``<body>``;
+``parse("<b><math><mi></b>")`` now keeps ``mi`` nested as ``<b><math><mi></mi></math></b>`` and ignores the unmatched
+``</b>``, matching html5lib and lexbor.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -1600,7 +1600,9 @@ static int adoption_agency(th_tree *tree, uint16_t atom) {
             afe_remove_at(tree, fi);
             return 1;
         }
-        /* in scope? */
+        /* in scope? The scope set includes the MathML/SVG integration points, so a
+           foreign scope boundary between the current node and fmt keeps fmt out of
+           scope and the end tag is ignored rather than running adoption. */
         int in_scope = 0;
         /* The html element bounds the stack walk. */
         for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
@@ -1608,7 +1610,7 @@ static int adoption_agency(th_tree *tree, uint16_t atom) {
                 in_scope = 1;
                 break;
             }
-            if (tree->open[index]->tag_flags & TH_TAG_SCOPING) {
+            if (is_scope_boundary(tree->open[index])) {
                 break;
             }
         }

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -325,6 +325,27 @@ def test_document_paths(html: str, needle: str) -> None:
     assert needle in _doc(html)
 
 
+@pytest.mark.parametrize(
+    ("html", "inner"),
+    [
+        pytest.param("<b><math><mi></b>", "<b><math><mi></mi></math></b>", id="mathml-mi"),
+        pytest.param("<i><math><mo></i>", "<i><math><mo></mo></math></i>", id="mathml-mo"),
+        pytest.param(
+            "<b><svg><foreignObject><p></b>",
+            "<b><svg><foreignObject><p></p></foreignObject></svg></b>",
+            id="svg-foreignobject",
+        ),
+        pytest.param("<b><svg><desc></b>", "<b><svg><desc></desc></svg></b>", id="svg-desc"),
+    ],
+)
+def test_formatting_end_tag_ignored_across_foreign_scope_boundary(html: str, inner: str) -> None:
+    # a MathML/SVG integration point is a scope boundary, so the formatting element is not in
+    # scope and the end tag is ignored instead of running adoption and splitting the subtree
+    body = parse(html).find("body")
+    assert body is not None
+    assert body.inner_html == inner
+
+
 @pytest.mark.parametrize("element", ["textarea", "title", "xmp"])
 def test_rawtext_in_table_restores_table_mode(element: str) -> None:
     # a fostered RCDATA/RAWTEXT element's end tag must return to "in table", not "in body",


### PR DESCRIPTION
A formatting end tag whose formatting element is separated from the current node by a MathML or SVG integration point (`mi`, `mo`, `mn`, `ms`, `mtext`, `foreignObject`, `desc`, `title`) wrongly ran the adoption agency. The spec's "have a particular element in scope" set includes these foreign elements, so the formatting element is *not* in scope and the end tag must be ignored — but the adoption agency's inline in-scope walk broke only on the HTML `TH_TAG_SCOPING` flag, missing the foreign boundaries. The result split the foreign subtree off and reparented it to `<body>`. 🌿

The fix reuses `is_scope_boundary`, which already encodes the foreign integration points (and is what `has_in_scope` uses), so the walk stops at the foreign boundary and the formatting element is correctly out of scope.

`parse("<b><math><mi></b>")` now produces `<b><math><mi></mi></math></b>` (the `</b>` is ignored), matching html5lib and lexbor; the same holds for `<i><math><mo></i>`, `<b><svg><foreignObject><p></b>`, and `<b><svg><desc></b>`. Closes #47.