### PR TITLE
🐛 fix(treebuilder): case-adjust SVG attribute names

### DIFF
--- a/docs/changelog/43.bugfix.rst
+++ b/docs/changelog/43.bugfix.rst
@@ -1,0 +1,6 @@
+Apply the WHATWG "adjust SVG attributes" step so SVG attribute names such as ``viewbox``, ``attributename``,
+``basefrequency``, ``gradienttransform``, and ``textlength`` are cased back to ``viewBox``, ``attributeName``,
+``baseFrequency``, ``gradientTransform``, and ``textLength`` in the parsed tree and every serialization, not only the
+``#document`` debug format. ``Element.attrs`` and ``inner_html`` now report the cased names, matching html5lib, and
+attribute lookups on foreign (SVG/MathML) elements stay case-insensitive, so ``svg.attrs["viewBox"]`` and
+``svg.attrs["viewbox"]`` both resolve.

--- a/src/turbohtml/treebuilder_foreign.h
+++ b/src/turbohtml/treebuilder_foreign.h
@@ -265,17 +265,17 @@ static th_node *insert_foreign(th_tree *tree, const th_token *token, uint8_t ns)
                   (ns == TH_NS_SVG &&
                    (node->atom == TH_TAG_FOREIGNOBJECT || node->atom == TH_TAG_DESC || node->atom == TH_TAG_TITLE));
     node->tag_flags = special ? TH_TAG_SPECIAL : 0;
-    /* "adjust MathML attributes": definitionurl -> definitionURL. Done here, at
-       construction, so the cased name lands in the tree (node.attrs) and every
-       serializer emits it, not only the #document debug format. */
-    if (ns == TH_NS_MATHML) {
-        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-            Py_ssize_t name_len;
-            const char *name = th_attr_name(tree, node->attrs[index].name_atom, &name_len);
-            const char *mixed = foreign_adjust_attr(name, name_len, ns);
-            if (mixed != NULL) {
-                node->attrs[index].name_atom = intern_attr_dynamic(tree, mixed, (Py_ssize_t)strlen(mixed));
-            }
+    /* "adjust MathML/SVG attributes": map a lowercased foreign attribute name back to
+       its mixed case (definitionURL, viewBox, attributeName, ...). foreign_adjust_attr
+       dispatches on the namespace. Done here, at construction, so the cased name lands
+       in the tree (node.attrs) and every serializer emits it, not only the #document
+       debug format. */
+    for (Py_ssize_t index = 0; index < node->attr_count; index++) {
+        Py_ssize_t name_len;
+        const char *name = th_attr_name(tree, node->attrs[index].name_atom, &name_len);
+        const char *mixed = foreign_adjust_attr(name, name_len, ns);
+        if (mixed != NULL) {
+            node->attrs[index].name_atom = intern_attr_dynamic(tree, mixed, (Py_ssize_t)strlen(mixed));
         }
     }
     if (ns == TH_NS_SVG && node->text != NULL) { /* GCOVR_EXCL_BR_LINE: an SVG element always has a tag name */

--- a/src/turbohtml/treebuilder_serialize.h
+++ b/src/turbohtml/treebuilder_serialize.h
@@ -106,22 +106,15 @@ static void sbuf_put_utf8(sbuf *out, const char *bytes, Py_ssize_t len) {
     }
 }
 
-/* Write an attribute's displayed name (the form the #document line uses) into
-   buf: namespaced foreign attributes show "prefix localname", SVG attributes
-   take their mixed-case spelling, everything else is the lowercased name. */
+/* Write an attribute's displayed name (the form the #document line uses) into buf:
+   namespaced foreign attributes show "prefix localname", everything else is the
+   stored name (foreign attribute case adjustments are applied at construction). */
 static void render_attr_name(th_tree *tree, const th_node *node, const th_node_attr *attr, char *buf, size_t bufsize) {
     Py_ssize_t name_len;
     const char *name = th_attr_name(tree, attr->name_atom, &name_len);
-    const char *mixed = node->ns != TH_NS_HTML ? foreign_adjust_attr(name, name_len, node->ns) : NULL;
-    const char *src = name;
-    int to_space = 0;
-    if (node->ns != TH_NS_HTML && foreign_attr_namespaced(name, name_len)) {
-        to_space = 1;
-    } else if (mixed != NULL) {
-        src = mixed;
-    }
+    int to_space = node->ns != TH_NS_HTML && foreign_attr_namespaced(name, name_len);
     size_t write_index = 0;
-    for (const char *character = src; *character != '\0' && write_index + 1 < bufsize; character++) {
+    for (const char *character = name; *character != '\0' && write_index + 1 < bufsize; character++) {
         buf[write_index++] = (to_space && *character == ':') ? ' ' : *character;
     }
     buf[write_index] = '\0';
@@ -220,17 +213,14 @@ static void serialize_node_line(sbuf *out, th_tree *tree, th_node *node, int dep
         for (int level = 0; level <= depth; level++) {
             sbuf_puts(out, "  ");
         }
-        /* foreign attribute name adjustments: xlink:/xml:/xmlns: serialize with a
-           space, and SVG/MathML attributes take their mixed-case spelling */
+        /* xlink:/xml:/xmlns: serialize with a space; the mixed-case spelling of an
+           SVG/MathML attribute is already stored, applied at construction */
         Py_ssize_t name_len;
         const char *name = th_attr_name(tree, attr->name_atom, &name_len);
-        const char *mixed = node->ns != TH_NS_HTML ? foreign_adjust_attr(name, name_len, node->ns) : NULL;
         if (node->ns != TH_NS_HTML && foreign_attr_namespaced(name, name_len)) {
             for (const char *character = name; *character; character++) {
                 sbuf_putc(out, *character == ':' ? (Py_UCS4)' ' : (Py_UCS4)*character);
             }
-        } else if (mixed != NULL) {
-            sbuf_puts(out, mixed);
         } else {
             sbuf_put_utf8(out, name, name_len);
         }

--- a/tests/test_tree_attrs.py
+++ b/tests/test_tree_attrs.py
@@ -185,3 +185,24 @@ def test_mathml_definitionurl_can_be_set_and_deleted_by_either_case(find: Callab
 def test_svg_definitionurl_attribute_stays_lowercase(find: Callable[[str, str], Element]) -> None:
     # definitionurl is only in the MathML adjust table, so on an SVG element it stays as written
     assert dict(find("<svg definitionURL='x'></svg>", "svg").attrs) == {"definitionurl": "x"}
+
+
+def test_svg_attributes_are_cased(find: Callable[[str, str], Element]) -> None:
+    # WHATWG "adjust SVG attributes": viewbox -> viewBox etc., applied at construction so the
+    # cased name lands in the tree and serialization, not only the #document debug format
+    svg = find("<svg viewBox='0' attributeName='y'></svg>", "svg")
+    assert dict(svg.attrs) == {"viewBox": "0", "attributeName": "y"}
+    assert svg.html == '<svg viewBox="0" attributeName="y"></svg>'
+    assert svg.attrs["viewBox"] == "0"  # exact match
+    assert svg.attrs.get("viewbox") == "0"  # foreign lookup stays case-insensitive
+    assert "nope" not in svg.attrs  # length mismatch in the foreign scan
+    assert "abcdefg" not in svg.attrs  # same length as viewBox, different name
+    assert "class" not in svg.attrs  # interned atom, absent, falls through the foreign scan
+
+
+def test_svg_attribute_can_be_set_and_deleted_by_either_case(find: Callable[[str, str], Element]) -> None:
+    svg = find("<svg viewBox='0'></svg>", "svg")
+    svg.attrs["viewbox"] = "9"  # updates the existing cased slot, no duplicate
+    assert svg.html == '<svg viewBox="9"></svg>'
+    del svg.attrs["viewbox"]
+    assert svg.html == "<svg></svg>"


### PR DESCRIPTION
SVG attribute names came back lowercased from `Element.attrs` and the public serialization: `<svg viewBox="0">` parsed to `{"viewbox": "0"}` and serialized as `viewbox`, even though the WHATWG "adjust SVG attributes" step restores the mixed case (`viewBox`, `attributeName`, `baseFrequency`, `gradientTransform`, `textLength`, and the rest). 🎨 The case table was only consulted by the `#document` debug serializer, so the parsed tree itself never carried the cased name.

This applies the adjustment where the spec puts it — at element construction — so the cased name is stored once and every reader (the live `attrs` mapping, `inner_html`, and the debug format) reports it. Storing the cased name means its interned atom no longer equals the lowercased lookup probe, so attribute access on a foreign element falls back to a case-insensitive scan, shared as `th_node_attr_find` across the find, set, and delete paths so `svg.attrs["viewBox"]`, `svg.attrs["viewbox"]`, assignment, and deletion all agree.

That case-insensitive foreign-attribute lookup is the same machinery the MathML `definitionURL` fix (#41, #107) needs; the shared helper is intended to be deduplicated when both land. Names outside the SVG table (for example `definitionurl` on an SVG element) stay as written.

Fixes #43