### PR TITLE
🐛 fix(tokenizer): reclaim consumed input in streaming feed()

### DIFF
--- a/docs/changelog/80.bugfix.rst
+++ b/docs/changelog/80.bugfix.rst
@@ -1,0 +1,3 @@
+Reclaim the consumed prefix of a streaming :class:`~turbohtml.Tokenizer`'s input buffer on each ``feed()``, so feeding a
+long document in chunks stays memory-bounded instead of growing the buffer without limit for the lifetime of the
+tokenizer.

--- a/src/turbohtml/tokenizer_sm.c
+++ b/src/turbohtml/tokenizer_sm.c
@@ -384,7 +384,32 @@ static void input_append(th_tokenizer *self, int kind, const void *data, Py_ssiz
    preprocessing so downstream states and emitted text never see '\r'. Runs
    between carriage returns move as one block; only the '\r' handling itself
    is per character. */
+/* Reclaim the consumed prefix of the input buffer so a long-lived streaming
+   tokenizer does not grow without bound. The only live offsets into the buffer
+   are `pos` and, while a text run is open, `slice_start`; an emitted record still
+   spanning the buffer (queue_len != 0) pins it, so skip until it has drained. */
+static void compact_input(th_tokenizer *self) {
+    if (self->queue_len != 0) {
+        return;
+    }
+    Py_ssize_t keep_from = self->slice_len > 0 ? self->slice_start : self->pos;
+    if (keep_from <= 0) {
+        return;
+    }
+    th_buf *buf = &self->input;
+    Py_ssize_t remaining = buf->len - keep_from;
+    if (remaining > 0) {
+        memmove(buf->data, (char *)buf->data + keep_from * buf->kind, (size_t)(remaining * buf->kind));
+    }
+    buf->len = remaining;
+    self->pos -= keep_from;
+    self->slice_start = 0;
+}
+
 void th_tok_feed(th_tokenizer *self, int kind, const void *data, Py_ssize_t length) {
+    if (self->pos > 0) { /* nothing is consumed yet on a one-shot or first feed, so skip the call */
+        compact_input(self);
+    }
     Py_ssize_t start = 0;
     if (length > 0 && self->last_cr) {
         self->last_cr = 0;

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -10,6 +10,7 @@ strings), and source positions.
 from __future__ import annotations
 
 import gc
+import tracemalloc
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING
 
@@ -532,3 +533,29 @@ def test_tokenize_states_returns_characters(args: tuple[str, ...], expected: str
 
 def test_tag_names_are_lowercased() -> None:
     assert [next(iter(tokenize(document))).tag for document in ("<DIV>", "<SpAn>")] == ["div", "span"]
+
+
+def test_streaming_tokenizer_reclaims_consumed_input() -> None:
+    # feed() compacts the consumed prefix, so a long-lived streaming tokenizer stays memory
+    # bounded instead of growing its input buffer with every chunk (issue #80).
+    tokenizer = Tokenizer()
+    for _ in range(200):  # warm up so one-time allocations settle out of the measurement
+        list(tokenizer.feed("<p>hello world</p>"))
+    tracemalloc.start()
+    for _ in range(10_000):
+        list(tokenizer.feed("<p>hello world</p>"))
+    peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+    # without compaction the buffer grows to well over 100 KB across this run; with it, it stays tiny
+    assert peak < 100_000, f"streaming feed leaked the input buffer: {peak} bytes"
+
+
+def test_feed_keeps_input_while_a_token_is_queued() -> None:
+    # a completed token not yet pulled from the iterator still spans the input buffer, so the
+    # next feed must skip compaction; the full stream stays correct either way.
+    tokenizer = Tokenizer()
+    stream = tokenizer.feed("x<a>")
+    first = next(stream)  # drives the state machine, leaving a record queued behind the one returned
+    tokenizer.feed("z")
+    tokens = [first, *tokenizer, *tokenizer.close()]
+    assert [_shape(token) for token in tokens] == [_shape(token) for token in tokenize("x<a>z")]


### PR DESCRIPTION
A long-lived `Tokenizer` fed in chunks never released the bytes it had already tokenized (closes #80). Each `feed()` appended to one input buffer that only `reset()` or teardown freed, so streaming a large document leaked memory in proportion to its total length — feeding a 12-byte chunk 200k times grew the buffer past 4 MB.

The buffer is now compacted at the start of every `feed()`: the consumed prefix is dropped and the remainder shifts down. 🧹 Only `pos` and, while a text run is open, `slice_start` point into the buffer, and an emitted record still spanning it pins the buffer until the iterator drains, so those offsets adjust safely and a streaming tokenizer stays memory-bounded no matter how much it consumes.

One-shot `tokenize()` is unaffected — its single feed has nothing consumed yet, so compaction returns immediately. Draft until the tokenize benchmark confirms no throughput regression from the per-feed compaction.