### PR TITLE
🐛 fix(tokenizer): report nameless DOCTYPE name as None

### DIFF
--- a/docs/changelog/48.bugfix.rst
+++ b/docs/changelog/48.bugfix.rst
@@ -1,0 +1,3 @@
+Report a nameless ``<!DOCTYPE>``'s name as ``None`` from the public ``Token.name`` instead of an empty string. The
+WHATWG tokenizer treats a DOCTYPE name as "missing", a state distinct from the empty string, so a DOCTYPE that never
+enters the name state now surfaces ``None``, matching the internal tuple path and the html5lib-tests oracle.

--- a/src/turbohtml/token_type.c
+++ b/src/turbohtml/token_type.c
@@ -220,7 +220,11 @@ static PyObject *token_get_self_closing(PyObject *self, void *Py_UNUSED(closure)
 
 static PyObject *token_get_name(PyObject *self, void *Py_UNUSED(closure)) {
     const th_token *record = &((TokenObject *)self)->record;
-    if (record->kind == TH_DOCTYPE) {
+    /* A DOCTYPE name is "missing" (distinct from the empty string) until the name
+       state appends a character, so it is either absent or at least one byte; an
+       empty buffer is the missing sentinel and surfaces as None, matching the
+       tuple builder and the html5lib-tests oracle. */
+    if (record->kind == TH_DOCTYPE && record->name.len > 0) {
         return buf_to_str(&record->name);
     }
     Py_RETURN_NONE;

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -62,7 +62,9 @@ def test_comment_token() -> None:
         pytest.param(
             "<!DOCTYPE HTML PUBLIC \"pub\" 'sys'>", (TokenType.DOCTYPE, "html", "pub", "sys", False), id="full"
         ),
-        pytest.param("<!DOCTYPE>", (TokenType.DOCTYPE, "", None, None, True), id="bare"),
+        # a nameless DOCTYPE name is "missing", a distinct state from the empty string, so it is None
+        pytest.param("<!DOCTYPE>", (TokenType.DOCTYPE, None, None, None, True), id="bare"),
+        pytest.param("<!DOCTYPE >", (TokenType.DOCTYPE, None, None, None, True), id="bare-trailing-space"),
         # a non-doctype token still exposes the doctype fields, all empty
         pytest.param("<p>", (TokenType.START_TAG, None, None, None, False), id="non-doctype"),
     ],


### PR DESCRIPTION
The public `tokenize()` API surfaced a nameless `<!DOCTYPE>` with `name == ''`, conflating the WHATWG "missing" sentinel with an actual empty string. The spec is explicit that a DOCTYPE token's name is "missing (which is a distinct state from the empty string)", and the html5lib-tests oracle (`test2.test`) encodes it as `null` — as does turbohtml's own internal `_tokenize_states` tuple path.

A DOCTYPE name is missing until the name state appends its first character, so the name buffer is empty only when the name is absent. The `Token.name` getter now returns `None` for an empty DOCTYPE name buffer, mirroring the tuple builder's existing `name.len ? str : None` guard. `force_quirks` was already correct.

`list(tokenize("<!DOCTYPE>"))[0].name` is now `None`. `parse()` was unaffected (it already produced a correct DOM name). Closes #48.