### PR TITLE
🐛 fix(tokenize): report missing DOCTYPE name as None

### DIFF
--- a/docs/changelog/48.bugfix.rst
+++ b/docs/changelog/48.bugfix.rst
@@ -1,0 +1,4 @@
+Report a nameless ``<!DOCTYPE>`` token's :attr:`~turbohtml.Token.name` as ``None`` rather than ``""``. The WHATWG
+tokenizer keeps a DOCTYPE name's "missing" state distinct from the empty string, and a DOCTYPE name is never
+present-but-empty, so the public getter now surfaces the missing name as ``None`` — matching the html5lib-tests oracle
+and turbohtml's own tuple-state path.

--- a/src/turbohtml/token_type.c
+++ b/src/turbohtml/token_type.c
@@ -220,7 +220,9 @@ static PyObject *token_get_self_closing(PyObject *self, void *Py_UNUSED(closure)
 
 static PyObject *token_get_name(PyObject *self, void *Py_UNUSED(closure)) {
     const th_token *record = &((TokenObject *)self)->record;
-    if (record->kind == TH_DOCTYPE) {
+    /* a DOCTYPE name is missing or non-empty, never present-but-empty, so an
+       empty buffer is the WHATWG "missing" sentinel and surfaces as None */
+    if (record->kind == TH_DOCTYPE && record->name.len) {
         return buf_to_str(&record->name);
     }
     Py_RETURN_NONE;

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -62,7 +62,8 @@ def test_comment_token() -> None:
         pytest.param(
             "<!DOCTYPE HTML PUBLIC \"pub\" 'sys'>", (TokenType.DOCTYPE, "html", "pub", "sys", False), id="full"
         ),
-        pytest.param("<!DOCTYPE>", (TokenType.DOCTYPE, "", None, None, True), id="bare"),
+        # a nameless DOCTYPE reports a missing (None) name, distinct from an empty string
+        pytest.param("<!DOCTYPE>", (TokenType.DOCTYPE, None, None, None, True), id="bare"),
         # a non-doctype token still exposes the doctype fields, all empty
         pytest.param("<p>", (TokenType.START_TAG, None, None, None, False), id="non-doctype"),
     ],


### PR DESCRIPTION
The public ``Token.name`` surfaced a nameless ``<!DOCTYPE>`` with an empty string, conflating the WHATWG "missing" sentinel with an actual empty name. The spec keeps a DOCTYPE name's missing state distinct from the empty string, and the html5lib-tests oracle encodes the nameless name as ``null`` — as does turbohtml's own ``_tokenize_states`` tuple path, so the public getter was internally inconsistent with it. 🧩

A DOCTYPE name is only ever missing or non-empty — the tokenizer creates it on the first name character, so it is never present-but-empty (unlike ``public_id``/``system_id``, which can be empty strings and therefore carry explicit ``has_*`` flags). The getter now treats an empty name buffer as the missing sentinel and returns ``None``, mirroring the tuple builder's existing ``name.len`` guard. ``parse()`` is unaffected; only the ``Token.name`` attribute changes.

Fixes #48