### PR TITLE
🐛 fix(tree): guard descendants walk against a detached cursor

### DIFF
--- a/docs/changelog/81.bugfix.rst
+++ b/docs/changelog/81.bugfix.rst
@@ -1,0 +1,3 @@
+Stop a crash when a node the :attr:`~turbohtml.Node.descendants` (or ``strings``) iterator has cached as its next
+position is detached with :meth:`~turbohtml.Node.extract` mid-iteration. The walk now ends safely once the cursor's
+ancestry no longer reaches the root instead of dereferencing a ``NULL`` parent pointer.

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -179,7 +179,9 @@ static th_node *preorder_next(th_node *current, th_node *root) {
     if (current->first_child != NULL) {
         return current->first_child;
     }
-    while (current != root) {
+    /* current can be NULL here if the cursor node was detached (extract()) mid-walk:
+       its parent chain no longer reaches root, so end the walk instead of dereferencing. */
+    while (current != NULL && current != root) {
         if (current->next_sibling != NULL) {
             return current->next_sibling;
         }

--- a/tests/test_tree_navigation.py
+++ b/tests/test_tree_navigation.py
@@ -63,6 +63,22 @@ def test_descendants_is_lazy_iterator(body: Element) -> None:
     assert isinstance(next(walker), Element)
 
 
+def test_descendants_survives_extracting_the_cached_next_node() -> None:
+    # extracting the node the cursor has cached as "next" must not crash the walk (issue #81):
+    # its parent chain no longer reaches the root, so the iteration ends instead of dereferencing NULL.
+    div = parse("<div><a></a><b></b></div>").find("div")
+    assert div is not None
+    walker = iter(div.descendants)
+    first = next(walker)  # yields <a>; the cursor now caches <b> as the next node
+    assert isinstance(first, Element)
+    assert first.tag == "a"
+    cached_next = div.find("b")
+    assert cached_next is not None
+    cached_next.extract()
+    tags = [node.tag for node in walker if isinstance(node, Element)]  # completes without segfaulting
+    assert tags in ([], ["b"])  # ends at once, or yields the now-detached <b> once and then stops
+
+
 def test_ancestors_reach_the_document(body: Element) -> None:
     bold = body.find("b")
     assert bold is not None


### PR DESCRIPTION
Advancing a `descendants` (or `strings`) iterator after `extract()` detached the node it had cached as its next position crashed the interpreter (closes #81). The detached node's parent chain no longer reaches the iteration root, so `preorder_next` walked up past a `NULL` parent and dereferenced it — a segfault reachable from ordinary mutate-during-iteration code.

The upward walk now stops once the parent becomes `NULL`, the same guard `subtree_next` already uses, so the iteration ends safely (yielding the now-detached node at most once) instead of running off the end. 🛡️

Draft until the descendant-traversal benchmark confirms the added NULL check costs nothing on the hot path.