### PR TITLE
🐛 fix(treebuilder): ignore stray DOCTYPE after initial mode

### DIFF
--- a/docs/changelog/49.bugfix.rst
+++ b/docs/changelog/49.bugfix.rst
@@ -1,0 +1,5 @@
+Ignore a stray ``<!DOCTYPE>`` encountered after the "initial" insertion mode without changing the insertion mode, per
+the WHATWG tree-construction rules. A second DOCTYPE previously drove the parser into the "in body" mode, fabricating a
+``<p>``, leaking leading whitespace into ``<body>``, and misplacing a leading comment inside ``<body>``;
+``parse("<!doctype html><!doctype><!--c-->")`` now keeps the comment before ``<html>`` with an empty body, matching
+html5lib.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2177,6 +2177,12 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
             mode = M_IN_TEMPLATE;
             continue;
         }
+        /* a DOCTYPE in any insertion mode other than "initial" is a parse error that is
+           ignored without changing the insertion mode (foreign content already handled
+           its own DOCTYPE above); only the initial mode builds the doctype node */
+        if (tok->kind == TH_DOCTYPE && mode != M_INITIAL) {
+            continue;
+        }
         /* every insertion mode has an explicit case, so the compiler default arm is unreachable */
         switch (mode) /* GCOVR_EXCL_BR_LINE */ {
         case M_INITIAL:
@@ -2370,7 +2376,8 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 mode = M_AFTER_HEAD;
                 goto reprocess;
             }
-            if (tok->kind == TH_END_TAG) {
+            /* only an end tag reaches here: text/comment/start break above, a DOCTYPE is ignored before the switch */
+            if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
                 uint16_t end_atom = tok_atom(tok);
                 if (end_atom == TH_TAG_HEAD) {
                     stack_pop(tree);
@@ -2386,9 +2393,6 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
             goto reprocess;
 
         case M_IN_HEAD_NOSCRIPT:
-            if (tok->kind == TH_DOCTYPE) {
-                break; /* parse error, ignored */
-            }
             if (tok->kind == TH_END_TAG) {
                 uint16_t end_atom = tok_atom(tok);
                 if (end_atom == TH_TAG_NOSCRIPT) {
@@ -2633,7 +2637,8 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 }
                 break;
             }
-            if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_FRAMESET) {
+            /* a DOCTYPE is ignored before the switch, so the kind!=end-tag branch here is dead */
+            if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_FRAMESET) { /* GCOVR_EXCL_BR_LINE */
                 if (current_node(tree)->atom != TH_TAG_HTML) {
                     stack_pop(tree);
                 }
@@ -3075,7 +3080,8 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 }
                 break;
             }
-            if (tok->kind == TH_END_TAG) {
+            /* only an end tag reaches here: text/comment/start break above, a DOCTYPE is ignored before the switch */
+            if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
                 uint8_t flags = tok->tag_flags;
                 uint16_t atom = tok->atom;
                 if (atom == TH_TAG_BODY || atom == TH_TAG_HTML) {
@@ -3190,7 +3196,8 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 any_other_end_tag(tree, atom, tok);
                 break;
             }
-            break;
+            break; /* GCOVR_EXCL_LINE: in body handles every text/comment/start/end token in a branch
+                      that breaks, and a DOCTYPE is ignored before the switch, so nothing reaches here */
 
         case M_TEXT:
             if (tok->kind == TH_TEXT) {
@@ -3340,7 +3347,8 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 mode = M_IN_BODY;
                 goto reprocess;
             }
-            if (tok->kind == TH_END_TAG) {
+            /* only an end tag reaches here: text/comment/start break or foster above, a DOCTYPE is ignored before it */
+            if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
                 uint16_t atom = tok_atom(tok);
                 if (atom == TH_TAG_TABLE) {
                     if (has_in_table_scope(tree, TH_TAG_TABLE)) {
@@ -3363,7 +3371,8 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 mode = M_IN_BODY;
                 goto reprocess;
             }
-            break;
+            break; /* GCOVR_EXCL_LINE: in table handles every text/comment/start/end token in a branch
+                      that breaks, and a DOCTYPE is ignored before the switch, so nothing reaches here */
 
         case M_IN_CAPTION: {
             uint16_t atom = tok_atom(tok);

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -354,6 +354,32 @@ def test_formatting_end_tag_ignored_across_foreign_scope_boundary(html: str, inn
     assert body.inner_html == inner
 
 
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param(
+            "<!doctype html><!doctype></p>",
+            "<!DOCTYPE html><html><head></head><body></body></html>",
+            id="stray-end-tag-after",
+        ),
+        pytest.param(
+            "<!doctype html><!doctype> x",
+            "<!DOCTYPE html><html><head></head><body>x</body></html>",
+            id="leading-space-not-leaked",
+        ),
+        pytest.param(
+            "<!doctype html><!doctype><!--c-->",
+            "<!DOCTYPE html><!--c--><html><head></head><body></body></html>",
+            id="comment-stays-before-html",
+        ),
+    ],
+)
+def test_stray_doctype_after_initial_is_ignored(html: str, expected: str) -> None:
+    # a DOCTYPE in any insertion mode other than "initial" is a parse error, ignored without
+    # changing the insertion mode, so a second DOCTYPE must not advance the parser into "in body"
+    assert parse(html).html == expected
+
+
 @pytest.mark.parametrize("element", ["textarea", "title", "xmp"])
 def test_rawtext_in_table_restores_table_mode(element: str) -> None:
     # a fostered RCDATA/RAWTEXT element's end tag must return to "in table", not "in body",


### PR DESCRIPTION
A second or stray `<!DOCTYPE>` encountered after the document is past the "initial" insertion mode must be a parse error that is ignored **without changing the insertion mode** (WHATWG §13.2.6.4 — a DOCTYPE token is in the ignore branch of every mode except initial). turbohtml instead let the stray DOCTYPE fall through to the "anything else" branch of the linear document modes, driving the parser into "in body": it fabricated a `<p>`, leaked leading whitespace into `<body>`, and misplaced a leading comment inside `<body>`. 📄

The fix ignores a non-initial DOCTYPE before the insertion-mode `switch` (foreign content already handled its own DOCTYPE just above), so it never advances the mode. The redundant per-mode DOCTYPE handler in "in head noscript" is removed.

A note on coverage: the conformance suite exercised several modes' end-tag fall-through branches *only* via the old buggy DOCTYPE reprocess chain (a stray DOCTYPE walking before-html → before-head → in-head → …). With the chain removed those non-end-tag branches become genuinely unreachable, so they carry justified `GCOVR_EXCL_BR_LINE` markers; line and branch coverage stay at 100%.

`parse("<!doctype html><!doctype><!--c-->")` now keeps the comment before `<html>` with an empty body, and the `</p>` / leading-whitespace variants match html5lib. Closes #49.