### PR TITLE
🐛 fix(tree): pickle elements with parser-only tag names

### DIFF
--- a/docs/changelog/83.bugfix.rst
+++ b/docs/changelog/83.bugfix.rst
@@ -1,0 +1,4 @@
+Round-trip a parsed element through :mod:`python:pickle` and :func:`python:copy.deepcopy` even when its tag name holds a
+character the public :class:`~turbohtml.Element` constructor rejects, such as the ``<`` the tokenizer keeps in ``a<b``
+from ``<a<b>``. Reconstruction rebuilds the element through a trusted builder rather than the validating constructor, so
+a parsed tree always survives pickling.

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -2136,16 +2136,11 @@ static int fill_element_attrs(th_tree *tree, th_node *node, PyObject *attrs, PyO
    whose UTF-8 exceeds this is simply treated as an unknown atom. */
 #define ELEMENT_TAG_LOWER_STACK_BYTES 64
 
-static PyObject *element_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
-    static char *keywords[] = {"tag", "attrs", NULL};
-    PyObject *tag;
-    PyObject *attrs = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "U|O", keywords, &tag, &attrs)) {
-        return NULL;
-    }
-    if (validate_name(tag, 0) < 0) {
-        return NULL;
-    }
+/* Build an Element wrapper for tag with attrs, without the public constructor's
+   name validation. The parser and pickle reconstruction produce tag names (e.g.
+   "a<b" from malformed input) that Element() rejects but that must round-trip
+   unchanged, so the trusted callers reach the element through this helper. */
+static inline PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs) {
     Py_ssize_t tag_len = PyUnicode_GET_LENGTH(tag);
     PyObject *keys = NULL;
     Py_ssize_t attr_count = 0;
@@ -2201,6 +2196,19 @@ static PyObject *element_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     }
     Py_XDECREF(keys);
     return wrap_fresh_tree_node(state, tree, node);
+}
+
+static PyObject *element_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
+    static char *keywords[] = {"tag", "attrs", NULL};
+    PyObject *tag;
+    PyObject *attrs = NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "U|O", keywords, &tag, &attrs)) {
+        return NULL;
+    }
+    if (validate_name(tag, 0) < 0) {
+        return NULL;
+    }
+    return make_element(type, tag, attrs);
 }
 
 /* Prepare child_obj to become a child of dest_parent in anchor's tree and return
@@ -2921,9 +2929,19 @@ PyObject *turbohtml_reconstruct(PyObject *module, PyObject *args) {
     case TH_NODE_PI:
         node = PyObject_CallObject(state->pi_type, data);
         break;
-    case TH_NODE_ELEMENT:
-        node = PyObject_CallObject(state->element_type, data);
+    case TH_NODE_ELEMENT: {
+        /* the parser keeps characters Element() rejects (e.g. "a<b"), so reconstruct
+           through the trusted builder rather than the validating public constructor */
+        PyObject *tag;
+        PyObject *element_attrs;
+        /* GCOVR_EXCL_START: node_reduce builds this (tag, attrs) tuple, so the parse never fails */
+        if (!PyArg_ParseTuple(data, "UO", &tag, &element_attrs)) {
+            return NULL;
+        }
+        /* GCOVR_EXCL_STOP */
+        node = make_element((PyTypeObject *)state->element_type, tag, element_attrs);
         break;
+    }
     case TH_NODE_DOCTYPE:
         node = reconstruct_doctype(state, data);
         break;

--- a/tests/test_tree_pickle.py
+++ b/tests/test_tree_pickle.py
@@ -42,6 +42,17 @@ def test_element_with_attributes_and_children_round_trips() -> None:
     assert clone.html == '<div class="card lg" id="x" hidden=""><h2>Title</h2>tail</div>'
 
 
+def test_parser_produced_invalid_tag_name_round_trips() -> None:
+    # the tokenizer keeps a '<' in a tag name ("a<b" from "<a<b>"), a name Element() rejects; pickle
+    # reconstruction must rebuild it through the trusted builder, not the validating constructor (issue #83).
+    element = next(node for node in parse("<a<b>x").descendants if isinstance(node, Element) and "<" in node.tag)
+    assert element.tag == "a<b"
+    clone = _roundtrip(element)
+    assert isinstance(clone, Element)
+    assert clone.tag == "a<b"
+    assert clone.html == element.html
+
+
 def test_nested_pi_and_cdata_survive_pickling() -> None:
     # serialize-and-reparse would fold these; pickling carries the child list
     host = Element("host")
@@ -94,9 +105,20 @@ def test_reconstruct_rejects_malformed_arguments() -> None:
         _reconstruct("not a triple")
 
 
-def test_reconstruct_propagates_construction_errors() -> None:
+def test_reconstruct_accepts_names_the_constructor_rejects() -> None:
     reduced = Element("div").__reduce__()
     assert isinstance(reduced, tuple)
     kind = reduced[1][0]  # the (kind, data, children) payload pickle would store
-    with pytest.raises(ValueError, match="invalid character"):
-        _reconstruct(kind, ("bad tag", {}), [])  # an invalid tag fails element construction
+    # _reconstruct is the trusted pickle hook, so it rebuilds whatever the parser stored,
+    # including a tag name like "a<b" that the validating public Element() rejects (issue #83)
+    node = _reconstruct(kind, ("a<b", {}), [])
+    assert node.tag == "a<b"
+
+
+def test_reconstruct_propagates_a_construction_failure() -> None:
+    reduced = Element("div").__reduce__()
+    kind = reduced[1][0]  # the (kind, data, children) payload pickle would store
+    # a genuinely broken payload still fails: a non-mapping attrs value cannot build an element,
+    # and reconstruction surfaces that error instead of returning a half-built node
+    with pytest.raises(AttributeError):
+        _reconstruct(kind, ("div", 123), [])


### PR DESCRIPTION
The tokenizer keeps characters in a tag name that the public `Element()` constructor rejects — the `<` in `a<b` parsed from `<a<b>`, for instance. Pickle and `deepcopy` reconstructed elements *through* that constructor, so a parsed tree holding such a name raised `ValueError: tag name contains an invalid character` on load and couldn't round-trip. Closes #83.

The element-building body is now a `make_element` helper that skips name validation. 🧩 The public constructor still validates and then calls it (so `Element("a<b")` keeps rejecting), while pickle reconstruction calls it directly — reconstruction handles trusted parser output, so it rebuilds whatever the parser stored. A genuinely broken payload (e.g. non-mapping attributes) still surfaces its error.