### PR TITLE
🐛 fix(linkify): end a URL at Unicode whitespace

### DIFF
--- a/docs/changelog/53.bugfix.rst
+++ b/docs/changelog/53.bugfix.rst
@@ -1,0 +1,6 @@
+End an auto-linked URL at non-ASCII Unicode whitespace in :func:`turbohtml.linkify.linkify`. A no-break space
+(``U+00A0``/``&nbsp;``), an ideographic space (``U+3000``), and the other Unicode ``White_Space`` code points are
+forbidden in host labels by UTS46 and bound a URL the way an ASCII space does, matching bleach and linkify-it-py;
+previously they were swallowed as host/URL characters, which over-linked a trailing word, dropped a link flanked by
+``&nbsp;``, or emitted a bare-domain anchor next to an orphaned scheme. Internationalized domains and zero-width format
+characters (ZWSP, BOM, word joiner) are unaffected.

--- a/src/turbohtml/linkify.c
+++ b/src/turbohtml/linkify.c
@@ -34,12 +34,21 @@ static inline int is_ascii_digit(Py_UCS4 c) {
     return c >= '0' && c <= '9';
 }
 
+/* A non-ASCII Unicode White_Space code point (the ASCII ones are c <= 0x20). UTS46
+   domain-to-ASCII forbids these in host labels, and they end a URL in running text,
+   so they bound a host or URL the way an ASCII space does; the zero-width format
+   characters (ZWSP, BOM, word joiner) are not White_Space and stay in the URL. */
+static inline int is_unicode_space(Py_UCS4 c) {
+    return c == 0x85 || c == 0xA0 || c == 0x1680 || (c >= 0x2000 && c <= 0x200A) || c == 0x2028 || c == 0x2029 ||
+           c == 0x202F || c == 0x205F || c == 0x3000;
+}
+
 /* A host label character: ASCII alphanumeric, underscore (an RFC 3986 unreserved
    character, valid anywhere in a reg-name host, as in ``_dmarc``/``cdn_1``), or
-   any non-ASCII code point so an internationalized domain stays in one piece (the
-   IRI case). */
+   any non-ASCII code point that is not Unicode whitespace, so an internationalized
+   domain stays in one piece (the IRI case) but an ``&nbsp;`` ends the host. */
 static inline int is_label_char(Py_UCS4 c) {
-    return is_ascii_alpha(c) || is_ascii_digit(c) || c == '_' || c >= 0x80;
+    return is_ascii_alpha(c) || is_ascii_digit(c) || c == '_' || (c >= 0x80 && !is_unicode_space(c));
 }
 
 /* Email local-part atext, per the addr-spec dot-atom plus the characters real
@@ -67,7 +76,7 @@ static inline int is_local_char(Py_UCS4 c) {
     case '~':
         return 1;
     default:
-        return is_ascii_alpha(c) || is_ascii_digit(c) || c >= 0x80;
+        return is_ascii_alpha(c) || is_ascii_digit(c) || (c >= 0x80 && !is_unicode_space(c));
     }
 }
 
@@ -82,7 +91,7 @@ static inline int is_scheme_char(Py_UCS4 c) {
    that end a URL in running text; brackets and parens are handled by balancing,
    not exclusion, so a Wikipedia URL keeps its trailing ``)``. */
 static inline int is_url_tail_char(Py_UCS4 c) {
-    if (c <= 0x20 || c == 0x7F) {
+    if (c <= 0x20 || c == 0x7F || is_unicode_space(c)) {
         return 0;
     }
     switch (c) {

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -76,10 +76,47 @@ def _no_callbacks() -> list[Callback]:
             '<a href="http://_dmarc.example.com/">http://_dmarc.example.com/</a>',
             id="underscore-leading-host-label-kept",
         ),
+        # Unicode whitespace bounds a URL the way an ASCII space does (issue #53)
+        pytest.param(
+            "http://example.com\xa0more",
+            '<a href="http://example.com">http://example.com</a>&nbsp;more',
+            id="nbsp-ends-url",
+        ),
+        pytest.param(
+            "a　http://x.com　b",
+            'a　<a href="http://x.com">http://x.com</a>　b',
+            id="ideographic-space-ends-url",
+        ),
+        pytest.param(
+            "http://example.com/p\xa0q",
+            '<a href="http://example.com/p">http://example.com/p</a>&nbsp;q',
+            id="nbsp-ends-url-path",
+        ),
+        # a non-whitespace non-ASCII code point keeps an internationalized domain intact
+        pytest.param("münchen.de", '<a href="http://münchen.de">münchen.de</a>', id="idn-host-label-kept"),
+        # zero-width format characters are not White_Space, so they stay in the URL
+        pytest.param(
+            "http://a.com/x\u200by",
+            '<a href="http://a.com/x\u200by">http://a.com/x\u200by</a>',
+            id="zero-width-space-stays-in-url",
+        ),
     ],
 )
 def test_linkify_plain(text: str, expected: str) -> None:
     assert linkify(text, callbacks=_no_callbacks()) == expected
+
+
+@pytest.mark.parametrize(
+    "cp",
+    [
+        0x85, 0xA0, 0x1680, 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006,
+        0x2007, 0x2008, 0x2009, 0x200A, 0x2028, 0x2029, 0x202F, 0x205F, 0x3000,
+    ],
+)  # fmt: skip
+def test_linkify_each_unicode_space_ends_url(cp: int) -> None:
+    # every Unicode White_Space code point bounds the host the way an ASCII space does
+    out = linkify(f"http://x.com{chr(cp)}y", callbacks=_no_callbacks())
+    assert out.startswith('<a href="http://x.com">http://x.com</a>')
 
 
 def test_linkify_default_callback_adds_nofollow() -> None:
@@ -125,6 +162,17 @@ def test_linkify_email_off_by_default() -> None:
 def test_linkify_email_when_enabled() -> None:
     out = linkify("reach bob@example.com now", parse_email=True, callbacks=_no_callbacks())
     assert out == 'reach <a href="mailto:bob@example.com">bob@example.com</a> now'
+
+
+def test_linkify_email_local_part_ends_at_unicode_space() -> None:
+    # Unicode whitespace bounds the email local part the way an ASCII space does (issue #53)
+    out = linkify("foo\xa0bar@example.com", parse_email=True, callbacks=_no_callbacks())
+    assert out == 'foo&nbsp;<a href="mailto:bar@example.com">bar@example.com</a>'
+
+
+def test_linkify_email_keeps_non_ascii_local_part() -> None:
+    out = linkify("naïve@example.com", parse_email=True, callbacks=_no_callbacks())
+    assert out == '<a href="mailto:naïve@example.com">naïve@example.com</a>'
 
 
 def test_linkify_veto_callback_keeps_plain_text() -> None:


### PR DESCRIPTION
`linkify` treated non-ASCII whitespace as ordinary URL characters, so a no-break space (`&nbsp;`, ubiquitous in real HTML), an ideographic space, and the rest of the Unicode `White_Space` set were swallowed into the host or path. 🔗 That produced three failure modes: a trailing word got pulled into the `href` (over-link), a URL flanked by `&nbsp;` produced no anchor at all (under-link), and a bare domain after a rejected scheme emitted an `href` whose scheme the visible link text omitted (malformed).

`is_label_char` accepted any code point `>= 0x80` to keep internationalized domains in one piece, and `is_url_tail_char` only bounded on ASCII whitespace. UTS46 domain-to-ASCII forbids the Unicode whitespace characters in host labels, so this adds `is_unicode_space` for the non-ASCII `White_Space` code points and excludes them from the host, email-local, and URL-tail character classes. bleach and linkify-it-py agree on exactly this boundary.

Internationalized domains still link (`münchen.de`), and the zero-width format characters (ZWSP, BOM, word joiner) — which are *not* `White_Space` — stay in the URL, matching linkify-it-py.

Fixes #53