### PR TITLE
🐛 fix(select): decode CSS escape sequences in identifiers

### DIFF
--- a/docs/changelog/50.bugfix.rst
+++ b/docs/changelog/50.bugfix.rst
@@ -1,0 +1,4 @@
+Accept CSS escape sequences in :meth:`~turbohtml.Node.select`/:meth:`~turbohtml.Node.select_one` identifiers. A
+backslash escape (``.foo\:bar``, ``#a\ b``) and a hex code-point escape (``.\A9``, ``.\0000A9``) in a class, id, type, or
+attribute-name selector are decoded per CSS Syntax Module 4.3.7 instead of raising ``ValueError('invalid CSS selector')``,
+so spec-valid selectors that name characters like ``:`` or ``.`` inside an identifier now match.

--- a/docs/changelog/50.bugfix.rst
+++ b/docs/changelog/50.bugfix.rst
@@ -1,4 +1,4 @@
 Accept CSS escape sequences in :meth:`~turbohtml.Node.select`/:meth:`~turbohtml.Node.select_one` identifiers. A
-backslash escape (``.foo\:bar``, ``#a\ b``) and a hex code-point escape (``.\A9``, ``.\0000A9``) in a class, id, type, or
-attribute-name selector are decoded per CSS Syntax Module 4.3.7 instead of raising ``ValueError('invalid CSS selector')``,
-so spec-valid selectors that name characters like ``:`` or ``.`` inside an identifier now match.
+backslash escape (``.foo\:bar``, ``#ab``) and a hex code-point escape (``.\A9``, ``.\0000A9``) in a class, id, type, or
+attribute-name selector are decoded per CSS Syntax Module 4.3.7 instead of raising ``ValueError('invalid CSS
+selector')``, so spec-valid selectors that name characters like ``:`` or ``.`` inside an identifier now match.

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -46,7 +46,7 @@ typedef struct {
 /* ---------------------------------------------------------------- parsing */
 
 typedef struct {
-    const Py_UCS4 *src;
+    Py_UCS4 *src; /* the owned source copy; sel_ident decodes escapes into it in place */
     Py_ssize_t pos;
     Py_ssize_t len;
     th_tree *tree;
@@ -57,20 +57,71 @@ static int sel_is_ident(Py_UCS4 ch) {
     return is_ascii_alpha(ch) || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' || ch >= 0x80;
 }
 
+static int sel_is_hex(Py_UCS4 ch) {
+    return (ch >= '0' && ch <= '9') || ((ch | 32) >= 'a' && (ch | 32) <= 'f');
+}
+
 static void sel_skip_ws(sel_parser *parser) {
     while (parser->pos < parser->len && is_space(parser->src[parser->pos])) {
         parser->pos++;
     }
 }
 
-/* Read an identifier run, returning its slice via *out / *out_len. */
+/* Whether the backslash at parser->pos begins a valid escape: a backslash is
+   one unless it precedes a CSS newline (LF/CR/FF); at end of input it still
+   escapes the U+FFFD replacement character. */
+static int sel_starts_escape(const sel_parser *parser) {
+    if (parser->pos + 1 >= parser->len) {
+        return 1;
+    }
+    Py_UCS4 next = parser->src[parser->pos + 1];
+    return next != '\n' && next != '\r' && next != '\x0c';
+}
+
+/* Consume an escaped code point (CSS Syntax 4.3.7); the leading backslash at
+   parser->pos is assumed to start a valid escape and is consumed here. */
+static Py_UCS4 sel_consume_escape(sel_parser *parser) {
+    parser->pos++; /* the backslash */
+    if (parser->pos >= parser->len) {
+        return 0xFFFD; /* a trailing backslash escapes the replacement character */
+    }
+    if (!sel_is_hex(parser->src[parser->pos])) {
+        return parser->src[parser->pos++]; /* the literal escaped character */
+    }
+    uint32_t value = 0;
+    for (int digit = 0; digit < 6 && parser->pos < parser->len && sel_is_hex(parser->src[parser->pos]); digit++) {
+        Py_UCS4 hex = parser->src[parser->pos++];
+        value = value * 16 + (hex <= '9' ? (uint32_t)(hex - '0') : (uint32_t)((hex | 32) - 'a' + 10));
+    }
+    if (parser->pos < parser->len && is_space(parser->src[parser->pos])) {
+        parser->pos++; /* one trailing whitespace closes the hex escape */
+    }
+    if (value == 0 || value > 0x10FFFF || (value >= 0xD800 && value <= 0xDFFF)) {
+        return 0xFFFD; /* null, surrogate, and out-of-range escapes fold to U+FFFD */
+    }
+    return (Py_UCS4)value;
+}
+
+/* Read an identifier run, decoding any CSS escapes in place (a decoded run is
+   never longer than its source), and return its slice via *out / *out_len. */
 static void sel_ident(sel_parser *parser, const Py_UCS4 **out, Py_ssize_t *out_len) {
     Py_ssize_t start = parser->pos;
-    while (parser->pos < parser->len && sel_is_ident(parser->src[parser->pos])) {
-        parser->pos++;
+    Py_ssize_t write = start;
+    while (parser->pos < parser->len) {
+        if (parser->src[parser->pos] == '\\') {
+            if (!sel_starts_escape(parser)) {
+                break; /* a backslash before a newline is not part of the identifier */
+            }
+            parser->src[write++] = sel_consume_escape(parser);
+            continue;
+        }
+        if (!sel_is_ident(parser->src[parser->pos])) {
+            break;
+        }
+        parser->src[write++] = parser->src[parser->pos++];
     }
     *out = parser->src + start;
-    *out_len = parser->pos - start;
+    *out_len = write - start;
     if (*out_len == 0) {
         parser->error = 1;
     }
@@ -224,7 +275,7 @@ static void sel_one(sel_parser *parser, sel_simple *simple) {
 }
 
 static int sel_starts_simple(Py_UCS4 ch) {
-    return ch == '*' || ch == '.' || ch == '#' || ch == '[' || sel_is_ident(ch);
+    return ch == '*' || ch == '.' || ch == '#' || ch == '[' || ch == '\\' || sel_is_ident(ch);
 }
 
 /* Parse a compound (one or more adjacent simples) into the given buffer. */

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -133,6 +133,27 @@ def test_select_over_doc(selector: str, tags: list[str]) -> None:
         # the scan reaches the end with no match, exercising the loop-exit branches
         pytest.param('<div class="a ">', ".zzz", [], id="trailing-whitespace-class-miss"),
         pytest.param('<div data-x="a ">', '[data-x~="zzz"]', [], id="trailing-whitespace-attr-miss"),
+        # CSS identifier escapes (Syntax 4.3.7): a backslash escapes the literal
+        # next character, and \HHHHHH (with one optional trailing space) a code point
+        pytest.param('<div class="foo:bar">', r".foo\:bar", ["div"], id="class-escaped-colon"),
+        pytest.param('<div class="foo.bar">', r".foo\.bar", ["div"], id="class-escaped-dot"),
+        pytest.param('<div id="a:b">', r"#a\:b", ["div"], id="id-escaped-colon"),
+        pytest.param('<div id="a b">', r"#a\ b", ["div"], id="id-escaped-space"),
+        pytest.param('<div class="©">', r".\A9 ", ["div"], id="class-hex-escape-trailing-space"),
+        pytest.param('<div class="©">', r".\0000A9", ["div"], id="class-hex-escape-six-digits"),
+        pytest.param("<div></div>", r"\64 iv", ["div"], id="type-hex-escape"),
+        pytest.param('<div data-x="a:b">', r"[data\-x=a\:b]", ["div"], id="attr-name-and-value-escapes"),
+        # a null, surrogate, or out-of-range hex escape folds to U+FFFD
+        pytest.param('<div class="�">', r".\0", ["div"], id="class-null-hex-escape-is-replacement"),
+        pytest.param('<div class="�">', r".\D800", ["div"], id="class-surrogate-hex-is-replacement"),
+        pytest.param("<div class='\ue000'>", r".\E000", ["div"], id="class-just-above-surrogate-is-kept"),
+        pytest.param('<div class="\U0010ffff">', r".\10FFFF", ["div"], id="class-max-code-point-hex-escape"),
+        pytest.param('<div class="�">', r".\110000", ["div"], id="class-out-of-range-hex-is-replacement"),
+        # a hex escape ends at end of input, at a non-hex char, or at one trailing space
+        pytest.param('<div class="©">', r".\A9", ["div"], id="class-hex-escape-at-eof"),
+        pytest.param('<div class="Az">', r".\41z", ["div"], id="class-hex-escape-stops-at-non-hex"),
+        # a trailing backslash escapes U+FFFD
+        pytest.param('<div class="x�">', ".x\\", ["div"], id="class-trailing-backslash-is-replacement"),
     ],
 )
 def test_select_over_custom_html(html: str, selector: str, tags: list[str]) -> None:
@@ -180,6 +201,11 @@ def test_select_one() -> None:
         pytest.param("p" + ".x" * 40, id="too-many-simples"),
         pytest.param(" ".join(["a"] * 40), id="too-many-compounds"),
         pytest.param(",".join(["a"] * 70), id="too-many-groups"),
+        # a backslash before any CSS newline (LF, CR, FF) does not start an escape,
+        # so the dangling backslash leaves an empty identifier
+        pytest.param(".a\\\nb", id="escape-before-lf"),
+        pytest.param(".a\\\rb", id="escape-before-cr"),
+        pytest.param(".a\\\x0cb", id="escape-before-ff"),
     ],
 )
 def test_invalid_selectors_raise(selector: str) -> None:


### PR DESCRIPTION
``select()`` and ``select_one()`` raised ``ValueError('invalid CSS selector')`` for any identifier containing a CSS escape — backslash escapes such as ``.foo\:bar`` and ``#a\ b``, and hex code-point escapes such as ``.\A9`` and ``.\0000A9``. These escapes are core identifier grammar that the ``.class``/``#id``/type syntax already supports, so this was a hard error on spec-valid input that both soupsieve and lxml.cssselect accept. 🧩 Class and id had an attribute-selector workaround, but escaped ``.``/``#`` syntax and escaped type selectors had none.

The identifier reader now consumes an escaped code point per CSS Syntax Module 4.3.7: a backslash escapes the literal next character, and ``\HHHHHH`` (one to six hex digits, with a single optional trailing space) a code point, with null, surrogate, and out-of-range values folding to U+FFFD. Decoding happens in place — a decoded run is never longer than its source, so the slice stays within the owned selector buffer and the matcher keeps comparing plain slices with no extra allocation. A leading backslash also begins a simple selector, covering escaped type selectors.

Fixes #50