### PR TITLE
🐛 fix(treebuilder): process stray <html> in colgroup via in-body

### DIFF
--- a/docs/changelog/56.bugfix.rst
+++ b/docs/changelog/56.bugfix.rst
@@ -1,0 +1,4 @@
+Process a stray ``<html>`` start tag in the "in column group" insertion mode with the in-body rules (merge attributes
+onto the open ``<html>``, leave the stack alone) instead of routing it through the anything-else branch. Previously the
+stray tag popped the open ``<colgroup>``, so ``parse("<table><colgroup><col><html><col>")`` produced two colgroups; it
+now keeps one colgroup with both ``<col>`` children, matching html5lib.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -3425,6 +3425,15 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 insert_comment(tree, tok, NULL);
                 break;
             }
+            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
+                /* a stray html start tag uses the in-body rules: merge attributes onto
+                   the open html and leave the stack (so the colgroup stays open) */
+                if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
+                    stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+                    merge_attrs(tree, tree->open[0], tok);
+                }
+                break;
+            }
             if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_COL) {
                 insert_element(tree, tok); /* col is void */
                 break;

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -333,6 +333,13 @@ def test_document_paths(html: str, needle: str) -> None:
     assert needle in _doc(html)
 
 
+def test_stray_html_in_colgroup_keeps_it_open() -> None:
+    # a stray <html> in "in column group" uses the in-body rules (merge attributes, leave the
+    # stack), so the colgroup stays open and the next <col> joins it instead of starting a new one
+    out = parse("<table><colgroup><col><html lang=en><col>").html
+    assert out == ('<html lang="en"><head></head><body><table><colgroup><col><col></colgroup></table></body></html>')
+
+
 @pytest.mark.parametrize(
     ("html", "inner"),
     [


### PR DESCRIPTION
In the "in column group" insertion mode, a stray `<html>` start tag must be processed using the in-body rules — merge attributes onto the existing `<html>` and leave the stack of open elements untouched. turbohtml instead routed it through the anything-else branch, which pops the open `<colgroup>`; the following `<col>` then started a brand-new colgroup, producing two colgroups where there should be one. 📐

The fix handles `<html>` explicitly in the colgroup mode exactly as the in-body mode does (guarded against an open template), so the colgroup stays open and both `<col>` children share it.

`parse("<table><colgroup><col><html><col>")` now yields a single colgroup with two cols, matching html5lib.

closes #56