### PR TITLE
🐛 fix(tokenizer): reject Tokenizer constructor arguments

### DIFF
--- a/docs/changelog/75.bugfix.rst
+++ b/docs/changelog/75.bugfix.rst
@@ -1,0 +1,3 @@
+Reject arguments passed to the :class:`~turbohtml.Tokenizer` constructor with a ``TypeError`` instead of silently
+ignoring them. A streaming tokenizer starts empty and takes no arguments, so ``Tokenizer("<p>")`` was a no-op that
+discarded its input; it now fails loudly.

--- a/src/turbohtml/tokenizer_type.c
+++ b/src/turbohtml/tokenizer_type.c
@@ -138,7 +138,11 @@ static PyType_Spec iter_spec = {
 
 /* -------------------------------------------------------------- tokenizer */
 
-static PyObject *tokenizer_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwds)) {
+static PyObject *tokenizer_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
+    static char *keywords[] = {NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, ":Tokenizer", keywords)) {
+        return NULL; /* a streaming tokenizer starts empty; reject any positional or keyword argument */
+    }
     TokenizerObject *self = (TokenizerObject *)type->tp_alloc(type, 0);
     if (self == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -135,6 +135,14 @@ def test_token_cannot_be_instantiated() -> None:
         Token()
 
 
+def test_tokenizer_takes_no_arguments() -> None:
+    # a streaming tokenizer starts empty; a constructor argument is an error, not a silent no-op
+    with pytest.raises(TypeError):
+        Tokenizer("<p>")  # ty: ignore[too-many-positional-arguments]
+    with pytest.raises(TypeError):
+        Tokenizer(source="<p>")  # ty: ignore[unknown-argument]
+
+
 def test_tokens_stay_valid_after_iteration() -> None:
     tokens = list(tokenize("<a x=1><b y=2>"))
     assert [token.tag for token in tokens] == ["a", "b"]


### PR DESCRIPTION
`Tokenizer.__new__` ignored its arguments, so `Tokenizer("<p>hello</p>")` built an empty tokenizer and silently discarded the string rather than streaming it — a caller expecting one-shot behavior got an empty result with no error. Closes #75.

A streaming tokenizer starts empty and takes no arguments, so the constructor now parses its (empty) argument list and raises `TypeError` for any positional or keyword argument, the way a no-argument constructor should.

Draft until the tokenize benchmark confirms the argument check costs nothing.