### PR TITLE
🐛 fix(select): apply HTML case-insensitive attribute set

### DIFF
--- a/docs/changelog/59.bugfix.rst
+++ b/docs/changelog/59.bugfix.rst
@@ -1,0 +1,6 @@
+Compare the HTML case-insensitive attribute set case-insensitively in :meth:`~turbohtml.Node.select`/
+:meth:`~turbohtml.Node.select_one` by default. Per the WHATWG "case-sensitivity of selectors" rules, a selector on one
+of a fixed set of attributes (``type``, ``rel``, ``lang``, ``method``, ``charset``, ...) compares its value ASCII
+case-insensitively on HTML elements without an explicit ``i`` flag, so ``input[type=text]`` now matches ``type="TEXT"``.
+An explicit ``s`` flag still forces a case-sensitive comparison, and the default does not apply to foreign (SVG/MathML)
+elements.

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -18,7 +18,8 @@ typedef struct {
     uint16_t tag_atom;  /* 'e': the tag atom, TH_TAG_UNKNOWN for a name outside the table */
     uint32_t attr_atom; /* '[': the attribute atom, UINT32_MAX when no element has the name */
     enum sel_attr_op op;
-    int ci;               /* '[': matched case-insensitively */
+    int ci;               /* '[': matched case-insensitively (explicit i flag) */
+    int ci_default;       /* '[': name is in the HTML case-insensitive set, no explicit s/i flag */
     const Py_UCS4 *name;  /* class / id / unknown tag name (into the owned source copy) */
     Py_ssize_t name_len;  /* also the attribute name for the rare unknown case */
     const Py_UCS4 *value; /* '[': the attribute value */
@@ -172,6 +173,53 @@ static uint32_t sel_attr_atom(th_tree *tree, const Py_UCS4 *name, Py_ssize_t len
     return th_attr_lookup(tree, bytes, at);
 }
 
+/* The HTML "case-sensitivity of selectors" attribute set: with no explicit s/i
+   flag, an attribute selector on one of these names compares its value ASCII
+   case-insensitively on HTML elements (WHATWG HTML, "Case-sensitivity of
+   selectors"). Kept sorted for the binary search in sel_attr_default_ci. */
+static const char *const SEL_CI_ATTRS[] = {
+    "accept",   "accept-charset", "align",    "alink",      "axis",   "bgcolor",  "charset",   "checked",  "clear",
+    "codetype", "color",          "compact",  "declare",    "defer",  "dir",      "direction", "disabled", "enctype",
+    "face",     "frame",          "hreflang", "http-equiv", "lang",   "language", "link",      "media",    "method",
+    "multiple", "nohref",         "noresize", "noshade",    "nowrap", "readonly", "rel",       "rev",      "rules",
+    "scope",    "scrolling",      "selected", "shape",      "target", "text",     "type",      "valign",   "valuetype",
+    "vlink",
+};
+
+/* Whether an attribute name (lowercased) is in the case-insensitive set. */
+static int sel_attr_default_ci(const Py_UCS4 *name, Py_ssize_t len) {
+    char buf[16]; /* the longest name, accept-charset, is 14 bytes */
+    if (len >= (Py_ssize_t)sizeof(buf)) {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 ch = name[index];
+        if (ch >= 'A' && ch <= 'Z') {
+            ch += 32;
+        }
+        if (ch >= 0x80) {
+            return 0; /* a non-ASCII name is never in the set */
+        }
+        buf[index] = (char)ch;
+    }
+    buf[len] = '\0';
+    Py_ssize_t lo = 0;
+    Py_ssize_t hi = (Py_ssize_t)(sizeof(SEL_CI_ATTRS) / sizeof(SEL_CI_ATTRS[0]));
+    while (lo < hi) {
+        Py_ssize_t mid = (lo + hi) / 2;
+        int cmp = strcmp(buf, SEL_CI_ATTRS[mid]);
+        if (cmp == 0) {
+            return 1;
+        }
+        if (cmp < 0) {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    return 0;
+}
+
 /* Parse a bracketed attribute selector (the leading '[' already consumed). */
 static void sel_attribute(sel_parser *parser, sel_simple *simple) {
     simple->kind = '[';
@@ -237,6 +285,8 @@ static void sel_attribute(sel_parser *parser, sel_simple *simple) {
     } else if (parser->pos < parser->len && (parser->src[parser->pos] | 32) == 's') {
         parser->pos++;
         sel_skip_ws(parser);
+    } else if (sel_attr_default_ci(name, name_len)) {
+        simple->ci_default = 1; /* the HTML set defaults to case-insensitive without a flag */
     }
     if (parser->pos >= parser->len || parser->src[parser->pos] != ']') {
         parser->error = 1;
@@ -250,6 +300,7 @@ static void sel_one(sel_parser *parser, sel_simple *simple) {
     simple->tag_atom = TH_TAG_UNKNOWN;
     simple->attr_atom = 0;
     simple->ci = 0;
+    simple->ci_default = 0;
     simple->name = NULL;
     simple->name_len = 0;
     simple->value = NULL;
@@ -480,35 +531,36 @@ static const th_node_attr *sel_find_attr(th_node *node, uint32_t atom) {
     return NULL;
 }
 
-/* Whether the attribute value satisfies the simple's operator and value. */
-static int sel_match_attr_op(const sel_simple *simple, const Py_UCS4 *value, Py_ssize_t value_len) {
+/* Whether the attribute value satisfies the simple's operator and value, folding
+   case per ci (the explicit flag combined with the HTML default-set decision). */
+static int sel_match_attr_op(const sel_simple *simple, const Py_UCS4 *value, Py_ssize_t value_len, int ci) {
     const Py_UCS4 *want = simple->value;
     Py_ssize_t want_len = simple->value_len;
     switch (simple->op) {
     case OP_EXISTS:
         return 1;
     case OP_EQ:
-        return sel_eq(value, value_len, want, want_len, simple->ci);
+        return sel_eq(value, value_len, want, want_len, ci);
     case OP_PREFIX:
-        return want_len > 0 && value_len >= want_len && sel_eq(value, want_len, want, want_len, simple->ci);
+        return want_len > 0 && value_len >= want_len && sel_eq(value, want_len, want, want_len, ci);
     case OP_SUFFIX:
         return want_len > 0 && value_len >= want_len &&
-               sel_eq(value + (value_len - want_len), want_len, want, want_len, simple->ci);
+               sel_eq(value + (value_len - want_len), want_len, want, want_len, ci);
     case OP_DASH:
-        return sel_eq(value, value_len, want, want_len, simple->ci) ||
-               (value_len > want_len && value[want_len] == '-' && sel_eq(value, want_len, want, want_len, simple->ci));
+        return sel_eq(value, value_len, want, want_len, ci) ||
+               (value_len > want_len && value[want_len] == '-' && sel_eq(value, want_len, want, want_len, ci));
     case OP_INCLUDE: {
         if (want_len == 0) {
             return 0;
         }
-        return contains_ws_token(value, value_len, want, want_len, simple->ci);
+        return contains_ws_token(value, value_len, want, want_len, ci);
     }
     default: /* OP_SUBSTR */
         if (want_len == 0) {
             return 0;
         }
         for (Py_ssize_t start = 0; start + want_len <= value_len; start++) {
-            if (sel_eq(value + start, want_len, want, want_len, simple->ci)) {
+            if (sel_eq(value + start, want_len, want, want_len, ci)) {
                 return 1;
             }
         }
@@ -547,7 +599,9 @@ static int sel_match_simple(th_node *node, const sel_simple *simple) {
         }
         const Py_UCS4 *value = attr->value != NULL ? attr->value : simple->value;
         Py_ssize_t value_len = attr->value != NULL ? attr->value_len : 0;
-        return sel_match_attr_op(simple, value, value_len);
+        /* the HTML case-insensitive set applies only to HTML-namespace elements */
+        int ci = simple->ci || (simple->ci_default && node->ns == TH_NS_HTML);
+        return sel_match_attr_op(simple, value, value_len, ci);
     }
     }
 }

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -154,6 +154,23 @@ def test_select_over_doc(selector: str, tags: list[str]) -> None:
         pytest.param('<div class="Az">', r".\41z", ["div"], id="class-hex-escape-stops-at-non-hex"),
         # a trailing backslash escapes U+FFFD
         pytest.param('<div class="x�">', ".x\\", ["div"], id="class-trailing-backslash-is-replacement"),
+        # the WHATWG "case-sensitivity of selectors" set: type/rel/... compare their
+        # value ASCII case-insensitively by default on HTML elements (no flag needed)
+        pytest.param('<input type="TEXT">', "input[type=text]", ["input"], id="ci-attr-set-default"),
+        # an uppercase attribute name in the selector still resolves to the set
+        pytest.param('<input type="x">', "[TYPE=X]", ["input"], id="ci-attr-set-uppercase-name"),
+        pytest.param('<input type="TEXT">', "[type~=text]", ["input"], id="ci-attr-set-include-op"),
+        pytest.param('<input type="TEXT">', "input[type=text s]", [], id="ci-attr-set-s-flag-forces-cs"),
+        # the default applies only to HTML-namespace elements, not foreign ones
+        pytest.param('<svg><rect type="FOO"></rect></svg>', "[type=foo]", [], id="ci-attr-set-not-foreign"),
+        # an attribute outside the set keeps the default case-sensitive comparison
+        pytest.param('<div data-x="ABC"></div>', "[data-x=abc]", [], id="non-ci-attr-stays-cs"),
+        # sel_attr_default_ci rejects a non-ASCII name, an over-long name, and names
+        # that fall before/after the set without matching it
+        pytest.param("<div></div>", "[café=x]", [], id="ci-attr-set-non-ascii-name"),
+        pytest.param("<div></div>", "[abcdefghijklmnopq=x]", [], id="ci-attr-set-overlong-name"),
+        pytest.param("<div></div>", "[aaa=x]", [], id="ci-attr-set-before-set"),
+        pytest.param("<div></div>", "[zzz=x]", [], id="ci-attr-set-after-set"),
     ],
 )
 def test_select_over_custom_html(html: str, selector: str, tags: list[str]) -> None:


### PR DESCRIPTION
``input[type=text]`` failed to match ``type="TEXT"``. Per the WHATWG "case-sensitivity of selectors" rules a selector on a fixed set of attributes — ``type``, ``rel``, ``lang``, ``method``, ``charset``, and others — compares its value ASCII case-insensitively on HTML elements by default, but turbohtml only folded case when an explicit ``i`` flag was supplied. 🧩 soupsieve and selectolax both honor this default; only lxml diverges.

An attribute selector whose name is in that set, with no explicit ``s`` or ``i`` flag, now defaults to a case-insensitive value comparison. The set membership is decided once at compile time by a binary search over the sorted name table, and the case fold is applied at match time only when the matched element is in the HTML namespace, so an explicit ``s`` flag still forces case-sensitive matching and foreign (SVG/MathML) elements keep comparing case-sensitively.

Fixes #59