### PR TITLE
🐛 fix(treebuilder): keep NUL-adjacent table whitespace inside

### DIFF
--- a/docs/changelog/58.bugfix.rst
+++ b/docs/changelog/58.bugfix.rst
@@ -1,0 +1,4 @@
+Keep an otherwise-whitespace ``<table>`` text run inside the table when it contains a U+0000. In the "in table text"
+insertion mode a NUL is a parse error that is dropped, but turbohtml treated the run as containing a non-whitespace
+character and foster-parented the whitespace out as a sibling before the table. The whitespace check now ignores NUL, so
+``parse("<table>\x00 ")`` keeps the space as a child of ``<table>``, matching html5lib.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2035,6 +2035,19 @@ static int all_whitespace(const Py_UCS4 *text, Py_ssize_t len) {
     return 1;
 }
 
+/* Like all_whitespace, but a U+0000 counts as ignorable: in "in table text" a NUL is
+   a parse error that is dropped, so an otherwise-whitespace run is still inserted in
+   the table rather than foster-parented out of it. */
+static int all_whitespace_or_nul(const Py_UCS4 *text, Py_ssize_t len) {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 character = text[index];
+        if (character != 0 && !is_space(character)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 /* The content model a start tag switches the tokenizer into, or -1 for none. */
 static int content_model_for(uint16_t atom, uint8_t flags) {
     if (atom == TH_TAG_SCRIPT) {
@@ -3234,7 +3247,7 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
             if (tok->kind == TH_TEXT) {
                 Py_ssize_t len;
                 Py_UCS4 *text = token_text(tree, tok, &len);
-                if (all_whitespace(text, len)) {
+                if (all_whitespace_or_nul(text, len)) {
                     insert_text(tree, text, len);
                 } else {
                     /* non-space character: foster-parent it out of the table */

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -334,6 +334,24 @@ def test_document_paths(html: str, needle: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param("<table>\x00 ", "<table> </table>", id="nul-then-space"),
+        pytest.param("<table> \x00 ", "<table>  </table>", id="space-nul-space"),
+        pytest.param("<table> \x00", "<table> </table>", id="space-then-nul"),
+        # control: a real non-whitespace char still foster-parents the run out of the table
+        pytest.param("<table>x\x00 ", "x <table></table>", id="nonspace-fosters"),
+    ],
+)
+def test_nul_in_table_text_keeps_whitespace_inside(html: str, expected: str) -> None:
+    # a U+0000 in "in table text" is dropped, so an otherwise-whitespace run is inserted
+    # inside the table rather than foster-parented out of it
+    body = parse(html).find("body")
+    assert body is not None
+    assert body.inner_html == expected
+
+
+@pytest.mark.parametrize(
     ("html", "inner"),
     [
         pytest.param("<b><math><mi></b>", "<b><math><mi></mi></math></b>", id="mathml-mi"),


### PR DESCRIPTION
In the "in table text" insertion mode a U+0000 NULL is a parse error that must be ignored, and when the remaining pending characters are all whitespace they are inserted **inside** the current node (the table). turbohtml dropped the NULL on insertion but decided whitespace-vs-foster on the raw run, so the NULL made an otherwise-whitespace run look non-whitespace and the space was foster-parented out as a sibling before the empty `<table>`. 🧱

The whitespace determination now ignores NUL (a dedicated `all_whitespace_or_nul` check), matching the fact that the NUL is dropped. `parse("<table>\x00 ")` keeps the space as a child of `<table>`; a run with a real non-whitespace char (`<table>x\x00 `) still foster-parents, matching html5lib.

closes #58