### PR TITLE
🐛 fix: require str for parse_fragment context and Token.attr name

### DIFF
--- a/docs/changelog/79.bugfix.rst
+++ b/docs/changelog/79.bugfix.rst
@@ -1,0 +1,4 @@
+Reject bytes passed where a ``str`` is documented — the ``context`` of :func:`~turbohtml.parse_fragment` and the
+``name`` of :meth:`turbohtml.Token.attr` — with a ``TypeError`` that names ``str``, instead of silently decoding the
+bytes as latin-1 into a garbage tag or attribute name. Wrong types other than bytes now also report that ``str`` is
+required rather than a bytes-like object.

--- a/src/turbohtml/token_type.c
+++ b/src/turbohtml/token_type.c
@@ -281,10 +281,15 @@ PyDoc_STRVAR(token_attr_doc, "attr(name, default=None)\n--\n\n"
                              "attribute yields None; a missing attribute yields default.");
 
 static PyObject *token_attr(PyObject *self, PyObject *args) {
-    const char *name;
-    Py_ssize_t name_len;
+    PyObject *name_obj;
     PyObject *fallback = Py_None;
-    if (!PyArg_ParseTuple(args, "s#|O:attr", &name, &name_len, &fallback)) {
+    /* require str: the "s#" format also accepts bytes, silently matching a latin-1-decoded name */
+    if (!PyArg_ParseTuple(args, "U|O:attr", &name_obj, &fallback)) {
+        return NULL;
+    }
+    Py_ssize_t name_len;
+    const char *name = PyUnicode_AsUTF8AndSize(name_obj, &name_len);
+    if (name == NULL) { /* a lone-surrogate name has no UTF-8 form */
         return NULL;
     }
     const th_token *record = &((TokenObject *)self)->record;

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -2820,10 +2820,18 @@ PyObject *turbohtml_parse(PyObject *module, PyObject *args, PyObject *kwargs) {
 PyObject *turbohtml_tree_parse_fragment(PyObject *module, PyObject *args, PyObject *kwargs) {
     static char *keywords[] = {"html", "context", NULL};
     PyObject *text;
+    PyObject *context_obj = NULL;
+    /* require str: the "s#" format also accepts bytes, which would decode as latin-1 garbage */
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "U|U:parse_fragment", keywords, &text, &context_obj)) {
+        return NULL;
+    }
     const char *context = "div";
     Py_ssize_t context_len = 3;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "U|s#:parse_fragment", keywords, &text, &context, &context_len)) {
-        return NULL;
+    if (context_obj != NULL) {
+        context = PyUnicode_AsUTF8AndSize(context_obj, &context_len);
+        if (context == NULL) { /* a lone-surrogate context has no UTF-8 form */
+            return NULL;
+        }
     }
     th_tree *tree = th_tree_parse_fragment(PyUnicode_KIND(text), PyUnicode_DATA(text), PyUnicode_GET_LENGTH(text),
                                            context, context_len);

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -115,6 +115,17 @@ def test_attr_on_non_tag_returns_default() -> None:
     assert text.attr("x", "fallback") == "fallback"
 
 
+def test_attr_name_must_be_str() -> None:
+    # a str-typed name rejects bytes (no silent latin-1 match) and other wrong types, naming str
+    (tag,) = list(tokenize("<a href=x>"))
+    with pytest.raises(TypeError):
+        tag.attr(b"href")  # ty: ignore[invalid-argument-type]
+    with pytest.raises(TypeError):
+        tag.attr(123)  # ty: ignore[invalid-argument-type]
+    with pytest.raises(UnicodeEncodeError):
+        tag.attr("\udfff")  # a lone surrogate has no UTF-8 form
+
+
 def test_token_repr() -> None:
     tokens = list(tokenize("a<p x=1></p><!--c--><!DOCTYPE html>"))
     assert repr(tokens[0]) == "Token(TEXT, data='a')"

--- a/tests/test_tree_api.py
+++ b/tests/test_tree_api.py
@@ -56,11 +56,18 @@ def test_template_content_is_a_bare_node(find: Callable[[str, str], Element]) ->
     [
         pytest.param(lambda: parse(123), id="parse"),  # ty: ignore[invalid-argument-type]  # not str or bytes-like
         pytest.param(lambda: parse_fragment(b"x"), id="parse_fragment"),  # ty: ignore[invalid-argument-type]  # non-str
+        # a str-typed context rejects bytes instead of latin-1-decoding it into a garbage tag name
+        pytest.param(lambda: parse_fragment("<a>", b"svg"), id="context"),  # ty: ignore[invalid-argument-type]
     ],
 )
 def test_entry_points_reject_non_str(call: Callable[[], object]) -> None:
     with pytest.raises(TypeError):
         call()
+
+
+def test_parse_fragment_context_with_lone_surrogate_is_rejected() -> None:
+    with pytest.raises(UnicodeEncodeError):
+        parse_fragment("<a>", "\udfff")  # a lone surrogate has no UTF-8 form
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`parse_fragment(..., context)` and `Token.attr(name, ...)` parsed their string argument with the `s#` format, which also accepts any bytes-like object and latin-1-decodes it into a tag or attribute name. So `parse_fragment("<a>", b"\xff\xfe")` built `Element('ÿþ')` and `tag.attr(b"href")` silently matched — both contradicting the type stubs that declare these `str`. A wrong type like `int` was even told `a bytes-like object is required`, steering callers toward bytes. Closes #79.

Both arguments are now parsed as `str` with the UTF-8 pulled out explicitly, so bytes and other non-str values raise a `TypeError` that names `str` — matching how the `html` argument of the same functions already behaves.

No benchmark: `s#` already runs the same UTF-8 conversion internally for str inputs, so str callers do identical work.