### PR TITLE
🐛 fix: accept slash separator after meta in encoding prescan

### DIFF
--- a/docs/changelog/91.bugfix.rst
+++ b/docs/changelog/91.bugfix.rst
@@ -1,0 +1,3 @@
+Recognize ``0x2F`` (``/``) as a separator after ``<meta`` in the encoding prescan, so ``<meta/charset=utf-8>`` resolves
+its declared encoding. WHATWG's "prescan a byte stream" accepts whitespace or ``/`` after the tag name; only whitespace
+was honored, so a slash-separated ``<meta>`` fell through to the windows-1252 default.

--- a/src/turbohtml/encoding.h
+++ b/src/turbohtml/encoding.h
@@ -345,7 +345,8 @@ static const th_encoding_entry *th_encoding_prescan(const unsigned char *buf, Py
             }
             pos += 3;
         } else if (pos + 6 <= len && buf[pos] == '<' && (buf[pos + 1] | 32) == 'm' && (buf[pos + 2] | 32) == 'e' &&
-                   (buf[pos + 3] | 32) == 't' && (buf[pos + 4] | 32) == 'a' && is_attr_space(buf[pos + 5])) {
+                   (buf[pos + 3] | 32) == 't' && (buf[pos + 4] | 32) == 'a' &&
+                   (is_attr_space(buf[pos + 5]) || buf[pos + 5] == '/')) {
             pos += 5;
             int got_pragma = 0;
             int need_pragma = -1; /* -1 unset, 0 from a charset attr, 1 from a content attr */

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -130,6 +130,11 @@ def test_whatwg_label_decodes(label: str, raw: bytes, char: str) -> None:
         # not actually a meta element
         pytest.param(b"<meto charset=utf-8>", "windows-1252", id="not-meta-name"),
         pytest.param(b"<metax>", "windows-1252", id="meta-no-space"),
+        # WHATWG accepts 0x2F as the separator after "meta", like whitespace
+        pytest.param(b"<meta/charset=utf-8>", "UTF-8", id="meta-slash-separator"),
+        pytest.param(
+            b'<meta/http-equiv="content-type" content="text/html;charset=utf-8">', "UTF-8", id="meta-slash-pragma"
+        ),
         # attribute parsing edges
         pytest.param(b"<meta charset", "windows-1252", id="name-at-eof"),
         pytest.param(b"<meta charset=>", "windows-1252", id="empty-value"),


### PR DESCRIPTION
A document declaring its encoding as `<meta/charset=utf-8>` was decoded as windows-1252, because the prescan only treated ASCII whitespace as the separator after the `meta` tag name. WHATWG's "prescan a byte stream to determine its encoding" accepts whitespace `or` `0x2F` (`/`) there, so the slash-separated form should resolve just like `<meta charset=utf-8>`. Closes #91.

The fix adds the `0x2F` case to the separator test. The scan position already stops before the separator byte, and the attribute scanner that follows skips `/` the same way it skips whitespace, so the pragma and `charset` forms both work without further change.

No benchmark: this runs once per byte-input parse in the prescan, never in the tokenizer loop, and adds a single byte comparison.