### PR TITLE
🐛 fix: raise TypeError for non-mapping Element attrs

### DIFF
--- a/docs/changelog/74.bugfix.rst
+++ b/docs/changelog/74.bugfix.rst
@@ -1,0 +1,4 @@
+Raise ``TypeError`` instead of ``AttributeError`` when :class:`~turbohtml.Element` is constructed with a non-mapping
+``attrs`` such as an ``int`` or ``list``. The constructor enumerates ``attrs`` through its ``keys()`` method, so a value
+without one previously surfaced the raw ``'int' object has no attribute 'keys'`` error; it now reports that ``attrs``
+must be a mapping. A ``keys()`` that exists but raises still propagates its own error rather than being relabeled.

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -2145,8 +2145,11 @@ static inline PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject
     PyObject *keys = NULL;
     Py_ssize_t attr_count = 0;
     if (attrs != NULL && attrs != Py_None) {
-        keys = PyMapping_Keys(attrs); /* raises if attrs is not a mapping */
+        keys = PyMapping_Keys(attrs);
         if (keys == NULL) {
+            if (PyErr_ExceptionMatches(PyExc_AttributeError)) { /* a non-mapping has no keys() to enumerate */
+                PyErr_SetString(PyExc_TypeError, "attrs must be a mapping");
+            }
             return NULL;
         }
         attr_count = PyList_GET_SIZE(keys);

--- a/tests/test_tree_construct.py
+++ b/tests/test_tree_construct.py
@@ -156,9 +156,11 @@ def test_element_list_member_must_be_str() -> None:
         Element("div", {"class": [1, 2]})  # ty: ignore[invalid-argument-type]  # members must be str
 
 
-def test_element_attrs_must_be_a_mapping() -> None:
-    with pytest.raises((TypeError, AttributeError)):
-        Element("div", 5)  # ty: ignore[invalid-argument-type]  # attrs must be a mapping
+@pytest.mark.parametrize("attrs", [5, [("a", "b")]], ids=["int", "list"])
+def test_element_attrs_must_be_a_mapping(attrs: object) -> None:
+    # a value without keys() is not a mapping; report that as a TypeError, not the raw AttributeError
+    with pytest.raises(TypeError, match="attrs must be a mapping"):
+        Element("div", attrs)  # ty: ignore[invalid-argument-type]  # attrs must be a mapping
 
 
 def test_element_mapping_getitem_failure_propagates() -> None:
@@ -171,3 +173,14 @@ def test_element_mapping_getitem_failure_propagates() -> None:
 
     with pytest.raises(KeyError):
         Element("div", BadMapping())  # ty: ignore[invalid-argument-type]  # a deliberately broken mapping
+
+
+def test_element_mapping_keys_failure_is_not_masked() -> None:
+    class RaisingKeys:
+        def keys(self) -> list[str]:  # noqa: PLR6301  # a mapping protocol method must be an instance method
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    # keys() exists but raises: surface that error rather than mislabeling it a non-mapping TypeError
+    with pytest.raises(RuntimeError):
+        Element("div", RaisingKeys())  # ty: ignore[invalid-argument-type]  # keys() raises

--- a/tests/test_tree_pickle.py
+++ b/tests/test_tree_pickle.py
@@ -119,6 +119,6 @@ def test_reconstruct_propagates_a_construction_failure() -> None:
     reduced = Element("div").__reduce__()
     kind = reduced[1][0]  # the (kind, data, children) payload pickle would store
     # a genuinely broken payload still fails: a non-mapping attrs value cannot build an element,
-    # and reconstruction surfaces that error instead of returning a half-built node
-    with pytest.raises(AttributeError):
+    # and reconstruction surfaces that TypeError instead of returning a half-built node
+    with pytest.raises(TypeError):
         _reconstruct(kind, ("div", 123), [])


### PR DESCRIPTION
Constructing `Element("div", 5)` or `Element("div", [("a", "b")])` raised `AttributeError: 'int' object has no attribute 'keys'`, leaking an implementation detail (the constructor enumerates `attrs` through `keys()`) instead of telling the caller they passed the wrong type. A wrong argument type should be a `TypeError`. Closes #74.

The builder now converts the missing-`keys()` `AttributeError` into a `TypeError` that names the mapping requirement, and only that case: a `keys()` method that exists but raises still propagates its own error, so a genuinely broken mapping is never mislabeled as a non-mapping. The same builder backs pickle reconstruction, so its deliberately-malformed-payload test moves to expecting the `TypeError` as well.

No benchmark: the added check runs only on the error path when `keys()` is absent or fails, never on a successful construction.