### PR TITLE
🐛 fix: report missing DOCTYPE identifier as None on the node

### DIFF
--- a/docs/changelog/68.bugfix.rst
+++ b/docs/changelog/68.bugfix.rst
@@ -1,0 +1,6 @@
+Report a ``<!DOCTYPE>`` identifier that the source never supplied as ``None`` on the parsed
+:class:`~turbohtml.Doctype` node, instead of an empty string. A ``<!DOCTYPE html SYSTEM "s">`` now exposes
+``public_id`` as ``None`` and ``<!DOCTYPE html PUBLIC "p">`` exposes ``system_id`` as ``None``, keeping a missing
+identifier distinct from a present-but-empty one such as ``<!DOCTYPE html PUBLIC "p" "">``. The distinction also
+survives pickling. The node previously collapsed an absent sibling identifier to ``''`` once either keyword was present,
+even though :func:`~turbohtml.tokenize` already reported it as ``None``.

--- a/docs/changelog/68.bugfix.rst
+++ b/docs/changelog/68.bugfix.rst
@@ -1,6 +1,6 @@
-Report a ``<!DOCTYPE>`` identifier that the source never supplied as ``None`` on the parsed
-:class:`~turbohtml.Doctype` node, instead of an empty string. A ``<!DOCTYPE html SYSTEM "s">`` now exposes
-``public_id`` as ``None`` and ``<!DOCTYPE html PUBLIC "p">`` exposes ``system_id`` as ``None``, keeping a missing
-identifier distinct from a present-but-empty one such as ``<!DOCTYPE html PUBLIC "p" "">``. The distinction also
-survives pickling. The node previously collapsed an absent sibling identifier to ``''`` once either keyword was present,
-even though :func:`~turbohtml.tokenize` already reported it as ``None``.
+Report a ``<!DOCTYPE>`` identifier that the source never supplied as ``None`` on the parsed :class:`~turbohtml.Doctype`
+node, instead of an empty string. A ``<!DOCTYPE html SYSTEM "s">`` now exposes ``public_id`` as ``None`` and ``<!DOCTYPE
+html PUBLIC "p">`` exposes ``system_id`` as ``None``, keeping a missing identifier distinct from a present-but-empty one
+such as ``<!DOCTYPE html PUBLIC "p" "">``. The distinction also survives pickling. The node previously collapsed an
+absent sibling identifier to ``''`` once either keyword was present, even though :func:`~turbohtml.tokenize` already
+reported it as ``None``.

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -2603,14 +2603,20 @@ static PyObject *doctype_get_name(PyObject *self, void *Py_UNUSED(closure)) {
 }
 
 /* The doctype's public id (want_system 0) or system id (want_system 1) as a str,
-   or None when the doctype carries no identifiers. */
+   or None when that identifier was not supplied. A supplied-but-empty identifier
+   is the empty string, distinct from a missing one (issue #68). */
 static PyObject *doctype_id(PyObject *self, int want_system) {
+    th_node *node = ((NodeObject *)self)->node;
     const Py_UCS4 *public_id;
     const Py_UCS4 *system_id;
     Py_ssize_t public_len;
     Py_ssize_t system_len;
-    if (!th_node_doctype_ids(((NodeObject *)self)->node, &public_id, &public_len, &system_id, &system_len)) {
-        Py_RETURN_NONE;
+    if (!th_node_doctype_ids(node, &public_id, &public_len, &system_id, &system_len)) {
+        Py_RETURN_NONE; /* the doctype carries no identifiers at all */
+    }
+    uint8_t supplied = want_system ? TH_DOCTYPE_HAS_SYSTEM : TH_DOCTYPE_HAS_PUBLIC;
+    if (!(node->tag_flags & supplied)) {
+        Py_RETURN_NONE; /* only the sibling identifier was supplied; this one is missing, not empty */
     }
     return want_system ? ucs4_to_str(system_id, system_len) : ucs4_to_str(public_id, public_len);
 }
@@ -2908,7 +2914,10 @@ static PyObject *node_reduce(PyObject *self, PyObject *Py_UNUSED(ignored)) {
 }
 
 /* Rebuild a doctype from its (name, public_id, system_id) triple, repacking the
-   identifiers into the node's stored "name \"public\" \"system\"" form. */
+   identifiers into the node's stored "name \"public\" \"system\"" form. Either
+   identifier may be None (not supplied); a missing one is written as an empty
+   string in the text but recorded as absent in tag_flags, so the round-trip
+   keeps missing distinct from present-but-empty (issue #68). */
 static PyObject *reconstruct_doctype(module_state *state, PyObject *data) {
     PyObject *name;
     PyObject *public_id;
@@ -2916,13 +2925,30 @@ static PyObject *reconstruct_doctype(module_state *state, PyObject *data) {
     if (!PyArg_ParseTuple(data, "OOO", &name, &public_id, &system_id)) { /* GCOVR_EXCL_BR_LINE: we build this tuple */
         return NULL;                                                     /* GCOVR_EXCL_LINE: unreachable */
     }
-    PyObject *packed =
-        public_id == Py_None ? Py_NewRef(name) : PyUnicode_FromFormat("%U \"%U\" \"%U\"", name, public_id, system_id);
+    int has_public = public_id != Py_None;
+    int has_system = system_id != Py_None;
+    PyObject *packed;
+    if (!has_public && !has_system) {
+        packed = Py_NewRef(name);
+    } else {
+        PyObject *empty = PyUnicode_New(0, 0);
+        if (empty == NULL) { /* GCOVR_EXCL_BR_LINE: the empty string is interned and cannot fail */
+            return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        packed = PyUnicode_FromFormat("%U \"%U\" \"%U\"", name, has_public ? public_id : empty,
+                                      has_system ? system_id : empty);
+        Py_DECREF(empty);
+    }
     if (packed == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     PyObject *node = data_node_in_fresh_tree(state, TH_NODE_DOCTYPE, packed);
     Py_DECREF(packed);
+    if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    ((NodeObject *)node)->node->tag_flags =
+        (uint8_t)((has_public ? TH_DOCTYPE_HAS_PUBLIC : 0) | (has_system ? TH_DOCTYPE_HAS_SYSTEM : 0));
     return node;
 }
 

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2200,6 +2200,8 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 th_node *node = node_new(tree, TH_NODE_DOCTYPE);
                 if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
                     node->text = build_doctype_text(tree, tok, &node->text_len);
+                    node->tag_flags = (uint8_t)((tok->has_public_id ? TH_DOCTYPE_HAS_PUBLIC : 0) |
+                                                (tok->has_system_id ? TH_DOCTYPE_HAS_SYSTEM : 0));
                     node_append(tree->document, node);
                 }
                 tree->quirks = doctype_is_quirky(tok);

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -33,6 +33,14 @@ enum th_node_type {
     TH_NODE_CDATA,   /* a CDATA section (construction only, same reason) */
 };
 
+/* A doctype node reuses its (element-only) tag_flags field to record which
+   identifiers the source actually supplied. The serialized text writes an empty
+   string for both a missing and a present-but-empty identifier, so these flags
+   are the only way to tell `<!DOCTYPE x SYSTEM "s">` (public missing) from
+   `<!DOCTYPE x PUBLIC "" "s">` (public present but empty). */
+#define TH_DOCTYPE_HAS_PUBLIC 0x40u
+#define TH_DOCTYPE_HAS_SYSTEM 0x80u
+
 /* An attribute on an element node. The name is interned to an atom: a static
    compile-time id for common names (attr_atom.h), or a per-tree dynamic id for
    the rest. attr_record() recovers the name bytes for serialization and

--- a/tests/test_tree_node_types.py
+++ b/tests/test_tree_node_types.py
@@ -26,14 +26,20 @@ def _doctype(markup: str) -> Doctype:
         pytest.param(
             '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">',
             "-//W3C//DTD HTML 4.01//EN",
-            "",
-            id="public-only-empty-system",
+            None,  # no system identifier was supplied, so it is missing, not empty
+            id="public-only-missing-system",
         ),
         pytest.param(
             '<!DOCTYPE html SYSTEM "about:legacy-compat">',
-            "",
+            None,  # SYSTEM supplies no public identifier, so it is missing, not empty
             "about:legacy-compat",
-            id="system-only-empty-public",
+            id="system-only-missing-public",
+        ),
+        pytest.param(
+            '<!DOCTYPE html PUBLIC "p" "">',
+            "p",
+            "",  # a system identifier given as "" is present but empty, distinct from missing
+            id="public-and-empty-system",
         ),
     ],
 )

--- a/tests/test_tree_pickle.py
+++ b/tests/test_tree_pickle.py
@@ -78,6 +78,10 @@ def test_document_round_trips() -> None:
             "http://www.w3.org/TR/html4/strict.dtd",
             id="public-and-system",
         ),
+        # a missing sibling identifier must stay None across the round-trip, not collapse to ""
+        pytest.param('<!DOCTYPE html PUBLIC "p">', "p", None, id="public-only-missing-system"),
+        pytest.param('<!DOCTYPE html SYSTEM "s">', None, "s", id="system-only-missing-public"),
+        pytest.param('<!DOCTYPE html PUBLIC "p" "">', "p", "", id="public-and-empty-system"),
     ],
 )
 def test_doctype_round_trips(markup: str, public_id: str | None, system_id: str | None) -> None:


### PR DESCRIPTION
When a `<!DOCTYPE>` supplied only one of its PUBLIC/SYSTEM identifiers, the parsed `Doctype` node reported the absent one as an empty string instead of `None`, so `<!DOCTYPE html PUBLIC "p">` and `<!DOCTYPE html PUBLIC "p" "">` were indistinguishable. The WHATWG tokenizer sets an identifier to the empty string only when a quote is consumed, otherwise it stays missing, and `tokenize()` already surfaced that as `None` — only the `parse()` DOM path collapsed it. Closes #68.

The node's serialized text follows html5lib's `#document` format, which writes `""` for a missing identifier just as it does for an empty one, so the text alone cannot carry the distinction. The fix records which identifiers the source supplied in the doctype node's `tag_flags`, a field that is otherwise meaningful only for elements and that the serializer and scope checks never read for a doctype. The getter returns `None` when the corresponding flag is clear, and pickle reconstruction repacks those flags from the `(name, public_id, system_id)` triple so a missing identifier stays missing across a round-trip rather than reappearing as `""`.

No benchmark: parsing writes one extra flag byte per doctype (at most once per document) and the getter adds a single bit test on attribute access, neither on a hot path.