### PR TITLE
🐛 fix: keep a trailing asterisk in a linkified URL

### DIFF
--- a/docs/changelog/61.bugfix.rst
+++ b/docs/changelog/61.bugfix.rst
@@ -1,0 +1,4 @@
+Keep a trailing ``*`` in a linkified URL instead of trimming it. ``*`` is an RFC 3986 sub-delim that is valid in a path
+or query, and both bleach and linkify_it retain it, yet linkify dropped a ``*`` at the very end of a URL from the match
+span even though it kept one mid-path. The ``href`` no longer silently points at a different resource than the visible
+text.

--- a/src/turbohtml/linkify.c
+++ b/src/turbohtml/linkify.c
@@ -227,9 +227,9 @@ static Py_ssize_t scan_url_tail(int kind, const void *data, Py_ssize_t host_end,
         }
         pos++;
         /* a closing bracket or a non-trailing-punctuation byte can end the link;
-           trailing . , ! ? : ; * are valid inside it but never its last byte */
-        if (round == 0 && square == 0 && c != '.' && c != ',' && c != '!' && c != '?' && c != ':' && c != ';' &&
-            c != '*') {
+           trailing . , ! ? : ; are valid inside it but never its last byte. '*' is
+           an RFC 3986 sub-delim that bleach and linkify_it keep, so it ends a link. */
+        if (round == 0 && square == 0 && c != '.' && c != ',' && c != '!' && c != '?' && c != ':' && c != ';') {
             end = pos;
         }
     }

--- a/tests/test_linkify.py
+++ b/tests/test_linkify.py
@@ -305,7 +305,9 @@ def test_bare_domain_path_with_embedded_scheme_keeps_http_prefix() -> None:
         pytest.param("(http://example.com/path)", False, False, [(1, 24, 0)], id="link-in-parens"),
         pytest.param("http://example.com/path.", False, False, [(0, 23, 0)], id="path-trailing-dot-trimmed"),
         pytest.param("http://example.com/a,b,", False, False, [(0, 22, 0)], id="path-trailing-comma-trimmed"),
-        pytest.param("http://example.com/p!?:;*", False, False, [(0, 20, 0)], id="path-trailing-punct-run-trimmed"),
+        pytest.param("http://example.com/p!?:;", False, False, [(0, 20, 0)], id="path-trailing-punct-run-trimmed"),
+        # '*' is an RFC 3986 sub-delim that bleach and linkify_it keep, so a trailing one stays in the link
+        pytest.param("http://example.com/path*", False, False, [(0, 24, 0)], id="path-trailing-star-kept"),
         pytest.param("http://example.com:notaport/x", False, False, [(0, 18, 0)], id="colon-not-a-port-ends-host"),
         pytest.param("http://example.com:8080", False, False, [(0, 23, 0)], id="port-at-end-of-string"),
         pytest.param("http://example.com?q=1", False, False, [(0, 22, 0)], id="query-led-tail"),


### PR DESCRIPTION
`linkify("http://example.com/path*")` dropped the trailing `*` from the link, producing an `href` of `http://example.com/path` next to the visible text `http://example.com/path*`. `*` is an RFC 3986 sub-delim, valid in a path or query, and the same `*` is kept mid-path (`/a*b`), so this was span-edge over-trimming rather than a deliberate policy. bleach 6.4 and linkify_it 2.1 both retain it, and linkify's docstring promises bleach-compatible behavior. Closes #61.

The tail scanner treated `*` as trailing punctuation that is valid inside a URL but never its last byte, alongside `. , ! ? : ;`. Removing `*` from that set lets a URL-final `*` extend the match span like any other tail character, while the genuine sentence punctuation keeps being trimmed.

No benchmark: the change removes one comparison from the tail-trim test, on the same scan path as before.