### PR TITLE
🐛 fix(treebuilder): foster out of a table-section fragment

### DIFF
--- a/docs/changelog/55.bugfix.rst
+++ b/docs/changelog/55.bugfix.rst
@@ -1,0 +1,5 @@
+Foster-parent out to the fragment root when parsing a fragment whose context is a table-section element (``tbody``,
+``table``, ``tr``, ``thead``, ``tfoot``) and no ``table`` element is on the stack of open elements. The WHATWG
+appropriate-place algorithm's "no last table" branch inserts at the first element on the stack, so
+``parse_fragment("<tr><li>x", context="tbody")`` now yields ``<tr></tr><li>x</li>`` (the ``<li>`` a sibling after the
+row) instead of nesting the ``<li>`` inside the open ``<tr>``, matching html5lib. Document-path fostering is unchanged.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -972,9 +972,7 @@ static void insertion_location_target(th_tree *tree, th_node *target, th_node **
     }
     if (tree->foster && (target->atom == TH_TAG_TABLE || target->atom == TH_TAG_TBODY || target->atom == TH_TAG_TFOOT ||
                          target->atom == TH_TAG_THEAD || target->atom == TH_TAG_TR)) {
-        /* GCOVR_EXCL_BR_LINE: foster always returns inside the loop */
-        /* foster always finds the table */
-        for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
+        for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) {
             th_node *open = tree->open[index];
             if (open->ns != TH_NS_HTML) { /* GCOVR_EXCL_BR_LINE: no foreign element sits above a fostered table */
                 continue; /* GCOVR_EXCL_LINE: no foreign element sits above the fostered table on the stack */
@@ -997,7 +995,12 @@ static void insertion_location_target(th_tree *tree, th_node *target, th_node **
                 return;
             }
         }
-    } /* GCOVR_EXCL_LINE: foster always returns inside the loop */
+        /* no table is on the stack: a table-section fragment context (tbody/table/
+           tr/...). The appropriate place is then the first element on the stack, the
+           fragment root, so the content fosters out as a sibling of the open row. */
+        *parent = tree->open[0];
+        return;
+    }
     *parent = target;
 }
 

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -444,6 +444,10 @@ def test_before_html_end_br_synthesizes_br() -> None:
         pytest.param("", "html", "| <head>\n| <body>", id="html-fragment-empty-synthesizes-head-body"),
         pytest.param("<title>t</title>", "html", '|     "t"\n| <body>', id="html-fragment-head-only-adds-body"),
         pytest.param("<!--c-->", "html", "| <!-- c -->\n| <head>\n| <body>", id="html-fragment-comment-then-head-body"),
+        # foster parenting in a table-section fragment context, where no <table> is on
+        # the stack, fosters out to the fragment root rather than nesting (issue #55)
+        pytest.param("<tr><li>x", "tbody", "| <tr>\n| <li>", id="foster-out-of-tbody-fragment"),
+        pytest.param("<tr><li>x", "table", "|   <tr>\n| <li>", id="foster-out-of-table-fragment"),
     ],
 )
 def test_fragment_paths(html: str, context: str, needle: str) -> None:


### PR DESCRIPTION
Parsing a fragment whose context is a table-section element kept foster-parented content nested inside the open row instead of pushing it out. 🪆 `parse_fragment("<tr><li>x", context="tbody")` built `<tr><li>x</li></tr>`, where html5lib makes the `<li>` a sibling after the row.

Foster parenting located the spot just before the nearest `table` element on the stack of open elements, assuming one is always there. In a table-section fragment context (`tbody`, `table`, `tr`, `thead`, `tfoot`) no `table` is ever on the stack, so the walk fell through and the content nested inside the row. The WHATWG appropriate-place algorithm covers this: when there is no last table, the adjusted insertion location is the first element on the stack. This adds that fall-through, so the content fosters out to the fragment root.

`context="tbody"` now yields `<tr></tr><li>x</li>` and `context="table"` yields `<tbody><tr></tr></tbody><li>x</li>`, both matching html5lib. The document path always has a `table` on the stack, so it is unaffected.

Fixes #55