### PR TITLE
🐛 fix(encoding): cap the meta charset prescan at 1024 bytes

### DIFF
--- a/docs/changelog/60.bugfix.rst
+++ b/docs/changelog/60.bugfix.rst
@@ -1,0 +1,3 @@
+Limit the ``<meta charset>`` prescan to the first 1024 bytes, per the WHATWG "prescan a byte stream to determine its
+encoding" algorithm. A ``<meta>`` whose end reaches byte 1024 or later is no longer honored, so the document falls back
+to windows-1252 instead of adopting a late declaration (and an arbitrarily large input is no longer scanned in full).

--- a/src/turbohtml/encoding.h
+++ b/src/turbohtml/encoding.h
@@ -330,13 +330,17 @@ static const char *prescan_charset_in_content(const char *content, char *out, si
     return NULL;
 }
 
-/* Prescan the input for a usable <meta> encoding, scanning the whole buffer as
-   html5lib does. A utf-16 label in this meta context is forced to utf-8. Returns
-   the table entry, or NULL when none is found. */
+/* Prescan the input for a usable <meta> encoding. Per the WHATWG "prescan a byte
+   stream to determine its encoding" algorithm only the first 1024 bytes are examined,
+   so a <meta> whose end reaches past that is not honored. A utf-16 label in this meta
+   context is forced to utf-8. Returns the table entry, or NULL when none is found. */
 static const th_encoding_entry *th_encoding_prescan(const unsigned char *buf, Py_ssize_t len) {
     Py_ssize_t pos = 0;
     char name[32];
     char value[128];
+    if (len > 1024) {
+        len = 1024;
+    }
     while (pos < len) {
         if (pos + 4 <= len && memcmp(buf + pos, "<!--", 4) == 0) {
             pos += 4;

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -78,6 +78,18 @@ def test_invalid_bytes_become_replacement_characters() -> None:
 
 
 @pytest.mark.parametrize(
+    ("pad", "expected"),
+    [
+        # <meta charset=utf-8> is 20 bytes; the prescan examines only the first 1024
+        pytest.param(1004, "UTF-8", id="meta-ends-at-1023-honored"),
+        pytest.param(1005, "windows-1252", id="meta-ends-at-1024-ignored"),
+    ],
+)
+def test_meta_prescan_stops_at_1024_bytes(pad: int, expected: str) -> None:
+    assert parse(b"a" * pad + b"<meta charset=utf-8>").encoding == expected
+
+
+@pytest.mark.parametrize(
     ("label", "expected"),
     [
         pytest.param("iso-8859-3", "ISO-8859-3", id="iso-8859-3"),

--- a/tests/test_encoding_conformance.py
+++ b/tests/test_encoding_conformance.py
@@ -10,6 +10,18 @@ from turbohtml import parse
 
 _SUITE = Path(__file__).parent / "html5lib-tests" / "encoding"
 
+# A few tests1.dat cases place the only <meta charset> well past byte 1024 (the
+# "N characters" boundary fixtures and the multi-script test, meta at 2026..8323)
+# and expect it honored. The WHATWG "prescan a byte stream to determine its
+# encoding" algorithm examines only the first 1024 bytes, so a meta beyond that is
+# ignored and the document falls back to windows-1252. The spec is authoritative
+# over the pinned .dat (see https://github.com/tox-dev/turbohtml/issues/60), so we
+# assert the spec-correct result. Keyed by (filename, case index) over the pinned
+# submodule.
+_SPEC_OVERRIDES: dict[tuple[str, int], str] = {
+    ("tests1.dat", index): "windows-1252" for index in (47, 48, 49, 50, 51, 52, 53)
+}
+
 
 def _cases() -> list:
     cases = []
@@ -19,6 +31,7 @@ def _cases() -> list:
             head, _, tail = chunk.partition(b"#encoding\n")
             data = head[:-1] if head.endswith(b"\n") else head
             encoding = tail.split(b"\n", 1)[0].decode("ascii").strip()
+            encoding = _SPEC_OVERRIDES.get((name, index), encoding)
             cases.append(pytest.param(data, encoding, id=f"{name}-{index}"))
     return cases
 


### PR DESCRIPTION
The WHATWG "prescan a byte stream to determine its encoding" algorithm examines only the first 1024 bytes, but `th_encoding_prescan` looped over the entire input with no positional cap, so a late `<meta charset>` whose end lands at or past byte 1024 was wrongly honored — and an arbitrarily large input was scanned in full. The scan is now capped at 1024 bytes.

A note on the oracle: the html5lib-tests **encoding** suite (`tests1.dat` cases 47–53) places the only `<meta charset>` past 1024 (at byte 2026–8323) and expects it honored. That matches html5lib's *parser*, but contradicts the WHATWG algorithm, which the project treats as authoritative over the pinned `.dat` (same situation as #32). Those seven cases therefore get spec-correct `windows-1252` overrides in the conformance harness, and a focused test pins the exact 1024-byte boundary.

closes #60