### PR TITLE
🐛 fix: match custom-element type selector case-insensitively

### DIFF
--- a/docs/changelog/62.bugfix.rst
+++ b/docs/changelog/62.bugfix.rst
@@ -1,0 +1,4 @@
+Match a type selector against a custom or unknown element name case-insensitively, so ``select("MY-CARD")`` finds a
+``<my-card>`` just as ``select("DIV")`` finds a ``<div>``. Type selectors are ASCII case-insensitive in HTML documents,
+which already worked for the builtin tag names resolved through the atom table; an element outside that table fell back
+to a case-sensitive comparison against its lowercased stored name, so an uppercase selector never matched.

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -524,7 +524,9 @@ static int sel_match_simple(th_node *node, const sel_simple *simple) {
         if (simple->tag_atom != TH_TAG_UNKNOWN) {
             return node->atom == simple->tag_atom;
         }
-        return sel_eq(node->text, node->text_len, simple->name, simple->name_len, 0);
+        /* a custom/unknown tag is stored lowercased; type selectors are ASCII case-insensitive
+           in HTML, so match it case-insensitively like the builtin-atom path above does */
+        return sel_eq(node->text, node->text_len, simple->name, simple->name_len, 1);
     case '#': {
         const th_node_attr *attr = sel_find_attr(node, TH_ATTR_ID);
         return attr != NULL && attr->value != NULL &&

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -29,6 +29,8 @@ def _sel(html: str, selector: str) -> list[str]:
         pytest.param(".item", ["li", "li"], id="class"),
         pytest.param("#s", ["section"], id="id"),
         pytest.param("my-widget", ["my-widget"], id="unknown-tag-by-name"),
+        # a type selector is ASCII case-insensitive even for a custom/unknown tag (issue #62)
+        pytest.param("MY-WIDGET", ["my-widget"], id="unknown-tag-folds-case"),
         pytest.param("li.sel", ["li"], id="compound-type-class"),
         pytest.param("p.lead.first", ["p"], id="compound-two-classes"),
         # attribute operators


### PR DESCRIPTION
`select("FOO")` returned nothing for `<foo>`, and `select("MY-CARD")` nothing for `<my-card>`, even though `select("DIV")` matches `<div>`. Type selectors are ASCII case-insensitive in HTML documents (CSS Selectors Level 4, "Case-sensitivity"), and the lowercase selector `foo` did match, confirming the element is stored lowercased and only the selector's case-sensitivity was wrong. soupsieve and selectolax both match. Closes #62.

A builtin tag name resolves through the atom table, which lowercases it, so the comparison is already case-insensitive. A name outside that table kept its original case and compared exactly against the lowercased stored tag, so an uppercase selector never matched. The fix folds case in that fallback comparison too, the way the builtin path effectively does, while `#id` and `.class` selectors stay case-sensitive as the spec requires.

No benchmark: the change folds case only on the rare custom/unknown type-selector path; the builtin atom compare and every other selector are untouched.