### PR TITLE
🐛 fix: fold HTML case-insensitive attribute set in selectors

### DIFF
--- a/docs/changelog/59.bugfix.rst
+++ b/docs/changelog/59.bugfix.rst
@@ -1,0 +1,5 @@
+Compare the value of an attribute in HTML's case-insensitive attribute set ASCII case-insensitively by default in a
+selector, so ``input[type=text]`` matches ``type="TEXT"``. The WHATWG "Case-sensitivity of selectors" rules fold the
+value of a fixed set of attributes (``type``, ``lang``, ``rel``, ``method``, ``charset`` and others) by default in an
+HTML document; turbohtml previously folded only with an explicit ``i`` flag. An explicit ``s`` flag still forces a
+case-sensitive comparison, and attributes outside the set stay case-sensitive.

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -11,6 +11,8 @@
 #include "ascii.h"
 #include "treebuilder.h"
 
+#include <string.h>
+
 enum sel_attr_op { OP_EXISTS, OP_EQ, OP_INCLUDE, OP_DASH, OP_PREFIX, OP_SUFFIX, OP_SUBSTR };
 
 typedef struct {
@@ -172,6 +174,41 @@ static uint32_t sel_attr_atom(th_tree *tree, const Py_UCS4 *name, Py_ssize_t len
     return th_attr_lookup(tree, bytes, at);
 }
 
+/* The HTML "case-insensitive" attribute set (WHATWG "Case-sensitivity of
+   selectors"): a selector comparing one of these attributes' values does so
+   ASCII case-insensitively by default in an HTML document, unless the selector
+   gives an explicit s/i flag. All names are ASCII and at most 14 bytes. */
+static const char *const sel_ci_attrs[] = {
+    "accept",   "accept-charset", "align",    "alink",      "axis",   "bgcolor",  "charset",   "checked",  "clear",
+    "codetype", "color",          "compact",  "declare",    "defer",  "dir",      "direction", "disabled", "enctype",
+    "face",     "frame",          "hreflang", "http-equiv", "lang",   "language", "link",      "media",    "method",
+    "multiple", "nohref",         "noresize", "noshade",    "nowrap", "readonly", "rel",       "rev",      "rules",
+    "scope",    "scrolling",      "selected", "shape",      "target", "text",     "type",      "valign",   "valuetype",
+    "vlink",
+};
+
+/* Whether an attribute name (selector text, any case) is in that set. */
+static int sel_attr_is_ci_default(const Py_UCS4 *name, Py_ssize_t len) {
+    char buf[16];
+    if (len >= (Py_ssize_t)sizeof(buf)) {
+        return 0; /* longer than any name in the set */
+    }
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 ch = name[index];
+        if (ch >= 'A' && ch <= 'Z') {
+            ch += 32;
+        }
+        buf[index] = ch < 0x80 ? (char)ch : '\x01'; /* a non-ASCII byte is never in the set */
+    }
+    buf[len] = '\0';
+    for (size_t index = 0; index < sizeof(sel_ci_attrs) / sizeof(sel_ci_attrs[0]); index++) {
+        if (strcmp(buf, sel_ci_attrs[index]) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* Parse a bracketed attribute selector (the leading '[' already consumed). */
 static void sel_attribute(sel_parser *parser, sel_simple *simple) {
     simple->kind = '[';
@@ -237,6 +274,8 @@ static void sel_attribute(sel_parser *parser, sel_simple *simple) {
     } else if (parser->pos < parser->len && (parser->src[parser->pos] | 32) == 's') {
         parser->pos++;
         sel_skip_ws(parser);
+    } else if (sel_attr_is_ci_default(name, name_len)) {
+        simple->ci = 1; /* HTML compares this attribute's value case-insensitively by default */
     }
     if (parser->pos >= parser->len || parser->src[parser->pos] != ']') {
         parser->error = 1;

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -123,6 +123,15 @@ def test_select_over_doc(selector: str, tags: list[str]) -> None:
         pytest.param("<div id>", "#x", [], id="valueless-id-matches-nothing"),
         pytest.param("<div class>", ".x", [], id="valueless-class-matches-nothing"),
         pytest.param("<DIV></DIV>", "DIV", ["div"], id="type-folds-case"),
+        # HTML's case-insensitive attribute set: type's value is folded by default (issue #59)
+        pytest.param("<input type=TEXT>", "[type=text]", ["input"], id="ci-attr-set-value-folds"),
+        pytest.param("<input type=TEXT>", "[TYPE=text]", ["input"], id="ci-attr-set-name-folds"),
+        pytest.param("<input type=TEXT>", "[type=text s]", [], id="ci-attr-set-s-flag-overrides"),
+        # an attribute outside the set keeps the case-sensitive default
+        pytest.param('<a href="/X">', '[href="/x"]', [], id="non-ci-attr-stays-case-sensitive"),
+        # a non-ASCII or over-long attribute name is never in the set, so it stays case-sensitive
+        pytest.param('<x café="Y">', "[café=y]", [], id="non-ascii-attr-not-in-ci-set"),
+        pytest.param('<x data-0123456789abc="Y">', "[data-0123456789abc=y]", [], id="overlong-attr-not-in-ci-set"),
         pytest.param('<div class="a_b">', ".a_b", ["div"], id="class-underscore"),
         pytest.param('<div class="café">', ".café", ["div"], id="class-non-ascii"),
         pytest.param("<café>x", "café", ["café"], id="type-non-ascii"),


### PR DESCRIPTION
`input[type=text]` returned nothing for `<input type="TEXT">`, even though the explicit-flag form `input[type=text i]` and the exact form `input[type=TEXT]` both matched. The WHATWG HTML standard's "Case-sensitivity of selectors" rules compare the value of a fixed set of attributes — `type`, `accept`, `charset`, `enctype`, `lang`, `method`, `rel`, `target` and others — ASCII case-insensitively by default in an HTML document, and soupsieve and selectolax both honor it. Closes #59.

An attribute selector now defaults its case flag to insensitive when the attribute name is in that set and the selector carries no explicit `s`/`i` flag. The set is the spec's list, checked once when the selector compiles. An explicit `s` flag still forces a case-sensitive match, an explicit `i` still forces insensitive, and any attribute outside the set keeps the case-sensitive default that CSS specifies.

No benchmark: the set membership is tested once per attribute selector at compile time; the per-node match path is unchanged.