### PR TITLE
🐛 fix: keep foreign element namespace across a pickle round-trip

### DIFF
--- a/docs/changelog/85.bugfix.rst
+++ b/docs/changelog/85.bugfix.rst
@@ -1,0 +1,4 @@
+Preserve a foreign-content element's namespace across a pickle round-trip. Pickling a detached SVG or MathML
+:class:`~turbohtml.Element` reset its ``namespace`` to ``Namespace.HTML``, because the ``__reduce__`` payload carried
+only the tag and attributes, unlike :func:`copy.deepcopy`. The payload now appends the namespace for a foreign element
+and the unpickle hook restores it, leaving HTML elements unchanged and rejecting an out-of-range namespace.

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -2896,7 +2896,11 @@ static PyObject *node_pickle_data(PyObject *self, th_node *node) {
         if (attrs == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
         }
-        return Py_BuildValue("(NN)", element_get_tag(self, NULL), attrs);
+        if (node->ns == TH_NS_HTML) {
+            return Py_BuildValue("(NN)", element_get_tag(self, NULL), attrs);
+        }
+        /* a foreign (SVG/MathML) element carries its namespace so the round-trip keeps it */
+        return Py_BuildValue("(NNi)", element_get_tag(self, NULL), attrs, (int)node->ns);
     }
     case TH_NODE_DOCUMENT:
     case TH_NODE_CONTENT:
@@ -2986,12 +2990,20 @@ PyObject *turbohtml_reconstruct(PyObject *module, PyObject *args) {
            through the trusted builder rather than the validating public constructor */
         PyObject *tag;
         PyObject *element_attrs;
-        /* GCOVR_EXCL_START: node_reduce builds this (tag, attrs) tuple, so the parse never fails */
-        if (!PyArg_ParseTuple(data, "UO", &tag, &element_attrs)) {
+        int ns = TH_NS_HTML; /* an HTML element omits the namespace; a foreign one appends it */
+        /* GCOVR_EXCL_START: node_reduce builds this (tag, attrs[, ns]) tuple, so the parse never fails */
+        if (!PyArg_ParseTuple(data, "UO|i", &tag, &element_attrs, &ns)) {
             return NULL;
         }
         /* GCOVR_EXCL_STOP */
+        if (ns < TH_NS_HTML || ns > TH_NS_MATHML) { /* guard the namespaces[] index against a crafted payload */
+            PyErr_SetString(PyExc_ValueError, "namespace out of range");
+            return NULL;
+        }
         node = make_element((PyTypeObject *)state->element_type, tag, element_attrs);
+        if (node != NULL) {
+            ((NodeObject *)node)->node->ns = (uint8_t)ns;
+        }
         break;
     }
     case TH_NODE_DOCTYPE:

--- a/tests/test_tree_pickle.py
+++ b/tests/test_tree_pickle.py
@@ -104,6 +104,33 @@ def test_pickled_element_is_independent() -> None:
     assert clone.html == "<p>x<b></b></p>"
 
 
+@pytest.mark.parametrize(
+    ("html", "container"),
+    [
+        pytest.param("<svg><rect></rect></svg>", "svg", id="svg"),
+        pytest.param("<math><mi>x</mi></math>", "math", id="mathml"),
+    ],
+)
+def test_foreign_element_round_trip_keeps_namespace(html: str, container: str) -> None:
+    parent = parse(html).find(container)
+    assert parent is not None
+    child = parent.children[0]
+    assert isinstance(child, Element)
+    clone = _roundtrip(child)
+    assert isinstance(clone, Element)
+    assert clone.namespace == child.namespace  # not reset to Namespace.HTML on the round-trip (issue #85)
+
+
+@pytest.mark.parametrize("ns", [-1, 99], ids=["below", "above"])
+def test_reconstruct_rejects_out_of_range_namespace(ns: int) -> None:
+    reduced = Element("div").__reduce__()
+    assert isinstance(reduced, tuple)
+    kind = reduced[1][0]  # the element kind from the (kind, data, children) payload
+    # a crafted payload must not index the namespaces table out of bounds
+    with pytest.raises(ValueError, match="namespace out of range"):
+        _reconstruct(kind, ("div", {}, ns), [])
+
+
 def test_reconstruct_rejects_malformed_arguments() -> None:
     with pytest.raises(TypeError):
         _reconstruct("not a triple")  # ty: ignore[missing-argument, invalid-argument-type]  # deliberately malformed


### PR DESCRIPTION
Pickling a detached SVG or MathML `Element` reset its `namespace` to `Namespace.HTML` on the round-trip, while `copy.deepcopy` of the same node preserved it. The `__reduce__` payload carried only the tag and attribute dict, so the unpickle hook rebuilt the element in the HTML namespace and silently corrupted foreign-content state, which is security-relevant for a sanitizer. Closes #85.

The element payload now appends the namespace when it is not HTML, so an HTML element keeps its compact `(tag, attrs)` form and a foreign element round-trips its namespace. The reconstruction hook reads the optional value and applies it, and guards the `namespaces` table index against a crafted out-of-range payload so a hostile pickle cannot index out of bounds.

No benchmark: the change is on the pickle and unpickle paths only, never during parsing or serialization.