### PR TITLE
🐛 fix: put plain xmlns on a foreign element in the xmlns namespace

### DIFF
--- a/docs/changelog/64.bugfix.rst
+++ b/docs/changelog/64.bugfix.rst
@@ -1,0 +1,4 @@
+Place a plain ``xmlns`` attribute on a foreign (SVG/MathML) element in the ``http://www.w3.org/2000/xmlns/`` namespace,
+the last missing row of the WHATWG "adjust foreign attributes" table. turbohtml already moved ``xmlns:xlink`` and the
+``xlink:`` and ``xml:`` attributes into their namespaces but left a prefix-less ``xmlns`` in the null namespace, so the
+tree-construction ``#document`` output rendered ``xmlns="..."`` where html5lib renders ``xmlns xmlns="..."``.

--- a/src/turbohtml/treebuilder_foreign.h
+++ b/src/turbohtml/treebuilder_foreign.h
@@ -151,12 +151,13 @@ static const char *foreign_adjust_attr(const char *lower, Py_ssize_t len, uint8_
 }
 
 /* True only for the foreign attribute names the spec puts in a namespace; those
-   serialize with a space (prefix localname). An arbitrary xml:/xlink: name that
-   is not in the table keeps its literal colon. */
+   serialize with a space (prefix localname). Plain "xmlns" has no prefix in its
+   stored name but still belongs to the xmlns namespace, so the renderer prepends
+   one. An arbitrary xml:/xlink: name not in the table keeps its literal colon. */
 static int foreign_attr_namespaced(const char *lower, Py_ssize_t len) {
     static const char *const NAMESPACED[] = {
-        "xlink:actuate", "xlink:arcrole", "xlink:href", "xlink:role", "xlink:show",
-        "xlink:title",   "xlink:type",    "xml:lang",   "xml:space",  "xmlns:xlink",
+        "xlink:actuate", "xlink:arcrole", "xlink:href", "xlink:role", "xlink:show",  "xlink:title",
+        "xlink:type",    "xml:lang",      "xml:space",  "xmlns",      "xmlns:xlink",
     };
     for (size_t index = 0; index < sizeof(NAMESPACED) / sizeof(NAMESPACED[0]); index++) {
         if ((Py_ssize_t)strlen(NAMESPACED[index]) == len && memcmp(NAMESPACED[index], lower, (size_t)len) == 0) {

--- a/src/turbohtml/treebuilder_serialize.h
+++ b/src/turbohtml/treebuilder_serialize.h
@@ -114,6 +114,13 @@ static void render_attr_name(th_tree *tree, const th_node *node, const th_node_a
     const char *name = th_attr_name(tree, attr->name_atom, &name_len);
     int to_space = node->ns != TH_NS_HTML && foreign_attr_namespaced(name, name_len);
     size_t write_index = 0;
+    if (to_space && memchr(name, ':', (size_t)name_len) == NULL) {
+        /* the only namespaced attribute without a prefix to split on is plain xmlns,
+           which belongs to the xmlns namespace and renders as "xmlns xmlns"; the
+           6-byte prefix always fits the 128-byte buffer, so no bound check is needed */
+        memcpy(buf, "xmlns ", 6);
+        write_index = 6;
+    }
     for (const char *character = name; *character != '\0' && write_index + 1 < bufsize; character++) {
         buf[write_index++] = (to_space && *character == ':') ? ' ' : *character;
     }
@@ -218,6 +225,9 @@ static void serialize_node_line(sbuf *out, th_tree *tree, th_node *node, int dep
         Py_ssize_t name_len;
         const char *name = th_attr_name(tree, attr->name_atom, &name_len);
         if (node->ns != TH_NS_HTML && foreign_attr_namespaced(name, name_len)) {
+            if (memchr(name, ':', (size_t)name_len) == NULL) {
+                sbuf_puts(out, "xmlns "); /* plain xmlns (no prefix to split on) renders with its namespace prefix */
+            }
             for (const char *character = name; *character; character++) {
                 sbuf_putc(out, *character == ':' ? (Py_UCS4)' ' : (Py_UCS4)*character);
             }

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -154,6 +154,17 @@ _LONG_NAME = "z" * 130
         pytest.param("<math><mtext><b>x</b></mtext></math>", "<b>", id="mathml-text-integration"),
         pytest.param("<svg><foreignObject><b>x</b></foreignObject></svg>", "<b>", id="svg-html-integration"),
         pytest.param("<svg><a xlink:href=x>y</a></svg>", 'xlink href="x"', id="foreign-namespaced-attribute"),
+        # plain xmlns on a foreign element belongs to the xmlns namespace, rendered "xmlns xmlns" (issue #64)
+        pytest.param(
+            '<svg xmlns="http://www.w3.org/2000/svg">',
+            'xmlns xmlns="http://www.w3.org/2000/svg"',
+            id="foreign-plain-xmlns",
+        ),
+        pytest.param(
+            '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">',
+            '|       xmlns xlink="http://www.w3.org/1999/xlink"\n|       xmlns xmlns="http://www.w3.org/2000/svg"',
+            id="foreign-plain-and-prefixed-xmlns-sorted",
+        ),
         pytest.param(
             "<math><mtext><svg><br></svg></mtext></math>", "<br>", id="breakout-stops-at-mathml-text-integration"
         ),


### PR DESCRIPTION
A plain `xmlns` attribute on a foreign (SVG/MathML) element stayed in the null namespace, the one missing row of WHATWG's "adjust foreign attributes" table. turbohtml already moves `xmlns:xlink`, the `xlink:` family, and the `xml:` attributes into their namespaces, so `<svg xmlns="http://www.w3.org/2000/svg">` rendered as `xmlns="..."` in the tree-construction `#document` output where html5lib (the reference) renders `xmlns xmlns="..."`. Closes #64.

`xmlns` is added to the namespaced-attribute set. Because it is the only namespaced foreign attribute with no colon to split into a prefix and local name, the `#document` renderer detects the absence of a colon and prepends the `xmlns` prefix, leaving the existing `prefix:local` attributes untouched. Regular HTML serialization still emits the literal `xmlns="..."`, matching html5lib's serializer.

No benchmark: the change touches only the html5lib `#document` conformance renderer, never the regular serialize or parse hot paths.