### PR TITLE
🐛 fix(selectors): accept namespace-qualified type selectors

### DIFF
--- a/docs/changelog/65.bugfix.rst
+++ b/docs/changelog/65.bugfix.rst
@@ -1,0 +1,5 @@
+Accept namespace-qualified type selectors in ``select()``/``select_one()``. ``*|E``, ``*|*``, ``|E``, ``|*``, and
+``ns|E`` were rejected with ``ValueError('invalid CSS selector')``; the namespace prefix is part of the Selectors Level
+4 type-selector grammar and, in a namespaceless HTML document, the qualified form reduces to its unqualified selector
+(``*|a`` matches ``a``, ``*|*`` matches every element). The prefix is now parsed and ignored, matching lxml.cssselect,
+selectolax, and bs4.

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -295,6 +295,22 @@ static void sel_attribute(sel_parser *parser, sel_simple *simple) {
     parser->pos++;
 }
 
+/* Parse the local part of a type selector (the part after an optional namespace
+   prefix): '*' for the universal selector or an identifier for a tag name. */
+static void sel_type_local(sel_parser *parser, sel_simple *simple) {
+    if (parser->pos < parser->len && parser->src[parser->pos] == '*') {
+        simple->kind = '*';
+        parser->pos++;
+    } else if (parser->pos < parser->len &&
+               (sel_is_ident(parser->src[parser->pos]) || parser->src[parser->pos] == '\\')) {
+        simple->kind = 'e';
+        sel_ident(parser, &simple->name, &simple->name_len);
+        simple->tag_atom = sel_tag_atom(simple->name, simple->name_len);
+    } else {
+        parser->error = 1; /* a namespace prefix must be followed by '*' or a type */
+    }
+}
+
 /* Parse one simple selector into *simple. */
 static void sel_one(sel_parser *parser, sel_simple *simple) {
     simple->tag_atom = TH_TAG_UNKNOWN;
@@ -306,27 +322,43 @@ static void sel_one(sel_parser *parser, sel_simple *simple) {
     simple->value = NULL;
     simple->value_len = 0;
     Py_UCS4 ch = parser->src[parser->pos];
-    if (ch == '*') {
-        simple->kind = '*';
-        parser->pos++;
-    } else if (ch == '.' || ch == '#') {
+    if (ch == '.' || ch == '#') {
         simple->kind = (char)ch;
         parser->pos++;
         sel_ident(parser, &simple->name, &simple->name_len);
     } else if (ch == '[') {
         parser->pos++;
         sel_attribute(parser, simple);
+    } else if (ch == '|') {
+        /* an empty (no-namespace) prefix; the prefix is ignored in a namespaceless
+           HTML document, so |E reduces to E and |* to the universal selector */
+        parser->pos++;
+        sel_type_local(parser, simple);
+    } else if (ch == '*' && parser->pos + 1 < parser->len && parser->src[parser->pos + 1] == '|') {
+        /* a '*|' any-namespace prefix; ignored in HTML, so *|E reduces to E */
+        parser->pos += 2;
+        sel_type_local(parser, simple);
+    } else if (ch == '*') {
+        simple->kind = '*';
+        parser->pos++;
     } else {
-        /* an identifier: sel_starts_simple guarantees at least one char, so
-           sel_ident here always succeeds */
-        simple->kind = 'e';
+        /* an identifier: a tag name, or a namespace prefix when a '|' follows it.
+           sel_starts_simple guarantees at least one char, so sel_ident succeeds */
         sel_ident(parser, &simple->name, &simple->name_len);
-        simple->tag_atom = sel_tag_atom(simple->name, simple->name_len);
+        if (parser->pos < parser->len && parser->src[parser->pos] == '|') {
+            parser->pos++; /* an 'ns|' prefix; ignored in HTML, only the local part selects */
+            simple->name = NULL;
+            simple->name_len = 0;
+            sel_type_local(parser, simple);
+        } else {
+            simple->kind = 'e';
+            simple->tag_atom = sel_tag_atom(simple->name, simple->name_len);
+        }
     }
 }
 
 static int sel_starts_simple(Py_UCS4 ch) {
-    return ch == '*' || ch == '.' || ch == '#' || ch == '[' || ch == '\\' || sel_is_ident(ch);
+    return ch == '*' || ch == '.' || ch == '#' || ch == '[' || ch == '\\' || ch == '|' || sel_is_ident(ch);
 }
 
 /* Parse a compound (one or more adjacent simples) into the given buffer. */

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -196,10 +196,40 @@ def test_select_one() -> None:
 
 
 @pytest.mark.parametrize(
+    ("selector", "tags"),
+    [
+        # a namespace prefix is ignored in a namespaceless HTML document
+        pytest.param("*|a", ["a"], id="any-ns-type"),
+        pytest.param("|a", ["a"], id="no-ns-type"),
+        pytest.param("ns|a", ["a"], id="named-ns-type"),
+        pytest.param("*|*", ["html", "head", "body", "root", "a", "b"], id="any-ns-universal"),
+        pytest.param("|*", ["html", "head", "body", "root", "a", "b"], id="no-ns-universal"),
+        pytest.param("ns|*", ["html", "head", "body", "root", "a", "b"], id="named-ns-universal"),
+    ],
+)
+def test_namespace_prefixed_type_selectors(selector: str, tags: list[str]) -> None:
+    assert _sel("<root><a>1</a><b>2</b></root>", selector) == tags
+
+
+def test_universal_followed_by_simple_is_not_a_namespace_prefix() -> None:
+    # a '*' not followed by '|' is the plain universal selector, then the next simple
+    assert _sel("<root><a class=x>1</a><b>2</b></root>", "*.x") == ["a"]
+
+
+def test_namespace_prefixed_local_part_decodes_escapes() -> None:
+    # the local part after a namespace prefix is a full identifier, so it decodes escapes
+    assert _sel("<root><a>1</a></root>", "*|\\61") == ["a"]
+
+
+@pytest.mark.parametrize(
     "selector",
     [
         pytest.param("", id="empty"),
         pytest.param("  ", id="whitespace"),
+        # a namespace prefix must be followed by a type or the universal selector
+        pytest.param("*|", id="star-prefix-at-eof"),
+        pytest.param("|", id="bare-pipe"),
+        pytest.param("*|[a]", id="prefix-then-attribute"),
         pytest.param(".", id="bare-dot"),
         pytest.param("#", id="bare-hash"),
         pytest.param("p..", id="double-dot"),


### PR DESCRIPTION
`select()`/`select_one()` raised `ValueError('invalid CSS selector')` for type selectors carrying a namespace prefix — `*|E`, `*|*`, `|E`, `|*`, `ns|E` — because the compound parser had no handling for the `|` separator. The optional namespace prefix is part of the Selectors Level 4 type-selector grammar, and in a namespaceless HTML document the qualified form reduces to its unqualified selector (`*|a` ⇒ `a`, `*|*` ⇒ `*`). 🎯

The parser now consumes and ignores the prefix (`*|`, `ns|`, or empty `|`) and selects on the local part, so `*|a` returns the `<a>` and `*|*` returns every element — matching lxml.cssselect, selectolax, and bs4. A prefix not followed by a type or universal selector (e.g. `*|`, `|`, `*|[a]`) is still a parse error.

closes #65