### PR TITLE
🐛 fix: require exact annotation-xml encoding for integration point

### DIFF
--- a/docs/changelog/92.bugfix.rst
+++ b/docs/changelog/92.bugfix.rst
@@ -1,0 +1,4 @@
+Require an exact ASCII case-insensitive match for a MathML ``annotation-xml`` element's ``encoding`` attribute before
+treating it as an HTML integration point. The check approximated ``text/html`` by three characters and accepted any
+21-character value as ``application/xhtml+xml``, so a near miss like ``encoding="text-html"`` wrongly became an
+integration point and kept HTML children nested instead of letting them break out of the foreign subtree.

--- a/src/turbohtml/treebuilder_foreign.h
+++ b/src/turbohtml/treebuilder_foreign.h
@@ -171,21 +171,34 @@ static int is_mathml_text_integration(const th_node *node) {
                                         node->atom == TH_TAG_MS || node->atom == TH_TAG_MTEXT);
 }
 
+/* ASCII case-insensitive match of a code-point run against a NUL-terminated ASCII string. */
+static int value_ci_eq(const Py_UCS4 *value, Py_ssize_t value_len, const char *target) {
+    if (value_len != (Py_ssize_t)strlen(target)) {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < value_len; index++) {
+        Py_UCS4 ch = value[index] >= 'A' && value[index] <= 'Z' ? value[index] + 32 : value[index];
+        if (ch != (Py_UCS4)(unsigned char)target[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 static int is_html_integration(const th_node *node) {
     if (node->ns == TH_NS_SVG) {
         return node->atom == TH_TAG_FOREIGNOBJECT || node->atom == TH_TAG_DESC || node->atom == TH_TAG_TITLE;
     }
-    /* annotation-xml is an HTML integration point only when it carries an encoding of text/html or
-       application/xhtml+xml. Only foreign nodes reach here after the html case, so a non-svg node is always mathml. */
+    /* annotation-xml is an HTML integration point only when its encoding attribute is an ASCII
+       case-insensitive match for exactly text/html or application/xhtml+xml. Only foreign nodes
+       reach here after the html case, so a non-svg node is always mathml. */
     if (node->ns == TH_NS_MATHML /* GCOVR_EXCL_BR_LINE */ && node->atom == TH_TAG_ANNOTATION_XML) {
         for (Py_ssize_t index = 0; index < node->attr_count; index++) {
             const th_node_attr *attr = &node->attrs[index];
-            if (attr->name_atom == TH_ATTR_ENCODING && attr->value != NULL) {
-                if ((attr->value_len == 9 && /* "text/html" case-insensitively */
-                     (attr->value[0] | 32) == 't' && (attr->value[1] | 32) == 'e' && (attr->value[5] | 32) == 'h') ||
-                    attr->value_len == 21) { /* application/xhtml+xml */
-                    return 1;
-                }
+            if (attr->name_atom == TH_ATTR_ENCODING && attr->value != NULL &&
+                (value_ci_eq(attr->value, attr->value_len, "text/html") ||
+                 value_ci_eq(attr->value, attr->value_len, "application/xhtml+xml"))) {
+                return 1;
             }
         }
     }

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -173,6 +173,25 @@ _LONG_NAME = "z" * 130
             "<div>",
             id="annotation-xml-non-html-encoding",
         ),
+        # the encoding must be an EXACT case-insensitive match; a near miss is not an integration
+        # point, so <b> breaks out to body level instead of nesting under annotation-xml (issue #92)
+        pytest.param(
+            "<math><annotation-xml encoding='text-html'><b>x</b></annotation-xml></math>",
+            'encoding="text-html"\n|     <b>',
+            id="annotation-xml-encoding-near-miss-breaks-out",
+        ),
+        # the application/xhtml+xml row was length-only, so any 21-char value matched; now it does not
+        pytest.param(
+            "<math><annotation-xml encoding='application/xhtml-xml'><b>x</b></annotation-xml></math>",
+            'encoding="application/xhtml-xml"\n|     <b>',
+            id="annotation-xml-encoding-21-char-near-miss-breaks-out",
+        ),
+        # an uppercase exact match is still an integration point, so <b> stays nested
+        pytest.param(
+            "<math><annotation-xml encoding='TEXT/HTML'><b>x</b></annotation-xml></math>",
+            'encoding="TEXT/HTML"\n|         <b>',
+            id="annotation-xml-encoding-uppercase-integration",
+        ),
         pytest.param("<math><mi><div>x</div></mi></math>", "<div>", id="mathml-mi-not-html-integration"),
         pytest.param("<svg><font face=x>y", "<font>", id="svg-font-face-breakout"),
         pytest.param("<svg><font size=x>y", "<font>", id="svg-font-size-breakout"),


### PR DESCRIPTION
A MathML `annotation-xml` element became an HTML integration point when its `encoding` attribute only approximately resembled `text/html`, so `encoding="text-html"` (and any other 21-character value, which the `application/xhtml+xml` branch accepted by length alone) wrongly qualified. Foreign-content breakout then failed: an HTML start tag like `<b>` stayed nested under the MathML subtree instead of popping out to body level. The WHATWG definition requires an ASCII case-insensitive match for exactly `text/html` or `application/xhtml+xml`. Closes #92.

The encoding value is now compared in full, case-insensitively, against each of the two exact strings, so a near miss is no longer an integration point and the HTML child breaks out as html5lib produces. An uppercase exact match such as `TEXT/HTML` still qualifies.

No benchmark: the comparison runs only for an `annotation-xml` element carrying an `encoding` attribute and reads at most 21 characters, off any hot path.