### PR TITLE
🐛 fix(treebuilder): keep foreign </br> inside its root

### DIFF
--- a/docs/changelog/63.bugfix.rst
+++ b/docs/changelog/63.bugfix.rst
@@ -1,0 +1,4 @@
+Place the synthesized ``<br>`` from a ``</br>`` end tag in foreign (SVG or MathML) content inside the foreign element
+rather than as a sibling under ``<body>``. Like ``</p>`` (issue #32), ``</br>`` is an "any other end tag" in the WHATWG
+foreign-content rules: nothing is popped and the token is reprocessed in the current insertion mode with the foreign
+element still current, so ``<svg></br>`` now builds ``<svg><br></svg>``, matching lexbor and html5lib.

--- a/src/turbohtml/treebuilder_foreign.h
+++ b/src/turbohtml/treebuilder_foreign.h
@@ -397,27 +397,11 @@ static int foreign_step(th_tree *tree, const th_token *token) {
         }
         return 1;
     }
-    /* end tag: </br> is a breakout tag like its start-tag form. </p> is not: it
-       is "any other end tag", which walks the stack without popping the foreign
-       element and processes the token under HTML rules, so the implied <p> lands
-       inside the foreign root rather than as a sibling. */
-    uint16_t atom = tok_atom(token);
-    if (atom == TH_TAG_BR) {
-        /* html is never foreign, so the breakout loop never empties the stack */
-        while (tree->open_len > 0) { /* GCOVR_EXCL_BR_LINE */
-            th_node *cur = current_node(tree);
-            if (cur->ns == TH_NS_HTML || is_mathml_text_integration(cur) || is_html_integration(cur) ||
-                cur == tree->fragment_root) {
-                break; /* never pop the fragment's context root */
-            }
-            stack_pop(tree);
-        }
-        return 0; /* reprocess under HTML rules */
-    }
-    /* otherwise walk up the stack: stop at the first HTML element and run the
-       HTML rules there (the token is reprocessed with the foreign element still
-       current), or match a foreign element by (case-insensitive) name and pop to
-       it; never pop the fragment context root */
+    /* "any other end tag", which includes </br> and </p>: walk up the stack, stop at
+       the first HTML element and run the HTML rules there (the token is reprocessed
+       with the foreign element still current, so a synthesized <br>/<p> lands inside
+       the foreign root rather than as a sibling), or match a foreign element by
+       (case-insensitive) name and pop to it; never pop the fragment context root */
     for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
         th_node *node = tree->open[index];
         if (node->ns == TH_NS_HTML) {

--- a/tests/test_treebuilder_conformance.py
+++ b/tests/test_treebuilder_conformance.py
@@ -58,16 +58,17 @@ def _build(data: str, context: str | None) -> str:
     return _html._parse_tree(data).rstrip("\n")
 
 
-# A few html5lib-tests cases encode the pre-errata "</p> in a foreign namespace"
-# behavior added in html5lib-tests 9b4a29c (2021) and never revised. They
+# A few html5lib-tests cases encode the pre-errata "</p> and </br> in a foreign
+# namespace" behavior added in html5lib-tests 9b4a29c (2021) and never revised. They
 # contradict the WHATWG tree-construction algorithm (§ 13.2.6.5, the "Any other end
 # tag" rule for foreign content): nothing is popped, the token is reprocessed in the
-# current insertion mode with the foreign element still current, so the implied <p>
-# lands *inside* the foreign root. In a foreign fragment context the root is the
-# topmost (and only) stack element, so the end tag returns immediately and is
+# current insertion mode with the foreign element still current, so the implied
+# <p>/<br> lands *inside* the foreign root. In a foreign fragment context the root is
+# the topmost (and only) stack element, so the end tag returns immediately and is
 # ignored. lexbor and html5lib's own library agree with the spec here; the pinned
 # .dat does not (and html5lib's library does not pass these cases either). We assert
-# the spec-correct trees instead. See https://github.com/tox-dev/turbohtml/issues/32.
+# the spec-correct trees instead. See https://github.com/tox-dev/turbohtml/issues/32
+# and https://github.com/tox-dev/turbohtml/issues/63.
 _SPEC_OVERRIDES: dict[tuple[str, str, str | None], str] = {
     ("tests26.dat", "<svg></p><foo>", None): (
         "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <p>\n|       <svg foo>"
@@ -77,6 +78,14 @@ _SPEC_OVERRIDES: dict[tuple[str, str, str | None], str] = {
     ),
     ("foreign-fragment.dat", "<svg></p><foo>", "div"): "| <svg svg>\n|   <p>\n|   <svg foo>",
     ("foreign-fragment.dat", "</p><foo>", "svg svg"): "| <svg foo>",
+    ("tests26.dat", "<svg></br><foo>", None): (
+        "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <br>\n|       <svg foo>"
+    ),
+    ("tests26.dat", "<math></br><foo>", None): (
+        "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <br>\n|       <math foo>"
+    ),
+    ("foreign-fragment.dat", "<svg></br><foo>", "div"): "| <svg svg>\n|   <br>\n|   <svg foo>",
+    ("foreign-fragment.dat", "</br><foo>", "svg svg"): "| <svg foo>",
 }
 
 

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -162,7 +162,13 @@ _LONG_NAME = "z" * 130
             "<br>",
             id="breakout-stops-at-html-integration",
         ),
-        pytest.param("<math><mtext><svg></br>q</svg></mtext></math>", "mtext", id="end-tag-breakout-in-foreign"),
+        # </br> in foreign content is not a breakout tag: like </p> it is "any other
+        # end tag", so the synthesized <br> lands inside the svg (issue #63)
+        pytest.param(
+            "<math><mtext><svg></br>q</svg></mtext></math>",
+            "<svg svg>\n|           <br>",
+            id="end-br-in-foreign-inserts-svg-child",
+        ),
         pytest.param(
             "<math><annotation-xml encoding='application/xhtml+xml'><div>x</div></annotation-xml></math>",
             "<div>",
@@ -180,6 +186,10 @@ _LONG_NAME = "z" * 130
         # foreign root, never as a sibling under <body> (issue #32)
         pytest.param("<svg></p>", "<svg svg>\n|       <p>", id="end-p-in-svg-inserts-child"),
         pytest.param("<math></p>", "<math math>\n|       <p>", id="end-p-in-math-inserts-child"),
+        # </br> is likewise "any other end tag": the synthesized <br> lands inside the
+        # foreign root rather than as a sibling under <body> (issue #63)
+        pytest.param("<svg></br>", "<svg svg>\n|       <br>", id="end-br-in-svg-inserts-child"),
+        pytest.param("<math></br>", "<math math>\n|       <br>", id="end-br-in-math-inserts-child"),
         # </p> in foreign content is not a breakout tag: per the spec's "any other
         # end tag" rule nothing is popped, so the implied <p> lands inside the svg
         pytest.param(
@@ -316,7 +326,7 @@ _LONG_NAME = "z" * 130
         pytest.param(
             "<svg><foreignObject><svg></p>x", "<svg svg>\n|           <p>", id="end-p-in-foreign-not-breakout"
         ),
-        pytest.param("<svg><desc><svg></br>y", "desc", id="end-br-breakout-stops-at-html-integration"),
+        pytest.param("<svg><desc><svg></br>y", "<svg svg>\n|           <br>", id="end-br-in-foreign-not-breakout"),
         pytest.param("<p " + _LONG_NAME + "=1 m=2>x", "z" * 40, id="attr-name-fills-sort-buffer"),
         pytest.param("<svg " + _LONG_NAME + "=1 m=2>y</svg>", "z" * 40, id="foreign-attr-name-fills-sort-buffer"),
         # a redundant <html> start tag before/in head keeps the head insertion


### PR DESCRIPTION
Parsing `<svg></br>` put the synthesized `<br>` next to the `<svg>` under `<body>` instead of inside it. 🌳 `</br>` was still treated as a breakout tag that pops the foreign element before handling the token — the same defect [#32](https://github.com/tox-dev/turbohtml/issues/32) fixed for `</p>`, which deliberately left `</br>` for a follow-up.

Like `</p>`, `</br>` is "any other end tag" in the WHATWG foreign-content rules: nothing is popped, and the token is reprocessed in the current insertion mode while the foreign element is still current, so the `<br>` belongs inside the foreign root. Dropping the `</br>` breakout lets the end-tag walk handle it the same way, building `<svg><br></svg>` to agree with lexbor and html5lib.

The four html5lib-tests cases that encode the pre-errata sibling layout for `</br>` are the same stale 2021 set as the `</p>` cases (which contradict § 13.2.6.5 and which html5lib's own library does not pass), so the conformance harness asserts the spec-correct trees for them.

Fixes #63