### PR TITLE
🐛 fix: keep raw-text serialization across construct and pickle

### DIFF
--- a/docs/changelog/86.bugfix.rst
+++ b/docs/changelog/86.bugfix.rst
@@ -1,0 +1,5 @@
+Carry an element's tree-construction category flags when it is constructed or reconstructed, so a raw-text element
+(``style``, ``xmp``, ``iframe`` and friends) keeps serializing its text verbatim. ``th_tree_make_element`` set the tag
+atom but left the flags zero, so an unpickled raw-text element lost its raw-text bit and began HTML-escaping its
+content, unlike :func:`copy.deepcopy`. Building one directly with :class:`~turbohtml.Element` now also serializes its
+text literally.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -407,6 +407,17 @@ uint16_t th_tag_lookup(const char *bytes, Py_ssize_t len) {
     return TH_TAG_UNKNOWN;
 }
 
+/* The category bitmask for an atom (0 for TH_TAG_UNKNOWN), so a constructed or
+   reconstructed element carries the same flags the parser derives from the name. */
+uint8_t th_tag_flags(uint16_t atom) {
+    for (int index = 0; index < th_tag_count; index++) {
+        if (th_tag_table[index].atom == atom) {
+            return th_tag_table[index].flags;
+        }
+    }
+    return 0;
+}
+
 /* --------------------------------------------------------------- nodes */
 
 static th_node *node_new(th_tree *tree, enum th_node_type type) {
@@ -487,6 +498,7 @@ th_node *th_tree_make_element(th_tree *tree, const Py_UCS4 *tag, Py_ssize_t tag_
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     node->atom = atom;
+    node->tag_flags = th_tag_flags(atom); /* so a constructed/unpickled raw-text element serializes literally */
     Py_UCS4 *owned = arena_alloc(tree, tag_len * (Py_ssize_t)sizeof(Py_UCS4));
     if (owned == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -205,4 +205,7 @@ uint32_t th_attr_lookup(th_tree *tree, const char *bytes, Py_ssize_t len);
    forms an empty type name. */
 uint16_t th_tag_lookup(const char *bytes, Py_ssize_t len);
 
+/* The tree-construction category bitmask for an atom (0 for TH_TAG_UNKNOWN). */
+uint8_t th_tag_flags(uint16_t atom);
+
 #endif /* TURBOHTML_TREEBUILDER_H */

--- a/tests/test_tree_construct.py
+++ b/tests/test_tree_construct.py
@@ -96,6 +96,13 @@ def test_element_void_has_no_end_tag() -> None:
     assert Element("br").html == "<br>"
 
 
+def test_element_rawtext_serializes_text_literally() -> None:
+    # a constructed raw-text element carries the atom's flags, so its text is not escaped (issue #86)
+    style = Element("style")
+    style.text = "a < b"
+    assert style.html == "<style>a < b</style>"
+
+
 def test_element_unknown_tag_constructs() -> None:
     assert Element("my-widget").html == "<my-widget></my-widget>"
     assert Element("x" * 70).tag == "x" * 70  # a tag too long for the atom table

--- a/tests/test_tree_pickle.py
+++ b/tests/test_tree_pickle.py
@@ -61,6 +61,15 @@ def test_nested_pi_and_cdata_survive_pickling() -> None:
     assert _roundtrip(host).html == "<host><?t d><![CDATA[raw]]></host>"
 
 
+@pytest.mark.parametrize("tag", ["style", "xmp", "iframe"])
+def test_rawtext_element_keeps_literal_text_across_pickle(tag: str) -> None:
+    # a raw-text element serializes its text verbatim; the round-trip must not start escaping it (issue #86)
+    element = parse(f"<{tag}>x < y</{tag}>").find(tag)
+    assert isinstance(element, Element)
+    assert element.html == f"<{tag}>x < y</{tag}>"
+    assert _roundtrip(element).html == element.html
+
+
 def test_document_round_trips() -> None:
     doc = parse("<!DOCTYPE html><title>Hi</title><p id=a>x</p><!--c-->")
     clone = _roundtrip(doc)


### PR DESCRIPTION
Pickling a detached raw-text `Element` (`style`, `xmp`, `iframe`, `noembed`, `noframes`) made it start HTML-escaping its verbatim text on the round-trip: `<style>x < y</style>` came back as `<style>x &lt; y</style>`, while `copy.deepcopy` preserved it. The builder `th_tree_make_element` set the tag atom but left the category flags zero, so the reconstructed element lost its `TH_TAG_RAWTEXT` bit; `script` and `plaintext` kept working only because the serializer special-cases their atom. Closes #86.

The root cause is that constructed and reconstructed elements never received the flags the parser derives from a tag name. This adds `th_tag_flags(atom)` — the accessor the `tag_atom.h` comment already refers to — and sets `tag_flags` from the atom when an element is built, so a constructed or unpickled element matches a parsed one. Building a raw-text element directly with `Element` now serializes its text literally too.

No benchmark: the lookup runs only when an element is constructed through the public/​pickle path, never during parsing, which sets flags straight from the token.