### PR TITLE
🐛 fix(sanitizer): always neutralize plaintext

### DIFF
--- a/docs/changelog/72.bugfix.rst
+++ b/docs/changelog/72.bugfix.rst
@@ -1,6 +1,6 @@
 Always neutralize ``<plaintext>`` in :func:`turbohtml.sanitizer.sanitize`, regardless of the policy allowlist, the way
 ``<xmp>`` and ``<script>`` already are. ``<plaintext>`` switches the tokenizer to a raw-text state that runs to end of
-input, so a policy that allowlisted it kept content such as ``</select><img src=x onerror=alert(1)>`` as an
-unescapable raw text node; the serialized output reparsed into a live ``<img>`` whose ``onerror`` fired (a mutation-XSS
-bypass) and was not idempotent. The element is now escaped to inert text, matching nh3's safe handling. The default,
-``strict``, and ``relaxed`` policies were never affected because they already escape ``<plaintext>``.
+input, so a policy that allowlisted it kept content such as ``</select><img src=x onerror=alert(1)>`` as an unescapable
+raw text node; the serialized output reparsed into a live ``<img>`` whose ``onerror`` fired (a mutation-XSS bypass) and
+was not idempotent. The element is now escaped to inert text, matching nh3's safe handling. The default, ``strict``, and
+``relaxed`` policies were never affected because they already escape ``<plaintext>``.

--- a/docs/changelog/72.bugfix.rst
+++ b/docs/changelog/72.bugfix.rst
@@ -1,0 +1,6 @@
+Always neutralize ``<plaintext>`` in :func:`turbohtml.sanitizer.sanitize`, regardless of the policy allowlist, the way
+``<xmp>`` and ``<script>`` already are. ``<plaintext>`` switches the tokenizer to a raw-text state that runs to end of
+input, so a policy that allowlisted it kept content such as ``</select><img src=x onerror=alert(1)>`` as an
+unescapable raw text node; the serialized output reparsed into a live ``<img>`` whose ``onerror`` fired (a mutation-XSS
+bypass) and was not idempotent. The element is now escaped to inert text, matching nh3's safe handling. The default,
+``strict``, and ``relaxed`` policies were never affected because they already escape ``<plaintext>``.

--- a/src/turbohtml/sanitize.c
+++ b/src/turbohtml/sanitize.c
@@ -45,6 +45,7 @@ static int is_unsafe_tag(uint16_t atom) {
     case TH_TAG_BASE:
     case TH_TAG_BASEFONT:
     case TH_TAG_TITLE:
+    case TH_TAG_PLAINTEXT:
     case TH_TAG_XMP:
     case TH_TAG_TEMPLATE:
         return 1;

--- a/tests/test_sanitizer_security.py
+++ b/tests/test_sanitizer_security.py
@@ -120,3 +120,20 @@ def test_oracle_detects_a_real_script() -> None:
 
 def test_oracle_detects_a_dangerous_url() -> None:
     assert _live_danger('<a href="javascript:alert(1)">x</a>') == ["href=javascript:alert(1)"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param("<select><plaintext></select><img src=x onerror=alert(1)>", id="plaintext-in-select"),
+        pytest.param("<plaintext><img src=x onerror=alert(1)>", id="bare-plaintext"),
+    ],
+)
+def test_allowlisted_plaintext_is_neutralized(payload: str) -> None:
+    # a custom policy may allowlist <plaintext>, but its content is raw text that cannot
+    # be escaped once the element is kept, so a </select><img onerror> tail would reparse
+    # into a live image. Like <xmp>, <plaintext> must always be neutralized (#72).
+    policy = Policy(tags=frozenset({"plaintext", "select", "img"}), attributes={"img": frozenset({"src"})})
+    out = sanitize(payload, policy)
+    assert _live_danger(out) == [], f"live XSS survived: {out!r}"
+    assert sanitize(out, policy) == out, "sanitizing is not idempotent"


### PR DESCRIPTION
A policy that allowlisted `<plaintext>` let a mutation-XSS slip through. 🛡️ The parser switches the tokenizer to a raw-text state on `<plaintext>` that runs to end of input, so content like `</select><img src=x onerror=alert(1)>` was captured as a single raw text node that cannot be escaped once the element is kept. The sanitizer emitted it verbatim, and the serialized output reparsed into a live `<img>` whose `onerror` fires — and the pass was not idempotent (each run appended another synthesized tail).

`<plaintext>` is a raw-text container, exactly like `<xmp>`, which is already neutralized regardless of the allowlist. This adds it to the always-unsafe set, so it is escaped to inert text whatever the policy says — matching nh3, which strips it. The default, `strict`, and `relaxed` policies already escaped `<plaintext>` and were never vulnerable; only a custom policy that explicitly allowlisted it was.

A new `_live_danger` reparse test confirms no live handler survives for `<select><plaintext></select><img onerror>` and bare `<plaintext><img onerror>`, and that sanitizing is idempotent.

Fixes #72