### PR TITLE
🐛 fix: pop open optgroup/option in a select-context fragment

### DIFF
--- a/docs/changelog/89.bugfix.rst
+++ b/docs/changelog/89.bugfix.rst
@@ -1,0 +1,4 @@
+Pop an open ``option`` or ``optgroup`` before inserting a new ``optgroup`` (or ``option``) start tag in a
+``select``-context fragment, so the elements become siblings instead of nesting. The "in select" pop only fired when a
+``select`` element was in scope, which never holds in a fragment whose context is ``select`` and whose ``select`` is
+implied, so ``parse_fragment("<optgroup>1<optgroup>2", context="select")`` produced one optgroup nested in the other.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2907,9 +2907,11 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                     break;
                 }
                 if (atom == TH_TAG_OPTION || atom == TH_TAG_OPTGROUP) {
-                    if (has_in_scope(tree, TH_TAG_SELECT)) {
-                        /* inside a select, implied end tags close open option
-                           and (for an optgroup start) optgroup elements */
+                    if (has_in_scope(tree, TH_TAG_SELECT) ||
+                        (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT)) {
+                        /* inside a select (or a select-context fragment, where no select node
+                           is on the stack), implied end tags close open option and (for an
+                           optgroup start) optgroup elements */
                         generate_implied_end_tags(tree, atom == TH_TAG_OPTION ? TH_TAG_OPTGROUP : TH_TAG_UNKNOWN);
                     } else if (current_node(tree)->atom == TH_TAG_OPTION) {
                         stack_pop(tree);

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -474,6 +474,18 @@ def test_before_html_end_br_synthesizes_br() -> None:
         pytest.param("</dd>y", "div", '| "y"', id="end-dd-no-scope"),
         pytest.param("<frame><frameset></frameset>", "frameset", "<frame>", id="frameset-context"),
         pytest.param("<option>a<select><option>b", "select", "<option>", id="select-ignores-nested-select"),
+        # in a select-context fragment a second optgroup/option pops the open one, making siblings (issue #89)
+        pytest.param(
+            "<optgroup>1<optgroup>2",
+            "select",
+            '| <optgroup>\n|   "1"\n| <optgroup>\n|   "2"',
+            id="select-optgroup-pops",
+        ),
+        pytest.param(
+            "<option>1<option>2", "select", '| <option>\n|   "1"\n| <option>\n|   "2"', id="select-option-pops"
+        ),
+        # a non-select-context fragment keeps an optgroup without the select-mode pop
+        pytest.param("<optgroup>x", "div", '| <optgroup>\n|   "x"', id="optgroup-in-non-select-fragment"),
         pytest.param("  <col>x", "colgroup", "<col>", id="colgroup-whitespace-then-content"),
         pytest.param("<select></select><td>next", "tr", "<td>", id="select-in-cell-resets"),
         pytest.param("<table></table>x", "td", '"x"', id="reset-table-close-td-context"),


### PR DESCRIPTION
`parse_fragment("<optgroup>1<optgroup>2", context="select")` produced one optgroup nested inside the other instead of two siblings. In the WHATWG "in select" insertion mode an `optgroup` (or `option`) start tag first pops an open `option`, and an `optgroup` start also pops an open `optgroup`, before inserting. turbohtml ran that pop only when a `select` element was in scope, which never holds in a fragment whose context is `select` and whose enclosing `select` is implied rather than a real node on the stack. Closes #89.

The optgroup/option start handler now also treats a select-context fragment as in-select, using the same `fragment_root` + `ctx_atom == select` test the `input` start tag in this mode already relies on. The implied-end-tag pop then closes the open option or optgroup so the new element lands as a sibling, matching html5lib.

No benchmark: this adds one comparison on the rare `optgroup`/`option` start-tag path, and only when no `select` is already in scope.