### PR TITLE
🐛 fix: pop open option before hr in a select-context fragment

### DIFF
--- a/docs/changelog/94.bugfix.rst
+++ b/docs/changelog/94.bugfix.rst
@@ -1,0 +1,4 @@
+Pop an open ``option`` or ``optgroup`` before inserting an ``hr`` in a ``select``-context fragment, so the ``hr`` lands
+at ``select`` level as a sibling of the options instead of nesting inside one. WHATWG added this ``hr`` rule to the "in
+select" insertion mode in 2024; turbohtml only applied it when a ``select`` element was in scope, which never holds in a
+fragment whose ``select`` context is implied.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2900,8 +2900,11 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                 }
                 if (atom == TH_TAG_HR) {
                     close_p_in_button_scope(tree);
-                    if (has_in_scope(tree, TH_TAG_SELECT)) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN); /* closes open option/optgroup */
+                    if (has_in_scope(tree, TH_TAG_SELECT) ||
+                        (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT)) {
+                        /* in a select (or a select-context fragment) close the open option/optgroup
+                           first, so the hr lands at select level rather than inside the option */
+                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
                     }
                     insert_element(tree, tok); /* void */
                     break;

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -507,6 +507,15 @@ def test_before_html_end_br_synthesizes_br() -> None:
         ),
         # a non-select-context fragment keeps an optgroup without the select-mode pop
         pytest.param("<optgroup>x", "div", '| <optgroup>\n|   "x"', id="optgroup-in-non-select-fragment"),
+        # an hr in a select-context fragment pops the open option, landing at select level (issue #94)
+        pytest.param(
+            "<option>a<hr><option>b",
+            "select",
+            '| <option>\n|   "a"\n| <hr>\n| <option>\n|   "b"',
+            id="select-hr-pops-option",
+        ),
+        # an hr in a non-select-context fragment is inserted without the select-mode pop
+        pytest.param("<hr>", "div", "| <hr>", id="hr-in-non-select-fragment"),
         pytest.param("  <col>x", "colgroup", "<col>", id="colgroup-whitespace-then-content"),
         pytest.param("<select></select><td>next", "tr", "<td>", id="select-in-cell-resets"),
         pytest.param("<table></table>x", "td", '"x"', id="reset-table-close-td-context"),


### PR DESCRIPTION
`parse_fragment("<option>a<hr><option>b", context="select")` nested the `hr` inside the first `option` instead of placing it at `select` level between the two options. WHATWG added an `hr` rule to the "in select" insertion mode in 2024: an `hr` start tag pops an open `option` (and `optgroup`) before inserting, so the `hr` becomes a sibling of the options. turbohtml applied that only when a `select` element was in scope, which never holds in a fragment whose enclosing `select` is the implied context rather than a node on the stack. Closes #94.

The `hr` start handler now also treats a select-context fragment as in-select, using the same `fragment_root` + `ctx_atom == select` test the sibling `optgroup`/`option` and `input` start tags use in this mode. The implied-end-tag pop closes the open option so the `hr` lands at select level, matching html5lib.

No benchmark: this adds one comparison on the `hr` start-tag path, and only when no `select` is already in scope.