### PR TITLE
🐛 fix: keep after-head whitespace under html, not in body

### DIFF
--- a/docs/changelog/88.bugfix.rst
+++ b/docs/changelog/88.bugfix.rst
@@ -1,0 +1,4 @@
+Insert whitespace seen in the "after head" insertion mode under the ``html`` element, between ``head`` and ``body``,
+rather than inside the ``body``. The leading whitespace of a mixed text run such as ``<head></head>  text`` now becomes
+a text node child of ``html`` and only the first non-whitespace character creates the ``body`` and starts "in body",
+matching the WHATWG algorithm and html5lib.

--- a/docs/changelog/88.bugfix.rst
+++ b/docs/changelog/88.bugfix.rst
@@ -1,4 +1,4 @@
 Insert whitespace seen in the "after head" insertion mode under the ``html`` element, between ``head`` and ``body``,
-rather than inside the ``body``. The leading whitespace of a mixed text run such as ``<head></head>  text`` now becomes
-a text node child of ``html`` and only the first non-whitespace character creates the ``body`` and starts "in body",
+rather than inside the ``body``. The leading whitespace of a mixed text run such as ``<head></head> text`` now becomes a
+text node child of ``html`` and only the first non-whitespace character creates the ``body`` and starts "in body",
 matching the WHATWG algorithm and html5lib.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2472,10 +2472,17 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
             if (tok->kind == TH_TEXT) {
                 Py_ssize_t len;
                 Py_UCS4 *text = token_text(tree, tok, &len);
-                if (all_whitespace(text, len)) {
-                    insert_text(tree, text, len);
+                Py_ssize_t ws = 0;
+                while (ws < len && is_space(text[ws])) {
+                    ws++;
+                }
+                if (ws > 0) {
+                    insert_text(tree, text, ws); /* leading whitespace goes under html, between head and body */
+                }
+                if (ws == len) {
                     break;
                 }
+                tree->text_offset += ws; /* the body is created below; reprocess only the remainder there */
             }
             if (tok->kind == TH_COMMENT) {
                 insert_comment(tree, tok, NULL);

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -115,6 +115,14 @@ _LONG_NAME = "z" * 130
         pytest.param("<pre>\nkept", '"kept"', id="pre-drops-leading-newline"),
         pytest.param("<pre>zkept", '"zkept"', id="pre-keeps-non-newline"),
         pytest.param("<listing>\nq", '"q"', id="listing-drops-leading-newline"),
+        # after-head whitespace lands under <html> (between head and body); only the rest starts the body (issue #88)
+        pytest.param(
+            "<head></head>  text",
+            '|   <head>\n|   "  "\n|   <body>\n|     "text"',
+            id="after-head-whitespace-under-html",
+        ),
+        pytest.param("<head></head>   ", '|   <head>\n|   "   "\n|   <body>', id="after-head-only-whitespace"),
+        pytest.param("<head></head>x", '|   <head>\n|   <body>\n|     "x"', id="after-head-no-leading-whitespace"),
         pytest.param("a\x00b", '"ab"', id="nul-stripped-from-text"),
         pytest.param("<template>" * 9 + "z", "content", id="template-stack-regrow"),
         pytest.param("<table><thead><tr><td>z</table>", "<td>", id="thead-table-scope-cell"),


### PR DESCRIPTION
`parse("<head></head>  text")` placed the leading whitespace inside the body (`<body>  text</body>`) instead of as a text node child of `html` between `head` and `body`. In the WHATWG "after head" insertion mode a whitespace character token is inserted at the current location — the `html` element, since `head` was popped on entering the mode — and only the first non-whitespace character runs "anything else", which creates the body and reprocesses. Closes #88.

turbohtml special-cased only an all-whitespace text token; a run with leading whitespace followed by content was not all-whitespace, so the entire run fell through to body creation. The handler now inserts the leading whitespace under `html` and reprocesses just the non-whitespace remainder under `body`, reusing the same `text_offset` prefix-consume mechanism the "in head" mode already uses to split a text token.

No benchmark: the change affects only a text token seen in the after-head mode, at most once per document, and reuses an existing code path.