### PR TITLE
✨ feat(select): tree-structural pseudo-classes

### DIFF
--- a/docs/changelog/98.feature.rst
+++ b/docs/changelog/98.feature.rst
@@ -1,0 +1,5 @@
+Support the CSS tree-structural pseudo-classes in :meth:`~turbohtml.Node.select`/:meth:`~turbohtml.Node.select_one`:
+``:root``, ``:empty``, ``:first-child``, ``:last-child``, ``:only-child``, ``:first-of-type``, ``:last-of-type``,
+``:only-of-type``, and the functional ``:nth-child()``, ``:nth-last-child()``, ``:nth-of-type()``, and
+``:nth-last-of-type()`` (with the full ``An+B`` microsyntax, including the ``even`` and ``odd`` keywords). Previously
+every pseudo-class raised ``ValueError('invalid CSS selector')``.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -332,8 +332,10 @@ node kind and unpacks the defining field (``tag`` for an :class:`~turbohtml.Elem
 
 :meth:`~turbohtml.Node.select` returns every descendant matching a CSS selector in document order;
 :meth:`~turbohtml.Node.select_one` returns the first or ``None``. The matcher covers type, ``#id``, ``.class``, and
-attribute selectors with the ``=``, ``~=``, ``|=``, ``^=``, ``$=``, ``*=`` operators, joined by the descendant, child
-(``>``), adjacent (``+``), and general-sibling (``~``) combinators, with comma groups:
+attribute selectors with the ``=``, ``~=``, ``|=``, ``^=``, ``$=``, ``*=`` operators, the tree-structural pseudo-classes
+(``:root``, ``:empty``, ``:first-child``, ``:last-child``, ``:only-child``, their ``-of-type`` variants, and the
+``:nth-child()`` family with the ``An+B`` microsyntax), joined by the descendant, child (``>``), adjacent (``+``), and
+general-sibling (``~``) combinators, with comma groups:
 
 .. testcode::
 
@@ -341,11 +343,13 @@ attribute selectors with the ``=``, ``~=``, ``|=``, ``^=``, ``$=``, ``*=`` opera
     doc = turbohtml.parse('<ul><li class=on>a<li><a href="/x">b</a></ul>')
     print([li.text for li in doc.select("li.on")])
     print(doc.select_one('a[href^="/"]').text)
+    print([li.text for li in doc.select("li:nth-child(odd)")])
 
 .. testoutput::
 
     ['a']
     b
+    ['a']
 
 To test a node you already hold rather than search beneath it, use :meth:`~turbohtml.Node.matches` (does this node
 match) or :meth:`~turbohtml.Node.closest` (the nearest matching self-or-ancestor):

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -13,13 +13,34 @@
 
 enum sel_attr_op { OP_EXISTS, OP_EQ, OP_INCLUDE, OP_DASH, OP_PREFIX, OP_SUFFIX, OP_SUBSTR };
 
+/* ':' tree-structural pseudo-classes. The nth-* variants carry An+B in nth_a/nth_b;
+   the others have fixed structural meaning. */
+enum sel_pseudo {
+    PSEUDO_NONE,
+    PSEUDO_ROOT,
+    PSEUDO_EMPTY,
+    PSEUDO_FIRST_CHILD,
+    PSEUDO_LAST_CHILD,
+    PSEUDO_ONLY_CHILD,
+    PSEUDO_FIRST_OF_TYPE,
+    PSEUDO_LAST_OF_TYPE,
+    PSEUDO_ONLY_OF_TYPE,
+    PSEUDO_NTH_CHILD,
+    PSEUDO_NTH_LAST_CHILD,
+    PSEUDO_NTH_OF_TYPE,
+    PSEUDO_NTH_LAST_OF_TYPE,
+};
+
 typedef struct {
-    char kind;          /* '*', 'e' type, '.' class, '#' id, '[' attribute */
+    char kind;          /* '*', 'e' type, '.' class, '#' id, '[' attribute, ':' pseudo-class */
     uint16_t tag_atom;  /* 'e': the tag atom, TH_TAG_UNKNOWN for a name outside the table */
     uint32_t attr_atom; /* '[': the attribute atom, UINT32_MAX when no element has the name */
     enum sel_attr_op op;
     int ci;               /* '[': matched case-insensitively (explicit i flag) */
     int ci_default;       /* '[': name is in the HTML case-insensitive set, no explicit s/i flag */
+    int pseudo;           /* ':': the pseudo-class id (enum sel_pseudo) */
+    int nth_a;            /* ':': the An+B "A" coefficient for an nth-* pseudo-class */
+    int nth_b;            /* ':': the An+B "B" coefficient for an nth-* pseudo-class */
     const Py_UCS4 *name;  /* class / id / unknown tag name (into the owned source copy) */
     Py_ssize_t name_len;  /* also the attribute name for the rare unknown case */
     const Py_UCS4 *value; /* '[': the attribute value */
@@ -311,12 +332,157 @@ static void sel_type_local(sel_parser *parser, sel_simple *simple) {
     }
 }
 
+/* Whether a name slice equals a lowercase ASCII keyword (ASCII case-insensitive). */
+static int sel_kw(const Py_UCS4 *name, Py_ssize_t len, const char *kw) {
+    if (len != (Py_ssize_t)strlen(kw)) {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 ch = name[index];
+        if (ch >= 'A' && ch <= 'Z') {
+            ch += 32;
+        }
+        if (ch != (Py_UCS4)(unsigned char)kw[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* Read a run of ASCII digits as a non-negative int; *seen reports any digit. */
+static int sel_read_int(sel_parser *parser, int *seen) {
+    int value = 0;
+    *seen = 0;
+    while (parser->pos < parser->len && parser->src[parser->pos] >= '0' && parser->src[parser->pos] <= '9') {
+        value = value * 10 + (int)(parser->src[parser->pos] - '0');
+        parser->pos++;
+        *seen = 1;
+    }
+    return value;
+}
+
+/* Parse the An+B microsyntax (CSS Syntax §"The An+B microsyntax") into a/b,
+   including the even/odd keywords. pos starts after '(' and stops at the ')'. */
+static void sel_parse_anb(sel_parser *parser, int *a, int *b) {
+    sel_skip_ws(parser);
+    if (parser->pos + 4 <= parser->len && sel_kw(parser->src + parser->pos, 4, "even")) {
+        parser->pos += 4;
+        *a = 2;
+        *b = 0;
+        sel_skip_ws(parser);
+        return;
+    }
+    if (parser->pos + 3 <= parser->len && sel_kw(parser->src + parser->pos, 3, "odd")) {
+        parser->pos += 3;
+        *a = 2;
+        *b = 1;
+        sel_skip_ws(parser);
+        return;
+    }
+    int sign = 1;
+    if (parser->pos < parser->len && (parser->src[parser->pos] == '+' || parser->src[parser->pos] == '-')) {
+        sign = parser->src[parser->pos] == '-' ? -1 : 1;
+        parser->pos++;
+    }
+    int seen_a;
+    int num = sel_read_int(parser, &seen_a);
+    if (parser->pos < parser->len && (parser->src[parser->pos] | 32) == 'n') {
+        parser->pos++;
+        *a = sign * (seen_a ? num : 1);
+        sel_skip_ws(parser);
+        if (parser->pos < parser->len && (parser->src[parser->pos] == '+' || parser->src[parser->pos] == '-')) {
+            int bsign = parser->src[parser->pos] == '-' ? -1 : 1;
+            parser->pos++;
+            sel_skip_ws(parser);
+            int seen_b;
+            int bval = sel_read_int(parser, &seen_b);
+            if (!seen_b) {
+                parser->error = 1;
+                return;
+            }
+            *b = bsign * bval;
+        } else {
+            *b = 0;
+        }
+    } else if (seen_a) {
+        *a = 0;
+        *b = sign * num;
+    } else {
+        parser->error = 1; /* a bare sign with no digits and no 'n' is invalid */
+        return;
+    }
+    sel_skip_ws(parser);
+}
+
+/* Parse a pseudo-class selector (the leading ':' already consumed). */
+static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
+    simple->kind = ':';
+    const Py_UCS4 *name;
+    Py_ssize_t name_len;
+    sel_ident(parser, &name, &name_len);
+    if (parser->error) {
+        return;
+    }
+    int functional = PSEUDO_NONE;
+    if (sel_kw(name, name_len, "root")) {
+        simple->pseudo = PSEUDO_ROOT;
+    } else if (sel_kw(name, name_len, "empty")) {
+        simple->pseudo = PSEUDO_EMPTY;
+    } else if (sel_kw(name, name_len, "first-child")) {
+        simple->pseudo = PSEUDO_FIRST_CHILD;
+    } else if (sel_kw(name, name_len, "last-child")) {
+        simple->pseudo = PSEUDO_LAST_CHILD;
+    } else if (sel_kw(name, name_len, "only-child")) {
+        simple->pseudo = PSEUDO_ONLY_CHILD;
+    } else if (sel_kw(name, name_len, "first-of-type")) {
+        simple->pseudo = PSEUDO_FIRST_OF_TYPE;
+    } else if (sel_kw(name, name_len, "last-of-type")) {
+        simple->pseudo = PSEUDO_LAST_OF_TYPE;
+    } else if (sel_kw(name, name_len, "only-of-type")) {
+        simple->pseudo = PSEUDO_ONLY_OF_TYPE;
+    } else if (sel_kw(name, name_len, "nth-child")) {
+        functional = PSEUDO_NTH_CHILD;
+    } else if (sel_kw(name, name_len, "nth-last-child")) {
+        functional = PSEUDO_NTH_LAST_CHILD;
+    } else if (sel_kw(name, name_len, "nth-of-type")) {
+        functional = PSEUDO_NTH_OF_TYPE;
+    } else if (sel_kw(name, name_len, "nth-last-of-type")) {
+        functional = PSEUDO_NTH_LAST_OF_TYPE;
+    } else {
+        parser->error = 1; /* an unknown pseudo-class invalidates the selector */
+        return;
+    }
+    if (functional != PSEUDO_NONE) {
+        simple->pseudo = functional;
+        if (parser->pos >= parser->len || parser->src[parser->pos] != '(') {
+            parser->error = 1;
+            return;
+        }
+        parser->pos++;
+        sel_parse_anb(parser, &simple->nth_a, &simple->nth_b);
+        if (parser->error) {
+            return;
+        }
+        if (parser->pos >= parser->len || parser->src[parser->pos] != ')') {
+            parser->error = 1;
+            return;
+        }
+        parser->pos++;
+    } else if (parser->pos < parser->len && parser->src[parser->pos] == '(') {
+        parser->error = 1; /* a non-functional pseudo-class takes no argument list */
+        return;
+    }
+}
+
 /* Parse one simple selector into *simple. */
 static void sel_one(sel_parser *parser, sel_simple *simple) {
     simple->tag_atom = TH_TAG_UNKNOWN;
     simple->attr_atom = 0;
     simple->ci = 0;
     simple->ci_default = 0;
+    simple->pseudo = PSEUDO_NONE;
+    simple->nth_a = 0;
+    simple->nth_b = 0;
     simple->name = NULL;
     simple->name_len = 0;
     simple->value = NULL;
@@ -326,6 +492,9 @@ static void sel_one(sel_parser *parser, sel_simple *simple) {
         simple->kind = (char)ch;
         parser->pos++;
         sel_ident(parser, &simple->name, &simple->name_len);
+    } else if (ch == ':') {
+        parser->pos++;
+        sel_pseudo(parser, simple);
     } else if (ch == '[') {
         parser->pos++;
         sel_attribute(parser, simple);
@@ -358,7 +527,7 @@ static void sel_one(sel_parser *parser, sel_simple *simple) {
 }
 
 static int sel_starts_simple(Py_UCS4 ch) {
-    return ch == '*' || ch == '.' || ch == '#' || ch == '[' || ch == '\\' || ch == '|' || sel_is_ident(ch);
+    return ch == '*' || ch == '.' || ch == '#' || ch == '[' || ch == ':' || ch == '\\' || ch == '|' || sel_is_ident(ch);
 }
 
 /* Parse a compound (one or more adjacent simples) into the given buffer. */
@@ -600,10 +769,101 @@ static int sel_match_attr_op(const sel_simple *simple, const Py_UCS4 *value, Py_
     }
 }
 
+/* Two elements share a type when their namespace and tag match; a custom tag
+   (no builtin atom) compares by lowercased name so distinct customs stay apart. */
+static int sel_same_type(const th_node *a, const th_node *b) {
+    if (a->ns != b->ns || a->atom != b->atom) {
+        return 0;
+    }
+    if (a->atom != TH_TAG_UNKNOWN) {
+        return 1;
+    }
+    return sel_eq(a->text, a->text_len, b->text, b->text_len, 0);
+}
+
+/* Whether node has no element sibling on the chosen side (next when from_end),
+   counting only same-type siblings when of_type. Drives the first/last/only
+   structural pseudo-classes. */
+static int sel_no_sibling(th_node *node, int from_end, int of_type) {
+    for (th_node *sibling = from_end ? node->next_sibling : node->prev_sibling; sibling != NULL;
+         sibling = from_end ? sibling->next_sibling : sibling->prev_sibling) {
+        if (sibling->type == TH_NODE_ELEMENT && (!of_type || sel_same_type(node, sibling))) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* The 1-based position of node among its element siblings (from the end when
+   from_end), counting only same-type siblings when of_type. */
+static int sel_sibling_index(th_node *node, int from_end, int of_type) {
+    int index = 1;
+    for (th_node *sibling = from_end ? node->next_sibling : node->prev_sibling; sibling != NULL;
+         sibling = from_end ? sibling->next_sibling : sibling->prev_sibling) {
+        if (sibling->type == TH_NODE_ELEMENT && (!of_type || sel_same_type(node, sibling))) {
+            index++;
+        }
+    }
+    return index;
+}
+
+/* Whether a 1-based index satisfies An+B for some non-negative n. */
+static int sel_nth_matches(int a, int b, int index) {
+    if (a == 0) {
+        return index == b;
+    }
+    int diff = index - b;
+    return diff % a == 0 && diff / a >= 0;
+}
+
+/* An element is :empty (CSS Selectors Level 3) when it has no element or text
+   children; comments and processing instructions do not count. */
+static int sel_is_empty(const th_node *node) {
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type == TH_NODE_ELEMENT || child->type == TH_NODE_TEXT) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int sel_match_pseudo(th_node *node, const sel_simple *simple) {
+    switch (simple->pseudo) { /* GCOVR_EXCL_BR_LINE: the parser only stores known pseudo ids */
+    case PSEUDO_ROOT:
+        /* the root element's parent is the document, never an element (a matched
+           node always has a parent, as the '>' combinator above relies on) */
+        return node->parent->type != TH_NODE_ELEMENT;
+    case PSEUDO_EMPTY:
+        return sel_is_empty(node);
+    case PSEUDO_FIRST_CHILD:
+        return sel_no_sibling(node, 0, 0);
+    case PSEUDO_LAST_CHILD:
+        return sel_no_sibling(node, 1, 0);
+    case PSEUDO_ONLY_CHILD:
+        return sel_no_sibling(node, 0, 0) && sel_no_sibling(node, 1, 0);
+    case PSEUDO_FIRST_OF_TYPE:
+        return sel_no_sibling(node, 0, 1);
+    case PSEUDO_LAST_OF_TYPE:
+        return sel_no_sibling(node, 1, 1);
+    case PSEUDO_ONLY_OF_TYPE:
+        return sel_no_sibling(node, 0, 1) && sel_no_sibling(node, 1, 1);
+    case PSEUDO_NTH_CHILD:
+        return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 0, 0));
+    case PSEUDO_NTH_LAST_CHILD:
+        return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 1, 0));
+    case PSEUDO_NTH_OF_TYPE:
+        return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 0, 1));
+    default: /* PSEUDO_NTH_LAST_OF_TYPE */
+        return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 1, 1));
+    }
+}
+
 static int sel_match_simple(th_node *node, const sel_simple *simple) {
     switch (simple->kind) {
     case '*':
         return 1;
+    case ':':
+        return sel_match_pseudo(node, simple);
     case 'e':
         if (simple->tag_atom != TH_TAG_UNKNOWN) {
             return node->atom == simple->tag_atom;

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -179,6 +179,77 @@ def test_select_over_custom_html(html: str, selector: str, tags: list[str]) -> N
     assert _sel(html, selector) == tags
 
 
+# a five-item list, a mixed-type container, and custom-element siblings so the
+# of-type pseudo-classes exercise both the builtin-atom and custom-name paths
+_PSEUDO = (
+    "<main>"
+    "<ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li></ul>"
+    "<section><h2>t</h2><p>a</p><span>b</span><p></p><!--c--></section>"
+    "<nav><x-a>1</x-a><x-b>2</x-b><x-a>3</x-a></nav>"
+    "<header><b>x</b><svg></svg></header>"
+    "<aside><!--z--></aside>"  # only a comment, so still :empty
+    "</main>"
+)
+
+
+# cases whose subjects share a tag are keyed on text, which encodes the position;
+# cases that identify elements by kind are keyed on tag in the by-tag test below
+@pytest.mark.parametrize(
+    ("selector", "texts"),
+    [
+        pytest.param("li:first-child", ["1"], id="first-child"),
+        pytest.param("li:last-child", ["5"], id="last-child"),
+        pytest.param("li:nth-child(1)", ["1"], id="nth-child-literal"),
+        pytest.param("li:nth-child(2n)", ["2", "4"], id="nth-child-even-coeff"),
+        pytest.param("li:nth-child(2n+1)", ["1", "3", "5"], id="nth-child-odd-coeff"),
+        pytest.param("li:nth-child(even)", ["2", "4"], id="nth-child-even-keyword"),
+        # pseudo-class names and An+B keywords are ASCII case-insensitive
+        pytest.param("li:NTH-CHILD(EVEN)", ["2", "4"], id="nth-child-uppercase"),
+        pytest.param("li:nth-child(odd)", ["1", "3", "5"], id="nth-child-odd-keyword"),
+        pytest.param("li:nth-child(-n+2)", ["1", "2"], id="nth-child-negative-a"),
+        pytest.param("li:nth-child(n)", ["1", "2", "3", "4", "5"], id="nth-child-bare-n"),
+        pytest.param("li:nth-child( 2n + 1 )", ["1", "3", "5"], id="nth-child-whitespace"),
+        pytest.param("li:nth-child(0)", [], id="nth-child-zero-matches-none"),
+        pytest.param("li:nth-child(2n-1)", ["1", "3", "5"], id="nth-child-minus-b"),
+        pytest.param("li:nth-last-child(1)", ["5"], id="nth-last-child"),
+        pytest.param("li:nth-last-child(2)", ["4"], id="nth-last-child-second-from-end"),
+        # of-type with a builtin atom: two <p> siblings around a <span>
+        pytest.param("p:first-of-type", ["a"], id="first-of-type"),
+        pytest.param("p:last-of-type", [""], id="last-of-type"),
+        pytest.param("p:nth-of-type(2)", [""], id="nth-of-type"),
+        pytest.param("p:nth-last-of-type(1)", [""], id="nth-last-of-type"),
+        # of-type with custom elements: distinct names must not be conflated
+        pytest.param("x-a:first-of-type", ["1"], id="custom-first-of-type"),
+        pytest.param("x-a:nth-of-type(2)", ["3"], id="custom-nth-of-type"),
+        pytest.param("x-b:only-of-type", ["2"], id="custom-only-of-type"),
+    ],
+)
+def test_structural_pseudo_by_text(selector: str, texts: list[str]) -> None:
+    assert [element.text for element in parse(_PSEUDO).select(selector)] == texts
+
+
+@pytest.mark.parametrize(
+    ("selector", "tags"),
+    [
+        pytest.param(":root", ["html"], id="root-is-html"),
+        # a non-functional pseudo-class followed by a combinator (not '(')
+        pytest.param(":root > head", ["head"], id="root-then-combinator"),
+        pytest.param(":empty", ["head", "p", "svg", "aside"], id="empty-element-or-comment-only"),
+        pytest.param("span:only-of-type", ["span"], id="only-of-type-hit"),
+        pytest.param("p:only-of-type", [], id="only-of-type-miss"),
+        pytest.param("x-a:only-of-type", [], id="custom-only-of-type-miss"),
+        # an html <b> beside an <svg> sibling stays distinct by namespace, so the
+        # <b> is still its parent's only element of that type
+        pytest.param("b:only-of-type", ["b"], id="only-of-type-distinct-namespace"),
+        pytest.param("main:only-child", ["main"], id="only-child-hit"),
+        pytest.param("h2:only-child", [], id="only-child-miss"),
+        pytest.param("aside:only-child", [], id="only-child-multiple-siblings"),
+    ],
+)
+def test_structural_pseudo_by_tag(selector: str, tags: list[str]) -> None:
+    assert [element.tag for element in parse(_PSEUDO).select(selector)] == tags
+
+
 def test_universal_under_a_root() -> None:
     assert (section := parse(_DOC).select_one("section")) is not None
     assert len(section.select("*")) == 8  # h2, p, a, p, ul, li, li, my-widget
@@ -255,6 +326,21 @@ def test_namespace_prefixed_local_part_decodes_escapes() -> None:
         pytest.param(".a\\\nb", id="escape-before-lf"),
         pytest.param(".a\\\rb", id="escape-before-cr"),
         pytest.param(".a\\\x0cb", id="escape-before-ff"),
+        # pseudo-classes: a bare or unknown one, a pseudo-element, a functional
+        # pseudo missing its argument list, and malformed An+B
+        pytest.param(":", id="bare-colon"),
+        pytest.param("::before", id="pseudo-element"),
+        pytest.param(":unknown", id="unknown-pseudo"),
+        pytest.param(":root(x)", id="non-functional-with-args"),
+        pytest.param(":nth-child", id="functional-without-args"),
+        pytest.param(":nth-child()", id="empty-anb"),
+        pytest.param(":nth-child(2n+)", id="anb-sign-without-digits"),
+        pytest.param(":nth-child(+)", id="anb-bare-sign"),
+        pytest.param(":nth-child(2n+1", id="anb-unclosed"),
+        pytest.param(":nth-child(", id="anb-eof-after-paren"),
+        pytest.param(":nth-child(2n", id="anb-eof-after-n"),
+        pytest.param(":nth-child.x", id="functional-without-paren"),
+        pytest.param(":nth-child(2n x)", id="anb-trailing-junk"),
     ],
 )
 def test_invalid_selectors_raise(selector: str) -> None:


### PR DESCRIPTION
``select()`` and ``select_one()`` raised ``ValueError('invalid CSS selector')`` for every pseudo-class — the parser had no ``:`` branch at all — so spec-valid selectors like ``p:first-child``, ``:root``, and ``:nth-child(1)`` were rejected outright. selectolax (lexbor) and lxml.cssselect both match them. 🧩

This adds the CSS tree-structural pseudo-classes: ``:root``, ``:empty``, ``:first-child``, ``:last-child``, ``:only-child``, ``:first-of-type``, ``:last-of-type``, ``:only-of-type``, and the functional ``:nth-child()``, ``:nth-last-child()``, ``:nth-of-type()``, and ``:nth-last-of-type()`` with the full ``An+B`` microsyntax (signs, the bare-``n`` and ``-n`` forms, and the ``even``/``odd`` keywords). Matching walks the node tree directly through sibling and parent pointers, so it allocates nothing; of-type comparisons key on the tag atom and fall back to the lowercased tag name for custom elements, so two different custom elements are not conflated. ``:empty`` follows Selectors Level 3 — a whitespace text node counts as content — because the selector engine and the lazy text-span realizer live in separate translation units. Malformed pseudo-classes and ``An+B`` arguments still raise.

Fixes #98