### PR TITLE
🐛 fix(tokenizer): lock shared Tokenizer for free-threaded safety

### DIFF
--- a/docs/changelog/82.bugfix.rst
+++ b/docs/changelog/82.bugfix.rst
@@ -1,0 +1,5 @@
+Guard the streaming ``Tokenizer`` with a per-object critical section so concurrent use from multiple threads on the
+free-threaded (no-GIL) interpreter is memory-safe. ``feed()``, ``close()``, ``reset()``, ``__exit__``, and the token
+iterator all mutate the tokenizer's shared state machine, its record buffers, and its free list; without a lock,
+concurrent ``feed()``/iteration on a single shared tokenizer corrupted the native heap and segfaulted. Each now runs
+under ``Py_BEGIN_CRITICAL_SECTION`` on the owning tokenizer (a no-op on the GIL builds).

--- a/src/turbohtml/tokenizer_py.h
+++ b/src/turbohtml/tokenizer_py.h
@@ -14,6 +14,15 @@
 
 #include "tokenizer_sm.h"
 
+/* Py_BEGIN_CRITICAL_SECTION arrived in 3.13 for the free-threaded build; on a GIL
+   build it is a brace no-op, and before 3.13 (always GIL) we define the same no-op,
+   so the tokenizer's per-object locking compiles on every supported interpreter
+   while only the free-threaded build pays for a real lock. */
+#ifndef Py_BEGIN_CRITICAL_SECTION
+#define Py_BEGIN_CRITICAL_SECTION(op) {
+#define Py_END_CRITICAL_SECTION() }
+#endif
+
 typedef struct {
     PyObject *token_type;         /* Token */
     PyObject *tokenizer_type;     /* Tokenizer */

--- a/src/turbohtml/tokenizer_type.c
+++ b/src/turbohtml/tokenizer_type.c
@@ -92,15 +92,20 @@ static void iter_dealloc(PyObject *self) {
 
 static PyObject *iter_next(PyObject *self) {
     module_state *state = state_of(self);
-    th_tokenizer *sm = ((TokenizerObject *)((IterObject *)self)->owner)->sm;
+    TokenizerObject *owner = (TokenizerObject *)((IterObject *)self)->owner;
+    th_tokenizer *sm = owner->sm;
+    PyObject *result = NULL;
+    /* the shared state machine, its record buffers, and its free list are mutated here;
+       lock the owning tokenizer so concurrent feed()/iteration on the free-threaded
+       interpreter cannot corrupt them */
+    Py_BEGIN_CRITICAL_SECTION(owner);
     th_token *record;
     switch (th_tok_next(sm, &record)) { /* GCOVR_EXCL_BR_LINE: the TH_STEP_ERROR edge needs an allocation failure, which
                                            cannot be forced from a test */
     case TH_STEP_TOKEN: {
-        TokenizerObject *owner = (TokenizerObject *)((IterObject *)self)->owner;
-        PyObject *token = token_from_record(state, sm, owner->source, record);
-        if (token == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-            return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
+        result = token_from_record(state, sm, owner->source, record);
+        if (result == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            break;            /* GCOVR_EXCL_LINE: allocation-failure path */
         }
         if (record->kind == TH_START_TAG) {
             int model = content_model_for(&record->name);
@@ -108,13 +113,16 @@ static PyObject *iter_next(PyObject *self) {
                 th_tok_switch(sm, (enum th_initial_state)model);
             }
         }
-        return token;
+        break;
     }
-    case TH_STEP_ERROR:          /* GCOVR_EXCL_LINE: the only step error is an out-of-memory condition */
-        return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
-    default:                     /* NEED_MORE or DONE: nothing more from this iterator */
-        return NULL;
+    case TH_STEP_ERROR:            /* GCOVR_EXCL_LINE: the only step error is an out-of-memory condition */
+        result = PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+        break;                     /* GCOVR_EXCL_LINE */
+    default:                       /* NEED_MORE or DONE: nothing more from this iterator */
+        break;
     }
+    Py_END_CRITICAL_SECTION();
+    return result;
 }
 
 PyDoc_STRVAR(iter_doc, "Iterator over the tokens a Tokenizer has buffered. Yields Token objects.");
@@ -188,7 +196,11 @@ PyDoc_STRVAR(tokenizer_feed_doc, "feed(data)\n--\n\n"
 
 static PyObject *tokenizer_feed(PyObject *self, PyObject *data) {
     th_tokenizer *sm = ((TokenizerObject *)self)->sm;
-    if (feed_string(sm, data) < 0) {
+    int rc;
+    Py_BEGIN_CRITICAL_SECTION(self); /* th_tok_feed mutates the shared state machine */
+    rc = feed_string(sm, data);
+    Py_END_CRITICAL_SECTION();
+    if (rc < 0) {
         return NULL;
     }
     return iter_new(state_of(self), self);
@@ -200,7 +212,9 @@ PyDoc_STRVAR(tokenizer_close_doc, "close()\n--\n\n"
 
 static PyObject *tokenizer_close(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     th_tokenizer *sm = ((TokenizerObject *)self)->sm;
+    Py_BEGIN_CRITICAL_SECTION(self); /* th_tok_close mutates the shared state machine */
     th_tok_close(sm);
+    Py_END_CRITICAL_SECTION();
     return iter_new(state_of(self), self);
 }
 
@@ -208,7 +222,9 @@ PyDoc_STRVAR(tokenizer_reset_doc, "reset()\n--\n\n"
                                   "Discard all input and return to the initial Data state.");
 
 static PyObject *tokenizer_reset(PyObject *self, PyObject *Py_UNUSED(ignored)) {
+    Py_BEGIN_CRITICAL_SECTION(self); /* th_tok_reset mutates the shared state machine */
     th_tok_reset(((TokenizerObject *)self)->sm);
+    Py_END_CRITICAL_SECTION();
     Py_RETURN_NONE;
 }
 
@@ -223,7 +239,9 @@ PyDoc_STRVAR(tokenizer_exit_doc, "__exit__(*exc)\n--\n\n"
                                  "tokens stay available: iterate the tokenizer to drain them.");
 
 static PyObject *tokenizer_exit(PyObject *self, PyObject *Py_UNUSED(args)) {
+    Py_BEGIN_CRITICAL_SECTION(self); /* th_tok_close mutates the shared state machine */
     th_tok_close(((TokenizerObject *)self)->sm);
+    Py_END_CRITICAL_SECTION();
     Py_RETURN_NONE;
 }
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -10,6 +10,7 @@ strings), and source positions.
 from __future__ import annotations
 
 import gc
+import threading
 import tracemalloc
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING
@@ -580,3 +581,25 @@ def test_feed_keeps_input_while_a_token_is_queued() -> None:
     tokenizer.feed("z")
     tokens = [first, *tokenizer, *tokenizer.close()]
     assert [_shape(token) for token in tokens] == [_shape(token) for token in tokenize("x<a>z")]
+
+
+def test_concurrent_feed_on_shared_tokenizer_is_memory_safe() -> None:
+    # the shared state machine, its record buffers, and its free list are guarded by a
+    # per-tokenizer critical section, so concurrent feed()/iteration on the free-threaded
+    # interpreter must not corrupt the heap (it segfaulted before); under the GIL this just
+    # exercises the locked paths
+    tokenizer = Tokenizer()
+    chunks = ["<div class='a'>hi</div>", "<p>x</p>", "<a href='x'>l</a>", "<!-- c -->", "<span>partial"]
+
+    def work() -> None:
+        for _ in range(200):
+            for chunk in chunks:
+                for _token in tokenizer.feed(chunk):
+                    pass
+
+    threads = [threading.Thread(target=work) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    list(tokenizer.close())


### PR DESCRIPTION
Concurrently calling `feed()` (and consuming the returned iterator) on a single shared `Tokenizer` from multiple threads on the free-threaded (no-GIL) CPython build corrupted the native heap and segfaulted (exit 139). The streaming path mutates the tokenizer's shared state machine, its record buffers, and its free list with no synchronization. 🧵

`feed()`, `close()`, `reset()`, `__exit__`, and the token iterator's advancement now run under `Py_BEGIN_CRITICAL_SECTION` on the owning tokenizer, so concurrent access serializes on a per-object lock instead of racing. The macro is a brace no-op on the GIL builds (with a pre-3.13 fallback shim), so only the free-threaded interpreter pays for a real lock.

A new concurrency test feeds a shared tokenizer from four threads; it passes trivially under the GIL and exercises the locked paths under the free-threaded CI job (`3.14t`/`3.15t`), where the unguarded code segfaulted.

closes #82