### PR TITLE
🐛 fix: pop open select for a keygen start tag in select mode

### DIFF
--- a/docs/changelog/93.bugfix.rst
+++ b/docs/changelog/93.bugfix.rst
@@ -1,0 +1,5 @@
+Pop an open ``select`` when a ``keygen`` start tag is seen in the "in select" insertion mode, so the ``keygen`` becomes
+a sibling after the now-closed ``select`` rather than nesting inside it (and is ignored in a select-context fragment).
+The ``input``/``keygen``/``textarea`` rule was only half-implemented for ``input``; ``keygen`` fell through to a plain
+insert. html5lib's library and the WHATWG algorithm both pop the ``select``; the pinned tree-construction ``.dat`` still
+encodes the older nesting, so those two cases are overridden to the spec-correct trees.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2973,9 +2973,9 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
                     }
                     break;
                 }
-                if (atom == TH_TAG_INPUT) {
-                    /* an input closes an open select entirely (and is ignored
-                       outright in a select-context fragment) */
+                if (atom == TH_TAG_INPUT || atom == TH_TAG_KEYGEN) {
+                    /* an input or keygen closes an open select entirely (and is
+                       ignored outright in a select-context fragment) */
                     if (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT) {
                         break;
                     }

--- a/tests/test_treebuilder_conformance.py
+++ b/tests/test_treebuilder_conformance.py
@@ -86,6 +86,12 @@ _SPEC_OVERRIDES: dict[tuple[str, str, str | None], str] = {
     ),
     ("foreign-fragment.dat", "<svg></br><foo>", "div"): "| <svg svg>\n|   <br>\n|   <svg foo>",
     ("foreign-fragment.dat", "</br><foo>", "svg svg"): "| <svg foo>",
+    # The "in select" mode pops an open select for an input/keygen/textarea start tag (and ignores
+    # it in a select-context fragment). The pinned .dat predates the keygen rule and still nests it;
+    # html5lib's own library pops it (sibling) for a document and ignores it in a select fragment,
+    # matching the WHATWG algorithm. See https://github.com/tox-dev/turbohtml/issues/93
+    ("tests7.dat", "<select><keygen>", None): "| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <keygen>",
+    ("tests_innerHTML_1.dat", "<keygen><option>", "select"): "| <option>",
 }
 
 


### PR DESCRIPTION
`parse("<select><keygen>z")` nested the `keygen` inside the open `<select>` instead of popping the select and placing `keygen` as a sibling after it. The WHATWG "in select" insertion mode handles `input`, `keygen`, and `textarea` the same way — pop until the select is popped, then reprocess (and ignore the token in a select-context fragment that has no select in scope). turbohtml implemented this for `input` but let `keygen` fall through to a plain insert. Closes #93.

`keygen` now goes through the same handler as `input`. I verified the direction against the reference: html5lib's library pops the select (keygen becomes a sibling) for a document and ignores keygen in a `select` fragment, matching the algorithm. The pinned html5lib-tests `.dat` predates the keygen rule and still nests it, so the two affected cases (`tests7.dat` `<select><keygen>`, `tests_innerHTML_1.dat` `<keygen><option>` in `select`) are pinned to the spec-correct trees through the existing `_SPEC_OVERRIDES` table — the same mechanism already used for the stale foreign `</p>`/`</br>` cases (#32/#63).

No benchmark: the change adds `keygen` to an existing start-tag branch, off any hot path.