### PR TITLE
🐛 fix(parse): template fragment enters in-template mode

### DIFF
--- a/docs/changelog/95.bugfix.rst
+++ b/docs/changelog/95.bugfix.rst
@@ -1,0 +1,4 @@
+Parse a ``template``-context fragment in the "in template" insertion mode. ``parse_fragment(..., context="template")`` ran
+in the "in body" mode, so table-section start tags (``td``, ``th``, ``tr``, ``col``, ``caption``, ``tbody``, ``tfoot``,
+``thead``) were ignored and only their text survived. Per the WHATWG fragment-parsing algorithm a ``template`` context
+pushes "in template" onto the template insertion mode stack, so those tags now build their elements.

--- a/docs/changelog/95.bugfix.rst
+++ b/docs/changelog/95.bugfix.rst
@@ -1,4 +1,5 @@
-Parse a ``template``-context fragment in the "in template" insertion mode. ``parse_fragment(..., context="template")`` ran
-in the "in body" mode, so table-section start tags (``td``, ``th``, ``tr``, ``col``, ``caption``, ``tbody``, ``tfoot``,
-``thead``) were ignored and only their text survived. Per the WHATWG fragment-parsing algorithm a ``template`` context
-pushes "in template" onto the template insertion mode stack, so those tags now build their elements.
+Parse a ``template``-context fragment in the "in template" insertion mode. ``parse_fragment(..., context="template")``
+ran in the "in body" mode, so table-section start tags (``td``, ``th``, ``tr``, ``col``, ``caption``, ``tbody``,
+``tfoot``, ``thead``) were ignored and only their text survived. Per the WHATWG fragment-parsing algorithm a
+``template`` context pushes "in template" onto the template insertion mode stack, so those tags now build their
+elements.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -1968,8 +1968,9 @@ static void tmpl_set(th_tree *tree, enum mode mode) {
     }
 }
 
+/* tmpl_top runs only for a template element, which carries a pushed mode. */
 static enum mode tmpl_top(th_tree *tree) {
-    return tree->tmpl_len > 0 ? (enum mode)tree->tmpl[tree->tmpl_len - 1] : M_IN_BODY;
+    return tree->tmpl_len > 0 /* GCOVR_EXCL_BR_LINE */ ? (enum mode)tree->tmpl[tree->tmpl_len - 1] : M_IN_BODY;
 }
 
 /* Reset the insertion mode appropriately: pick the mode implied by the current
@@ -3900,6 +3901,8 @@ static enum mode fragment_mode(uint16_t ctx) {
         return M_IN_COLUMN_GROUP;
     case TH_TAG_TABLE:
         return M_IN_TABLE;
+    case TH_TAG_TEMPLATE:
+        return M_IN_TEMPLATE;
     case TH_TAG_FRAMESET:
         return M_IN_FRAMESET;
     case TH_TAG_HTML:
@@ -3983,7 +3986,8 @@ th_tree *th_tree_parse_fragment(int kind, const void *data, Py_ssize_t length, c
     tree->fragment_root = root;
     tree->ctx_atom = ctx_atom;
     if (ctx_atom == TH_TAG_TEMPLATE) {
-        tree->head = root; /* keep reset logic happy; template mode deferred */
+        tree->head = root;              /* keep reset logic happy */
+        tmpl_push(tree, M_IN_TEMPLATE); /* a template context starts in "in template" */
     }
     /* a foreign context element makes the root act as that element's namespace,
        so the foreign-content rules apply to the fragment's content */

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -513,6 +513,16 @@ def test_before_html_end_br_synthesizes_br() -> None:
         # the stack, fosters out to the fragment root rather than nesting (issue #55)
         pytest.param("<tr><li>x", "tbody", "| <tr>\n| <li>", id="foster-out-of-tbody-fragment"),
         pytest.param("<tr><li>x", "table", "|   <tr>\n| <li>", id="foster-out-of-table-fragment"),
+        # a template context starts in "in template" mode, so table-section start tags
+        # build their elements instead of dropping to text (issue #95)
+        pytest.param("<td>x", "template", '| <td>\n|   "x"', id="template-fragment-td"),
+        pytest.param("<col>", "template", "| <col>", id="template-fragment-col"),
+        pytest.param("<tr><td>y", "template", "| <tr>\n|   <td>", id="template-fragment-tr-td"),
+        pytest.param("<caption>c", "template", '| <caption>\n|   "c"', id="template-fragment-caption"),
+        pytest.param("<tbody><tr><td>z", "template", "| <tbody>\n|   <tr>", id="template-fragment-tbody"),
+        pytest.param("<thead><tr><th>h", "template", "| <thead>\n|   <tr>", id="template-fragment-thead"),
+        # ordinary in-body content in a template context is unaffected
+        pytest.param("<p>x", "template", '| <p>\n|   "x"', id="template-fragment-plain-body"),
     ],
 )
 def test_fragment_paths(html: str, context: str, needle: str) -> None:


### PR DESCRIPTION
``parse_fragment(html, context="template")`` parsed in the "in body" insertion mode, so a table-section start tag — ``td``, ``th``, ``tr``, ``col``, ``caption``, ``tbody``, ``tfoot``, ``thead`` — was ignored and only its text survived. ``parse_fragment("<td>x", context="template")`` produced ``<template>x</template>`` instead of a ``td`` holding ``x``. 🧩

Per the WHATWG fragment-parsing algorithm, a ``template`` context element pushes "in template" onto the stack of template insertion modes, and reset-insertion-mode then resolves a template element to the current template insertion mode. ``fragment_mode`` now returns ``M_IN_TEMPLATE`` for a template context and the fragment setup pushes that mode, so the "in template" rules route each table-section tag into the matching table sub-mode and build its element. The existing ``tmpl_top`` empty-stack fallback becomes unreachable — a template element is on the stack (or is the fragment context) exactly when a mode has been pushed — and is marked the same way the adjacent ``tmpl_set`` already is.

This follows the spec, which html5lib 1.1 lags here; the html5lib-tests conformance suite is unaffected.

Fixes #95