### PR TITLE
🐛 fix(treebuilder): pop select for a table tag in select-in-table

### DIFF
--- a/docs/changelog/90.bugfix.rst
+++ b/docs/changelog/90.bugfix.rst
@@ -1,0 +1,5 @@
+Pop an open ``<select>`` when a table-family start tag (``caption``, ``table``, ``tbody``, ``tfoot``, ``thead``, ``tr``,
+``td``, ``th``) appears in the "in select in table" context, instead of nesting the element inside the select. Per the
+WHATWG "in select in table" insertion mode the token pops the select, resets the insertion mode, and is reprocessed, so
+``parse("<table><tr><td><select><table>")`` now puts the inner table as a sibling of the (closed, empty) ``<select>`` in
+the cell, matching html5lib.

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -2205,6 +2205,21 @@ static void run(th_tree *tree, th_tokenizer *sm, enum mode start_mode) {
             mode = M_IN_TEMPLATE;
             continue;
         }
+        /* "in select in table": a select opened in a table context does not get its own
+           mode here, so a table-family start tag would nest inside the still-open select.
+           Per the spec it pops the select, resets the insertion mode, and reprocesses, so
+           the table element becomes a sibling of the closed select (#90). */
+        if (tok->kind == TH_START_TAG && has_in_scope(tree, TH_TAG_SELECT) &&
+            (mode == M_IN_TABLE || mode == M_IN_TABLE_BODY || mode == M_IN_ROW || mode == M_IN_CELL ||
+             mode == M_IN_CAPTION)) {
+            uint16_t a = tok_atom(tok);
+            if (a == TH_TAG_CAPTION || a == TH_TAG_TABLE || a == TH_TAG_TBODY || a == TH_TAG_TFOOT ||
+                a == TH_TAG_THEAD || a == TH_TAG_TR || a == TH_TAG_TD || a == TH_TAG_TH) {
+                pop_until_atom(tree, TH_TAG_SELECT);
+                mode = reset_insertion_mode(tree);
+                goto reprocess;
+            }
+        }
         /* a DOCTYPE in any insertion mode other than "initial" is a parse error that is
            ignored without changing the insertion mode (foreign content already handled
            its own DOCTYPE above); only the initial mode builds the doctype node */

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -392,7 +392,9 @@ def test_table_family_start_tag_pops_select_in_table(tag: str) -> None:
 
 def test_non_table_start_tag_stays_in_select_in_table() -> None:
     # a non-table-family start tag is not affected: an option stays inside the select
-    assert parse("<table><tr><td><select><option>x").find("select").inner_html == "<option>x</option>"
+    select = parse("<table><tr><td><select><option>x").find("select")
+    assert select is not None
+    assert select.inner_html == "<option>x</option>"
 
 
 def test_stray_html_in_colgroup_keeps_it_open() -> None:

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -381,6 +381,20 @@ def test_document_paths(html: str, needle: str) -> None:
     assert needle in _doc(html)
 
 
+@pytest.mark.parametrize("tag", ["caption", "table", "tbody", "tfoot", "thead", "tr", "td", "th"])
+def test_table_family_start_tag_pops_select_in_table(tag: str) -> None:
+    # "in select in table": a table-family start tag pops the open select and reprocesses,
+    # so it never nests inside the select (the select is left empty as a sibling)
+    select = parse(f"<table><tr><td><select><{tag}>").find("select")
+    assert select is not None
+    assert not select.inner_html
+
+
+def test_non_table_start_tag_stays_in_select_in_table() -> None:
+    # a non-table-family start tag is not affected: an option stays inside the select
+    assert parse("<table><tr><td><select><option>x").find("select").inner_html == "<option>x</option>"
+
+
 def test_stray_html_in_colgroup_keeps_it_open() -> None:
     # a stray <html> in "in column group" uses the in-body rules (merge attributes, leave the
     # stack), so the colgroup stays open and the next <col> joins it instead of starting a new one


### PR DESCRIPTION
In the WHATWG "in select in table" insertion mode, a table-family start tag (`caption`, `table`, `tbody`, `tfoot`, `thead`, `tr`, `td`, `th`) must pop the open `<select>`, reset the insertion mode, and reprocess the token — so the element becomes a sibling of the now-closed select rather than nesting inside it. turbohtml models select content as plain in-body content with no dedicated mode, so the table tag was nesting inside the still-open select. 📊

The fix adds a pre-switch hook: when the insertion mode is a table mode (`in table`/`in table body`/`in row`/`in cell`/`in caption`) and a `<select>` is in scope, a table-family start tag pops to the select, resets the insertion mode, and reprocesses.

`parse("<table><tr><td><select><table>")` now yields `td > select(empty) + table` (sibling), matching html5lib; a non-table tag like `<option>` still stays inside the select.

closes #90