### PR TITLE
✨ feat(select): :is(), :where(), and :has() pseudo-classes

### DIFF
--- a/docs/changelog/96.feature.rst
+++ b/docs/changelog/96.feature.rst
@@ -1,0 +1,7 @@
+Match the Selectors Level 4 functional pseudo-classes ``:is()``, ``:where()``, and ``:has()`` in
+:meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and
+:meth:`~turbohtml.Node.closest`, instead of rejecting them as invalid. ``:is()`` and ``:where()`` match an element
+against a nested selector list (a tree matcher treats them identically, since they differ only in specificity), and
+``:has()`` keeps an element when a relative selector -- with an optional leading ``>``, ``+``, or ``~`` combinator --
+finds a match anchored at it, so ``article:has(> img)`` and ``h2:has(+ p)`` work. The nested lists may themselves nest,
+and matching agrees with soupsieve and lexbor.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -187,7 +187,8 @@ The query surface builds on that node model. Navigation covers parents, siblings
 :attr:`~turbohtml.Node.following` / :attr:`~turbohtml.Node.preceding` iterators, plus the sequence protocol over a
 node's children. :meth:`~turbohtml.Node.find` and :meth:`~turbohtml.Node.find_all` filter a chosen
 :class:`~turbohtml.Axis` by tag and attributes, where a filter is a string, regex, callable, or list.
-:meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.select_one` run a native CSS matcher, and
+:meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.select_one` run a native CSS matcher -- type, id, class,
+attribute, the four combinators, and the ``:is()``/``:where()``/``:has()`` functional pseudo-classes -- and
 :meth:`~turbohtml.Node.matches` / :meth:`~turbohtml.Node.closest` test a node in place. Selectors compile against the
 tree, so a tag or attribute name resolves to the same interned atom the parser assigned and each match is an integer
 compare. Output runs back through :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -351,6 +351,24 @@ general-sibling (``~``) combinators, with comma groups:
     b
     ['a']
 
+The Selectors Level 4 functional pseudo-classes are supported too: ``:is()`` and ``:where()`` match an element against a
+nested selector list (they differ only in specificity, which a tree matcher ignores), and ``:has()`` keeps an element
+when a relative selector finds a match anchored at it:
+
+.. testcode::
+
+    page = turbohtml.parse(
+        '<article><h1>Post</h1><figure><img></figure></article>'
+        "<article><h1>Note</h1></article>"
+    )
+    print([a.select_one("h1").text for a in page.select("article:has(img)")])
+    print([e.tag for e in page.select(":is(h1, figure)")])
+
+.. testoutput::
+
+    ['Post']
+    ['h1', 'figure', 'h1']
+
 To test a node you already hold rather than search beneath it, use :meth:`~turbohtml.Node.matches` (does this node
 match) or :meth:`~turbohtml.Node.closest` (the nearest matching self-or-ancestor):
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -389,6 +389,37 @@ than BeautifulSoup.
       - 47.4 µs
       - 2.12 ms
 
+The relational ``:has()`` pseudo-class is the costliest selector to evaluate, since a naive matcher rescans each
+candidate's subtree. turbohtml runs ``div:has(a)`` against the same pages and stays ahead of every alternative: roughly
+three times faster than lxml and selectolax on the large page and over a hundred times faster than BeautifulSoup. The
+matcher walks each anchor's descendants once and skips the sibling scan for descendant and child relationships, so the
+relational lookup keeps the same interned-atom comparison the flat selectors use.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 28 18 18 18 18
+
+    - - select ``div:has(a)``
+      - turbohtml
+      - lxml
+      - selectolax
+      - BeautifulSoup
+    - - wpt page (4 kB)
+      - 0.8 µs
+      - 16.3 µs
+      - 4.8 µs
+      - 130 µs
+    - - wpt page (9.6 kB)
+      - 0.9 µs
+      - 18.2 µs
+      - 5.8 µs
+      - 154 µs
+    - - wpt page (92 kB)
+      - 11.9 µs
+      - 33.6 µs
+      - 37.8 µs
+      - 1.40 ms
+
 *************
  Serializing
 *************

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -3,7 +3,8 @@
    names resolve to interned atoms once and every match is an integer compare.
    Matching is right-to-left with backtracking on the descendant and general
    sibling combinators. This covers the common subset: type, universal, class,
-   id, attribute operators, and the four combinators, grouped by commas. */
+   id, attribute operators, the four combinators, the :is()/:where()/:has()
+   functional pseudo-classes, all grouped by commas. */
 
 #ifndef TURBOHTML_SELECTOR_H
 #define TURBOHTML_SELECTOR_H
@@ -13,8 +14,13 @@
 
 enum sel_attr_op { OP_EXISTS, OP_EQ, OP_INCLUDE, OP_DASH, OP_PREFIX, OP_SUFFIX, OP_SUBSTR };
 
-/* ':' tree-structural pseudo-classes. The nth-* variants carry An+B in nth_a/nth_b;
-   the others have fixed structural meaning. */
+/* The functional pseudo-classes hold a nested selector list built from sel_complex,
+   so the type is forward-declared here. */
+typedef struct sel_complex sel_complex;
+
+/* ':' pseudo-classes. The structural ones have fixed meaning (the nth-* variants
+   carry An+B in nth_a/nth_b); the functional ones (:is/:where/:has) carry a nested
+   selector list in sub. */
 enum sel_pseudo {
     PSEUDO_NONE,
     PSEUDO_ROOT,
@@ -29,6 +35,9 @@ enum sel_pseudo {
     PSEUDO_NTH_LAST_CHILD,
     PSEUDO_NTH_OF_TYPE,
     PSEUDO_NTH_LAST_OF_TYPE,
+    PSEUDO_IS,
+    PSEUDO_WHERE,
+    PSEUDO_HAS,
 };
 
 typedef struct {
@@ -45,6 +54,8 @@ typedef struct {
     Py_ssize_t name_len;  /* also the attribute name for the rare unknown case */
     const Py_UCS4 *value; /* '[': the attribute value */
     Py_ssize_t value_len;
+    sel_complex *sub; /* ':': the nested selector list for :is()/:where()/:has() */
+    int sub_count;    /* ':': number of comma-separated alternatives in sub */
 } sel_simple;
 
 typedef struct {
@@ -53,10 +64,10 @@ typedef struct {
     char combinator; /* ' ', '>', '+', '~': the combinator joining the compound on the left */
 } sel_compound;
 
-typedef struct {
+struct sel_complex {
     sel_compound *compounds; /* left to right; matched from the rightmost (the subject) */
     int count;
-} sel_complex;
+};
 
 typedef struct {
     Py_UCS4 *source; /* an owned copy of the selector text the slices point into */
@@ -414,6 +425,11 @@ static void sel_parse_anb(sel_parser *parser, int *a, int *b) {
     sel_skip_ws(parser);
 }
 
+/* Parse the comma-separated selector list inside a :is()/:where()/:has(); defined
+   below, after the complex-selector parser it drives. */
+static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_count, int nested, int relative);
+static void sel_free_alts(sel_complex *alts, int count);
+
 /* Parse a pseudo-class selector (the leading ':' already consumed). */
 static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
     simple->kind = ':';
@@ -423,7 +439,8 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
     if (parser->error) {
         return;
     }
-    int functional = PSEUDO_NONE;
+    int functional = PSEUDO_NONE; /* an nth-* pseudo-class taking An+B */
+    int listy = PSEUDO_NONE;      /* :is()/:where()/:has() taking a selector list */
     if (sel_kw(name, name_len, "root")) {
         simple->pseudo = PSEUDO_ROOT;
     } else if (sel_kw(name, name_len, "empty")) {
@@ -448,6 +465,12 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
         functional = PSEUDO_NTH_OF_TYPE;
     } else if (sel_kw(name, name_len, "nth-last-of-type")) {
         functional = PSEUDO_NTH_LAST_OF_TYPE;
+    } else if (sel_kw(name, name_len, "is")) {
+        listy = PSEUDO_IS;
+    } else if (sel_kw(name, name_len, "where")) {
+        listy = PSEUDO_WHERE;
+    } else if (sel_kw(name, name_len, "has")) {
+        listy = PSEUDO_HAS;
     } else {
         parser->error = 1; /* an unknown pseudo-class invalidates the selector */
         return;
@@ -468,6 +491,14 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
             return;
         }
         parser->pos++;
+    } else if (listy != PSEUDO_NONE) {
+        simple->pseudo = listy;
+        if (parser->pos >= parser->len || parser->src[parser->pos] != '(') {
+            parser->error = 1; /* :is()/:where()/:has() require an argument list */
+            return;
+        }
+        parser->pos++;
+        sel_parse_alts(parser, &simple->sub, &simple->sub_count, 1, listy == PSEUDO_HAS);
     } else if (parser->pos < parser->len && parser->src[parser->pos] == '(') {
         parser->error = 1; /* a non-functional pseudo-class takes no argument list */
         return;
@@ -487,6 +518,8 @@ static void sel_one(sel_parser *parser, sel_simple *simple) {
     simple->name_len = 0;
     simple->value = NULL;
     simple->value_len = 0;
+    simple->sub = NULL;
+    simple->sub_count = 0;
     Py_UCS4 ch = parser->src[parser->pos];
     if (ch == '.' || ch == '#') {
         simple->kind = (char)ch;
@@ -536,32 +569,70 @@ static int sel_compound_parse(sel_parser *parser, sel_simple *buffer, int capaci
     while (parser->pos < parser->len && sel_starts_simple(parser->src[parser->pos])) {
         if (count >= capacity) {
             parser->error = 1;
-            return count;
+            break;
         }
         sel_one(parser, &buffer[count]);
         if (parser->error) {
-            return count;
+            break;
         }
         count++;
     }
     if (count == 0) {
         parser->error = 1;
     }
+    if (parser->error) {
+        /* free the nested lists of the pseudo-classes parsed before the failure; the
+           simple that failed left its own sub NULL (sel_parse_alts cleans up on error) */
+        for (int index = 0; index < count; index++) {
+            if (buffer[index].sub != NULL) {
+                sel_free_alts(buffer[index].sub, buffer[index].sub_count);
+            }
+        }
+        return 0;
+    }
     return count;
 }
 
 /* Parse one complex selector (compounds joined by combinators) into *complex,
    allocating its compounds. Returns 0, or -1 with parser->error set. */
+static void sel_free_alts(sel_complex *alts, int count);
+
 static void free_compounds(sel_compound *compounds, int count) {
     for (int index = 0; index < count; index++) {
+        for (int simple = 0; simple < compounds[index].count; simple++) {
+            if (compounds[index].simples[simple].sub != NULL) { /* a functional pseudo-class's nested list */
+                sel_free_alts(compounds[index].simples[simple].sub, compounds[index].simples[simple].sub_count);
+            }
+        }
         PyMem_Free(compounds[index].simples);
     }
 }
 
-static int sel_complex_parse(sel_parser *parser, sel_complex *complex) {
+/* Free a comma-separated list of complex selectors and the array holding it (used
+   for the top-level compiled selector and every nested :is()/:where()/:has() list). */
+static void sel_free_alts(sel_complex *alts, int count) {
+    for (int index = 0; index < count; index++) {
+        free_compounds(alts[index].compounds, alts[index].count);
+        PyMem_Free(alts[index].compounds);
+    }
+    PyMem_Free(alts);
+}
+
+static int sel_complex_parse(sel_parser *parser, sel_complex *complex, int nested, int relative) {
     sel_compound temp[32];
     int count = 0;
     char combinator = ' ';
+    /* a relative selector (the argument of :has()) may open with a combinator, which
+       joins its first compound to the anchor element instead of a left-hand compound */
+    if (relative) {
+        sel_skip_ws(parser);
+        Py_UCS4 lead = parser->pos < parser->len ? parser->src[parser->pos] : 0;
+        if (lead == '>' || lead == '+' || lead == '~') {
+            combinator = (char)lead;
+            parser->pos++;
+            sel_skip_ws(parser);
+        }
+    }
     while (1) {
         if (count >= 32) {
             parser->error = 1;
@@ -588,7 +659,7 @@ static int sel_complex_parse(sel_parser *parser, sel_complex *complex) {
             break;
         }
         Py_UCS4 ch = parser->src[parser->pos];
-        if (ch == ',') {
+        if (ch == ',' || (nested && ch == ')')) {
             break;
         }
         if (ch == '>' || ch == '+' || ch == '~') {
@@ -618,14 +689,63 @@ static int sel_complex_parse(sel_parser *parser, sel_complex *complex) {
     return 0;
 }
 
-static void selector_free(sel_compiled *compiled) {
-    for (int index = 0; index < compiled->count; index++) {
-        for (int inner = 0; inner < compiled->alts[index].count; inner++) {
-            PyMem_Free(compiled->alts[index].compounds[inner].simples);
+/* Parse a comma-separated list of complex selectors into a freshly allocated array.
+   nested stops the list at a closing ')' (the :is()/:where()/:has() argument case)
+   and requires that ')'; relative lets each complex open with a combinator (:has()).
+   Returns 0 with the out parameters set, or -1 with parser->error set. */
+static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_count, int nested, int relative) {
+    sel_complex temp[64];
+    int count = 0;
+    while (1) {
+        sel_skip_ws(parser);
+        if (count >= 64) {
+            parser->error = 1;
+            break;
         }
-        PyMem_Free(compiled->alts[index].compounds);
+        if (sel_complex_parse(parser, &temp[count], nested, relative) < 0) {
+            break;
+        }
+        count++;
+        sel_skip_ws(parser);
+        if (parser->pos >= parser->len) {
+            if (nested) {
+                parser->error = 1; /* a ':is(...' that never closes its '(' */
+            }
+            break;
+        }
+        if (parser->src[parser->pos] == ',') {
+            parser->pos++;
+            continue;
+        }
+        /* a successful complex stops only at a comma, the end, or -- when nested -- the
+           closing ')' that ends the argument list; consume it and finish */
+        parser->pos++;
+        break;
     }
-    PyMem_Free(compiled->alts);
+    if (parser->error) {
+        for (int index = 0; index < count; index++) {
+            free_compounds(temp[index].compounds, temp[index].count);
+            PyMem_Free(temp[index].compounds);
+        }
+        return -1;
+    }
+    sel_complex *owned = PyMem_Malloc((size_t)count * sizeof(sel_complex));
+    if (owned == NULL) {                              /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+        for (int index = 0; index < count; index++) { /* GCOVR_EXCL_LINE: allocation-failure path */
+            free_compounds(temp[index].compounds, temp[index].count); /* GCOVR_EXCL_LINE */
+            PyMem_Free(temp[index].compounds);                        /* GCOVR_EXCL_LINE: allocation-failure path */
+        } /* GCOVR_EXCL_LINE: allocation-failure path */
+        parser->error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;         /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    memcpy(owned, temp, (size_t)count * sizeof(sel_complex));
+    *out_alts = owned;
+    *out_count = count;
+    return 0;
+}
+
+static void selector_free(sel_compiled *compiled) {
+    sel_free_alts(compiled->alts, compiled->count);
     PyMem_Free(compiled->source);
     PyMem_Free(compiled);
 }
@@ -643,50 +763,23 @@ static sel_compiled *selector_compile(th_tree *tree, PyObject *selector_str) {
         return NULL;                /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     sel_parser parser = {compiled->source, 0, PyUnicode_GET_LENGTH(selector_str), tree, 0};
-    sel_complex temp[64];
-    int count = 0;
-    while (1) {
-        sel_skip_ws(&parser);
-        if (count >= 64) {
-            parser.error = 1;
-            break;
-        }
-        if (sel_complex_parse(&parser, &temp[count]) < 0) {
-            break;
-        }
-        count++;
-        sel_skip_ws(&parser);
-        if (parser.pos >= parser.len) {
-            break;
-        }
-        parser.pos++; /* a successful complex stops only at the end or a comma */
-    }
-    if (parser.error) { /* an empty or malformed selector always sets the error */
-        for (int index = 0; index < count; index++) {
-            free_compounds(temp[index].compounds, temp[index].count);
-            PyMem_Free(temp[index].compounds);
-        }
+    if (sel_parse_alts(&parser, &compiled->alts, &compiled->count, 0, 0) < 0) {
         PyMem_Free(compiled->source);
         PyMem_Free(compiled);
         PyErr_SetString(PyExc_ValueError, "invalid CSS selector");
         return NULL;
     }
-    compiled->alts = PyMem_Malloc((size_t)count * sizeof(sel_complex));
-    if (compiled->alts == NULL) {                     /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
-        for (int index = 0; index < count; index++) { /* GCOVR_EXCL_LINE: allocation-failure path */
-            free_compounds(temp[index].compounds, temp[index].count); /* GCOVR_EXCL_LINE */
-            PyMem_Free(temp[index].compounds);                        /* GCOVR_EXCL_LINE: allocation-failure path */
-        } /* GCOVR_EXCL_LINE: allocation-failure path */
-        PyMem_Free(compiled->source);    /* GCOVR_EXCL_LINE: allocation-failure path */
-        PyMem_Free(compiled);            /* GCOVR_EXCL_LINE: allocation-failure path */
-        return (void *)PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
-    memcpy(compiled->alts, temp, (size_t)count * sizeof(sel_complex));
-    compiled->count = count;
     return compiled;
 }
 
 /* --------------------------------------------------------------- matching */
+
+/* The functional pseudo-classes recurse into the matcher: :is()/:where() test the
+   element against a nested list, and :has() searches for a relative match, so the
+   matching primitives they call are forward-declared here. */
+static int sel_match_compound(th_node *node, const sel_compound *compound);
+static int sel_matches_alts(th_node *node, const sel_complex *alts, int count);
+static int sel_has_match(th_node *anchor, const sel_complex *alts, int count);
 
 static Py_UCS4 sel_fold(Py_UCS4 ch, int ci) {
     return (ci && ch >= 'A' && ch <= 'Z') ? ch + 32 : ch;
@@ -853,8 +946,15 @@ static int sel_match_pseudo(th_node *node, const sel_simple *simple) {
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 1, 0));
     case PSEUDO_NTH_OF_TYPE:
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 0, 1));
-    default: /* PSEUDO_NTH_LAST_OF_TYPE */
+    case PSEUDO_NTH_LAST_OF_TYPE:
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 1, 1));
+    /* the functional pseudo-classes: :is()/:where() match the element against the
+       nested list; :has() searches for a relative match anchored at it */
+    case PSEUDO_IS:
+    case PSEUDO_WHERE:
+        return sel_matches_alts(node, simple->sub, simple->sub_count);
+    default: /* PSEUDO_HAS */
+        return sel_has_match(node, simple->sub, simple->sub_count);
     }
 }
 
@@ -921,11 +1021,36 @@ static th_node *sel_prev_element(th_node *node) {
     return NULL;
 }
 
-/* node matches compounds[index]; verify the combinators and compounds to its
-   left, with backtracking on the descendant and general-sibling axes. */
-static int sel_match_from(th_node *node, const sel_complex *complex, int index) {
+/* node matches compounds[index]; verify the combinators and compounds to its left,
+   with backtracking on the descendant and general-sibling axes. anchor is NULL for an
+   ordinary selector (the leftmost compound is the end); for a :has() relative selector
+   it is the element :has() tests, and the leftmost compound's leading combinator must
+   connect to it. The interior-combinator machinery is shared by both. */
+static int sel_match_from(th_node *node, const sel_complex *complex, int index, th_node *anchor) {
     if (index == 0) {
-        return 1;
+        if (anchor == NULL) {
+            return 1;
+        }
+        switch (complex->compounds[0].combinator) {
+        case '>':
+            return node->parent == anchor;
+        case '+':
+            return sel_prev_element(node) == anchor;
+        case '~':
+            for (th_node *prev = sel_prev_element(node); prev != NULL; prev = sel_prev_element(prev)) {
+                if (prev == anchor) {
+                    return 1;
+                }
+            }
+            return 0;
+        default: /* descendant */
+            for (th_node *ancestor = node->parent; ancestor != NULL; ancestor = ancestor->parent) {
+                if (ancestor == anchor) {
+                    return 1;
+                }
+            }
+            return 0;
+        }
     }
     const sel_compound *target = &complex->compounds[index - 1];
     switch (complex->compounds[index].combinator) {
@@ -933,22 +1058,22 @@ static int sel_match_from(th_node *node, const sel_complex *complex, int index) 
         /* a matched node is an element, so it always has a parent (the document
            at the root), which sel_match_compound rejects as a non-element */
         th_node *parent = node->parent;
-        return sel_match_compound(parent, target) && sel_match_from(parent, complex, index - 1);
+        return sel_match_compound(parent, target) && sel_match_from(parent, complex, index - 1, anchor);
     }
     case '+': {
         th_node *prev = sel_prev_element(node);
-        return prev != NULL && sel_match_compound(prev, target) && sel_match_from(prev, complex, index - 1);
+        return prev != NULL && sel_match_compound(prev, target) && sel_match_from(prev, complex, index - 1, anchor);
     }
     case '~':
         for (th_node *prev = sel_prev_element(node); prev != NULL; prev = sel_prev_element(prev)) {
-            if (sel_match_compound(prev, target) && sel_match_from(prev, complex, index - 1)) {
+            if (sel_match_compound(prev, target) && sel_match_from(prev, complex, index - 1, anchor)) {
                 return 1;
             }
         }
         return 0;
     default: /* descendant */
         for (th_node *ancestor = node->parent; ancestor != NULL; ancestor = ancestor->parent) {
-            if (sel_match_compound(ancestor, target) && sel_match_from(ancestor, complex, index - 1)) {
+            if (sel_match_compound(ancestor, target) && sel_match_from(ancestor, complex, index - 1, anchor)) {
                 return 1;
             }
         }
@@ -956,15 +1081,68 @@ static int sel_match_from(th_node *node, const sel_complex *complex, int index) 
     }
 }
 
-static int selector_matches(th_node *node, const sel_compiled *compiled) {
-    for (int index = 0; index < compiled->count; index++) {
-        const sel_complex *complex = &compiled->alts[index];
+/* node matches some alternative in alts: it is the subject (rightmost compound) of
+   one complex whose combinators to the left verify. The top-level match and the
+   :is()/:where() pseudo-classes share this. */
+static int sel_matches_alts(th_node *node, const sel_complex *alts, int count) {
+    for (int index = 0; index < count; index++) {
+        const sel_complex *complex = &alts[index];
         int subject = complex->count - 1;
-        if (sel_match_compound(node, &complex->compounds[subject]) && sel_match_from(node, complex, subject)) {
+        if (sel_match_compound(node, &complex->compounds[subject]) && sel_match_from(node, complex, subject, NULL)) {
             return 1;
         }
     }
     return 0;
+}
+
+/* Whether any element in the subtree below node is the subject of rel anchored at
+   anchor (the element :has() is testing), checked recursively in document order. */
+static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor) {
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type != TH_NODE_ELEMENT) {
+            continue;
+        }
+        if ((sel_match_compound(child, &rel->compounds[subject]) && sel_match_from(child, rel, subject, anchor)) ||
+            sel_has_subtree(child, rel, subject, anchor)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Whether the anchor element satisfies any :has() relative selector. A relative
+   selector reaches the anchor's descendants and, through a leading sibling
+   combinator, its following siblings and their subtrees. */
+static int sel_has_match(th_node *anchor, const sel_complex *alts, int count) {
+    for (int index = 0; index < count; index++) {
+        const sel_complex *rel = &alts[index];
+        int subject = rel->count - 1;
+        if (sel_has_subtree(anchor, rel, subject, anchor)) {
+            return 1;
+        }
+        /* only a leading sibling combinator (:has(+ x) / :has(~ x)) can match outside
+           the anchor's subtree; a descendant or child relative selector cannot, so its
+           following-sibling scan would always fail and is skipped */
+        char lead = rel->compounds[0].combinator;
+        if (lead != '+' && lead != '~') {
+            continue;
+        }
+        for (th_node *sibling = anchor->next_sibling; sibling != NULL; sibling = sibling->next_sibling) {
+            if (sibling->type != TH_NODE_ELEMENT) {
+                continue;
+            }
+            if ((sel_match_compound(sibling, &rel->compounds[subject]) &&
+                 sel_match_from(sibling, rel, subject, anchor)) ||
+                sel_has_subtree(sibling, rel, subject, anchor)) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+static int selector_matches(th_node *node, const sel_compiled *compiled) {
+    return sel_matches_alts(node, compiled->alts, compiled->count);
 }
 
 /* The lone simple selector of a selector that is one group, one compound, one

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -292,11 +292,90 @@ def test_namespace_prefixed_local_part_decodes_escapes() -> None:
     assert _sel("<root><a>1</a></root>", "*|\\61") == ["a"]
 
 
+_PSEUDO_DOC = (
+    "<main>"
+    '<section id="s">'
+    "<h2>T</h2>"
+    '<p class="lead">one <a href="/x">link</a></p>'
+    "<p>two</p>"
+    '<ul><li>a</li><li class="sel">b</li></ul>'
+    "</section>"
+    '<aside id="a"><span>side</span></aside>'
+    "</main>"
+)
+
+
+@pytest.mark.parametrize(
+    ("selector", "tags"),
+    [
+        # :is() and :where() match any nested alternative; :where() differs only in specificity
+        pytest.param(":is(h2, ul)", ["h2", "ul"], id="is-list"),
+        pytest.param(":IS(h2, ul)", ["h2", "ul"], id="is-uppercase-name"),  # pseudo-class names fold case
+        pytest.param(":where(li)", ["li", "li"], id="where"),
+        pytest.param("section :is(p, a)", ["p", "a", "p"], id="is-after-descendant"),
+        pytest.param(":is(.lead) a", ["a"], id="is-class-then-descendant"),
+        pytest.param("section:is(#s, .none)", ["section"], id="is-compound-subject"),
+        pytest.param(":is(:where(li.sel))", ["li"], id="nested-is-where"),
+        pytest.param(":is(em, strong)", [], id="is-no-match"),
+        # :has() leading combinators: descendant, child, next-sibling, subsequent-sibling
+        pytest.param("section:has(a)", ["section"], id="has-descendant"),
+        pytest.param("section:has(> h2)", ["section"], id="has-child"),
+        pytest.param("section:has(> a)", [], id="has-child-no-match"),
+        pytest.param("h2:has(+ p)", ["h2"], id="has-next-sibling"),
+        pytest.param("h2:has(~ ul)", ["h2"], id="has-subsequent-sibling"),
+        pytest.param("li:has(~ li)", ["li"], id="has-subsequent-sibling-li"),
+        # :has() multi-compound relative selectors exercise the interior combinators
+        pytest.param("section:has(p a)", ["section"], id="has-descendant-chain"),
+        pytest.param("section:has(p > a)", ["section"], id="has-child-chain"),
+        pytest.param("section:has(h2 + p)", ["section"], id="has-next-sibling-chain"),
+        pytest.param("section:has(h2 ~ ul)", ["section"], id="has-subsequent-chain"),
+        # a leading sibling combinator reaches the anchor's following siblings and subtrees
+        pytest.param("section:has(+ aside)", ["section"], id="has-next-sibling-element"),
+        pytest.param("section:has(~ aside span)", ["section"], id="has-sibling-subtree"),
+        # a following sibling matches the subject tag but is not adjacent, so the '+'
+        # chain back to the anchor fails while the sibling walk keeps scanning
+        pytest.param("h2:has(+ ul)", [], id="has-next-sibling-not-adjacent"),
+        pytest.param("aside:has(p)", [], id="has-no-match"),
+        pytest.param("aside:has(+ x)", [], id="has-no-following-sibling"),
+        # no-match cases where the subject is found but its combinator chain does not
+        # reach the anchor, exercising every relative-combinator dead end
+        pytest.param("section:has(~ li)", [], id="has-tilde-subject-is-descendant"),
+        pytest.param("section:has(span)", [], id="has-descendant-in-sibling-subtree"),
+        pytest.param("section:has(li ~ h2)", [], id="has-tilde-chain-no-match"),
+        pytest.param("section:has(ul a)", [], id="has-descendant-chain-no-match"),
+        # an interior compound that matches only an ancestor of the anchor (main is
+        # above section) is not within the anchor's subtree, so :has() does not match
+        pytest.param("section:has(main p)", [], id="has-interior-compound-above-anchor"),
+    ],
+)
+def test_functional_pseudo_classes(selector: str, tags: list[str]) -> None:
+    assert _sel(_PSEUDO_DOC, selector) == tags
+
+
+def test_has_skips_non_element_following_sibling() -> None:
+    # a comment between the anchor and a following sibling must not break :has()
+    doc = parse("<main><section></section><!--c--><aside><b>x</b></aside></main>")
+    assert [element.tag for element in doc.select("section:has(~ aside b)")] == ["section"]
+
+
 @pytest.mark.parametrize(
     "selector",
     [
         pytest.param("", id="empty"),
         pytest.param("  ", id="whitespace"),
+        # functional pseudo-classes (the structural pseudo cases are grouped below)
+        pytest.param(":unknown(p)", id="unsupported-pseudo"),
+        pytest.param(":is", id="is-without-args"),
+        pytest.param(":is(", id="is-unterminated"),
+        pytest.param(":is(p", id="is-unterminated-after-arg"),
+        pytest.param(":is()", id="is-empty-args"),
+        pytest.param(":is(p,)", id="is-trailing-comma"),
+        pytest.param(":is(.)", id="is-invalid-inner"),
+        pytest.param(":is.x", id="pseudo-name-then-non-paren"),
+        pytest.param(":ix(p)", id="pseudo-name-char-mismatch"),
+        pytest.param(":1s(p)", id="pseudo-name-with-digit"),  # a below-'A' byte in the case fold
+        pytest.param(":is(p):has(", id="pseudo-then-failing-pseudo"),
+        pytest.param(":has(>)", id="has-dangling-combinator"),
         # a namespace prefix must be followed by a type or the universal selector
         pytest.param("*|", id="star-prefix-at-eof"),
         pytest.param("|", id="bare-pipe"),

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -363,6 +363,29 @@ def lexbor_select(tree: LexborHTMLParser) -> None:
     tree.css(CSS_SELECTOR)
 
 
+HAS_SELECTOR = "div:has(a)"  # the :has() relational pseudo-class: a div that contains a link
+
+
+def turbo_has_select(doc: Document) -> None:
+    """Run the :has() relational selector with turbohtml's select."""
+    doc.select(HAS_SELECTOR)
+
+
+def bs4_has_select(soup: BeautifulSoup) -> None:
+    """Run the :has() relational selector with BeautifulSoup's soupsieve."""
+    soup.select(HAS_SELECTOR)
+
+
+def lxml_has_select(tree: HtmlElement) -> None:
+    """Run the :has() relational selector with lxml's cssselect."""
+    tree.cssselect(HAS_SELECTOR)
+
+
+def lexbor_has_select(tree: LexborHTMLParser) -> None:
+    """Run the :has() relational selector with selectolax's css."""
+    tree.css(HAS_SELECTOR)
+
+
 def turbo_serialize(doc: Document) -> None:
     """Serialize back to HTML with turbohtml's html property."""
     _ = doc.html
@@ -455,12 +478,12 @@ def print_build_table(means: dict[str, float], cases: list[str]) -> None:
         print(row)
 
 
-# Read-path competitors, fastest-first: a tree builder plus the find/select/serialize trio. turbohtml leads each table.
+# Read-path competitors, fastest-first: a tree builder plus the find/select/serialize/:has ops. turbohtml leads each.
 READPATH_LIBS: tuple[tuple[str, Callable[[str], object], tuple[Callable[..., None], ...]], ...] = (
-    ("turbohtml", turbo_tree, (turbo_find, turbo_select, turbo_serialize)),
-    ("lxml", lxml_tree, (lxml_find, lxml_select, lxml_serialize)),
-    ("selectolax", lexbor_tree, (lexbor_find, lexbor_select, lexbor_serialize)),
-    ("BeautifulSoup", bs4_tree, (bs4_find, bs4_select, bs4_serialize)),
+    ("turbohtml", turbo_tree, (turbo_find, turbo_select, turbo_serialize, turbo_has_select)),
+    ("lxml", lxml_tree, (lxml_find, lxml_select, lxml_serialize, lxml_has_select)),
+    ("selectolax", lexbor_tree, (lexbor_find, lexbor_select, lexbor_serialize, lexbor_has_select)),
+    ("BeautifulSoup", bs4_tree, (bs4_find, bs4_select, bs4_serialize, bs4_has_select)),
 )
 
 # wpt pages from 4 kB to 92 kB; the multi-MB specs are skipped here since every
@@ -876,6 +899,7 @@ def main() -> None:
     parse_cases = run_parse_suite(bench) if "parse" in suites else []
     find_cases = run_readpath_suite(bench, 0, "find") if "query" in suites else []
     select_cases = run_readpath_suite(bench, 1, "select") if "query" in suites else []
+    has_select_cases = run_readpath_suite(bench, 3, "select :has") if "query" in suites else []
     serialize_cases = run_readpath_suite(bench, 2, "serialize") if "serialize" in suites else []
     build_cases = run_build_suite(bench) if "build" in suites else []
     edit_cases = run_edit_suite(bench) if "edit" in suites else []
@@ -890,6 +914,7 @@ def main() -> None:
     print_parse_table(means, parse_cases)
     print_readpath_table(means, "find", find_cases)
     print_readpath_table(means, "select", select_cases)
+    print_readpath_table(means, "select :has", has_select_cases)
     print_readpath_table(means, "serialize", serialize_cases)
     print_build_table(means, build_cases)
     print_edit_table(means, edit_cases)


### PR DESCRIPTION
`select()`, `select_one()`, `matches()`, and `closest()` raised `ValueError("invalid CSS selector")` for the Selectors Level 4 functional pseudo-classes, even though they are parseable and normatively defined. 🧩 This adds them: `:is()` and `:where()` match an element against a nested selector list (a tree matcher treats them identically, since they differ only in specificity), and `:has()` keeps an element when a relative selector finds a match anchored at it — with an optional leading `>`, `+`, or `~` combinator, so `article:has(> img)` and `h2:has(+ p)` work.

The simple-selector carries a nested compiled list. The parser factors the comma-separated alternative loop into one `sel_parse_alts`, reused for the top level and for each pseudo-class argument, with a `relative` mode that lets a `:has()` argument open with a combinator. The matcher reuses a single `sel_match_from` for ordinary and relative selectors: an `anchor` argument (NULL for an ordinary selector) makes the leftmost compound's leading combinator connect to the `:has()` anchor instead of ending the chain, so the interior-combinator machinery is shared and stays covered by the existing combinator tests. ⚙️ Nested lists may themselves nest, and matching agrees byte-for-byte with soupsieve and lexbor on the cross-checks. For descendant and child relationships `:has()` skips the sibling scan, so the relational lookup keeps the same interned-atom comparison the flat selectors use.

The flat `select` benchmark is unchanged (the new `:` parse branch falls through immediately for non-pseudo selectors), and a `div:has(a)` case joins the read-path comparison against lxml, selectolax, and BeautifulSoup. 📊 turbohtml leads every column — roughly three times faster than lxml and selectolax on the large page and over a hundred times faster than BeautifulSoup — and the numbers land in `performance.rst` beside the existing selector tables. The docs gain `:is()`/`:has()` examples.

Fixes #96