### PR TITLE
🧪 test(freethread): stress, GIL guard, and ThreadSanitizer

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -22,7 +22,7 @@ jobs:
         # The C-coverage gate runs where gcov/llvm-cov exist; on Windows the same
         # suite runs without it (MSVC has no gcov), gated natively in tox.toml.
         os: ["ubuntu-24.04", "macos-15", "windows-2025"]
-        py: ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "3.15t", "3.14t", "3.13t"]
+        py: ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "3.15t", "3.14t"]
         include:
           - {os: "ubuntu-24.04", label: Linux, cov: "gcov"}
           - {os: "macos-15", label: macOS, cov: "xcrun llvm-cov gcov"}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -62,3 +62,23 @@ jobs:
         run: uvx --with tox-uv tox run -e ${{ matrix.tox_env }}
         env:
           UV_PYTHON_PREFERENCE: only-managed
+  tsan:
+    name: 🧵 ThreadSanitizer
+    runs-on: ubuntu-24.04
+    # prebuilt no-GIL CPython compiled with --with-thread-sanitizer; building one is slow and fiddly
+    container:
+      image: ghcr.io/nascheme/cpython-tsan:3.14t
+      options: --shm-size=2g # TSan shadow memory needs the headroom
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: 🔄 Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: ✅ Run tsan
+        run: uvx --with tox-uv tox run -e tsan
+        env:
+          UV_PYTHON_PREFERENCE: only-system # use the container's TSan interpreter, not a uv-managed one

--- a/docs/changelog/84.bugfix.rst
+++ b/docs/changelog/84.bugfix.rst
@@ -5,4 +5,4 @@ thread rewired through ``extract`` or another structural edit, segfaulting. Ever
 takes a per-tree :c:macro:`Py_BEGIN_CRITICAL_SECTION` on the owning tree handle, a no-op on the GIL build (so
 single-threaded performance is unchanged) and a cheap per-tree lock on the free-threaded build (so independent trees
 still run fully in parallel), mirroring the tokenizer fix and CPython's own list and dict. The free-threaded test matrix
-now also covers Python 3.13t alongside 3.14t and 3.15t.
+covers Python 3.14t and 3.15t, where free-threading is officially supported.

--- a/docs/changelog/84.misc.rst
+++ b/docs/changelog/84.misc.rst
@@ -1,0 +1,4 @@
+Validate free-threaded safety with three layers: the free-threaded tox envs re-run the thread-safety suite under
+``pytest-run-parallel`` (one thread per core), a ``conftest`` guard fails the run if a C extension silently re-enables
+the GIL, and a new ``tox -e tsan`` env plus CI job run the suite under ThreadSanitizer in the
+``ghcr.io/nascheme/cpython-tsan`` image to detect data races directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,13 +60,14 @@ dev = [
 ]
 test = [
   "covdefaults>=2.3",
-  "jinja2>=3.1",         # the markup migration test renders templates with markupsafe swapped for turbohtml.markup
+  "jinja2>=3.1",              # the markup migration test renders templates with markupsafe swapped for turbohtml.markup
   "meson>=1.11.1",
   "meson-python>=0.19",
   "ninja>=1.13",
   "pytest>=9.0.3",
   "pytest-cov>=7.1",
   "pytest-mock>=3.15.1",
+  "pytest-run-parallel>=0.8", # runs each test in many threads to surface free-threaded data races
 ]
 type = [
   "ty>=0.0.44",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ width, so width-sensitive tests run under all three kinds.
 
 from __future__ import annotations
 
+import sys
+import sysconfig
 from typing import TYPE_CHECKING, TypeVar
 
 import pytest
@@ -14,6 +16,20 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 _N = TypeVar("_N", bound=Node)
+
+_FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+_gil_enabled_at_start = sys._is_gil_enabled() if _FREE_THREADED else True
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    """Fail the run if a C extension silently re-enabled the GIL on a free-threaded build.
+
+    ``_html`` declares ``Py_MOD_GIL_NOT_USED``; importing any extension that forgets that slot
+    flips the GIL back on and quietly masks every free-threaded race we test for (issue #84).
+    """
+    # untestable without building a deliberately GIL-re-enabling extension to import mid-run
+    if _FREE_THREADED and not _gil_enabled_at_start and sys._is_gil_enabled():  # pragma: no cover
+        session.exitstatus = 1
 
 
 @pytest.fixture(params=[1, 2, 4], ids=["ucs1", "ucs2", "ucs4"])

--- a/tests/test_tree_freethread.py
+++ b/tests/test_tree_freethread.py
@@ -5,6 +5,10 @@ safety of its mutable tree. A reader and a mutator sharing a tree may produce a
 stale result, but must never segfault (issue #84). Under the GIL build the
 threads serialize; under a free-threaded build they run truly in parallel, so
 these exercise the per-tree critical sections the operations take.
+
+The free-threaded tox envs and the ThreadSanitizer job re-run this module under
+``pytest --parallel-threads=auto --iterations=N`` (pytest-run-parallel), which
+runs each test in one thread per core at once, multiplying the contention.
 """
 
 from __future__ import annotations

--- a/tools/tsan-suppressions.txt
+++ b/tools/tsan-suppressions.txt
@@ -1,0 +1,9 @@
+# ThreadSanitizer suppressions for the free-threaded `tox -e tsan` run.
+#
+# Format: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+# Each entry MUST carry a comment linking a GitHub issue with a reproducer and
+# the TSan output, so a suppression can be revisited and removed.
+#
+# There are no active suppressions. CPython's own free-threaded suppression list
+# is empty on the supported branches, so any race TSan reports against the `_html`
+# extension is almost certainly a real bug in our C code, not interpreter noise.

--- a/tox.toml
+++ b/tox.toml
@@ -1,30 +1,16 @@
 requires = [ "tox>=4.55.1", "tox-uv>=1.35.2" ]
-env_list = [
-  "3.15",
-  "3.14",
-  "3.13",
-  "3.12",
-  "3.11",
-  "3.10",
-  "3.13t",
-  "3.14t",
-  "3.15t",
-  "docs",
-  "fix",
-  "pkg_meta",
-  "type"
-]
+env_list = [ "3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "3.14t", "3.15t", "docs", "fix", "pkg_meta", "type" ]
 skip_missing_interpreters = true
 
 [env_run_base]
-description = { replace = "if", condition = "factor['3.15'] or factor['3.13t'] or factor['3.14t'] or factor['3.15t']", then = "run the test suite under {env_name} with the Python coverage gate (no gcov for this interpreter)", else = "run the test suite under {env_name} with the Python and C coverage gates" }
+description = { replace = "if", condition = "factor['3.15'] or factor['3.14t'] or factor['3.15t']", then = "run the test suite under {env_name} with the Python coverage gate (no gcov for this interpreter)", else = "run the test suite under {env_name} with the Python and C coverage gates" }
 package = "skip"  # we install an instrumented editable build ourselves below
 # gcovr (via lxml) has no wheels for 3.15 or the free-threaded builds, and there is
 # no gcov on Windows, so pull it in only where the coverage gate actually runs
 deps = [
-  { replace = "if", condition = "factor.win32 or factor['3.15'] or factor['3.13t'] or factor['3.14t'] or factor['3.15t']", then = [
-
-  ], else = [ "gcovr>=8.4" ], extend = true },
+  { replace = "if", condition = "factor.win32 or factor['3.15'] or factor['3.14t'] or factor['3.15t']", then = [], else = [
+    "gcovr>=8.4"
+  ], extend = true },
 ]
 dependency_groups = [ "test" ]
 pass_env = [ "COV_GCOV", "PYTEST_*" ]
@@ -48,9 +34,7 @@ commands_pre = [
     "{tox_root}",
     "--config-settings=build-dir={env_dir}{/}cbuild",
     # instrument for C coverage except where gcov/gcovr are unavailable (Windows, 3.15, free-threaded)
-    { replace = "if", condition = "factor.win32 or factor['3.15'] or factor['3.13t'] or factor['3.14t'] or factor['3.15t']", then = [
-
-    ], else = [
+    { replace = "if", condition = "factor.win32 or factor['3.15'] or factor['3.14t'] or factor['3.15t']", then = [], else = [
       "--config-settings=setup-args=-Dbuildtype=debug",
       "--config-settings=setup-args=-Db_ndebug=true",
       "--config-settings=setup-args=-Db_coverage=true",
@@ -82,7 +66,7 @@ commands = [
   # ternaries whose non-compact sides PyUnicode_New objects can never take, so 3.10
   # floors at 97% (gcc counts a few more of these dead branches than llvm). 3.11+
   # collapsed those macros to branchless inline functions.
-  { replace = "if", condition = "factor.win32 or factor['3.15'] or factor['3.13t'] or factor['3.14t'] or factor['3.15t']", then = [
+  { replace = "if", condition = "factor.win32 or factor['3.15'] or factor['3.14t'] or factor['3.15t']", then = [
     "python",
     "-c",
     "print('C coverage gate skipped on this interpreter (no gcov/gcovr)')",

--- a/tox.toml
+++ b/tox.toml
@@ -88,6 +88,15 @@ commands = [
     "--txt",
     "-",
   ] },
+  # free-threaded build only: re-run the thread-safety tests with one thread per core
+  # (pytest-run-parallel) to surface data races the single-threaded coverage run hides
+  { replace = "if", condition = "factor['3.14t'] or factor['3.15t']", then = [
+    "pytest",
+    "{tox_root}{/}tests{/}test_tree_freethread.py",
+    "--no-cov",
+    "--parallel-threads=auto",
+    "--iterations=20",
+  ], else = [ "python", "-c", "print('free-threaded parallel stress skipped (GIL build)')" ] },
 ]
 
 [env.docs]
@@ -189,3 +198,37 @@ dependency_groups = [ "release" ]
 pass_env = [ "GH_TOKEN" ]
 commands_pre = []
 commands = [ [ "python", "{tox_root}{/}tasks{/}release.py", "--version", "{posargs}" ] ]
+
+[env.tsan]
+description = "detect data races with ThreadSanitizer; run inside ghcr.io/nascheme/cpython-tsan:3.14t"
+# the no-GIL TSan interpreter is the container's own python, not a uv-managed one
+base_python = [ "python3.14t" ]
+package = "skip"
+dependency_groups = [ "test" ]
+set_env = { UV_PYTHON_PREFERENCE = "only-system", CC = "clang", CXX = "clang++", TSAN_OPTIONS = "halt_on_error=0 allocator_may_return_null=1 suppressions={tox_root}{/}tools{/}tsan-suppressions.txt" }
+commands_pre = [
+  # build the extension with TSan instrumentation against the container's TSan interpreter
+  [
+    "uv",
+    "pip",
+    "install",
+    "--reinstall",
+    "--no-deps",
+    "--no-build-isolation",
+    "--editable",
+    "{tox_root}",
+    "--config-settings=build-dir={env_dir}{/}cbuild",
+    "--config-settings=setup-args=-Db_sanitize=thread",
+    "--config-settings=setup-args=-Dbuildtype=debugoptimized",
+  ],
+]
+commands = [
+  [
+    "pytest",
+    "-s",                                           # let TSan reports reach the console; pytest otherwise captures them
+    "--no-cov",
+    "--parallel-threads=auto",
+    "--iterations=20",
+    "{tox_root}{/}tests{/}test_tree_freethread.py",
+  ],
+]

--- a/tox.toml
+++ b/tox.toml
@@ -205,7 +205,8 @@ description = "detect data races with ThreadSanitizer; run inside ghcr.io/nasche
 base_python = [ "python3.14t" ]
 package = "skip"
 dependency_groups = [ "test" ]
-set_env = { UV_PYTHON_PREFERENCE = "only-system", CC = "clang", CXX = "clang++", TSAN_OPTIONS = "halt_on_error=0 allocator_may_return_null=1 suppressions={tox_root}{/}tools{/}tsan-suppressions.txt" }
+# let meson autodetect the container's TSan-capable compiler (the one CPython was built with); do not force CC=clang
+set_env = { UV_PYTHON_PREFERENCE = "only-system", TSAN_OPTIONS = "halt_on_error=0 allocator_may_return_null=1 suppressions={tox_root}{/}tools{/}tsan-suppressions.txt" }
 commands_pre = [
   # build the extension with TSan instrumentation against the container's TSan interpreter
   [


### PR DESCRIPTION
Follow-up to #157, which merged the per-tree locking for free-threaded safety but auto-merged at an earlier commit, before two pieces landed: dropping the experimental `3.13t` interpreter and the tooling that validates the locking actually holds.

A barrier stress test only probabilistically hits the C-level use-after-free that #84 fixed, and that crash could not be reproduced locally at all. 🧵 This adds the validation the ecosystem relies on, in three layers. The free-threaded tox envs re-run the thread-safety suite under `pytest-run-parallel` (one thread per core), so every run on `3.14t`/`3.15t` exercises the per-tree critical sections under real parallelism. A `conftest` guard fails the run if a C extension silently re-enables the GIL, the regression that quietly masks every race. A new `tox -e tsan` env plus a CI job build the extension with `-fsanitize=thread` inside the prebuilt `ghcr.io/nascheme/cpython-tsan` image and run under ThreadSanitizer, which catches a data race from a single interleaving instead of hoping a timing window hits.

It also drops `3.13t` from the matrix and tox. Free-threading is experimental in 3.13 and officially supported from 3.14 (PEP 779), and the project ships no `3.13t` wheel, so testing it validated an interpreter users could only reach by building from source. Coverage now matches the wheels we publish.

Once this lands and the `🧵 ThreadSanitizer` job runs green on `main`, it goes back to being a required check. I lifted that requirement temporarily so the absent job would not block open PRs.