### PR TITLE
⚡ perf(tree): cache one Python wrapper per node

### DIFF
--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -131,10 +131,9 @@ static PyObject *type_for_node(module_state *state, const th_node *node) {
     return state->node_type;
 }
 
-static PyObject *node_wrap(module_state *state, PyObject *handle, th_node *node) {
-    if (node == NULL) {
-        Py_RETURN_NONE;
-    }
+/* Allocate a fresh wrapper for node and record it as the node's cached wrapper
+   (a borrowed pointer the wrapper clears on dealloc). Caller holds handle's lock. */
+static PyObject *node_wrap_new(module_state *state, PyObject *handle, th_node *node) {
     PyTypeObject *type = (PyTypeObject *)type_for_node(state, node);
     NodeObject *self = (NodeObject *)type->tp_alloc(type, 0);
     if (self == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -142,12 +141,54 @@ static PyObject *node_wrap(module_state *state, PyObject *handle, th_node *node)
     }
     self->handle = Py_NewRef(handle);
     self->node = node;
+#ifdef Py_GIL_DISABLED
+    PyUnstable_EnableTryIncRef((PyObject *)self); /* let a concurrent lookup safely re-incref it */
+#endif
+    node->py_wrapper = (PyObject *)self;
     return (PyObject *)self;
+}
+
+/* One wrapper per node: reuse the cached one so identity holds (node is node) and
+   hot traversal/query loops don't churn wrapper objects. The cache slot is a
+   borrowed reference guarded by the tree handle's critical section. */
+static PyObject *node_wrap(module_state *state, PyObject *handle, th_node *node) {
+    if (node == NULL) {
+        Py_RETURN_NONE;
+    }
+    PyObject *result;
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    PyObject *cached = node->py_wrapper;
+    if (cached != NULL) {
+#ifdef Py_GIL_DISABLED
+        /* the cached wrapper may be mid-dealloc on another thread; only reuse it if
+           we can still take a strong reference, else mint a fresh one */
+        result = PyUnstable_TryIncRef(cached) ? cached : node_wrap_new(state, handle, node);
+#else
+        result = Py_NewRef(cached);
+#endif
+    } else {
+        result = node_wrap_new(state, handle, node);
+    }
+    Py_END_CRITICAL_SECTION();
+    return result;
 }
 
 static void node_dealloc(PyObject *self) {
     PyTypeObject *type = Py_TYPE(self);
-    Py_DECREF(((NodeObject *)self)->handle);
+    PyObject *handle = ((NodeObject *)self)->handle;
+    th_node *node = ((NodeObject *)self)->node;
+    /* drop the cache slot if it still points at us (a concurrent lookup may have
+       already replaced it after failing to re-incref this dying wrapper) */
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    /* GCOVR_EXCL_BR_START: the slot only points elsewhere when a concurrent lookup
+       replaced it after failing to re-incref this dying wrapper, which cannot happen
+       on the GIL coverage build (no second thread races the dealloc) */
+    if (node->py_wrapper == self) {
+        node->py_wrapper = NULL;
+    }
+    /* GCOVR_EXCL_BR_STOP */
+    Py_END_CRITICAL_SECTION();
+    Py_DECREF(handle);
     type->tp_free(self);
     Py_DECREF(type);
 }

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -78,6 +78,10 @@ struct th_node {
     Py_ssize_t text_len;
     th_node_attr *attrs;
     Py_ssize_t attr_count;
+    /* Borrowed pointer to the live Python wrapper, or NULL. The Python layer caches
+       one wrapper per node here for object identity and to avoid per-access churn;
+       the wrapper clears this on dealloc. The tree engine never touches it. */
+    PyObject *py_wrapper;
 };
 
 typedef struct th_tree th_tree;

--- a/tests/test_tree_identity.py
+++ b/tests/test_tree_identity.py
@@ -1,0 +1,59 @@
+"""Each live node has one wrapper, so the same node is the same Python object.
+
+The C layer caches one wrapper per node (cleared when the wrapper dies), giving
+``node is node`` identity and sparing hot traversal/query loops the per-access
+wrapper churn.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import turbohtml
+
+_DOC = "<html><body><div id=a><p>x</p><p>y</p></div></body></html>"
+
+
+def test_repeated_find_returns_the_same_object() -> None:
+    doc = turbohtml.parse(_DOC)
+    assert doc.find("div") is doc.find("div")
+
+
+def test_find_and_find_all_agree_on_identity() -> None:
+    doc = turbohtml.parse(_DOC)
+    assert doc.find("p") is doc.find_all("p")[0]
+
+
+@pytest.mark.parametrize(
+    "axis",
+    [
+        pytest.param(lambda n: n.parent, id="parent"),
+        pytest.param(lambda n: n.next_sibling, id="next_sibling"),
+        pytest.param(lambda n: n.previous_sibling, id="previous_sibling"),
+    ],
+)
+def test_navigation_axes_preserve_identity(axis: object) -> None:
+    doc = turbohtml.parse(_DOC)
+    paras = doc.find_all("p")
+    node = paras[1]
+    assert axis(node) is axis(node)  # ty: ignore[not-callable]
+
+
+def test_child_parent_round_trip_is_identical() -> None:
+    doc = turbohtml.parse(_DOC)
+    div = doc.find("div")
+    assert div.find("p").parent is div
+
+
+def test_children_iteration_matches_indexing_identity() -> None:
+    doc = turbohtml.parse(_DOC)
+    div = doc.find("div")
+    assert next(iter(div.children)) is next(iter(div.children))
+
+
+def test_same_tree_move_preserves_identity() -> None:
+    doc = turbohtml.parse(_DOC)
+    paragraph = doc.find("p")
+    body = doc.find("body")
+    body.append(paragraph)  # relink within the same tree
+    assert body.find_all("p")[-1] is paragraph


### PR DESCRIPTION
Every node access minted a fresh wrapper, so node identity never held
(node is not node) and hot traversal/query loops churned wrapper objects.
Cache the wrapper on the node (an lxml-style borrowed _private slot,
cleared on dealloc) so each live node has exactly one wrapper.

Under the free-threaded build a concurrent lookup may race a wrapper's
dealloc, so the slot is guarded by the tree handle's critical section and
the reuse path takes a strong reference via PyUnstable_TryIncRef, minting
a fresh wrapper only when the cached one is already dying.

This is the foundation for making cross-tree append an O(1) move: a real
move must re-point every live wrapper in the subtree, which is only
possible once wrappers are discoverable from their node.
