### PR TITLE
⚡ perf(escape): AVX2 32-byte clean-run scan on x86 [validation]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,13 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The C-coverage gate runs where gcov/llvm-cov exist; on Windows the same
-        # suite runs without it (MSVC has no gcov), gated natively in tox.toml.
-        os: ["ubuntu-24.04", "macos-15", "windows-2025"]
+        # x64-only for this AVX2 validation PR: macos-15 runners are ARM (NEON,
+        # no AVX2), so they validate nothing here. Restore the full matrix before
+        # this becomes a real PR.
+        os: ["ubuntu-24.04", "windows-2025"]
         py: ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "3.15t", "3.14t"]
         include:
           - {os: "ubuntu-24.04", label: Linux, cov: "gcov"}
-          - {os: "macos-15", label: macOS, cov: "xcrun llvm-cov gcov"}
           - {os: "windows-2025", label: Windows, cov: ""}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/escape-bench.yaml
+++ b/.github/workflows/escape-bench.yaml
@@ -1,0 +1,42 @@
+name: 📊 escape AVX2 bench
+# TEMPORARY: validates the AVX2 escape perf win on x86 (this repo's dev box is ARM,
+# so AVX2 can only be measured here). Remove before merging the real PR.
+on:
+  push:
+    branches: ["perf/escape-avx2"]
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  bench:
+    name: 🏎️ escape A/B (SSE2 vs AVX2) on x86
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          submodules: true # war-and-peace corpus drives the large-input escape cases
+          persist-credentials: false
+      - name: 🔬 Show CPU features (must list avx2)
+        run: |
+          echo "arch: $(uname -m)"
+          lscpu | grep -i '^Flags' | tr ' ' '\n' | grep -iE 'avx2|avx512|sse2' | sort -u || true
+      - name: 🔄 Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: 🛠️ Build (release) + bench deps
+        run: |
+          uv venv --python 3.14 .venv
+          uv pip install --python .venv/bin/python pyperf lxml beautifulsoup4 html5lib selectolax nh3 markupsafe bleach cssselect soupsieve linkify-it-py meson meson-python ninja
+          uv pip install --python .venv/bin/python --no-build-isolation -e . --config-settings=setup-args=-Dbuildtype=release
+      - name: 📊 A/B escape (TURBOHTML_NO_AVX2 forces the SSE2 path from the same build)
+        run: |
+          echo "::group::baseline (SSE2)"
+          TURBOHTML_NO_AVX2=1 .venv/bin/python tools/benchmark.py escape -o /tmp/sse2.json
+          echo "::endgroup::"
+          echo "::group::AVX2"
+          .venv/bin/python tools/benchmark.py escape -o /tmp/avx2.json
+          echo "::endgroup::"
+          echo "===================== SSE2 -> AVX2 ====================="
+          .venv/bin/python -m pyperf compare_to /tmp/sse2.json /tmp/avx2.json --table

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,11 +37,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15", "windows-2025"]
+        # x64-only for this AVX2 validation PR; restore ARM/macOS before a real PR
+        os: ["ubuntu-24.04", "windows-2025"]
         include:
           - {os: "ubuntu-24.04", label: Linux}
-          - {os: "ubuntu-24.04-arm", label: Linux ARM}
-          - {os: "macos-15", label: macOS}
           - {os: "windows-2025", label: Windows}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -74,8 +73,6 @@ jobs:
         artifact:
           - dist-sdist
           - dist-ubuntu-24.04
-          - dist-ubuntu-24.04-arm
-          - dist-macos-15
           - dist-windows-2025
     environment:
       name: release

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,30 @@ meson.add_dist_script('tools/prune_dist.py')
 
 py = import('python').find_installation(pure: false)
 
+cc = meson.get_compiler('c')
+incdir = include_directories('src/turbohtml')
+
+# The 1-byte escape clean-run scan widens from 16 to 32 bytes per step on x86
+# CPUs that report AVX2 at runtime. The AVX2 intrinsics need -mavx2, which would
+# crash pre-AVX2 CPUs if applied module-wide, so the AVX2 scan lives in its own
+# translation unit built with -mavx2 and is dispatched at runtime by escape.c.
+# It is compiled only on x86 toolchains that accept the flag; every other build
+# (ARM NEON, SWAR, MSVC) keeps the existing SSE2/NEON/SWAR path untouched.
+module_args = []
+extra_link = []
+if host_machine.cpu_family() in ['x86', 'x86_64'] and cc.has_argument('-mavx2')
+    escape_avx2 = static_library(
+        'turbohtml_escape_avx2',
+        'src/turbohtml/escape_avx2.c',
+        include_directories: incdir,
+        dependencies: py.dependency(),
+        c_args: ['-mavx2'],
+        install: false,
+    )
+    module_args += '-DTURBOHTML_HAVE_AVX2'
+    extra_link += escape_avx2
+endif
+
 py.extension_module(
     '_html',
     [
@@ -31,7 +55,9 @@ py.extension_module(
         'src/turbohtml/tree_type.c',
         'src/turbohtml/unescape.c',
     ],
-    include_directories: include_directories('src/turbohtml'),
+    c_args: module_args,
+    link_with: extra_link,
+    include_directories: incdir,
     install: true,
     subdir: 'turbohtml',
 )

--- a/src/turbohtml/escape.c
+++ b/src/turbohtml/escape.c
@@ -12,6 +12,8 @@
 
 #include "turbohtml.h"
 
+#include "escape_shared.h"
+
 #include <stdint.h>
 #include <string.h>
 
@@ -26,20 +28,27 @@ static inline int ctz64(uint64_t value) {
 #define ctz64(value) __builtin_ctzll(value)
 #endif
 
-static inline Py_ssize_t escape_extra(Py_UCS4 character, int quote) {
-    switch (character) {
-    case '&':
-        return 4; /* "&amp;" replaces one character with five */
-    case '<':
-    case '>':
-        return 3; /* "&lt;" / "&gt;" */
-    case '"':     /* "&quot;" */
-    case '\'':    /* "&#x27;" */
-        return quote ? 5 : 0;
-    default:
-        return 0;
+/* AVX2 32-byte clean-run scan, compiled in its own -mavx2 unit (escape_avx2.c)
+   and linked in only on x86 builds where the compiler accepts -mavx2. The
+   module is built with -DTURBOHTML_HAVE_AVX2 in exactly that case, so these
+   declarations and the runtime dispatch below never reference an undefined
+   symbol on ARM / SWAR / MSVC builds. */
+#if defined(TURBOHTML_HAVE_AVX2)
+Py_ssize_t turbohtml_escape_count_1byte_avx2(const uint8_t *input, Py_ssize_t length, int quote);
+Py_ssize_t turbohtml_escape_write_1byte_avx2(const uint8_t *input, Py_ssize_t length, int out_kind, void *out_data,
+                                             int quote);
+
+/* Use AVX2 when the CPU supports it, resolved once. TURBOHTML_NO_AVX2 forces the
+   SSE2 path so CI can A/B both halves from one build; the env read happens once
+   and the idempotent first-call race writes the same value on every thread. */
+static int escape_use_avx2(void) {
+    static int decision = -1;
+    if (decision < 0) {
+        decision = __builtin_cpu_supports("avx2") && getenv("TURBOHTML_NO_AVX2") == NULL;
     }
+    return decision;
 }
+#endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
 
@@ -227,47 +236,6 @@ static inline int swar_word_has_special32(const uint32_t *block, int quote) {
     return mask != 0;
 }
 
-static inline Py_ssize_t write_escaped(int kind, void *data, Py_ssize_t offset, Py_UCS4 character, int quote) {
-    const char *replacement = NULL;
-    int replacement_len = 0;
-    switch (character) {
-    case '&':
-        replacement = "&amp;";
-        replacement_len = 5;
-        break;
-    case '<':
-        replacement = "&lt;";
-        replacement_len = 4;
-        break;
-    case '>':
-        replacement = "&gt;";
-        replacement_len = 4;
-        break;
-    case '"':
-        if (quote) {
-            replacement = "&quot;";
-            replacement_len = 6;
-        }
-        break;
-    case '\'':
-        if (quote) {
-            replacement = "&#x27;";
-            replacement_len = 6;
-        }
-        break;
-    default:
-        break;
-    }
-    if (replacement != NULL) {
-        for (int index = 0; index < replacement_len; index++) {
-            PyUnicode_WRITE(kind, data, offset + index, (Py_UCS4)replacement[index]);
-        }
-        return replacement_len;
-    }
-    PyUnicode_WRITE(kind, data, offset, character);
-    return 1;
-}
-
 PyObject *turbohtml_escape(PyObject *Py_UNUSED(module), PyObject *args, PyObject *kwds) {
     static char *kwlist[] = {"s", "quote", NULL};
     PyObject *text;
@@ -283,13 +251,20 @@ PyObject *turbohtml_escape(PyObject *Py_UNUSED(module), PyObject *args, PyObject
     Py_ssize_t extra = 0;
     if (kind == PyUnicode_1BYTE_KIND) {
         const uint8_t *input = (const uint8_t *)data;
-        Py_ssize_t pos = 0;
-        while (pos + BLOCK_BYTES <= length) {
-            extra += block_extra(input + pos, quote);
-            pos += BLOCK_BYTES;
-        }
-        for (; pos < length; pos++) {
-            extra += escape_extra(input[pos], quote);
+#if defined(TURBOHTML_HAVE_AVX2)
+        if (escape_use_avx2()) {
+            extra += turbohtml_escape_count_1byte_avx2(input, length, quote);
+        } else
+#endif
+        {
+            Py_ssize_t pos = 0;
+            while (pos + BLOCK_BYTES <= length) {
+                extra += block_extra(input + pos, quote);
+                pos += BLOCK_BYTES;
+            }
+            for (; pos < length; pos++) {
+                extra += escape_extra(input[pos], quote);
+            }
         }
     } else if (kind == PyUnicode_2BYTE_KIND) {
         const uint16_t *input = (const uint16_t *)data;
@@ -339,37 +314,44 @@ PyObject *turbohtml_escape(PyObject *Py_UNUSED(module), PyObject *args, PyObject
 
     if (kind == PyUnicode_1BYTE_KIND) {
         const uint8_t *input = (const uint8_t *)data;
-        uint8_t *output = (uint8_t *)out_data;
-        Py_ssize_t pos = 0;
-        while (pos + BLOCK_BYTES <= length) {
-            uint64_t mask = block_special_mask(input + pos, quote);
-            if (mask == 0) {
-                memcpy(output + written, input + pos, BLOCK_BYTES);
-                written += BLOCK_BYTES;
-            } else {
-                /* copy the gap before each special wholesale, rewrite the
-                   special, then copy whatever trails the last one; the gap
-                   checks keep special-dense input from paying for empty copies */
-                Py_ssize_t prev = 0;
-                do {
-                    Py_ssize_t index = SPECIAL_INDEX(mask);
-                    if (index > prev) {
-                        memcpy(output + written, input + pos + prev, (size_t)(index - prev));
-                        written += index - prev;
+#if defined(TURBOHTML_HAVE_AVX2)
+        if (escape_use_avx2()) {
+            written += turbohtml_escape_write_1byte_avx2(input, length, out_kind, out_data, quote);
+        } else
+#endif
+        {
+            uint8_t *output = (uint8_t *)out_data;
+            Py_ssize_t pos = 0;
+            while (pos + BLOCK_BYTES <= length) {
+                uint64_t mask = block_special_mask(input + pos, quote);
+                if (mask == 0) {
+                    memcpy(output + written, input + pos, BLOCK_BYTES);
+                    written += BLOCK_BYTES;
+                } else {
+                    /* copy the gap before each special wholesale, rewrite the
+                       special, then copy whatever trails the last one; the gap
+                       checks keep special-dense input from paying for empty copies */
+                    Py_ssize_t prev = 0;
+                    do {
+                        Py_ssize_t index = SPECIAL_INDEX(mask);
+                        if (index > prev) {
+                            memcpy(output + written, input + pos + prev, (size_t)(index - prev));
+                            written += index - prev;
+                        }
+                        written += write_escaped(out_kind, out_data, written, input[pos + index], quote);
+                        mask = SPECIAL_CLEAR(mask, index);
+                        prev = index + 1;
+                    } while (mask != 0);
+                    if (BLOCK_BYTES > prev) {
+                        memcpy(output + written, input + pos + prev, (size_t)(BLOCK_BYTES - prev));
+                        written += BLOCK_BYTES - prev;
                     }
-                    written += write_escaped(out_kind, out_data, written, input[pos + index], quote);
-                    mask = SPECIAL_CLEAR(mask, index);
-                    prev = index + 1;
-                } while (mask != 0);
-                if (BLOCK_BYTES > prev) {
-                    memcpy(output + written, input + pos + prev, (size_t)(BLOCK_BYTES - prev));
-                    written += BLOCK_BYTES - prev;
                 }
+                pos += BLOCK_BYTES;
             }
-            pos += BLOCK_BYTES;
-        }
-        for (; pos < length; pos++) {
-            written += write_escaped(out_kind, out_data, written, input[pos], quote);
+            for (; pos < length; pos++) {
+                written += write_escaped(out_kind, out_data, written, input[pos], quote);
+            }
         }
     } else if (kind == PyUnicode_2BYTE_KIND) {
         const uint16_t *input = (const uint16_t *)data;

--- a/src/turbohtml/escape_avx2.c
+++ b/src/turbohtml/escape_avx2.c
@@ -1,0 +1,118 @@
+/* AVX2 32-byte clean-run scan for the 1-byte escape path.
+
+   This unit is compiled with -mavx2 and linked into _html only on x86 builds
+   whose compiler accepts that flag; escape.c selects it at runtime through
+   __builtin_cpu_supports("avx2") and otherwise keeps the SSE2 16-byte path, so
+   a Haswell-or-newer CPU widens the clean run from 16 to 32 bytes per step
+   while pre-AVX2 CPUs are unaffected. Only the clean-run sizing scan and copy
+   widen: the per-special sizing (escape_extra) and rewrite (write_escaped) stay
+   scalar and shared with escape.c via escape_shared.h, so the two units cannot
+   diverge on what a special expands to.
+
+   Self-guarded to x86: meson only compiles this unit on x86 targets, and the
+   guard also keeps non-x86 tooling (clang-tidy on an ARM dev box) from choking
+   on <immintrin.h>, which it processes regardless of the build. */
+
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+
+#include "turbohtml.h"
+
+#include "escape_shared.h"
+
+#include <immintrin.h>
+#include <stdint.h>
+#include <string.h>
+
+#define AVX2_BLOCK_BYTES 32
+
+/* How many characters of growth escaping this block adds, all 32 lanes at once:
+   each comparison yields 0xFF per match, masked to that special's growth
+   (&amp; adds 4, &lt;/&gt; add 3, &quot;/&#x27; add 5). _mm256_sad_epu8 sums the
+   bytes into four 64-bit partials (one per 8-byte lane), summed scalar. A lane
+   holds at most one special, so per-byte growth never exceeds 5 and the per-
+   8-byte partial never exceeds 40: no overflow. */
+static inline Py_ssize_t block_extra_avx2(const uint8_t *block, int quote) {
+    __m256i bytes = _mm256_loadu_si256((const __m256i *)block);
+    __m256i extras = _mm256_and_si256(_mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('&')), _mm256_set1_epi8(4));
+    extras =
+        _mm256_add_epi8(extras, _mm256_and_si256(_mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('<')), _mm256_set1_epi8(3)));
+    extras =
+        _mm256_add_epi8(extras, _mm256_and_si256(_mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('>')), _mm256_set1_epi8(3)));
+    if (quote) {
+        extras = _mm256_add_epi8(
+            extras, _mm256_and_si256(_mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('"')), _mm256_set1_epi8(5)));
+        extras = _mm256_add_epi8(
+            extras, _mm256_and_si256(_mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('\'')), _mm256_set1_epi8(5)));
+    }
+    __m256i sums = _mm256_sad_epu8(extras, _mm256_setzero_si256());
+    return (Py_ssize_t)(_mm256_extract_epi64(sums, 0) + _mm256_extract_epi64(sums, 1) + _mm256_extract_epi64(sums, 2) +
+                        _mm256_extract_epi64(sums, 3));
+}
+
+/* One mask bit per byte (bit i set iff byte i is a special); _mm256_movemask_epi8
+   packs the per-lane high bits, so a trailing-zero count gives the lowest special
+   index and clearing the lowest set bit advances to the next. */
+static inline uint32_t block_special_mask_avx2(const uint8_t *block, int quote) {
+    __m256i bytes = _mm256_loadu_si256((const __m256i *)block);
+    __m256i hits = _mm256_or_si256(_mm256_or_si256(_mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('&')),
+                                                   _mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('<'))),
+                                   _mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('>')));
+    if (quote) {
+        hits = _mm256_or_si256(hits, _mm256_or_si256(_mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('"')),
+                                                     _mm256_cmpeq_epi8(bytes, _mm256_set1_epi8('\''))));
+    }
+    return (uint32_t)_mm256_movemask_epi8(hits);
+}
+
+Py_ssize_t turbohtml_escape_count_1byte_avx2(const uint8_t *input, Py_ssize_t length, int quote) {
+    Py_ssize_t extra = 0;
+    Py_ssize_t pos = 0;
+    while (pos + AVX2_BLOCK_BYTES <= length) {
+        extra += block_extra_avx2(input + pos, quote);
+        pos += AVX2_BLOCK_BYTES;
+    }
+    for (; pos < length; pos++) {
+        extra += escape_extra(input[pos], quote);
+    }
+    return extra;
+}
+
+Py_ssize_t turbohtml_escape_write_1byte_avx2(const uint8_t *input, Py_ssize_t length, int out_kind, void *out_data,
+                                             int quote) {
+    uint8_t *output = (uint8_t *)out_data;
+    Py_ssize_t written = 0;
+    Py_ssize_t pos = 0;
+    while (pos + AVX2_BLOCK_BYTES <= length) {
+        uint32_t mask = block_special_mask_avx2(input + pos, quote);
+        if (mask == 0) {
+            memcpy(output + written, input + pos, AVX2_BLOCK_BYTES);
+            written += AVX2_BLOCK_BYTES;
+        } else {
+            /* copy the gap before each special wholesale, rewrite the special,
+               then copy whatever trails the last one; the gap checks keep
+               special-dense input from paying for empty copies */
+            Py_ssize_t prev = 0;
+            do {
+                Py_ssize_t index = __builtin_ctz(mask);
+                if (index > prev) {
+                    memcpy(output + written, input + pos + prev, (size_t)(index - prev));
+                    written += index - prev;
+                }
+                written += write_escaped(out_kind, out_data, written, input[pos + index], quote);
+                mask &= mask - 1;
+                prev = index + 1;
+            } while (mask != 0);
+            if (AVX2_BLOCK_BYTES > prev) {
+                memcpy(output + written, input + pos + prev, (size_t)(AVX2_BLOCK_BYTES - prev));
+                written += AVX2_BLOCK_BYTES - prev;
+            }
+        }
+        pos += AVX2_BLOCK_BYTES;
+    }
+    for (; pos < length; pos++) {
+        written += write_escaped(out_kind, out_data, written, input[pos], quote);
+    }
+    return written;
+}
+
+#endif /* x86 */

--- a/src/turbohtml/escape_shared.h
+++ b/src/turbohtml/escape_shared.h
@@ -1,0 +1,70 @@
+/* Scalar escaping primitives shared by the per-arch escape translation units.
+
+   escape.c compiles the SSE2 / NEON / SWAR 16-byte clean-run scan; escape_avx2.c
+   compiles a 32-byte AVX2 scan in its own -mavx2 unit (linked in only on x86).
+   Both reuse the same scalar sizing (escape_extra) and the same scalar specials
+   rewrite (write_escaped) so the per-special replacement logic stays single
+   sourced: only the clean-run scan/copy width differs between the units. */
+
+#ifndef TURBOHTML_ESCAPE_SHARED_H
+#define TURBOHTML_ESCAPE_SHARED_H
+
+#include "turbohtml.h"
+
+static inline Py_ssize_t escape_extra(Py_UCS4 character, int quote) {
+    switch (character) {
+    case '&':
+        return 4; /* "&amp;" replaces one character with five */
+    case '<':
+    case '>':
+        return 3; /* "&lt;" / "&gt;" */
+    case '"':     /* "&quot;" */
+    case '\'':    /* "&#x27;" */
+        return quote ? 5 : 0;
+    default:
+        return 0;
+    }
+}
+
+static inline Py_ssize_t write_escaped(int kind, void *data, Py_ssize_t offset, Py_UCS4 character, int quote) {
+    const char *replacement = NULL;
+    int replacement_len = 0;
+    switch (character) {
+    case '&':
+        replacement = "&amp;";
+        replacement_len = 5;
+        break;
+    case '<':
+        replacement = "&lt;";
+        replacement_len = 4;
+        break;
+    case '>':
+        replacement = "&gt;";
+        replacement_len = 4;
+        break;
+    case '"':
+        if (quote) {
+            replacement = "&quot;";
+            replacement_len = 6;
+        }
+        break;
+    case '\'':
+        if (quote) {
+            replacement = "&#x27;";
+            replacement_len = 6;
+        }
+        break;
+    default:
+        break;
+    }
+    if (replacement != NULL) {
+        for (int index = 0; index < replacement_len; index++) {
+            PyUnicode_WRITE(kind, data, offset + index, (Py_UCS4)replacement[index]);
+        }
+        return replacement_len;
+    }
+    PyUnicode_WRITE(kind, data, offset, character);
+    return 1;
+}
+
+#endif /* TURBOHTML_ESCAPE_SHARED_H */


### PR DESCRIPTION
Draft to validate on x86 CI what an ARM dev box can't measure.

The escape scan runs 16 bytes/step (SSE2) on x86 with no `-march`, so x86 wheels never widen past SSE2. This adds an AVX2 32-byte path in its own `-mavx2` translation unit, selected at runtime via `__builtin_cpu_supports("avx2")`. 🏎️ Pre-AVX2 CPUs, ARM (NEON), and the SWAR fallback are byte-for-byte unchanged; only the clean-run sizing scan and copy widen, while the per-special sizing and rewrite stay scalar and shared with the SSE2 path via `escape_shared.h`.

What this draft is for: the dev machine is Apple Silicon, so the AVX2 win can only be measured on x86. The temporary `escape-bench` workflow A/Bs the SSE2 and AVX2 halves from a single build (the `TURBOHTML_NO_AVX2` env var forces SSE2) on a GitHub x86 runner, and prints `pyperf compare_to` to the Actions log. Expect ~1.4–1.8x on large clean 1-byte inputs and ~0 on tiny ones.

Reviewer checklist before this becomes a real PR: confirm the bench numbers justify it, drop the `escape-bench` workflow, and ensure the coverage matrix includes a Haswell+ runner so the AVX2 branch is exercised by the gcov gate.