### PR TITLE
🧪 test(treebuilder): lock foreign </p>/</br> containment

### DIFF
--- a/docs/changelog/63.misc.rst
+++ b/docs/changelog/63.misc.rst
@@ -1,0 +1,5 @@
+Add a dedicated regression test (``tests/test_foreign_end_tag_breakout.py``) that asserts ``</p>`` and ``</br>`` end
+tags in SVG/MathML content stay *inside* the foreign root, independently of the conformance harness's overrides. This
+locks the spec-correct decision from issues #32 and #63 and stands as the standing rejection of the proposed "foreign
+breakout" divergence, which would have matched the stale ``html5lib-tests`` ``.dat`` fixtures over the literal WHATWG
+algorithm, lexbor, and html5lib's own library.

--- a/tests/test_foreign_end_tag_breakout.py
+++ b/tests/test_foreign_end_tag_breakout.py
@@ -1,0 +1,65 @@
+"""Lock in the spec-correct handling of ``</p>``/``</br>`` end tags in foreign content.
+
+A ``</p>`` or ``</br>`` end tag seen while the current node is an SVG/MathML element
+is an "Any other end tag" in foreign content (WHATWG HTML § 13.2.6.5). The algorithm
+walks up the stack of open elements; the first HTML-namespace ancestor reprocesses the
+token in the current insertion mode *without popping the foreign element*. "In body"
+then inserts an implied ``<p>`` (or rewrites ``</br>`` to a ``<br>`` start tag) at the
+current insertion location — still *inside* the foreign root. Nothing breaks out.
+
+The pinned ``html5lib-tests`` ``.dat`` fixtures (``tests26.dat``, ``foreign-fragment.dat``)
+encode the pre-errata 2021 behavior where the implied element becomes a *sibling* of the
+foreign root. That fixture is stale: html5lib's own 1.1 library, lexbor, and the literal
+spec all produce containment, not breakout. These tests assert the spec-correct trees
+directly so the decision survives independently of the conformance harness's overrides —
+they are the standing rejection of the proposed "foreign breakout" divergence.
+
+See https://github.com/tox-dev/turbohtml/issues/32 and
+https://github.com/tox-dev/turbohtml/issues/63.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import _html
+
+_DOCUMENT_CASES = [
+    pytest.param(
+        "<svg></p><foo>",
+        "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <p>\n|       <svg foo>",
+        id="svg-end-p",
+    ),
+    pytest.param(
+        "<svg></br><foo>",
+        "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <br>\n|       <svg foo>",
+        id="svg-end-br",
+    ),
+    pytest.param(
+        "<math></p><foo>",
+        "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <p>\n|       <math foo>",
+        id="math-end-p",
+    ),
+    pytest.param(
+        "<math></br><foo>",
+        "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <br>\n|       <math foo>",
+        id="math-end-br",
+    ),
+]
+
+_FRAGMENT_CASES = [
+    pytest.param("<svg></p><foo>", "div", "| <svg svg>\n|   <p>\n|   <svg foo>", id="div-svg-end-p"),
+    pytest.param("<svg></br><foo>", "div", "| <svg svg>\n|   <br>\n|   <svg foo>", id="div-svg-end-br"),
+    pytest.param("</p><foo>", "svg svg", "| <svg foo>", id="svg-root-end-p"),
+    pytest.param("</br><foo>", "svg svg", "| <svg foo>", id="svg-root-end-br"),
+]
+
+
+@pytest.mark.parametrize(("data", "expected"), _DOCUMENT_CASES)
+def test_foreign_end_tag_stays_inside_root(data: str, expected: str) -> None:
+    assert _html._parse_tree(data).rstrip("\n") == expected
+
+
+@pytest.mark.parametrize(("data", "context", "expected"), _FRAGMENT_CASES)
+def test_foreign_end_tag_in_fragment(data: str, context: str, expected: str) -> None:
+    assert _html._parse_fragment(data, context).rstrip("\n") == expected


### PR DESCRIPTION
turbohtml builds the spec-correct tree for a `</p>` or `</br>` end tag seen inside SVG/MathML content: the implied `<p>`/`<br>` stays inside the foreign root rather than breaking out as a sibling. 🌳 That behavior was settled in issues #32 and #63, but the only thing pinning it was the conformance harness's `_SPEC_OVERRIDES` dict, so a one-line edit could silently reverse it to match the pinned `html5lib-tests` `.dat` fixtures.

Those fixtures encode pre-errata 2021 breakout behavior. The literal WHATWG "any other end tag" rule (§ 13.2.6.5) walks up the stack and reprocesses the token in the current insertion mode without popping the foreign element, so "in body" inserts the implied element at the current location — inside the root. ✅ lexbor and html5lib's own 1.1 library both agree with the spec, not the `.dat`. This adds a dedicated regression test covering the eight document and fragment cases so the decision is explicit and stands on its own as the rejection of the proposed "foreign breakout" divergence.

No parser behavior changes; this only documents and locks an existing decision.

closes #63