### PR TITLE
🐛 fix(select): fold class/ID case in quirks mode

### DIFF
--- a/docs/changelog/176.bugfix.rst
+++ b/docs/changelog/176.bugfix.rst
@@ -1,0 +1,5 @@
+Match ``#id`` and ``.class`` selectors ASCII case-insensitively in a quirks-mode document (one parsed with no doctype),
+as `Selectors-4 §6.1 <https://www.w3.org/TR/selectors-4/#class-html>`_ and `§6.2
+<https://www.w3.org/TR/selectors-4/#id-selectors>`_ require. ``select(".foo")`` now finds ``<div class=FOO>`` in a
+quirks document, while a standards-mode document (with a doctype) keeps the case-sensitive comparison. The fold reaches
+class and ID selectors nested in ``:is()``, ``:where()``, and ``:has()``.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -191,9 +191,10 @@ node's children. :meth:`~turbohtml.Node.find` and :meth:`~turbohtml.Node.find_al
 attribute, the four combinators, and the ``:is()``/``:where()``/``:has()`` functional pseudo-classes -- and
 :meth:`~turbohtml.Node.matches` / :meth:`~turbohtml.Node.closest` test a node in place. Selectors compile against the
 tree, so a tag or attribute name resolves to the same interned atom the parser assigned and each match is an integer
-compare. Output runs back through :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and
-:meth:`~turbohtml.Node.encode`, WHATWG-conformant by default with the escaping selectable through
-:class:`~turbohtml.Formatter`.
+compare. Compiling against the tree also captures its document mode, so ``#id`` and ``.class`` fold ASCII case in a
+quirks-mode document and compare exactly otherwise, as the Selectors standard requires. Output runs back through
+:attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and :meth:`~turbohtml.Node.encode`, WHATWG-conformant
+by default with the escaping selectable through :class:`~turbohtml.Formatter`.
 
 *******************
  Mutating the tree

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -369,6 +369,21 @@ when a relative selector finds a match anchored at it:
     ['Post']
     ['h1', 'figure', 'h1']
 
+``#id`` and ``.class`` selectors compare case-sensitively in a standards-mode document and ASCII case-insensitively in a
+quirks-mode one (a document with no doctype), matching how a browser resolves them. Add a ``<!doctype html>`` to keep
+the comparison exact:
+
+.. testcode::
+
+    markup = '<div class="Lead" id="Main">x</div>'
+    print(turbohtml.parse(markup).select_one(".lead").tag)  # quirks: folds case
+    print(turbohtml.parse("<!doctype html>" + markup).select_one(".lead"))  # standards: exact
+
+.. testoutput::
+
+    div
+    None
+
 To test a node you already hold rather than search beneath it, use :meth:`~turbohtml.Node.matches` (does this node
 match) or :meth:`~turbohtml.Node.closest` (the nearest matching self-or-ancestor):
 

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -74,6 +74,7 @@ typedef struct {
     sel_complex *alts;
     int count;
     int failed; /* an allocation or a syntax error happened during compile */
+    int quirks; /* the tree was parsed in quirks mode: class/ID match case-insensitively */
 } sel_compiled;
 
 /* ---------------------------------------------------------------- parsing */
@@ -762,6 +763,7 @@ static sel_compiled *selector_compile(th_tree *tree, PyObject *selector_str) {
         PyMem_Free(compiled);       /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;                /* GCOVR_EXCL_LINE: allocation-failure path */
     }
+    compiled->quirks = th_tree_quirks(tree);
     sel_parser parser = {compiled->source, 0, PyUnicode_GET_LENGTH(selector_str), tree, 0};
     if (sel_parse_alts(&parser, &compiled->alts, &compiled->count, 0, 0) < 0) {
         PyMem_Free(compiled->source);
@@ -777,9 +779,9 @@ static sel_compiled *selector_compile(th_tree *tree, PyObject *selector_str) {
 /* The functional pseudo-classes recurse into the matcher: :is()/:where() test the
    element against a nested list, and :has() searches for a relative match, so the
    matching primitives they call are forward-declared here. */
-static int sel_match_compound(th_node *node, const sel_compound *compound);
-static int sel_matches_alts(th_node *node, const sel_complex *alts, int count);
-static int sel_has_match(th_node *anchor, const sel_complex *alts, int count);
+static int sel_match_compound(th_node *node, const sel_compound *compound, int quirks);
+static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, int quirks);
+static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, int quirks);
 
 static Py_UCS4 sel_fold(Py_UCS4 ch, int ci) {
     return (ci && ch >= 'A' && ch <= 'Z') ? ch + 32 : ch;
@@ -920,7 +922,7 @@ static int sel_is_empty(const th_node *node) {
     return 1;
 }
 
-static int sel_match_pseudo(th_node *node, const sel_simple *simple) {
+static int sel_match_pseudo(th_node *node, const sel_simple *simple, int quirks) {
     switch (simple->pseudo) { /* GCOVR_EXCL_BR_LINE: the parser only stores known pseudo ids */
     case PSEUDO_ROOT:
         /* the root element's parent is the document, never an element (a matched
@@ -952,18 +954,18 @@ static int sel_match_pseudo(th_node *node, const sel_simple *simple) {
        nested list; :has() searches for a relative match anchored at it */
     case PSEUDO_IS:
     case PSEUDO_WHERE:
-        return sel_matches_alts(node, simple->sub, simple->sub_count);
+        return sel_matches_alts(node, simple->sub, simple->sub_count, quirks);
     default: /* PSEUDO_HAS */
-        return sel_has_match(node, simple->sub, simple->sub_count);
+        return sel_has_match(node, simple->sub, simple->sub_count, quirks);
     }
 }
 
-static int sel_match_simple(th_node *node, const sel_simple *simple) {
+static int sel_match_simple(th_node *node, const sel_simple *simple, int quirks) {
     switch (simple->kind) {
     case '*':
         return 1;
     case ':':
-        return sel_match_pseudo(node, simple);
+        return sel_match_pseudo(node, simple, quirks);
     case 'e':
         if (simple->tag_atom != TH_TAG_UNKNOWN) {
             return node->atom == simple->tag_atom;
@@ -972,16 +974,18 @@ static int sel_match_simple(th_node *node, const sel_simple *simple) {
            in HTML, so match it case-insensitively like the builtin-atom path above does */
         return sel_eq(node->text, node->text_len, simple->name, simple->name_len, 1);
     case '#': {
+        /* class/ID selectors are case-sensitive in no-quirks mode, ASCII
+           case-insensitive in quirks mode (Selectors-4 §6.1/§6.2) */
         const th_node_attr *attr = sel_find_attr(node, TH_ATTR_ID);
         return attr != NULL && attr->value != NULL &&
-               sel_eq(attr->value, attr->value_len, simple->name, simple->name_len, 0);
+               sel_eq(attr->value, attr->value_len, simple->name, simple->name_len, quirks);
     }
     case '.': {
         const th_node_attr *attr = sel_find_attr(node, TH_ATTR_CLASS);
         if (attr == NULL || attr->value == NULL) {
             return 0;
         }
-        return contains_ws_token(attr->value, attr->value_len, simple->name, simple->name_len, 0);
+        return contains_ws_token(attr->value, attr->value_len, simple->name, simple->name_len, quirks);
     }
     default: { /* '[' */
         if (simple->attr_atom == UINT32_MAX) {
@@ -1000,12 +1004,12 @@ static int sel_match_simple(th_node *node, const sel_simple *simple) {
     }
 }
 
-static int sel_match_compound(th_node *node, const sel_compound *compound) {
+static int sel_match_compound(th_node *node, const sel_compound *compound, int quirks) {
     if (node->type != TH_NODE_ELEMENT) {
         return 0;
     }
     for (int index = 0; index < compound->count; index++) {
-        if (!sel_match_simple(node, &compound->simples[index])) {
+        if (!sel_match_simple(node, &compound->simples[index], quirks)) {
             return 0;
         }
     }
@@ -1026,7 +1030,7 @@ static th_node *sel_prev_element(th_node *node) {
    ordinary selector (the leftmost compound is the end); for a :has() relative selector
    it is the element :has() tests, and the leftmost compound's leading combinator must
    connect to it. The interior-combinator machinery is shared by both. */
-static int sel_match_from(th_node *node, const sel_complex *complex, int index, th_node *anchor) {
+static int sel_match_from(th_node *node, const sel_complex *complex, int index, th_node *anchor, int quirks) {
     if (index == 0) {
         if (anchor == NULL) {
             return 1;
@@ -1058,22 +1062,24 @@ static int sel_match_from(th_node *node, const sel_complex *complex, int index, 
         /* a matched node is an element, so it always has a parent (the document
            at the root), which sel_match_compound rejects as a non-element */
         th_node *parent = node->parent;
-        return sel_match_compound(parent, target) && sel_match_from(parent, complex, index - 1, anchor);
+        return sel_match_compound(parent, target, quirks) && sel_match_from(parent, complex, index - 1, anchor, quirks);
     }
     case '+': {
         th_node *prev = sel_prev_element(node);
-        return prev != NULL && sel_match_compound(prev, target) && sel_match_from(prev, complex, index - 1, anchor);
+        return prev != NULL && sel_match_compound(prev, target, quirks) &&
+               sel_match_from(prev, complex, index - 1, anchor, quirks);
     }
     case '~':
         for (th_node *prev = sel_prev_element(node); prev != NULL; prev = sel_prev_element(prev)) {
-            if (sel_match_compound(prev, target) && sel_match_from(prev, complex, index - 1, anchor)) {
+            if (sel_match_compound(prev, target, quirks) && sel_match_from(prev, complex, index - 1, anchor, quirks)) {
                 return 1;
             }
         }
         return 0;
     default: /* descendant */
         for (th_node *ancestor = node->parent; ancestor != NULL; ancestor = ancestor->parent) {
-            if (sel_match_compound(ancestor, target) && sel_match_from(ancestor, complex, index - 1, anchor)) {
+            if (sel_match_compound(ancestor, target, quirks) &&
+                sel_match_from(ancestor, complex, index - 1, anchor, quirks)) {
                 return 1;
             }
         }
@@ -1084,11 +1090,12 @@ static int sel_match_from(th_node *node, const sel_complex *complex, int index, 
 /* node matches some alternative in alts: it is the subject (rightmost compound) of
    one complex whose combinators to the left verify. The top-level match and the
    :is()/:where() pseudo-classes share this. */
-static int sel_matches_alts(th_node *node, const sel_complex *alts, int count) {
+static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, int quirks) {
     for (int index = 0; index < count; index++) {
         const sel_complex *complex = &alts[index];
         int subject = complex->count - 1;
-        if (sel_match_compound(node, &complex->compounds[subject]) && sel_match_from(node, complex, subject, NULL)) {
+        if (sel_match_compound(node, &complex->compounds[subject], quirks) &&
+            sel_match_from(node, complex, subject, NULL, quirks)) {
             return 1;
         }
     }
@@ -1097,13 +1104,14 @@ static int sel_matches_alts(th_node *node, const sel_complex *alts, int count) {
 
 /* Whether any element in the subtree below node is the subject of rel anchored at
    anchor (the element :has() is testing), checked recursively in document order. */
-static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor) {
+static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor, int quirks) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
         if (child->type != TH_NODE_ELEMENT) {
             continue;
         }
-        if ((sel_match_compound(child, &rel->compounds[subject]) && sel_match_from(child, rel, subject, anchor)) ||
-            sel_has_subtree(child, rel, subject, anchor)) {
+        if ((sel_match_compound(child, &rel->compounds[subject], quirks) &&
+             sel_match_from(child, rel, subject, anchor, quirks)) ||
+            sel_has_subtree(child, rel, subject, anchor, quirks)) {
             return 1;
         }
     }
@@ -1113,11 +1121,11 @@ static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, t
 /* Whether the anchor element satisfies any :has() relative selector. A relative
    selector reaches the anchor's descendants and, through a leading sibling
    combinator, its following siblings and their subtrees. */
-static int sel_has_match(th_node *anchor, const sel_complex *alts, int count) {
+static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, int quirks) {
     for (int index = 0; index < count; index++) {
         const sel_complex *rel = &alts[index];
         int subject = rel->count - 1;
-        if (sel_has_subtree(anchor, rel, subject, anchor)) {
+        if (sel_has_subtree(anchor, rel, subject, anchor, quirks)) {
             return 1;
         }
         /* only a leading sibling combinator (:has(+ x) / :has(~ x)) can match outside
@@ -1131,9 +1139,9 @@ static int sel_has_match(th_node *anchor, const sel_complex *alts, int count) {
             if (sibling->type != TH_NODE_ELEMENT) {
                 continue;
             }
-            if ((sel_match_compound(sibling, &rel->compounds[subject]) &&
-                 sel_match_from(sibling, rel, subject, anchor)) ||
-                sel_has_subtree(sibling, rel, subject, anchor)) {
+            if ((sel_match_compound(sibling, &rel->compounds[subject], quirks) &&
+                 sel_match_from(sibling, rel, subject, anchor, quirks)) ||
+                sel_has_subtree(sibling, rel, subject, anchor, quirks)) {
                 return 1;
             }
         }
@@ -1142,7 +1150,7 @@ static int sel_has_match(th_node *anchor, const sel_complex *alts, int count) {
 }
 
 static int selector_matches(th_node *node, const sel_compiled *compiled) {
-    return sel_matches_alts(node, compiled->alts, compiled->count);
+    return sel_matches_alts(node, compiled->alts, compiled->count, compiled->quirks);
 }
 
 /* The lone simple selector of a selector that is one group, one compound, one

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -1900,7 +1900,8 @@ static PyObject *node_select(PyObject *self, PyObject *arg) {
             Py_ssize_t end = handle_obj->index_offsets[subject + 1];
             for (Py_ssize_t pos = handle_obj->index_offsets[subject]; pos < end; pos++) {
                 th_node *node = handle_obj->index_nodes[pos];
-                int matched = single != NULL ? sel_match_simple(node, single) : selector_matches(node, compiled);
+                int matched = single != NULL ? sel_match_simple(node, single, compiled->quirks)
+                                             : selector_matches(node, compiled);
                 if (matched && append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
                     break;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1911,7 +1912,8 @@ static PyObject *node_select(PyObject *self, PyObject *arg) {
                 if (node->type != TH_NODE_ELEMENT) {
                     continue;
                 }
-                int matched = single != NULL ? sel_match_simple(node, single) : selector_matches(node, compiled);
+                int matched = single != NULL ? sel_match_simple(node, single, compiled->quirks)
+                                             : selector_matches(node, compiled);
                 if (matched && append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
                     break;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1947,7 +1949,8 @@ static PyObject *node_select_one(PyObject *self, PyObject *arg) {
             Py_ssize_t end = handle_obj->index_offsets[subject + 1];
             for (Py_ssize_t pos = handle_obj->index_offsets[subject]; pos < end; pos++) {
                 th_node *node = handle_obj->index_nodes[pos];
-                if (single != NULL ? sel_match_simple(node, single) : selector_matches(node, compiled)) {
+                if (single != NULL ? sel_match_simple(node, single, compiled->quirks)
+                                   : selector_matches(node, compiled)) {
                     found = node;
                     break;
                 }
@@ -1957,7 +1960,8 @@ static PyObject *node_select_one(PyObject *self, PyObject *arg) {
                 if (node->type != TH_NODE_ELEMENT) {
                     continue;
                 }
-                if (single != NULL ? sel_match_simple(node, single) : selector_matches(node, compiled)) {
+                if (single != NULL ? sel_match_simple(node, single, compiled->quirks)
+                                   : selector_matches(node, compiled)) {
                     found = node;
                     break;
                 }

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -397,6 +397,10 @@ uint32_t th_tree_attr_generation(const th_tree *tree) {
     return tree->attr_rec_count;
 }
 
+int th_tree_quirks(const th_tree *tree) {
+    return tree->quirks;
+}
+
 /* Resolve a lowercased tag name (UTF-8 bytes) to its atom, or TH_TAG_UNKNOWN for
    a name outside the table (the caller then compares the tag name as text). */
 uint16_t th_tag_lookup(const char *bytes, Py_ssize_t len) {

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -167,6 +167,11 @@ th_node *th_tree_document(th_tree *tree);
    cached compiled selector whose attribute atoms were resolved against the tree. */
 uint32_t th_tree_attr_generation(const th_tree *tree);
 
+/* Whether the tree was parsed in quirks mode (no doctype or a quirky one). In
+   quirks mode CSS class and ID selectors match ASCII case-insensitively
+   (Selectors-4 §6.1/§6.2); programmatic trees default to no-quirks. */
+int th_tree_quirks(const th_tree *tree);
+
 /* Materialize one text/comment/doctype node's own character data (realizing a
    zero-copy span on demand) into a freshly PyMem-allocated UCS4 buffer.
    *out_len receives the length; returns NULL on allocation failure. */

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -179,6 +179,29 @@ def test_select_over_custom_html(html: str, selector: str, tags: list[str]) -> N
     assert _sel(html, selector) == tags
 
 
+# Selectors-4 §6.1/§6.2: class and ID selectors match ASCII case-insensitively in a
+# quirks-mode document (no doctype) and case-sensitively otherwise. The body is the
+# same markup under both modes; only the leading doctype flips the document mode.
+@pytest.mark.parametrize(
+    ("selector", "quirks_tags", "standards_tags"),
+    [
+        pytest.param(".foo", ["div"], [], id="class-lowercase-selector"),
+        pytest.param(".FOO", ["div"], ["div"], id="class-exact-case-selector"),
+        pytest.param(".FoO", ["div"], [], id="class-mixed-case-selector"),
+        pytest.param("#bar", ["div"], [], id="id-lowercase-selector"),
+        pytest.param("#BAR", ["div"], ["div"], id="id-exact-case-selector"),
+        pytest.param("#BaR", ["div"], [], id="id-mixed-case-selector"),
+        # the quirks fold reaches selectors nested in :is()/:where()/:has()
+        pytest.param(":is(.foo)", ["div"], [], id="class-in-is"),
+        pytest.param("div:has(> .qux)", ["div"], [], id="class-in-has"),
+    ],
+)
+def test_class_id_case_folds_only_in_quirks(selector: str, quirks_tags: list[str], standards_tags: list[str]) -> None:
+    body = '<div class="FOO BAZ" id="BAR"><span class="QUX">x</span></div>'
+    assert _sel(body, selector) == quirks_tags
+    assert _sel(f"<!doctype html>{body}", selector) == standards_tags
+
+
 # a five-item list, a mixed-type container, and custom-element siblings so the
 # of-type pseudo-classes exercise both the builtin-atom and custom-name paths
 _PSEUDO = (


### PR DESCRIPTION
A document parsed without a doctype lands in quirks mode, and the Selectors standard ([§6.1](https://www.w3.org/TR/selectors-4/#class-html), [§6.2](https://www.w3.org/TR/selectors-4/#id-selectors)) says class and ID selectors must compare ASCII case-insensitively there, the way a browser resolves them. 🧭 turbohtml always compared case-sensitively, so `select(".foo")` missed `<div class=FOO>` in the quirks documents that `parse()` produces by default, while standards-mode documents stayed correct.

A selector already compiles against the tree it will run on, so the compiled selector now captures that tree's quirks flag and threads it into the matching primitives, which pick the case-sensitive or case-insensitive comparison from it. Routing the flag through the shared primitives means the fold also reaches class and ID selectors nested inside `:is()`, `:where()`, and `:has()`. The tree struct is opaque outside `treebuilder.c`, so the flag is read through a small accessor.

Standards-mode matching is unchanged: a document with a `<!doctype html>` keeps the exact, case-sensitive comparison.

closes #176