### PR TITLE
🐛 fix(select): match whitespace-only elements with :empty

### DIFF
--- a/docs/changelog/177.bugfix.rst
+++ b/docs/changelog/177.bugfix.rst
@@ -1,0 +1,4 @@
+Match elements that contain only document white space with ``:empty``, following `Selectors-4 §13.2
+<https://www.w3.org/TR/selectors-4/#the-empty-pseudo>`_. The matcher previously used the Level 3 rule that rejected any
+text child, so ``select("p:empty")`` missed ``<p> </p>``. Comment-only elements still match, and a non-breaking space
+(U+00A0, which is not white space) still counts as content.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -388,6 +388,18 @@ the comparison exact:
     div
     None
 
+``:empty`` follows Selectors Level 4: an element counts as empty when its only children are comments or document white
+space, so a blank item matches while one holding a non-breaking space (``&nbsp;`` is not white space) does not:
+
+.. testcode::
+
+    items = turbohtml.parse("<ul><li> </li><li>&nbsp;</li><li><!--TODO--></li><li>x</li></ul>")
+    print([li.text for li in items.select("li:empty")])
+
+.. testoutput::
+
+    [' ', '']
+
 To test a node you already hold rather than search beneath it, use :meth:`~turbohtml.Node.matches` (does this node
 match) or :meth:`~turbohtml.Node.closest` (the nearest matching self-or-ancestor):
 

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -74,8 +74,9 @@ typedef struct {
     Py_UCS4 *source; /* an owned copy of the selector text the slices point into */
     sel_complex *alts;
     int count;
-    int failed; /* an allocation or a syntax error happened during compile */
-    int quirks; /* the tree was parsed in quirks mode: class/ID match case-insensitively */
+    int failed;    /* an allocation or a syntax error happened during compile */
+    int quirks;    /* the tree was parsed in quirks mode: class/ID match case-insensitively */
+    th_tree *tree; /* the tree this selector runs on; :empty reads text spans through it */
 } sel_compiled;
 
 /* ---------------------------------------------------------------- parsing */
@@ -767,6 +768,7 @@ static sel_compiled *selector_compile(th_tree *tree, PyObject *selector_str) {
         return NULL;                /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     compiled->quirks = th_tree_quirks(tree);
+    compiled->tree = tree;
     sel_parser parser = {compiled->source, 0, PyUnicode_GET_LENGTH(selector_str), tree, 0};
     if (sel_parse_alts(&parser, &compiled->alts, &compiled->count, 0, 0) < 0) {
         PyMem_Free(compiled->source);
@@ -782,9 +784,9 @@ static sel_compiled *selector_compile(th_tree *tree, PyObject *selector_str) {
 /* The functional pseudo-classes recurse into the matcher: :is()/:where() test the
    element against a nested list, and :has() searches for a relative match, so the
    matching primitives they call are forward-declared here. */
-static int sel_match_compound(th_node *node, const sel_compound *compound, int quirks);
-static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, int quirks);
-static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, int quirks);
+static int sel_match_compound(th_node *node, const sel_compound *compound, int quirks, th_tree *tree);
+static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, int quirks, th_tree *tree);
+static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, int quirks, th_tree *tree);
 
 static Py_UCS4 sel_fold(Py_UCS4 ch, int ci) {
     return (ci && ch >= 'A' && ch <= 'Z') ? ch + 32 : ch;
@@ -914,25 +916,31 @@ static int sel_nth_matches(int a, int b, int index) {
     return diff % a == 0 && diff / a >= 0;
 }
 
-/* An element is :empty (CSS Selectors Level 3) when it has no element or text
-   children; comments and processing instructions do not count. */
-static int sel_is_empty(const th_node *node) {
+/* An element is :empty (Selectors-4 §13.2) when it has no children except,
+   optionally, document white space: any element child or a text child holding a
+   non-whitespace code point makes it non-empty, while comments, processing
+   instructions, and whitespace-only text do not count. Level 3 rejected
+   whitespace-only elements; Level 4 changed that, so `<p> </p>` now matches. */
+static int sel_is_empty(const th_node *node, th_tree *tree) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type == TH_NODE_ELEMENT || child->type == TH_NODE_TEXT) {
+        if (child->type == TH_NODE_ELEMENT) {
+            return 0;
+        }
+        if (child->type == TH_NODE_TEXT && !th_node_text_is_blank(tree, child)) {
             return 0;
         }
     }
     return 1;
 }
 
-static int sel_match_pseudo(th_node *node, const sel_simple *simple, int quirks) {
+static int sel_match_pseudo(th_node *node, const sel_simple *simple, int quirks, th_tree *tree) {
     switch (simple->pseudo) { /* GCOVR_EXCL_BR_LINE: the parser only stores known pseudo ids */
     case PSEUDO_ROOT:
         /* the root element's parent is the document, never an element (a matched
            node always has a parent, as the '>' combinator above relies on) */
         return node->parent->type != TH_NODE_ELEMENT;
     case PSEUDO_EMPTY:
-        return sel_is_empty(node);
+        return sel_is_empty(node, tree);
     case PSEUDO_FIRST_CHILD:
         return sel_no_sibling(node, 0, 0);
     case PSEUDO_LAST_CHILD:
@@ -958,20 +966,20 @@ static int sel_match_pseudo(th_node *node, const sel_simple *simple, int quirks)
        anchored at it */
     case PSEUDO_IS:
     case PSEUDO_WHERE:
-        return sel_matches_alts(node, simple->sub, simple->sub_count, quirks);
+        return sel_matches_alts(node, simple->sub, simple->sub_count, quirks, tree);
     case PSEUDO_NOT:
-        return !sel_matches_alts(node, simple->sub, simple->sub_count, quirks);
+        return !sel_matches_alts(node, simple->sub, simple->sub_count, quirks, tree);
     default: /* PSEUDO_HAS */
-        return sel_has_match(node, simple->sub, simple->sub_count, quirks);
+        return sel_has_match(node, simple->sub, simple->sub_count, quirks, tree);
     }
 }
 
-static int sel_match_simple(th_node *node, const sel_simple *simple, int quirks) {
+static int sel_match_simple(th_node *node, const sel_simple *simple, int quirks, th_tree *tree) {
     switch (simple->kind) {
     case '*':
         return 1;
     case ':':
-        return sel_match_pseudo(node, simple, quirks);
+        return sel_match_pseudo(node, simple, quirks, tree);
     case 'e':
         if (simple->tag_atom != TH_TAG_UNKNOWN) {
             return node->atom == simple->tag_atom;
@@ -1010,12 +1018,12 @@ static int sel_match_simple(th_node *node, const sel_simple *simple, int quirks)
     }
 }
 
-static int sel_match_compound(th_node *node, const sel_compound *compound, int quirks) {
+static int sel_match_compound(th_node *node, const sel_compound *compound, int quirks, th_tree *tree) {
     if (node->type != TH_NODE_ELEMENT) {
         return 0;
     }
     for (int index = 0; index < compound->count; index++) {
-        if (!sel_match_simple(node, &compound->simples[index], quirks)) {
+        if (!sel_match_simple(node, &compound->simples[index], quirks, tree)) {
             return 0;
         }
     }
@@ -1036,7 +1044,8 @@ static th_node *sel_prev_element(th_node *node) {
    ordinary selector (the leftmost compound is the end); for a :has() relative selector
    it is the element :has() tests, and the leftmost compound's leading combinator must
    connect to it. The interior-combinator machinery is shared by both. */
-static int sel_match_from(th_node *node, const sel_complex *complex, int index, th_node *anchor, int quirks) {
+static int sel_match_from(th_node *node, const sel_complex *complex, int index, th_node *anchor, int quirks,
+                          th_tree *tree) {
     if (index == 0) {
         if (anchor == NULL) {
             return 1;
@@ -1068,24 +1077,26 @@ static int sel_match_from(th_node *node, const sel_complex *complex, int index, 
         /* a matched node is an element, so it always has a parent (the document
            at the root), which sel_match_compound rejects as a non-element */
         th_node *parent = node->parent;
-        return sel_match_compound(parent, target, quirks) && sel_match_from(parent, complex, index - 1, anchor, quirks);
+        return sel_match_compound(parent, target, quirks, tree) &&
+               sel_match_from(parent, complex, index - 1, anchor, quirks, tree);
     }
     case '+': {
         th_node *prev = sel_prev_element(node);
-        return prev != NULL && sel_match_compound(prev, target, quirks) &&
-               sel_match_from(prev, complex, index - 1, anchor, quirks);
+        return prev != NULL && sel_match_compound(prev, target, quirks, tree) &&
+               sel_match_from(prev, complex, index - 1, anchor, quirks, tree);
     }
     case '~':
         for (th_node *prev = sel_prev_element(node); prev != NULL; prev = sel_prev_element(prev)) {
-            if (sel_match_compound(prev, target, quirks) && sel_match_from(prev, complex, index - 1, anchor, quirks)) {
+            if (sel_match_compound(prev, target, quirks, tree) &&
+                sel_match_from(prev, complex, index - 1, anchor, quirks, tree)) {
                 return 1;
             }
         }
         return 0;
     default: /* descendant */
         for (th_node *ancestor = node->parent; ancestor != NULL; ancestor = ancestor->parent) {
-            if (sel_match_compound(ancestor, target, quirks) &&
-                sel_match_from(ancestor, complex, index - 1, anchor, quirks)) {
+            if (sel_match_compound(ancestor, target, quirks, tree) &&
+                sel_match_from(ancestor, complex, index - 1, anchor, quirks, tree)) {
                 return 1;
             }
         }
@@ -1096,12 +1107,12 @@ static int sel_match_from(th_node *node, const sel_complex *complex, int index, 
 /* node matches some alternative in alts: it is the subject (rightmost compound) of
    one complex whose combinators to the left verify. The top-level match and the
    :is()/:where() pseudo-classes share this. */
-static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, int quirks) {
+static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, int quirks, th_tree *tree) {
     for (int index = 0; index < count; index++) {
         const sel_complex *complex = &alts[index];
         int subject = complex->count - 1;
-        if (sel_match_compound(node, &complex->compounds[subject], quirks) &&
-            sel_match_from(node, complex, subject, NULL, quirks)) {
+        if (sel_match_compound(node, &complex->compounds[subject], quirks, tree) &&
+            sel_match_from(node, complex, subject, NULL, quirks, tree)) {
             return 1;
         }
     }
@@ -1110,14 +1121,15 @@ static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, i
 
 /* Whether any element in the subtree below node is the subject of rel anchored at
    anchor (the element :has() is testing), checked recursively in document order. */
-static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor, int quirks) {
+static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor, int quirks,
+                           th_tree *tree) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
         if (child->type != TH_NODE_ELEMENT) {
             continue;
         }
-        if ((sel_match_compound(child, &rel->compounds[subject], quirks) &&
-             sel_match_from(child, rel, subject, anchor, quirks)) ||
-            sel_has_subtree(child, rel, subject, anchor, quirks)) {
+        if ((sel_match_compound(child, &rel->compounds[subject], quirks, tree) &&
+             sel_match_from(child, rel, subject, anchor, quirks, tree)) ||
+            sel_has_subtree(child, rel, subject, anchor, quirks, tree)) {
             return 1;
         }
     }
@@ -1127,11 +1139,11 @@ static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, t
 /* Whether the anchor element satisfies any :has() relative selector. A relative
    selector reaches the anchor's descendants and, through a leading sibling
    combinator, its following siblings and their subtrees. */
-static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, int quirks) {
+static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, int quirks, th_tree *tree) {
     for (int index = 0; index < count; index++) {
         const sel_complex *rel = &alts[index];
         int subject = rel->count - 1;
-        if (sel_has_subtree(anchor, rel, subject, anchor, quirks)) {
+        if (sel_has_subtree(anchor, rel, subject, anchor, quirks, tree)) {
             return 1;
         }
         /* only a leading sibling combinator (:has(+ x) / :has(~ x)) can match outside
@@ -1145,9 +1157,9 @@ static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, in
             if (sibling->type != TH_NODE_ELEMENT) {
                 continue;
             }
-            if ((sel_match_compound(sibling, &rel->compounds[subject], quirks) &&
-                 sel_match_from(sibling, rel, subject, anchor, quirks)) ||
-                sel_has_subtree(sibling, rel, subject, anchor, quirks)) {
+            if ((sel_match_compound(sibling, &rel->compounds[subject], quirks, tree) &&
+                 sel_match_from(sibling, rel, subject, anchor, quirks, tree)) ||
+                sel_has_subtree(sibling, rel, subject, anchor, quirks, tree)) {
                 return 1;
             }
         }
@@ -1156,7 +1168,7 @@ static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, in
 }
 
 static int selector_matches(th_node *node, const sel_compiled *compiled) {
-    return sel_matches_alts(node, compiled->alts, compiled->count, compiled->quirks);
+    return sel_matches_alts(node, compiled->alts, compiled->count, compiled->quirks, compiled->tree);
 }
 
 /* The lone simple selector of a selector that is one group, one compound, one

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -1902,7 +1902,7 @@ static PyObject *node_select(PyObject *self, PyObject *arg) {
             Py_ssize_t end = handle_obj->index_offsets[subject + 1];
             for (Py_ssize_t pos = handle_obj->index_offsets[subject]; pos < end; pos++) {
                 th_node *node = handle_obj->index_nodes[pos];
-                int matched = single != NULL ? sel_match_simple(node, single, compiled->quirks)
+                int matched = single != NULL ? sel_match_simple(node, single, compiled->quirks, compiled->tree)
                                              : selector_matches(node, compiled);
                 if (matched && append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1914,7 +1914,7 @@ static PyObject *node_select(PyObject *self, PyObject *arg) {
                 if (node->type != TH_NODE_ELEMENT) {
                     continue;
                 }
-                int matched = single != NULL ? sel_match_simple(node, single, compiled->quirks)
+                int matched = single != NULL ? sel_match_simple(node, single, compiled->quirks, compiled->tree)
                                              : selector_matches(node, compiled);
                 if (matched && append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1951,7 +1951,7 @@ static PyObject *node_select_one(PyObject *self, PyObject *arg) {
             Py_ssize_t end = handle_obj->index_offsets[subject + 1];
             for (Py_ssize_t pos = handle_obj->index_offsets[subject]; pos < end; pos++) {
                 th_node *node = handle_obj->index_nodes[pos];
-                if (single != NULL ? sel_match_simple(node, single, compiled->quirks)
+                if (single != NULL ? sel_match_simple(node, single, compiled->quirks, compiled->tree)
                                    : selector_matches(node, compiled)) {
                     found = node;
                     break;
@@ -1962,7 +1962,7 @@ static PyObject *node_select_one(PyObject *self, PyObject *arg) {
                 if (node->type != TH_NODE_ELEMENT) {
                     continue;
                 }
-                if (single != NULL ? sel_match_simple(node, single, compiled->quirks)
+                if (single != NULL ? sel_match_simple(node, single, compiled->quirks, compiled->tree)
                                    : selector_matches(node, compiled)) {
                     found = node;
                     break;

--- a/src/turbohtml/treebuilder.c
+++ b/src/turbohtml/treebuilder.c
@@ -401,6 +401,16 @@ int th_tree_quirks(const th_tree *tree) {
     return tree->quirks;
 }
 
+int th_node_text_is_blank(th_tree *tree, th_node *node) {
+    const Py_UCS4 *text = need_text(tree, node); /* realize a zero-copy span before scanning */
+    for (Py_ssize_t index = 0; index < node->text_len; index++) {
+        if (!is_space(text[index])) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 /* Resolve a lowercased tag name (UTF-8 bytes) to its atom, or TH_TAG_UNKNOWN for
    a name outside the table (the caller then compares the tag name as text). */
 uint16_t th_tag_lookup(const char *bytes, Py_ssize_t len) {

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -172,6 +172,11 @@ uint32_t th_tree_attr_generation(const th_tree *tree);
    (Selectors-4 §6.1/§6.2); programmatic trees default to no-quirks. */
 int th_tree_quirks(const th_tree *tree);
 
+/* Whether a text node holds only HTML ASCII whitespace (or nothing), realizing a
+   zero-copy span on demand. The :empty selector uses it to ignore the document
+   white space Selectors-4 §13.2 permits inside an otherwise empty element. */
+int th_node_text_is_blank(th_tree *tree, th_node *node);
+
 /* Materialize one text/comment/doctype node's own character data (realizing a
    zero-copy span on demand) into a freshly PyMem-allocated UCS4 buffer.
    *out_len receives the length; returns NULL on allocation failure. */

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -273,6 +273,27 @@ def test_structural_pseudo_by_tag(selector: str, tags: list[str]) -> None:
     assert [element.tag for element in parse(_PSEUDO).select(selector)] == tags
 
 
+# Selectors-4 §13.2 changed :empty from Level 3: an element holding only document
+# white space still matches, while any non-whitespace text or element child does not.
+@pytest.mark.parametrize(
+    ("html", "tags"),
+    [
+        pytest.param("<p></p>", ["p"], id="no-children"),
+        pytest.param("<p> </p>", ["p"], id="single-space"),
+        pytest.param("<p>\t\n\f </p>", ["p"], id="mixed-ascii-whitespace"),
+        pytest.param("<p><!--c--></p>", ["p"], id="comment-only"),
+        pytest.param("<p> <!--c--> </p>", ["p"], id="whitespace-around-comment"),
+        pytest.param("<p>x</p>", [], id="text"),
+        pytest.param("<p> x </p>", [], id="whitespace-around-text"),
+        pytest.param("<p>\xa0</p>", [], id="non-breaking-space-is-not-whitespace"),
+        pytest.param("<p><span></span></p>", [], id="element-child"),
+        pytest.param("<p> <span></span> </p>", [], id="element-child-among-whitespace"),
+    ],
+)
+def test_empty_ignores_document_whitespace(html: str, tags: list[str]) -> None:
+    assert _sel(html, "p:empty") == tags
+
+
 def test_universal_under_a_root() -> None:
     assert (section := parse(_DOC).select_one("section")) is not None
     assert len(section.select("*")) == 8  # h2, p, a, p, ul, li, li, my-widget


### PR DESCRIPTION
`:empty` was matching the Selectors Level 3 definition, under which any text child disqualified an element. [Selectors-4 §13.2](https://www.w3.org/TR/selectors-4/#the-empty-pseudo) changed that: an element is empty when its only children are comments or document white space, the way a browser resolves it. 🧹 As a result `select("p:empty")` missed `<p> </p>`, even though the spec's own examples list it as a match.

A text child now counts as content only when it carries a non-whitespace code point, so whitespace-only text joins comments in being ignored, while a non-breaking space (U+00A0, which is not white space) still keeps an element out of the set. Inspecting a text node's content means realizing its zero-copy span, which needs the owning tree, so the compiled selector now carries that tree and threads it into the match primitives. A small `treebuilder` helper does the realize-and-scan so the span and encoding handling stays beside the existing span code.

Comment-only elements such as `<p><!--c--></p>` keep matching as before.

closes #177