### PR TITLE
✨ feat(select): support the :not() negation pseudo-class

### DIFF
--- a/docs/changelog/173.feature.rst
+++ b/docs/changelog/173.feature.rst
@@ -1,0 +1,7 @@
+Match the Selectors Level 4 negation pseudo-class ``:not()`` in :meth:`~turbohtml.Node.select`,
+:meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and :meth:`~turbohtml.Node.closest`, instead of
+rejecting it as invalid. ``:not()`` takes a full ``<complex-selector-list>``, so it negates compound and complex
+selectors -- ``p:not(.a, .b)`` and ``p:not(div p)`` -- and nests with the other functional pseudo-classes, making the
+spec example ``section:not(:has(h1))`` and compositions such as ``ul:has(:not(a))`` work. The argument list is
+non-forgiving: a syntactically invalid arm invalidates the whole selector, and matching agrees with soupsieve and
+lexbor.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -188,7 +188,7 @@ The query surface builds on that node model. Navigation covers parents, siblings
 node's children. :meth:`~turbohtml.Node.find` and :meth:`~turbohtml.Node.find_all` filter a chosen
 :class:`~turbohtml.Axis` by tag and attributes, where a filter is a string, regex, callable, or list.
 :meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.select_one` run a native CSS matcher -- type, id, class,
-attribute, the four combinators, and the ``:is()``/``:where()``/``:has()`` functional pseudo-classes -- and
+attribute, the four combinators, and the ``:is()``/``:where()``/``:has()``/``:not()`` functional pseudo-classes -- and
 :meth:`~turbohtml.Node.matches` / :meth:`~turbohtml.Node.closest` test a node in place. Selectors compile against the
 tree, so a tag or attribute name resolves to the same interned atom the parser assigned and each match is an integer
 compare. Compiling against the tree also captures its document mode, so ``#id`` and ``.class`` fold ASCII case in a

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -352,8 +352,10 @@ general-sibling (``~``) combinators, with comma groups:
     ['a']
 
 The Selectors Level 4 functional pseudo-classes are supported too: ``:is()`` and ``:where()`` match an element against a
-nested selector list (they differ only in specificity, which a tree matcher ignores), and ``:has()`` keeps an element
-when a relative selector finds a match anchored at it:
+nested selector list (they differ only in specificity, which a tree matcher ignores), ``:has()`` keeps an element when a
+relative selector finds a match anchored at it, and ``:not()`` keeps an element that matches none of its arguments.
+``:not()`` takes a full selector list, so it negates compound and complex selectors -- not just a single class or type
+-- and nests with the others (``article:not(:has(img))`` selects the image-less articles):
 
 .. testcode::
 
@@ -363,11 +365,13 @@ when a relative selector finds a match anchored at it:
     )
     print([a.select_one("h1").text for a in page.select("article:has(img)")])
     print([e.tag for e in page.select(":is(h1, figure)")])
+    print([a.select_one("h1").text for a in page.select("article:not(:has(img))")])
 
 .. testoutput::
 
     ['Post']
     ['h1', 'figure', 'h1']
+    ['Note']
 
 ``#id`` and ``.class`` selectors compare case-sensitively in a standards-mode document and ASCII case-insensitively in a
 quirks-mode one (a document with no doctype), matching how a browser resolves them. Add a ``<!doctype html>`` to keep

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -201,6 +201,18 @@ From any node you can walk outward as well as inward: :attr:`~turbohtml.Node.par
     Element('p')
     ['p', 'body', 'html']
 
+For richer queries, :meth:`~turbohtml.Node.select` takes a CSS selector and returns every matching descendant in
+document order. The negation pseudo-class ``:not()`` keeps the elements that match none of its arguments -- here, the
+descendants of ``body`` that are not links:
+
+.. testcode::
+
+    print([node.tag for node in doc.select("body :not(a)")])
+
+.. testoutput::
+
+    ['h1', 'p']
+
 Because the node types are a sealed hierarchy, structural pattern matching works: each subtype unpacks its defining
 field:
 

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -3,7 +3,7 @@
    names resolve to interned atoms once and every match is an integer compare.
    Matching is right-to-left with backtracking on the descendant and general
    sibling combinators. This covers the common subset: type, universal, class,
-   id, attribute operators, the four combinators, the :is()/:where()/:has()
+   id, attribute operators, the four combinators, the :is()/:where()/:has()/:not()
    functional pseudo-classes, all grouped by commas. */
 
 #ifndef TURBOHTML_SELECTOR_H
@@ -19,8 +19,8 @@ enum sel_attr_op { OP_EXISTS, OP_EQ, OP_INCLUDE, OP_DASH, OP_PREFIX, OP_SUFFIX, 
 typedef struct sel_complex sel_complex;
 
 /* ':' pseudo-classes. The structural ones have fixed meaning (the nth-* variants
-   carry An+B in nth_a/nth_b); the functional ones (:is/:where/:has) carry a nested
-   selector list in sub. */
+   carry An+B in nth_a/nth_b); the functional ones (:is/:where/:has/:not) carry a
+   nested selector list in sub. */
 enum sel_pseudo {
     PSEUDO_NONE,
     PSEUDO_ROOT,
@@ -38,6 +38,7 @@ enum sel_pseudo {
     PSEUDO_IS,
     PSEUDO_WHERE,
     PSEUDO_HAS,
+    PSEUDO_NOT,
 };
 
 typedef struct {
@@ -54,7 +55,7 @@ typedef struct {
     Py_ssize_t name_len;  /* also the attribute name for the rare unknown case */
     const Py_UCS4 *value; /* '[': the attribute value */
     Py_ssize_t value_len;
-    sel_complex *sub; /* ':': the nested selector list for :is()/:where()/:has() */
+    sel_complex *sub; /* ':': the nested selector list for :is()/:where()/:has()/:not() */
     int sub_count;    /* ':': number of comma-separated alternatives in sub */
 } sel_simple;
 
@@ -441,7 +442,7 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
         return;
     }
     int functional = PSEUDO_NONE; /* an nth-* pseudo-class taking An+B */
-    int listy = PSEUDO_NONE;      /* :is()/:where()/:has() taking a selector list */
+    int listy = PSEUDO_NONE;      /* :is()/:where()/:has()/:not() taking a selector list */
     if (sel_kw(name, name_len, "root")) {
         simple->pseudo = PSEUDO_ROOT;
     } else if (sel_kw(name, name_len, "empty")) {
@@ -472,6 +473,8 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
         listy = PSEUDO_WHERE;
     } else if (sel_kw(name, name_len, "has")) {
         listy = PSEUDO_HAS;
+    } else if (sel_kw(name, name_len, "not")) {
+        listy = PSEUDO_NOT;
     } else {
         parser->error = 1; /* an unknown pseudo-class invalidates the selector */
         return;
@@ -951,10 +954,13 @@ static int sel_match_pseudo(th_node *node, const sel_simple *simple, int quirks)
     case PSEUDO_NTH_LAST_OF_TYPE:
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 1, 1));
     /* the functional pseudo-classes: :is()/:where() match the element against the
-       nested list; :has() searches for a relative match anchored at it */
+       nested list; :not() is its negation; :has() searches for a relative match
+       anchored at it */
     case PSEUDO_IS:
     case PSEUDO_WHERE:
         return sel_matches_alts(node, simple->sub, simple->sub_count, quirks);
+    case PSEUDO_NOT:
+        return !sel_matches_alts(node, simple->sub, simple->sub_count, quirks);
     default: /* PSEUDO_HAS */
         return sel_has_match(node, simple->sub, simple->sub_count, quirks);
     }

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -623,7 +623,9 @@ static PyObject *node_css_closest(PyObject *self, PyObject *arg);
 
 PyDoc_STRVAR(select_doc, "select(selector, /)\n--\n\n"
                          "Return the list of descendant Elements matching the CSS selector, in\n"
-                         "document order.");
+                         "document order. The selector grammar covers type, #id, .class, and\n"
+                         "attribute selectors, the four combinators, the structural pseudo-classes,\n"
+                         "and the :is(), :where(), :has(), and :not() functional pseudo-classes.");
 
 PyDoc_STRVAR(select_one_doc, "select_one(selector, /)\n--\n\n"
                              "Return the first descendant Element matching the CSS selector, or None.");

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -369,6 +369,17 @@ _PSEUDO_DOC = (
         # an interior compound that matches only an ancestor of the anchor (main is
         # above section) is not within the anchor's subtree, so :has() does not match
         pytest.param("section:has(main p)", [], id="has-interior-compound-above-anchor"),
+        # :not() keeps an element when it matches none of its (non-forgiving) arms
+        pytest.param("p:not(.lead)", ["p"], id="not-simple"),
+        pytest.param("li:not(.sel)", ["li"], id="not-class-miss"),
+        pytest.param("p:not(.lead, .none)", ["p"], id="not-list"),
+        pytest.param("p:not(.missing)", ["p", "p"], id="not-no-arm-matches"),
+        pytest.param("p:not(:has(a))", ["p"], id="not-with-has"),
+        pytest.param("section > :not(h2)", ["p", "p", "ul"], id="not-child-subject"),
+        pytest.param(":not(html, head, body, section, ul, aside, main *)", ["main"], id="not-complex-arm"),
+        pytest.param("li:not(.sel):not(.none)", ["li"], id="not-chained"),
+        pytest.param(":is(li):not(.sel)", ["li"], id="not-after-is"),
+        pytest.param("section:not(*)", [], id="not-universal-excludes-all"),
     ],
 )
 def test_functional_pseudo_classes(selector: str, tags: list[str]) -> None:
@@ -399,6 +410,13 @@ def test_has_skips_non_element_following_sibling() -> None:
         pytest.param(":1s(p)", id="pseudo-name-with-digit"),  # a below-'A' byte in the case fold
         pytest.param(":is(p):has(", id="pseudo-then-failing-pseudo"),
         pytest.param(":has(>)", id="has-dangling-combinator"),
+        # :not() takes a non-forgiving selector list, so any bad arm invalidates it
+        pytest.param(":not", id="not-without-args"),
+        pytest.param(":not(", id="not-unterminated"),
+        pytest.param(":not()", id="not-empty-args"),
+        pytest.param(":not(.)", id="not-invalid-inner"),
+        pytest.param(":not(:bogus)", id="not-unknown-nested-pseudo"),
+        pytest.param(":not(p,)", id="not-trailing-comma"),
         # a namespace prefix must be followed by a type or the universal selector
         pytest.param("*|", id="star-prefix-at-eof"),
         pytest.param("|", id="bare-pipe"),


### PR DESCRIPTION
turbohtml's `select()` rejected every form of the negation pseudo-class `:not()` as an invalid selector, from the simple `p:not(.a)` to the list `p:not(.a, .b)` and the complex `p:not(div p)`. 🚫 Because the rejection propagated through any selector that nested it, the literal Selectors-4 example `section:not(:has(h1))` and compositions such as `ul:has(:not(a))` failed too. `:not()` is widely used, so the gap turned many otherwise-valid selectors into hard errors.

`:not()` takes a `<complex-real-selector-list>`, the same grammar `:is()` already parses, so it reads its argument through the existing `sel_parse_alts` and negates the shared `sel_matches_alts` matcher: an element matches when it is the subject of none of the arms. ✨ The argument list stays non-forgiving per §4.3, so a syntactically invalid arm still invalidates the whole selector, and matching agrees with soupsieve and lexbor.

The change is additive on the read path. The subject-atom index still applies, so `p:not(.a)` enumerates only the `p` bucket, and any selector that does not use `:not()` compiles to the same hot path as before. Matching is available through `select`, `select_one`, `matches`, and `closest`.

closes #173