### PR TITLE
🐛 fix(parser): treat empty DOCTYPE system id as quirks

### DIFF
--- a/docs/changelog/189.bugfix.rst
+++ b/docs/changelog/189.bugfix.rst
@@ -1,0 +1,5 @@
+Treat a present-but-empty DOCTYPE system identifier the same as a missing one when deciding quirks mode for the
+``-//W3C//DTD HTML 4.01 Frameset//`` and ``-//W3C//DTD HTML 4.01 Transitional//`` public identifiers, as the WHATWG
+initial insertion mode requires ("the system identifier is missing or the empty string"). ``<!DOCTYPE html PUBLIC
+"-//W3C//DTD HTML 4.01 Frameset//EN" "">`` now enters quirks mode; only a non-empty system identifier downgrades these
+to limited-quirks.

--- a/src/turbohtml/treebuilder_quirks.h
+++ b/src/turbohtml/treebuilder_quirks.h
@@ -20,6 +20,11 @@ static int buf_imatches(const th_buf *buf, const char *pat, int whole) {
 /* WHATWG quirks-mode triggers: forced-quirks flag, a non-html name, or a
    legacy public/system identifier. */
 static int doctype_is_quirky(const th_token *tok) {
+    static const char *const QUIRKY_EXACT[] = {
+        "-//W3O//DTD W3 HTML Strict 3.0//EN//",
+        "-/W3C/DTD HTML 4.0 Transitional/EN",
+        "HTML",
+    };
     static const char *const QUIRKY_PREFIXES[] = {
         "+//Silmaril//dtd html Pro v0r11 19970101//",
         "-//AS//DTD HTML 3.0 asWedit + extensions//",
@@ -81,10 +86,10 @@ static int doctype_is_quirky(const th_token *tok) {
         return 1;
     }
     if (tok->has_public_id) {
-        if (buf_imatches(&tok->public_id, "-//W3O//DTD W3 HTML Strict 3.0//EN//", 1) ||
-            buf_imatches(&tok->public_id, "-/W3C/DTD HTML 4.0 Transitional/EN", 1) ||
-            buf_imatches(&tok->public_id, "HTML", 1)) {
-            return 1;
+        for (size_t index = 0; index < sizeof(QUIRKY_EXACT) / sizeof(QUIRKY_EXACT[0]); index++) {
+            if (buf_imatches(&tok->public_id, QUIRKY_EXACT[index], 1)) {
+                return 1;
+            }
         }
         for (size_t index = 0; index < sizeof(QUIRKY_PREFIXES) / sizeof(QUIRKY_PREFIXES[0]); index++) {
             if (buf_imatches(&tok->public_id, QUIRKY_PREFIXES[index], 0)) {

--- a/src/turbohtml/treebuilder_quirks.h
+++ b/src/turbohtml/treebuilder_quirks.h
@@ -91,8 +91,12 @@ static int doctype_is_quirky(const th_token *tok) {
                 return 1;
             }
         }
-        if (!tok->has_system_id && (buf_imatches(&tok->public_id, "-//W3C//DTD HTML 4.01 Frameset//", 0) ||
-                                    buf_imatches(&tok->public_id, "-//W3C//DTD HTML 4.01 Transitional//", 0))) {
+        /* the spec triggers quirks when the system identifier is "missing or the empty
+           string"; only a non-empty system identifier downgrades these two public
+           identifiers to limited-quirks (which turbohtml treats as no-quirks) */
+        if ((!tok->has_system_id || tok->system_id.len == 0) &&
+            (buf_imatches(&tok->public_id, "-//W3C//DTD HTML 4.01 Frameset//", 0) ||
+             buf_imatches(&tok->public_id, "-//W3C//DTD HTML 4.01 Transitional//", 0))) {
             return 1;
         }
     }

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -108,6 +108,30 @@ _LONG_NAME = "z" * 130
             "|       <table>",
             id="quirks-public-id-w3o-strict",
         ),
+        # WHATWG initial mode: a -//W3C//DTD HTML 4.01 Frameset/Transitional public id puts
+        # the document in quirks mode when the system id is missing OR the empty string (so
+        # <table> nests in the still-open <p>); a non-empty system id downgrades it to
+        # limited-quirks (no-quirks here), closing the <p> so <table> becomes its sibling
+        pytest.param(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN"><p><table>',
+            "|     <p>\n|       <table>",
+            id="quirks-4.01-frameset-missing-sysid",
+        ),
+        pytest.param(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" ""><p><table>',
+            "|     <p>\n|       <table>",
+            id="quirks-4.01-frameset-empty-sysid",
+        ),
+        pytest.param(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" ""><p><table>',
+            "|     <p>\n|       <table>",
+            id="quirks-4.01-transitional-empty-sysid",
+        ),
+        pytest.param(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "x"><p><table>',
+            "|     <p>\n|     <table>",
+            id="limited-quirks-4.01-frameset-nonempty-sysid",
+        ),
         pytest.param("<p>" + "x" * 70000, "x" * 40, id="text-larger-than-arena-block"),
         pytest.param("<html a=1><html ő=2>", 'a="1"', id="merge-wide-attr-name"),
         pytest.param("<input type=HIDDEN>", "<input>", id="uppercase-hidden-input-type"),

--- a/tests/test_treebuilder_internals.py
+++ b/tests/test_treebuilder_internals.py
@@ -103,6 +103,13 @@ _LONG_NAME = "z" * 130
             "|       <table>",
             id="quirks-public-id-4.0-transitional",
         ),
+        # a same-length near-miss of the 4.0-transitional exact id is not quirky, so the
+        # <p> closes and <table> becomes its sibling (exercises the exact-match mismatch)
+        pytest.param(
+            '<!DOCTYPE html PUBLIC "-/W3C/DTD HTML 4.0 Transitional/EX"><p><table>',
+            "|     <p>\n|     <table>",
+            id="no-quirks-public-id-4.0-transitional-near-miss",
+        ),
         pytest.param(
             '<!DOCTYPE html PUBLIC "-//W3O//DTD W3 HTML Strict 3.0//EN//"><p><table>',
             "|       <table>",


### PR DESCRIPTION
Auditing the initial insertion mode against the literal WHATWG spec (not html5lib, which is stale here) surfaced a quirks-mode gap. 📐 The spec puts a document in quirks mode when a `-//W3C//DTD HTML 4.01 Frameset//` or `-//W3C//DTD HTML 4.01 Transitional//` public identifier pairs with a system identifier that is *"missing **or the empty string**"*; only a *"neither missing nor the empty string"* system identifier downgrades these to limited-quirks. `doctype_is_quirky` keyed solely on the system identifier being absent, so `<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "">` parsed as no-quirks when it should be quirks.

The fix extends the condition to also fire for a present-but-empty system identifier, leaving the non-empty case as limited-quirks (no-quirks here). html5lib 1.1 predates the *"or the empty string"* wording — so it reports limited-quirks for this input and the html5lib-tests corpus never exercises it. The behavior is therefore locked with a hand-written test that observes quirks through `<table>` nesting inside a still-open `<p>`.

closes #189