### PR TITLE
🐛 fix(select): make :is()/:where() forgiving selector lists

### DIFF
--- a/docs/changelog/174.bugfix.rst
+++ b/docs/changelog/174.bugfix.rst
@@ -1,0 +1,8 @@
+Parse the ``:is()`` and ``:where()`` arguments as a Selectors Level 4 forgiving selector list (§16.1) in
+:meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and
+:meth:`~turbohtml.Node.closest`. An arm that fails to parse -- an unsupported pseudo-class, a malformed compound, or an
+empty arm from a stray comma -- is now dropped so the remaining arms stay usable, instead of invalidating the whole
+selector, and an all-dropped list (including ``:is()``) is valid and matches nothing. ``:not()`` and ``:has()`` keep
+their non-forgiving real-list semantics, where a bad arm is still an error, and the top-level selector list stays
+non-forgiving as the standard requires. Recovery skips delimiters inside strings and balanced brackets, so a comma in a
+dropped arm's ``[attr="a, b"]`` does not split it.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -192,7 +192,9 @@ node's children. :meth:`~turbohtml.Node.find` and :meth:`~turbohtml.Node.find_al
 attribute, the four combinators, the ``:is()``/``:where()``/``:has()``/``:not()`` functional pseudo-classes, and the
 ``:scope``, form/UI (``:checked``, ``:disabled``, ``:default``, ...), ``:lang()`` and ``:dir()`` pseudo-classes that a
 static tree can determine -- and :meth:`~turbohtml.Node.matches` / :meth:`~turbohtml.Node.closest` test a node in place.
-The pseudo-classes that depend on live interaction or navigation state (``:hover``, ``:focus``, ``:target``,
+``:is()`` and ``:where()`` parse their argument as a forgiving selector list (a bad arm is dropped, the rest stay
+usable), while ``:not()`` and ``:has()`` take a real list where any bad arm is an error, as the Selectors standard
+specifies. The pseudo-classes that depend on live interaction or navigation state (``:hover``, ``:focus``, ``:target``,
 ``:visited``, ``:link``, ...) parse but match nothing, since a parsed document has no such state. Selectors compile
 against the tree, so a tag or attribute name resolves to the same interned atom the parser assigned and each match is an
 integer compare. Compiling against the tree also captures its document mode, so ``#id`` and ``.class`` fold ASCII case

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -403,6 +403,19 @@ The interaction- and navigation-state pseudo-classes -- ``:hover``, ``:focus``, 
 match nothing, since a parsed tree has no live UA state. They stay usable inside ``:is()`` and ``:not()`` rather than
 raising, so ``a:not(:visited)`` keeps every link.
 
+``:is()`` and ``:where()`` take a *forgiving* selector list: an arm that fails to parse is dropped and the rest stay
+usable, so one unsupported or malformed arm never invalidates the whole selector (``:not()`` and ``:has()`` take a real
+list, where a bad arm is still an error):
+
+.. testcode::
+
+    doc = turbohtml.parse("<p>one</p><div>two</div>")
+    print([e.tag for e in doc.select(":is(p, :totally-unknown)")])
+
+.. testoutput::
+
+    ['p']
+
 ``#id`` and ``.class`` selectors compare case-sensitively in a standards-mode document and ASCII case-insensitively in a
 quirks-mode one (a document with no doctype), matching how a browser resolves them. Add a ``<!doctype html>`` to keep
 the comparison exact:

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -224,6 +224,17 @@ Selectors also reach the form and UI pseudo-classes the markup determines, such 
 
     1
 
+``:is()`` and ``:where()`` are forgiving, so an arm they cannot parse is dropped and the rest still select -- a typo in
+one alternative does not break the query:
+
+.. testcode::
+
+    print([node.tag for node in doc.select(":is(h1, :oops)")])
+
+.. testoutput::
+
+    ['h1']
+
 Because the node types are a sealed hierarchy, structural pattern matching works: each subtype unpacks its defining
 field:
 

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -454,7 +454,8 @@ static void sel_parse_anb(sel_parser *parser, int *a, int *b) {
 
 /* Parse the comma-separated selector list inside a :is()/:where()/:has(); defined
    below, after the complex-selector parser it drives. */
-static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_count, int nested, int relative);
+static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_count, int nested, int relative,
+                          int forgiving);
 static void sel_free_alts(sel_complex *alts, int count);
 
 /* The pseudo-classes that depend on live UA/interaction or navigation state a
@@ -602,7 +603,10 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
             return;
         }
         parser->pos++;
-        sel_parse_alts(parser, &simple->sub, &simple->sub_count, 1, listy == PSEUDO_HAS);
+        /* :is()/:where() take a forgiving selector list (a bad arm is dropped); :has()
+           and :not() take a real list, so any bad arm invalidates the whole selector */
+        int forgiving = listy == PSEUDO_IS || listy == PSEUDO_WHERE;
+        sel_parse_alts(parser, &simple->sub, &simple->sub_count, 1, listy == PSEUDO_HAS, forgiving);
     } else if (langdir != PSEUDO_NONE) {
         simple->pseudo = langdir;
         if (parser->pos >= parser->len || parser->src[parser->pos] != '(') {
@@ -813,11 +817,53 @@ static int sel_complex_parse(sel_parser *parser, sel_complex *complex, int neste
     return 0;
 }
 
+/* Recover from a failed arm in a forgiving selector list: advance to the next
+   top-level ',' or the ')' that closes the list (or the end), skipping balanced
+   brackets and quoted strings so a delimiter inside them does not end the arm. */
+static void sel_skip_bad_arm(sel_parser *parser) {
+    int depth = 0;
+    while (parser->pos < parser->len) {
+        Py_UCS4 ch = parser->src[parser->pos];
+        if (ch == '"' || ch == '\'') {
+            Py_UCS4 quote = ch;
+            parser->pos++;
+            while (parser->pos < parser->len && parser->src[parser->pos] != quote) {
+                if (parser->src[parser->pos] == '\\' && parser->pos + 1 < parser->len) {
+                    parser->pos++; /* the escaped character cannot close the string */
+                }
+                parser->pos++;
+            }
+            if (parser->pos < parser->len) {
+                parser->pos++; /* the closing quote */
+            }
+            continue;
+        }
+        if (ch == '(' || ch == '[') {
+            depth++;
+        } else if (ch == ']') {
+            if (depth > 0) {
+                depth--;
+            }
+        } else if (ch == ')') {
+            if (depth == 0) {
+                return; /* the ')' that ends the forgiving list */
+            }
+            depth--;
+        } else if (ch == ',' && depth == 0) {
+            return; /* the next arm */
+        }
+        parser->pos++;
+    }
+}
+
 /* Parse a comma-separated list of complex selectors into a freshly allocated array.
    nested stops the list at a closing ')' (the :is()/:where()/:has() argument case)
-   and requires that ')'; relative lets each complex open with a combinator (:has()).
-   Returns 0 with the out parameters set, or -1 with parser->error set. */
-static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_count, int nested, int relative) {
+   and requires that ')'; relative lets each complex open with a combinator (:has());
+   forgiving drops an arm that fails to parse instead of failing the whole list (the
+   :is()/:where() rule), and may leave an empty list (*out_alts NULL) that matches
+   nothing. Returns 0 with the out parameters set, or -1 with parser->error set. */
+static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_count, int nested, int relative,
+                          int forgiving) {
     sel_complex temp[64];
     int count = 0;
     while (1) {
@@ -826,10 +872,14 @@ static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_c
             parser->error = 1;
             break;
         }
-        if (sel_complex_parse(parser, &temp[count], nested, relative) < 0) {
+        if (sel_complex_parse(parser, &temp[count], nested, relative) == 0) {
+            count++;
+        } else if (forgiving) {
+            parser->error = 0; /* drop the unparsable arm and recover to the next one */
+            sel_skip_bad_arm(parser);
+        } else {
             break;
         }
-        count++;
         sel_skip_ws(parser);
         if (parser->pos >= parser->len) {
             if (nested) {
@@ -841,8 +891,8 @@ static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_c
             parser->pos++;
             continue;
         }
-        /* a successful complex stops only at a comma, the end, or -- when nested -- the
-           closing ')' that ends the argument list; consume it and finish */
+        /* an arm stops only at a comma, the end, or -- when nested -- the closing
+           ')' that ends the argument list; consume it and finish */
         parser->pos++;
         break;
     }
@@ -852,6 +902,11 @@ static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_c
             PyMem_Free(temp[index].compounds);
         }
         return -1;
+    }
+    if (count == 0) {
+        *out_alts = NULL; /* a forgiving list whose arms all dropped matches nothing */
+        *out_count = 0;
+        return 0;
     }
     sel_complex *owned = PyMem_Malloc((size_t)count * sizeof(sel_complex));
     if (owned == NULL) {                              /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
@@ -889,7 +944,7 @@ static sel_compiled *selector_compile(th_tree *tree, PyObject *selector_str) {
     compiled->quirks = th_tree_quirks(tree);
     compiled->tree = tree;
     sel_parser parser = {compiled->source, 0, PyUnicode_GET_LENGTH(selector_str), tree, 0};
-    if (sel_parse_alts(&parser, &compiled->alts, &compiled->count, 0, 0) < 0) {
+    if (sel_parse_alts(&parser, &compiled->alts, &compiled->count, 0, 0, 0) < 0) {
         PyMem_Free(compiled->source);
         PyMem_Free(compiled);
         PyErr_SetString(PyExc_ValueError, "invalid CSS selector");

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -641,7 +641,8 @@ PyDoc_STRVAR(select_doc, "select(selector, /)\n--\n\n"
                          "attribute selectors, the four combinators, the structural pseudo-classes,\n"
                          "the :is(), :where(), :has(), and :not() functional pseudo-classes, and the\n"
                          ":scope, form/UI, :lang() and :dir() pseudo-classes a static tree can\n"
-                         "determine; live-state pseudo-classes (:hover, :focus, ...) match nothing.");
+                         "determine; live-state pseudo-classes (:hover, :focus, ...) match nothing.\n"
+                         ":is() and :where() take a forgiving list, so a bad arm is dropped.");
 
 PyDoc_STRVAR(select_one_doc, "select_one(selector, /)\n--\n\n"
                              "Return the first descendant Element matching the CSS selector, or None.");

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -401,6 +401,26 @@ _PSEUDO_DOC = (
         pytest.param("li:not(.sel):not(.none)", ["li"], id="not-chained"),
         pytest.param(":is(li):not(.sel)", ["li"], id="not-after-is"),
         pytest.param("section:not(*)", [], id="not-universal-excludes-all"),
+        # :is()/:where() are forgiving: an arm that fails to parse is dropped and the
+        # rest stay usable, so a bad arm never invalidates the whole selector
+        pytest.param(":is(:bogus, h2)", ["h2"], id="is-drops-bad-arm"),
+        pytest.param(":where(::bogus, li)", ["li", "li"], id="where-drops-pseudo-element-arm"),
+        pytest.param(":is(:bogus)", [], id="is-all-arms-bad-matches-nothing"),
+        pytest.param(":where(:bogus)", [], id="where-bad-matches-nothing"),
+        pytest.param(":is()", [], id="is-empty-matches-nothing"),
+        pytest.param(":is(h2, )", ["h2"], id="is-trailing-comma-drops-empty-arm"),
+        pytest.param(":is(.)", [], id="is-invalid-inner-dropped"),
+        pytest.param(":is(:bogus, ul) li", ["li", "li"], id="is-forgiving-then-descendant"),
+        # a bad arm carrying a string or balanced brackets recovers to the real comma
+        pytest.param(':is([x="a, b"]:bogus, h2)', ["h2"], id="is-recover-past-string"),
+        pytest.param(":is(:x(a, b), h2)", ["h2"], id="is-recover-past-parens"),
+        # recovery skips delimiters inside strings and balanced brackets/parens
+        pytest.param(':is(@"a, b", h2)', ["h2"], id="is-recover-comma-in-string"),
+        pytest.param(":is(@'a, b', h2)", ["h2"], id="is-recover-comma-in-single-quoted"),
+        pytest.param(":is(@[a, b], h2)", ["h2"], id="is-recover-comma-in-brackets"),
+        pytest.param(":is(@(a, b), h2)", ["h2"], id="is-recover-comma-in-parens"),
+        pytest.param(":is(@], h2)", ["h2"], id="is-recover-unbalanced-bracket"),
+        pytest.param(r':is(@"a\"b", h2)', ["h2"], id="is-recover-escaped-quote"),
     ],
 )
 def test_functional_pseudo_classes(selector: str, tags: list[str]) -> None:
@@ -423,9 +443,10 @@ def test_has_skips_non_element_following_sibling() -> None:
         pytest.param(":is", id="is-without-args"),
         pytest.param(":is(", id="is-unterminated"),
         pytest.param(":is(p", id="is-unterminated-after-arg"),
-        pytest.param(":is()", id="is-empty-args"),
-        pytest.param(":is(p,)", id="is-trailing-comma"),
-        pytest.param(":is(.)", id="is-invalid-inner"),
+        # a forgiving list still needs its ')': an arm that runs to the end (here with
+        # an unterminated string, or a trailing backslash) leaves the '(' unclosed
+        pytest.param(':is(@"x', id="is-forgiving-unterminated-string"),
+        pytest.param(':is(@"x\\', id="is-forgiving-trailing-backslash"),
         pytest.param(":is.x", id="pseudo-name-then-non-paren"),
         pytest.param(":ix(p)", id="pseudo-name-char-mismatch"),
         pytest.param(":1s(p)", id="pseudo-name-with-digit"),  # a below-'A' byte in the case fold


### PR DESCRIPTION
`:is()` and `:where()` take a *forgiving* selector list (Selectors-4 §16.1): an arm that fails to parse must be dropped so the remaining arms stay usable. turbohtml instead propagated any nested parse failure and rejected the whole selector — and because the unsupported-pseudo-class set is large, that turned many otherwise-valid `:is()`/`:where()` selectors into hard errors. 🚫

The argument parser now takes a `forgiving` flag, set for `:is()`/`:where()` and clear for `:not()`/`:has()` and the top-level list. When set, a complex arm that fails to parse is dropped: the error is cleared and recovery skips to the next top-level comma or the closing paren, stepping over delimiters inside strings and balanced brackets so a comma in `[attr="a, b"]` does not split the arm. ✨ An all-dropped list — including `:is()` — is valid and matches nothing. `:not()` and `:has()` keep their non-forgiving real-list semantics, where a bad arm is still an error, and the top-level selector list stays non-forgiving as the standard requires.

This follows the spec and browsers; soupsieve is not forgiving here (it raises on an unknown pseudo-class), so it is not the reference for this behavior.

closes #174