### PR TITLE
✨ feat(select): state, :scope, :lang() and :dir() pseudo-classes

### DIFF
--- a/docs/changelog/178.feature.rst
+++ b/docs/changelog/178.feature.rst
@@ -1,0 +1,9 @@
+Add the statically-determinable Selectors-4 pseudo-classes to the CSS matcher used by :meth:`~turbohtml.Node.select`,
+:meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and :meth:`~turbohtml.Node.closest`. The form-state
+set is supported -- ``:checked``, ``:enabled``, ``:disabled`` (honoring a disabled ``<fieldset>`` and its first
+``<legend>`` exception and a disabled ``<optgroup>``), ``:required``, ``:optional``, ``:read-only``, ``:read-write``
+(including ``contenteditable`` hosts), and ``:default`` -- along with ``:scope`` (the element the query runs on),
+``:lang()`` (RFC 4647 basic filtering, so ``:lang(en)`` matches ``en-US``), and ``:dir(ltr|rtl)``. The live
+user-interaction pseudo-classes (``:hover``, ``:focus``, ``:focus-within``, ``:active``, ``:target``, ``:visited``,
+``:link``, ``:any-link``) now parse as valid and resolve to a no-op instead of raising, since a static document cannot
+express them.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -189,17 +189,22 @@ The query surface builds on that node model. Navigation covers parents, siblings
 node's children. :meth:`~turbohtml.Node.find` and :meth:`~turbohtml.Node.find_all` filter a chosen
 :class:`~turbohtml.Axis` by tag and attributes, where a filter is a string, regex, callable, or list.
 :meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.select_one` run a native CSS matcher -- type, id, class,
-attribute, the four combinators, and the ``:is()``/``:where()``/``:has()``/``:not()`` functional pseudo-classes -- and
-:meth:`~turbohtml.Node.matches` / :meth:`~turbohtml.Node.closest` test a node in place. Selectors compile against the
-tree, so a tag or attribute name resolves to the same interned atom the parser assigned and each match is an integer
-compare. Compiling against the tree also captures its document mode, so ``#id`` and ``.class`` fold ASCII case in a
-quirks-mode document and compare exactly otherwise, as the Selectors standard requires. :meth:`~turbohtml.Node.xpath`,
-:meth:`~turbohtml.Node.xpath_one`, and :meth:`~turbohtml.Node.xpath_iter` evaluate XPath 1.0 over the same model: a
-native-C engine compiles each expression once into an immutable, per-tree-cached program, resolves name tests to
-interned atoms, and collapses the ``//`` abbreviation to a single ``descendant`` walk, so the structural axes,
-predicates, operators, unions, and the core function library run at lxml's speed. Output runs back through
-:attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and :meth:`~turbohtml.Node.encode`, WHATWG-conformant
-by default with the escaping selectable through :class:`~turbohtml.Formatter`.
+attribute, the four combinators, the ``:is()``/``:where()``/``:has()``/``:not()`` functional pseudo-classes, the
+form-state pseudo-classes (``:checked``, ``:enabled``/``:disabled``, ``:required``/``:optional``,
+``:read-only``/``:read-write``, ``:default``), and ``:scope``/``:lang()``/``:dir()`` -- and
+:meth:`~turbohtml.Node.matches` / :meth:`~turbohtml.Node.closest` test a node in place. The scope chosen is to support
+every pseudo-class a parsed tree can decide from attributes and structure; the live user-interaction pseudo-classes
+(``:hover``, ``:focus``, ``:target``, ``:visited``, and the rest) parse as valid but never match, since a static
+document has no such state to read. Selectors compile against the tree, so a tag or attribute name resolves to the same
+interned atom the parser assigned and each match is an integer compare. Compiling against the tree also captures its
+document mode, so ``#id`` and ``.class`` fold ASCII case in a quirks-mode document and compare exactly otherwise, as the
+Selectors standard requires. :meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.xpath_one`, and
+:meth:`~turbohtml.Node.xpath_iter` evaluate XPath 1.0 over the same model: a native-C engine compiles each expression
+once into an immutable, per-tree-cached program, resolves name tests to interned atoms, and collapses the ``//``
+abbreviation to a single ``descendant`` walk, so the structural axes, predicates, operators, unions, and the core
+function library run at lxml's speed. Output runs back through :attr:`~turbohtml.Node.html`,
+:meth:`~turbohtml.Node.serialize`, and :meth:`~turbohtml.Node.encode`, WHATWG-conformant by default with the escaping
+selectable through :class:`~turbohtml.Formatter`.
 
 *******************
  Mutating the tree

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -400,6 +400,28 @@ space, so a blank item matches while one holding a non-breaking space (``&nbsp;`
 
     [' ', '']
 
+The form-state pseudo-classes select controls by attribute and structure -- ``:checked``, ``:enabled``/``:disabled``
+(honoring a disabled ``<fieldset>`` and its ``<legend>`` exception), ``:required``/``:optional``,
+``:read-only``/``:read-write``, and ``:default`` -- while ``:scope`` is the element the query runs on and ``:lang()`` /
+``:dir()`` resolve the nearest ``lang`` / ``dir`` attribute (``:lang(en)`` also matches ``en-US``):
+
+.. testcode::
+
+    form = turbohtml.parse("<form><input name=a required><input name=b disabled><input name=c value=x></form>")
+    print([i.attrs["name"] for i in form.select(":required")])
+    print([i.attrs["name"] for i in form.select("input:enabled")])
+    page = turbohtml.parse("<article id=post><h1>Post</h1><p lang=fr>Bonjour</p></article>")
+    print([p.text for p in page.select_one("#post").select(":scope > :lang(fr)")])
+
+.. testoutput::
+
+    ['a']
+    ['a', 'c']
+    ['Bonjour']
+
+The live user-interaction pseudo-classes (``:hover``, ``:focus``, ``:focus-within``, ``:active``, ``:target``,
+``:visited``, ``:link``, ``:any-link``) parse as valid but never match, because a static document holds no such state.
+
 To test a node you already hold rather than search beneath it, use :meth:`~turbohtml.Node.matches` (does this node
 match) or :meth:`~turbohtml.Node.closest` (the nearest matching self-or-ancestor):
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -213,6 +213,18 @@ descendants of ``body`` that are not links:
 
     ['h1', 'p']
 
+The state pseudo-classes select form controls by their attributes -- for example ``:checked`` finds the ticked boxes and
+selected options:
+
+.. testcode::
+
+    form = turbohtml.parse("<form><input checked type=checkbox><input type=checkbox></form>")
+    print([box.attrs.get("type") for box in form.select(":checked")])
+
+.. testoutput::
+
+    ['checkbox']
+
 Because the node types are a sealed hierarchy, structural pattern matching works: each subtype unpacks its defining
 field:
 

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -20,7 +20,9 @@ typedef struct sel_complex sel_complex;
 
 /* ':' pseudo-classes. The structural ones have fixed meaning (the nth-* variants
    carry An+B in nth_a/nth_b); the functional ones (:is/:where/:has/:not) carry a
-   nested selector list in sub. */
+   nested selector list in sub; the state ones read attributes/structure; :lang()
+   and :dir() carry an argument (in name / nth_a); PSEUDO_NEVER is the live-UA-state
+   set (:hover/:focus/...) that is valid but never matches a static tree. */
 enum sel_pseudo {
     PSEUDO_NONE,
     PSEUDO_ROOT,
@@ -39,6 +41,18 @@ enum sel_pseudo {
     PSEUDO_WHERE,
     PSEUDO_HAS,
     PSEUDO_NOT,
+    PSEUDO_SCOPE,
+    PSEUDO_CHECKED,
+    PSEUDO_DISABLED,
+    PSEUDO_ENABLED,
+    PSEUDO_REQUIRED,
+    PSEUDO_OPTIONAL,
+    PSEUDO_READ_ONLY,
+    PSEUDO_READ_WRITE,
+    PSEUDO_DEFAULT,
+    PSEUDO_LANG,
+    PSEUDO_DIR,
+    PSEUDO_NEVER,
 };
 
 typedef struct {
@@ -433,6 +447,20 @@ static void sel_parse_anb(sel_parser *parser, int *a, int *b) {
 static int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_count, int nested, int relative);
 static void sel_free_alts(sel_complex *alts, int count);
 
+/* The live UA/interaction-state pseudo-classes a static query engine cannot resolve:
+   accepted as valid syntax but matched as a no-op (Selectors-4 §10/§11 dynamic set,
+   plus :link/:any-link which need navigation state). */
+static int sel_is_never_pseudo(const Py_UCS4 *name, Py_ssize_t len) {
+    static const char *const NEVER[] = {"hover",  "focus",   "focus-within", "active",
+                                        "target", "visited", "link",         "any-link"};
+    for (size_t index = 0; index < sizeof(NEVER) / sizeof(NEVER[0]); index++) {
+        if (sel_kw(name, len, NEVER[index])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* Parse a pseudo-class selector (the leading ':' already consumed). */
 static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
     simple->kind = ':';
@@ -444,6 +472,7 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
     }
     int functional = PSEUDO_NONE; /* an nth-* pseudo-class taking An+B */
     int listy = PSEUDO_NONE;      /* :is()/:where()/:has()/:not() taking a selector list */
+    int argy = PSEUDO_NONE;       /* :lang()/:dir() taking a single argument */
     if (sel_kw(name, name_len, "root")) {
         simple->pseudo = PSEUDO_ROOT;
     } else if (sel_kw(name, name_len, "empty")) {
@@ -476,6 +505,32 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
         listy = PSEUDO_HAS;
     } else if (sel_kw(name, name_len, "not")) {
         listy = PSEUDO_NOT;
+    } else if (sel_kw(name, name_len, "scope")) {
+        simple->pseudo = PSEUDO_SCOPE;
+    } else if (sel_kw(name, name_len, "checked")) {
+        simple->pseudo = PSEUDO_CHECKED;
+    } else if (sel_kw(name, name_len, "disabled")) {
+        simple->pseudo = PSEUDO_DISABLED;
+    } else if (sel_kw(name, name_len, "enabled")) {
+        simple->pseudo = PSEUDO_ENABLED;
+    } else if (sel_kw(name, name_len, "required")) {
+        simple->pseudo = PSEUDO_REQUIRED;
+    } else if (sel_kw(name, name_len, "optional")) {
+        simple->pseudo = PSEUDO_OPTIONAL;
+    } else if (sel_kw(name, name_len, "read-only")) {
+        simple->pseudo = PSEUDO_READ_ONLY;
+    } else if (sel_kw(name, name_len, "read-write")) {
+        simple->pseudo = PSEUDO_READ_WRITE;
+    } else if (sel_kw(name, name_len, "default")) {
+        simple->pseudo = PSEUDO_DEFAULT;
+    } else if (sel_kw(name, name_len, "lang")) {
+        argy = PSEUDO_LANG;
+    } else if (sel_kw(name, name_len, "dir")) {
+        argy = PSEUDO_DIR;
+    } else if (sel_is_never_pseudo(name, name_len)) {
+        /* live UA/interaction state (:hover/:focus/...): valid but never matches a
+           static document, so it is accepted and resolves to a no-op rather than raising */
+        simple->pseudo = PSEUDO_NEVER;
     } else {
         parser->error = 1; /* an unknown pseudo-class invalidates the selector */
         return;
@@ -504,6 +559,45 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
         }
         parser->pos++;
         sel_parse_alts(parser, &simple->sub, &simple->sub_count, 1, listy == PSEUDO_HAS);
+    } else if (argy != PSEUDO_NONE) {
+        simple->pseudo = argy;
+        if (parser->pos >= parser->len || parser->src[parser->pos] != '(') {
+            parser->error = 1; /* :lang()/:dir() require an argument */
+            return;
+        }
+        parser->pos++;
+        sel_skip_ws(parser);
+        if (argy == PSEUDO_DIR) {
+            const Py_UCS4 *arg;
+            Py_ssize_t arg_len;
+            sel_ident(parser, &arg, &arg_len); /* sets parser->error on an empty identifier */
+            if (parser->error) {
+                return;
+            }
+            /* a valid but unrecognized direction keeps :dir() valid yet never matching */
+            simple->nth_a = sel_kw(arg, arg_len, "ltr") ? 1 : (sel_kw(arg, arg_len, "rtl") ? 2 : 0);
+            sel_skip_ws(parser);
+        } else { /* PSEUDO_LANG: keep the raw range list, tokenised on comma at match time */
+            Py_ssize_t start = parser->pos;
+            while (parser->pos < parser->len && parser->src[parser->pos] != ')') {
+                parser->pos++;
+            }
+            Py_ssize_t end = parser->pos;
+            while (end > start && is_space(parser->src[end - 1])) {
+                end--;
+            }
+            if (end == start) {
+                parser->error = 1; /* :lang() needs at least one range */
+                return;
+            }
+            simple->name = parser->src + start;
+            simple->name_len = end - start;
+        }
+        if (parser->pos >= parser->len || parser->src[parser->pos] != ')') {
+            parser->error = 1;
+            return;
+        }
+        parser->pos++;
     } else if (parser->pos < parser->len && parser->src[parser->pos] == '(') {
         parser->error = 1; /* a non-functional pseudo-class takes no argument list */
         return;
@@ -781,12 +875,23 @@ static sel_compiled *selector_compile(th_tree *tree, PyObject *selector_str) {
 
 /* --------------------------------------------------------------- matching */
 
+/* Call-scoped context threaded through the matcher: the tree (so :empty can read
+   text spans and the state pseudos resolve attributes), the origin element the
+   query was invoked on (so :scope can match it), and the quirks flag (so class/ID
+   fold case). It is per-call, not per-compile, so it is built fresh by each
+   select()/matches()/closest() rather than stored on the cached compiled selector. */
+typedef struct {
+    th_tree *tree;
+    th_node *origin;
+    int quirks;
+} sel_match_ctx;
+
 /* The functional pseudo-classes recurse into the matcher: :is()/:where() test the
    element against a nested list, and :has() searches for a relative match, so the
    matching primitives they call are forward-declared here. */
-static int sel_match_compound(th_node *node, const sel_compound *compound, int quirks, th_tree *tree);
-static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, int quirks, th_tree *tree);
-static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, int quirks, th_tree *tree);
+static int sel_match_compound(th_node *node, const sel_compound *compound, const sel_match_ctx *ctx);
+static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, const sel_match_ctx *ctx);
+static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, const sel_match_ctx *ctx);
 
 static Py_UCS4 sel_fold(Py_UCS4 ch, int ci) {
     return (ci && ch >= 'A' && ch <= 'Z') ? ch + 32 : ch;
@@ -933,14 +1038,250 @@ static int sel_is_empty(const th_node *node, th_tree *tree) {
     return 1;
 }
 
-static int sel_match_pseudo(th_node *node, const sel_simple *simple, int quirks, th_tree *tree) {
+/* ---- state pseudo-classes (Selectors-4 §11/§12): all statically determinable
+   from attributes and structure, so they read the parsed tree directly ---- */
+
+static int sel_has_attr(th_node *node, uint32_t atom) {
+    return sel_find_attr(node, atom) != NULL;
+}
+
+/* A node's tag atom when it is an HTML element, else TH_TAG_UNKNOWN. Folding the
+   namespace test into the atom lookup keeps the form-control checks a single
+   compare (a foreign or non-element node never equals a control atom) and avoids
+   the namespace clause on every check. */
+static uint16_t sel_html_atom(const th_node *node) {
+    return node->ns == TH_NS_HTML ? node->atom : TH_TAG_UNKNOWN;
+}
+
+/* Whether node is an HTML element whose tag atom is one of count entries in set. */
+static int sel_atom_in_set(const th_node *node, const uint16_t *set, size_t count) {
+    if (node->ns != TH_NS_HTML) {
+        return 0;
+    }
+    for (size_t index = 0; index < count; index++) {
+        if (node->atom == set[index]) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Whether an <input>'s type keyword is one of count entries in types; a missing or
+   empty type attribute behaves as type="text" (HTML invalid-value default). */
+static int sel_input_type_in(th_node *node, const char *const *types, size_t count) {
+    static const Py_UCS4 text_default[] = {'t', 'e', 'x', 't'};
+    const th_node_attr *attr = sel_find_attr(node, TH_ATTR_TYPE);
+    const Py_UCS4 *value = text_default;
+    Py_ssize_t value_len = 4;
+    /* a parsed attribute stores an empty value as NULL, so value != NULL means a
+       non-empty type; a missing or empty type keeps the "text" default */
+    if (attr != NULL && attr->value != NULL) {
+        value = attr->value;
+        value_len = attr->value_len;
+    }
+    for (size_t index = 0; index < count; index++) {
+        if (sel_kw(value, value_len, types[index])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Whether node sits within fieldset's first <legend> child (the carve-out that
+   keeps a control enabled even when an ancestor fieldset is disabled). */
+static int sel_in_first_legend(const th_node *node, const th_node *fieldset) {
+    const th_node *legend = NULL;
+    for (const th_node *child = fieldset->first_child; child != NULL; child = child->next_sibling) {
+        if (sel_html_atom(child) == TH_TAG_LEGEND) { /* a non-element child has atom UNKNOWN, never LEGEND */
+            legend = child;
+            break;
+        }
+    }
+    if (legend == NULL) {
+        return 0;
+    }
+    /* node is always a descendant of fieldset (the caller found fieldset by walking
+       node's ancestors), so the walk reaches fieldset before running off the top */
+    for (const th_node *ancestor = node; ancestor != fieldset; ancestor = ancestor->parent) {
+        if (ancestor == legend) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* The "actually disabled" predicate (HTML form-control infrastructure). */
+static int sel_is_disabled(th_node *node) {
+    static const uint16_t FORM_CONTROLS[] = {TH_TAG_BUTTON, TH_TAG_INPUT, TH_TAG_SELECT, TH_TAG_TEXTAREA};
+    uint16_t atom = sel_html_atom(node);
+    if (atom == TH_TAG_OPTGROUP || atom == TH_TAG_FIELDSET) {
+        return sel_has_attr(node, TH_ATTR_DISABLED);
+    }
+    if (atom == TH_TAG_OPTION) {
+        return sel_has_attr(node, TH_ATTR_DISABLED) ||
+               (sel_html_atom(node->parent) == TH_TAG_OPTGROUP && sel_has_attr(node->parent, TH_ATTR_DISABLED));
+    }
+    if (!sel_atom_in_set(node, FORM_CONTROLS, sizeof(FORM_CONTROLS) / sizeof(FORM_CONTROLS[0]))) {
+        return 0; /* a foreign or non-control element is never disabled */
+    }
+    if (sel_has_attr(node, TH_ATTR_DISABLED)) {
+        return 1;
+    }
+    for (th_node *ancestor = node->parent; ancestor != NULL; ancestor = ancestor->parent) {
+        if (sel_html_atom(ancestor) == TH_TAG_FIELDSET && sel_has_attr(ancestor, TH_ATTR_DISABLED) &&
+            !sel_in_first_legend(node, ancestor)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int sel_is_enabled(th_node *node) {
+    static const uint16_t ENABLEABLE[] = {TH_TAG_BUTTON,   TH_TAG_INPUT,  TH_TAG_SELECT,  TH_TAG_TEXTAREA,
+                                          TH_TAG_OPTGROUP, TH_TAG_OPTION, TH_TAG_FIELDSET};
+    return sel_atom_in_set(node, ENABLEABLE, sizeof(ENABLEABLE) / sizeof(ENABLEABLE[0])) && !sel_is_disabled(node);
+}
+
+/* :checked / :default share their static form: a checkbox/radio with the checked
+   content attribute, or an option with the selected content attribute. */
+static int sel_is_checked(th_node *node) {
+    static const char *const TOGGLE_TYPES[] = {"checkbox", "radio"};
+    uint16_t atom = sel_html_atom(node);
+    if (atom == TH_TAG_OPTION) {
+        return sel_has_attr(node, TH_ATTR_SELECTED);
+    }
+    if (atom == TH_TAG_INPUT) {
+        return sel_input_type_in(node, TOGGLE_TYPES, 2) && sel_has_attr(node, TH_ATTR_CHECKED);
+    }
+    return 0;
+}
+
+static int sel_is_required_candidate(const th_node *node) {
+    static const uint16_t SET[] = {TH_TAG_INPUT, TH_TAG_SELECT, TH_TAG_TEXTAREA};
+    return sel_atom_in_set(node, SET, sizeof(SET) / sizeof(SET[0]));
+}
+
+/* Whether node is an editing host: the nearest self-or-ancestor carrying a
+   contenteditable attribute resolves to the "true" state (value "" or "true");
+   "false" stops inheritance, an invalid value keeps walking up. */
+static int sel_is_editable(th_node *node) {
+    /* the document and other ancestors carry no contenteditable attribute, so the
+       walk simply runs to the top; sel_find_attr returns NULL for a non-element */
+    for (th_node *current = node; current != NULL; current = current->parent) {
+        const th_node_attr *attr = sel_find_attr(current, TH_ATTR_CONTENTEDITABLE);
+        if (attr == NULL) {
+            continue;
+        }
+        /* an empty value is stored as NULL, and both the empty and "true" states make
+           the element editable */
+        if (attr->value == NULL || sel_kw(attr->value, attr->value_len, "true")) {
+            return 1;
+        }
+        if (sel_kw(attr->value, attr->value_len, "false")) {
+            return 0;
+        }
+    }
+    return 0;
+}
+
+static int sel_is_readwrite(th_node *node) {
+    static const char *const MUTABLE_TYPES[] = {"text", "search", "url",  "tel",  "email",          "password",
+                                                "date", "month",  "week", "time", "datetime-local", "number"};
+    uint16_t atom = sel_html_atom(node);
+    if (atom == TH_TAG_TEXTAREA) {
+        return !sel_has_attr(node, TH_ATTR_READONLY) && !sel_is_disabled(node);
+    }
+    if (atom == TH_TAG_INPUT) {
+        if (!sel_input_type_in(node, MUTABLE_TYPES, sizeof(MUTABLE_TYPES) / sizeof(MUTABLE_TYPES[0]))) {
+            return 0; /* a non-text input (checkbox, button, ...) is never read-write */
+        }
+        return !sel_has_attr(node, TH_ATTR_READONLY) && !sel_is_disabled(node);
+    }
+    return sel_is_editable(node);
+}
+
+/* The nearest self-or-ancestor element carrying attribute atom, or NULL. */
+static const th_node_attr *sel_ancestor_attr(th_node *node, uint32_t atom) {
+    for (th_node *current = node; current != NULL; current = current->parent) {
+        const th_node_attr *attr = sel_find_attr(current, atom);
+        if (attr != NULL) {
+            return attr;
+        }
+    }
+    return NULL;
+}
+
+/* :dir(ltr|rtl) against the nearest dir attribute (want is 1=ltr, 2=rtl, 0=other).
+   dir="auto" and invalid values establish no statically resolvable direction. */
+static int sel_dir_matches(th_node *node, int want) {
+    const th_node_attr *attr = sel_ancestor_attr(node, TH_ATTR_DIR);
+    if (attr == NULL) {
+        return 0;
+    }
+    /* an empty dir value is stored as NULL/length 0, which sel_kw rejects below */
+    if (sel_kw(attr->value, attr->value_len, "ltr")) {
+        return want == 1;
+    }
+    if (sel_kw(attr->value, attr->value_len, "rtl")) {
+        return want == 2;
+    }
+    return 0;
+}
+
+/* RFC 4647 basic filtering of one language range against a language tag. */
+static int sel_lang_range_matches(const Py_UCS4 *lang, Py_ssize_t lang_len, const Py_UCS4 *range,
+                                  Py_ssize_t range_len) {
+    if (range_len == 1 && range[0] == '*') {
+        return lang_len > 0;
+    }
+    if (lang_len < range_len || !sel_eq(lang, range_len, range, range_len, 1)) {
+        return 0;
+    }
+    return lang_len == range_len || lang[range_len] == '-';
+}
+
+/* :lang(...) against the nearest lang attribute, matching any comma-separated range
+   stored in simple->name (each an identifier, a quoted string, or *). */
+static int sel_lang_matches(th_node *node, const sel_simple *simple) {
+    const th_node_attr *attr = sel_ancestor_attr(node, TH_ATTR_LANG);
+    if (attr == NULL) {
+        return 0;
+    }
+    /* an empty lang value (stored as NULL/length 0) matches no range below */
+    Py_ssize_t pos = 0;
+    while (pos < simple->name_len) {
+        while (pos < simple->name_len && (is_space(simple->name[pos]) || simple->name[pos] == ',')) {
+            pos++;
+        }
+        Py_ssize_t start = pos;
+        while (pos < simple->name_len && simple->name[pos] != ',') {
+            pos++;
+        }
+        Py_ssize_t end = pos;
+        while (end > start && is_space(simple->name[end - 1])) {
+            end--;
+        }
+        const Py_UCS4 *token = simple->name + start;
+        Py_ssize_t token_len = end - start;
+        if (token_len >= 2 && (token[0] == '"' || token[0] == '\'') && token[token_len - 1] == token[0]) {
+            token++;
+            token_len -= 2;
+        }
+        if (token_len > 0 && sel_lang_range_matches(attr->value, attr->value_len, token, token_len)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int sel_match_pseudo(th_node *node, const sel_simple *simple, const sel_match_ctx *ctx) {
     switch (simple->pseudo) { /* GCOVR_EXCL_BR_LINE: the parser only stores known pseudo ids */
     case PSEUDO_ROOT:
         /* the root element's parent is the document, never an element (a matched
            node always has a parent, as the '>' combinator above relies on) */
         return node->parent->type != TH_NODE_ELEMENT;
     case PSEUDO_EMPTY:
-        return sel_is_empty(node, tree);
+        return sel_is_empty(node, ctx->tree);
     case PSEUDO_FIRST_CHILD:
         return sel_no_sibling(node, 0, 0);
     case PSEUDO_LAST_CHILD:
@@ -966,20 +1307,47 @@ static int sel_match_pseudo(th_node *node, const sel_simple *simple, int quirks,
        anchored at it */
     case PSEUDO_IS:
     case PSEUDO_WHERE:
-        return sel_matches_alts(node, simple->sub, simple->sub_count, quirks, tree);
+        return sel_matches_alts(node, simple->sub, simple->sub_count, ctx);
     case PSEUDO_NOT:
-        return !sel_matches_alts(node, simple->sub, simple->sub_count, quirks, tree);
-    default: /* PSEUDO_HAS */
-        return sel_has_match(node, simple->sub, simple->sub_count, quirks, tree);
+        return !sel_matches_alts(node, simple->sub, simple->sub_count, ctx);
+    case PSEUDO_HAS:
+        return sel_has_match(node, simple->sub, simple->sub_count, ctx);
+    /* state pseudo-classes (Selectors-4 §11/§12) read attributes and structure */
+    case PSEUDO_SCOPE:
+        return node == ctx->origin;
+    case PSEUDO_CHECKED:
+        return sel_is_checked(node);
+    case PSEUDO_DISABLED:
+        return sel_is_disabled(node);
+    case PSEUDO_ENABLED:
+        return sel_is_enabled(node);
+    case PSEUDO_REQUIRED:
+        return sel_is_required_candidate(node) && sel_has_attr(node, TH_ATTR_REQUIRED);
+    case PSEUDO_OPTIONAL:
+        return sel_is_required_candidate(node) && !sel_has_attr(node, TH_ATTR_REQUIRED);
+    case PSEUDO_READ_ONLY:
+        return !sel_is_readwrite(node);
+    case PSEUDO_READ_WRITE:
+        return sel_is_readwrite(node);
+    case PSEUDO_DEFAULT:
+        /* the statically-knowable defaults; a form's default submit button needs
+           form-owner association a static tree does not model */
+        return sel_is_checked(node);
+    case PSEUDO_LANG:
+        return sel_lang_matches(node, simple);
+    case PSEUDO_DIR:
+        return sel_dir_matches(node, simple->nth_a);
+    default: /* PSEUDO_NEVER: live UA/interaction state never holds in a static tree */
+        return 0;
     }
 }
 
-static int sel_match_simple(th_node *node, const sel_simple *simple, int quirks, th_tree *tree) {
+static int sel_match_simple(th_node *node, const sel_simple *simple, const sel_match_ctx *ctx) {
     switch (simple->kind) {
     case '*':
         return 1;
     case ':':
-        return sel_match_pseudo(node, simple, quirks, tree);
+        return sel_match_pseudo(node, simple, ctx);
     case 'e':
         if (simple->tag_atom != TH_TAG_UNKNOWN) {
             return node->atom == simple->tag_atom;
@@ -992,14 +1360,14 @@ static int sel_match_simple(th_node *node, const sel_simple *simple, int quirks,
            case-insensitive in quirks mode (Selectors-4 §6.1/§6.2) */
         const th_node_attr *attr = sel_find_attr(node, TH_ATTR_ID);
         return attr != NULL && attr->value != NULL &&
-               sel_eq(attr->value, attr->value_len, simple->name, simple->name_len, quirks);
+               sel_eq(attr->value, attr->value_len, simple->name, simple->name_len, ctx->quirks);
     }
     case '.': {
         const th_node_attr *attr = sel_find_attr(node, TH_ATTR_CLASS);
         if (attr == NULL || attr->value == NULL) {
             return 0;
         }
-        return contains_ws_token(attr->value, attr->value_len, simple->name, simple->name_len, quirks);
+        return contains_ws_token(attr->value, attr->value_len, simple->name, simple->name_len, ctx->quirks);
     }
     default: { /* '[' */
         if (simple->attr_atom == UINT32_MAX) {
@@ -1018,12 +1386,12 @@ static int sel_match_simple(th_node *node, const sel_simple *simple, int quirks,
     }
 }
 
-static int sel_match_compound(th_node *node, const sel_compound *compound, int quirks, th_tree *tree) {
+static int sel_match_compound(th_node *node, const sel_compound *compound, const sel_match_ctx *ctx) {
     if (node->type != TH_NODE_ELEMENT) {
         return 0;
     }
     for (int index = 0; index < compound->count; index++) {
-        if (!sel_match_simple(node, &compound->simples[index], quirks, tree)) {
+        if (!sel_match_simple(node, &compound->simples[index], ctx)) {
             return 0;
         }
     }
@@ -1044,8 +1412,8 @@ static th_node *sel_prev_element(th_node *node) {
    ordinary selector (the leftmost compound is the end); for a :has() relative selector
    it is the element :has() tests, and the leftmost compound's leading combinator must
    connect to it. The interior-combinator machinery is shared by both. */
-static int sel_match_from(th_node *node, const sel_complex *complex, int index, th_node *anchor, int quirks,
-                          th_tree *tree) {
+static int sel_match_from(th_node *node, const sel_complex *complex, int index, th_node *anchor,
+                          const sel_match_ctx *ctx) {
     if (index == 0) {
         if (anchor == NULL) {
             return 1;
@@ -1077,26 +1445,24 @@ static int sel_match_from(th_node *node, const sel_complex *complex, int index, 
         /* a matched node is an element, so it always has a parent (the document
            at the root), which sel_match_compound rejects as a non-element */
         th_node *parent = node->parent;
-        return sel_match_compound(parent, target, quirks, tree) &&
-               sel_match_from(parent, complex, index - 1, anchor, quirks, tree);
+        return sel_match_compound(parent, target, ctx) && sel_match_from(parent, complex, index - 1, anchor, ctx);
     }
     case '+': {
         th_node *prev = sel_prev_element(node);
-        return prev != NULL && sel_match_compound(prev, target, quirks, tree) &&
-               sel_match_from(prev, complex, index - 1, anchor, quirks, tree);
+        return prev != NULL && sel_match_compound(prev, target, ctx) &&
+               sel_match_from(prev, complex, index - 1, anchor, ctx);
     }
     case '~':
         for (th_node *prev = sel_prev_element(node); prev != NULL; prev = sel_prev_element(prev)) {
-            if (sel_match_compound(prev, target, quirks, tree) &&
-                sel_match_from(prev, complex, index - 1, anchor, quirks, tree)) {
+            if (sel_match_compound(prev, target, ctx) && sel_match_from(prev, complex, index - 1, anchor, ctx)) {
                 return 1;
             }
         }
         return 0;
     default: /* descendant */
         for (th_node *ancestor = node->parent; ancestor != NULL; ancestor = ancestor->parent) {
-            if (sel_match_compound(ancestor, target, quirks, tree) &&
-                sel_match_from(ancestor, complex, index - 1, anchor, quirks, tree)) {
+            if (sel_match_compound(ancestor, target, ctx) &&
+                sel_match_from(ancestor, complex, index - 1, anchor, ctx)) {
                 return 1;
             }
         }
@@ -1107,12 +1473,12 @@ static int sel_match_from(th_node *node, const sel_complex *complex, int index, 
 /* node matches some alternative in alts: it is the subject (rightmost compound) of
    one complex whose combinators to the left verify. The top-level match and the
    :is()/:where() pseudo-classes share this. */
-static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, int quirks, th_tree *tree) {
+static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, const sel_match_ctx *ctx) {
     for (int index = 0; index < count; index++) {
         const sel_complex *complex = &alts[index];
         int subject = complex->count - 1;
-        if (sel_match_compound(node, &complex->compounds[subject], quirks, tree) &&
-            sel_match_from(node, complex, subject, NULL, quirks, tree)) {
+        if (sel_match_compound(node, &complex->compounds[subject], ctx) &&
+            sel_match_from(node, complex, subject, NULL, ctx)) {
             return 1;
         }
     }
@@ -1121,15 +1487,15 @@ static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, i
 
 /* Whether any element in the subtree below node is the subject of rel anchored at
    anchor (the element :has() is testing), checked recursively in document order. */
-static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor, int quirks,
-                           th_tree *tree) {
+static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor,
+                           const sel_match_ctx *ctx) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
         if (child->type != TH_NODE_ELEMENT) {
             continue;
         }
-        if ((sel_match_compound(child, &rel->compounds[subject], quirks, tree) &&
-             sel_match_from(child, rel, subject, anchor, quirks, tree)) ||
-            sel_has_subtree(child, rel, subject, anchor, quirks, tree)) {
+        if ((sel_match_compound(child, &rel->compounds[subject], ctx) &&
+             sel_match_from(child, rel, subject, anchor, ctx)) ||
+            sel_has_subtree(child, rel, subject, anchor, ctx)) {
             return 1;
         }
     }
@@ -1139,11 +1505,11 @@ static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, t
 /* Whether the anchor element satisfies any :has() relative selector. A relative
    selector reaches the anchor's descendants and, through a leading sibling
    combinator, its following siblings and their subtrees. */
-static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, int quirks, th_tree *tree) {
+static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, const sel_match_ctx *ctx) {
     for (int index = 0; index < count; index++) {
         const sel_complex *rel = &alts[index];
         int subject = rel->count - 1;
-        if (sel_has_subtree(anchor, rel, subject, anchor, quirks, tree)) {
+        if (sel_has_subtree(anchor, rel, subject, anchor, ctx)) {
             return 1;
         }
         /* only a leading sibling combinator (:has(+ x) / :has(~ x)) can match outside
@@ -1157,9 +1523,9 @@ static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, in
             if (sibling->type != TH_NODE_ELEMENT) {
                 continue;
             }
-            if ((sel_match_compound(sibling, &rel->compounds[subject], quirks, tree) &&
-                 sel_match_from(sibling, rel, subject, anchor, quirks, tree)) ||
-                sel_has_subtree(sibling, rel, subject, anchor, quirks, tree)) {
+            if ((sel_match_compound(sibling, &rel->compounds[subject], ctx) &&
+                 sel_match_from(sibling, rel, subject, anchor, ctx)) ||
+                sel_has_subtree(sibling, rel, subject, anchor, ctx)) {
                 return 1;
             }
         }
@@ -1167,8 +1533,9 @@ static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, in
     return 0;
 }
 
-static int selector_matches(th_node *node, const sel_compiled *compiled) {
-    return sel_matches_alts(node, compiled->alts, compiled->count, compiled->quirks, compiled->tree);
+static int selector_matches(th_node *node, const sel_compiled *compiled, th_node *origin) {
+    sel_match_ctx ctx = {compiled->tree, origin, compiled->quirks};
+    return sel_matches_alts(node, compiled->alts, compiled->count, &ctx);
 }
 
 /* The lone simple selector of a selector that is one group, one compound, one

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -1924,14 +1924,15 @@ static PyObject *node_select(PyObject *self, PyObject *arg) {
            with sel_match_simple directly, skipping the group/combinator machinery */
         const sel_simple *single = sel_single_simple(compiled);
         uint16_t subject = selector_subject_atom(compiled);
+        sel_match_ctx ctx = {compiled->tree, origin, compiled->quirks};
         if (handle_use_index(handle_obj, origin, subject != TH_TAG_UNKNOWN)) {
             /* only the candidate subjects need the matcher, drawn in document order
                from the atom bucket instead of a full pre-order walk */
             Py_ssize_t end = handle_obj->index_offsets[subject + 1];
             for (Py_ssize_t pos = handle_obj->index_offsets[subject]; pos < end; pos++) {
                 th_node *node = handle_obj->index_nodes[pos];
-                int matched = single != NULL ? sel_match_simple(node, single, compiled->quirks, compiled->tree)
-                                             : selector_matches(node, compiled);
+                int matched =
+                    single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin);
                 if (matched && append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
                     break;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1942,8 +1943,8 @@ static PyObject *node_select(PyObject *self, PyObject *arg) {
                 if (node->type != TH_NODE_ELEMENT) {
                     continue;
                 }
-                int matched = single != NULL ? sel_match_simple(node, single, compiled->quirks, compiled->tree)
-                                             : selector_matches(node, compiled);
+                int matched =
+                    single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin);
                 if (matched && append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
                     break;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1975,12 +1976,12 @@ static PyObject *node_select_one(PyObject *self, PyObject *arg) {
     } else {
         const sel_simple *single = sel_single_simple(compiled);
         uint16_t subject = selector_subject_atom(compiled);
+        sel_match_ctx ctx = {compiled->tree, origin, compiled->quirks};
         if (handle_use_index(handle_obj, origin, subject != TH_TAG_UNKNOWN)) {
             Py_ssize_t end = handle_obj->index_offsets[subject + 1];
             for (Py_ssize_t pos = handle_obj->index_offsets[subject]; pos < end; pos++) {
                 th_node *node = handle_obj->index_nodes[pos];
-                if (single != NULL ? sel_match_simple(node, single, compiled->quirks, compiled->tree)
-                                   : selector_matches(node, compiled)) {
+                if (single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin)) {
                     found = node;
                     break;
                 }
@@ -1990,8 +1991,7 @@ static PyObject *node_select_one(PyObject *self, PyObject *arg) {
                 if (node->type != TH_NODE_ELEMENT) {
                     continue;
                 }
-                if (single != NULL ? sel_match_simple(node, single, compiled->quirks, compiled->tree)
-                                   : selector_matches(node, compiled)) {
+                if (single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin)) {
                     found = node;
                     break;
                 }
@@ -2193,7 +2193,7 @@ static PyObject *node_css_matches(PyObject *self, PyObject *arg) {
     if (compiled == NULL) {
         error = 1;
     } else {
-        matched = node->type == TH_NODE_ELEMENT && selector_matches(node, compiled);
+        matched = node->type == TH_NODE_ELEMENT && selector_matches(node, compiled, node);
     }
     Py_END_CRITICAL_SECTION();
     if (error) {
@@ -2214,8 +2214,9 @@ static PyObject *node_css_closest(PyObject *self, PyObject *arg) {
     if (compiled == NULL) {
         error = 1;
     } else {
-        for (th_node *node = ((NodeObject *)self)->node; node != NULL; node = node->parent) {
-            if (node->type == TH_NODE_ELEMENT && selector_matches(node, compiled)) {
+        th_node *origin = ((NodeObject *)self)->node; /* :scope refers to the receiver, not each ancestor */
+        for (th_node *node = origin; node != NULL; node = node->parent) {
+            if (node->type == TH_NODE_ELEMENT && selector_matches(node, compiled, origin)) {
                 found = node;
                 break;
             }

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -639,7 +639,12 @@ PyDoc_STRVAR(select_doc, "select(selector, /)\n--\n\n"
                          "Return the list of descendant Elements matching the CSS selector, in\n"
                          "document order. The selector grammar covers type, #id, .class, and\n"
                          "attribute selectors, the four combinators, the structural pseudo-classes,\n"
-                         "and the :is(), :where(), :has(), and :not() functional pseudo-classes.");
+                         "the :is(), :where(), :has(), and :not() functional pseudo-classes, the\n"
+                         "form-state pseudo-classes (:checked, :enabled, :disabled, :required,\n"
+                         ":optional, :read-only, :read-write, :default), and :scope, :lang(), and\n"
+                         ":dir(). Live user-interaction pseudo-classes (:hover, :focus, :active,\n"
+                         ":target, :visited, :link, :any-link, :focus-within) parse but never match\n"
+                         "a static document.");
 
 PyDoc_STRVAR(select_one_doc, "select_one(selector, /)\n--\n\n"
                              "Return the first descendant Element matching the CSS selector, or None.");

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -413,6 +413,230 @@ def test_has_skips_non_element_following_sibling() -> None:
     assert [element.tag for element in doc.select("section:has(~ aside b)")] == ["section"]
 
 
+def _ids(html: str, selector: str, root: str = "#wrap") -> list[str]:
+    container = parse(html).select_one(root)
+    assert container is not None
+    result: list[str] = []
+    for element in container.select(selector):
+        ident = element.attrs.get("id")
+        result.append(ident if isinstance(ident, str) else element.tag)
+    return result
+
+
+# every form control kind, the disabled-fieldset / first-legend carve-out, a disabled
+# optgroup, contenteditable hosts, and read-only/read-write inputs in one tree
+_FORM = (
+    "<div id=wrap>"
+    "<input id=text><input id=text-ro readonly>"
+    "<input id=cb type=checkbox checked><input id=cb-off type=checkbox>"
+    "<input id=radio type=radio checked><input id=req required><input id=dis disabled>"
+    "<select id=sel required></select><textarea id=ta></textarea><textarea id=ta-ro readonly></textarea>"
+    "<fieldset id=fs disabled><legend><input id=in-legend></legend><input id=in-fs></fieldset>"
+    "<select id=sel2><optgroup id=og disabled><option id=opt-og>a</option></optgroup>"
+    "<optgroup id=og2><option id=opt-sel selected>b</option><option id=opt-plain>c</option></optgroup></select>"
+    "<div id=edit contenteditable><span id=edit-child>x</span></div>"
+    "<div id=noedit contenteditable=false></div><div id=plain></div>"
+    # a foreign (SVG) element is never a form control, exercising the namespace guards
+    "<svg id=svg></svg>"
+    "</div>"
+)
+
+
+@pytest.mark.parametrize(
+    ("selector", "ids"),
+    [
+        pytest.param(":checked", ["cb", "radio", "opt-sel"], id="checked"),
+        pytest.param(":default", ["cb", "radio", "opt-sel"], id="default"),
+        # actually-disabled: own attribute, a disabled fieldset's controls (but not its
+        # first legend's), and a disabled optgroup's options
+        pytest.param(":disabled", ["dis", "fs", "in-fs", "og", "opt-og"], id="disabled"),
+        pytest.param(
+            ":enabled",
+            [
+                "text",
+                "text-ro",
+                "cb",
+                "cb-off",
+                "radio",
+                "req",
+                "sel",
+                "ta",
+                "ta-ro",
+                "in-legend",
+                "sel2",
+                "og2",
+                "opt-sel",
+                "opt-plain",
+            ],
+            id="enabled",
+        ),
+        pytest.param(":required", ["req", "sel"], id="required"),
+        pytest.param(
+            ":optional",
+            ["text", "text-ro", "cb", "cb-off", "radio", "dis", "ta", "ta-ro", "in-legend", "in-fs", "sel2"],
+            id="optional",
+        ),
+        pytest.param(":read-write", ["text", "req", "ta", "in-legend", "edit", "edit-child"], id="read-write"),
+        pytest.param("input:read-only", ["text-ro", "cb", "cb-off", "radio", "dis", "in-fs"], id="read-only-input"),
+        pytest.param("div:read-write", ["edit"], id="read-write-div"),
+        pytest.param("div:read-only", ["noedit", "plain"], id="read-only-div"),
+    ],
+)
+def test_form_state_pseudo(selector: str, ids: list[str]) -> None:
+    assert _ids(_FORM, selector) == ids
+
+
+@pytest.mark.parametrize(
+    ("html", "selector", "ids"),
+    [
+        # an option disabled by its own attribute (not via an optgroup)
+        pytest.param(
+            "<div id=wrap><select><option id=t disabled>a</option></select></div>",
+            ":disabled",
+            ["t"],
+            id="option-own-disabled",
+        ),
+        # a disabled fieldset with no legend at all disables its controls
+        pytest.param(
+            "<div id=wrap><fieldset disabled><input id=t></fieldset></div>",
+            ":disabled",
+            ["fieldset", "t"],
+            id="disabled-fieldset-without-legend",
+        ),
+        # a disabled fieldset whose first child is not a legend still disables controls
+        pytest.param(
+            "<div id=wrap><fieldset disabled><p></p><legend></legend><input id=t></fieldset></div>",
+            ":disabled",
+            ["fieldset", "t"],
+            id="disabled-fieldset-non-legend-first-child",
+        ),
+        # an option directly in a select (no optgroup) is not disabled by association
+        pytest.param(
+            "<div id=wrap><select><option id=o>a</option></select></div>",
+            ":disabled",
+            [],
+            id="option-directly-in-select-not-disabled",
+        ),
+        # a control inside a fieldset that is not disabled stays enabled
+        pytest.param(
+            "<div id=wrap><fieldset><input id=o></fieldset></div>",
+            ":disabled",
+            [],
+            id="control-in-enabled-fieldset",
+        ),
+        # a disabled textarea is not read-write
+        pytest.param(
+            "<div id=wrap><textarea id=t disabled></textarea></div>", ":read-write", [], id="disabled-textarea"
+        ),
+        # a valueless or empty type attribute defaults to text, so it is not :checked
+        pytest.param("<div id=wrap><input id=t type></div>", ":checked", [], id="input-valueless-type"),
+        pytest.param('<div id=wrap><input id=t type=""></div>', ":checked", [], id="input-empty-type"),
+        # an empty contenteditable value is the "true" state
+        pytest.param(
+            '<div id=wrap><div id=t contenteditable=""></div></div>',
+            ":read-write",
+            ["t"],
+            id="contenteditable-empty-is-true",
+        ),
+        # an invalid contenteditable value is ignored, so editability inherits from above
+        pytest.param(
+            "<div id=wrap><div contenteditable=true><span id=t contenteditable=maybe>x</span></div></div>",
+            ":read-write",
+            ["div", "t"],
+            id="contenteditable-invalid-value-inherits",
+        ),
+    ],
+)
+def test_form_state_pseudo_edge_cases(html: str, selector: str, ids: list[str]) -> None:
+    assert _ids(html, selector) == ids
+
+
+_LANGDIR = (
+    "<div id=wrap><p id=en lang=en-US><b id=enb>x</b></p><p id=fr lang=fr>y</p>"
+    '<p id=de lang="de">z</p><p id=none>n</p><p id=langless lang>q</p>'
+    "<div id=rtl dir=rtl><span id=rtlc>a</span></div><div id=ltr dir=ltr></div>"
+    "<div id=auto dir=auto></div><div id=bad dir=weird></div></div>"
+)
+
+
+@pytest.mark.parametrize(
+    ("selector", "ids"),
+    [
+        # :lang() filters by the nearest lang attribute with RFC 4647 basic filtering
+        pytest.param(":lang(en)", ["en", "enb"], id="lang-prefix-matches-subtag"),
+        pytest.param(":lang(en-US)", ["en", "enb"], id="lang-exact"),
+        pytest.param(":lang(fr)", ["fr"], id="lang-other"),
+        pytest.param(":lang(EN)", ["en", "enb"], id="lang-case-insensitive"),
+        pytest.param(":lang(*)", ["en", "enb", "fr", "de"], id="lang-wildcard-any-language"),
+        pytest.param(":lang(de, fr)", ["fr", "de"], id="lang-comma-list"),
+        pytest.param(':lang("en")', ["en", "enb"], id="lang-double-quoted-range"),
+        pytest.param(":lang('en')", ["en", "enb"], id="lang-single-quoted-range"),
+        pytest.param(':lang("en)', [], id="lang-unbalanced-quote-not-stripped"),
+        pytest.param(":lang(es)", [], id="lang-no-match"),
+        # a single-character range that is not the wildcard, and a valueless lang
+        # attribute (never matches) and an empty range token (matches nothing)
+        pytest.param(":lang(d)", [], id="lang-single-char-non-wildcard"),
+        pytest.param(":lang(,)", [], id="lang-empty-range-token"),
+        # whitespace around the argument and around each range token is trimmed
+        pytest.param(":lang(en )", ["en", "enb"], id="lang-trailing-whitespace"),
+        pytest.param(":lang(en , fr)", ["en", "enb", "fr"], id="lang-whitespace-before-comma"),
+        # :dir() resolves the nearest dir attribute; auto and unknown values do not match
+        pytest.param(":dir(rtl)", ["rtl", "rtlc"], id="dir-rtl-inherited"),
+        pytest.param(":dir(ltr)", ["ltr"], id="dir-ltr"),
+        pytest.param(":dir(foo)", [], id="dir-unknown-keyword-never-matches"),
+    ],
+)
+def test_lang_dir_pseudo(selector: str, ids: list[str]) -> None:
+    assert _ids(_LANGDIR, selector) == ids
+
+
+_SCOPE_DOC = "<section id=s><p id=p1>a</p><div><p id=p2>b</p></div></section><p id=p3>c</p>"
+
+
+@pytest.mark.parametrize(
+    ("selector", "ids"),
+    [
+        pytest.param(":scope > p", ["p1"], id="scope-child"),
+        pytest.param(":scope p", ["p1", "p2"], id="scope-descendant"),
+        pytest.param(":scope", [], id="scope-excludes-the-origin-itself"),
+    ],
+)
+def test_scope_pseudo_in_select(selector: str, ids: list[str]) -> None:
+    assert _ids(_SCOPE_DOC, selector, root="#s") == ids
+
+
+def test_scope_pseudo_in_matches_and_closest() -> None:
+    # :scope is the contextual reference element, which for matches()/closest() is the
+    # receiver, so every element matches :scope and closest() resolves to itself
+    section = parse(_SCOPE_DOC).select_one("#s")
+    assert section is not None
+    assert section.matches(":scope")
+    nested = parse(_SCOPE_DOC).select_one("#p2")
+    assert nested is not None
+    assert nested.matches(":scope")
+    closest = nested.closest(":scope")  # the receiver, not an ancestor under test
+    assert closest is not None
+    assert closest.attrs.get("id") == "p2"
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        pytest.param(":hover", id="hover"),
+        pytest.param(":focus", id="focus"),
+        pytest.param(":focus-within", id="focus-within"),
+        pytest.param(":active", id="active"),
+        pytest.param(":target", id="target"),
+        pytest.param(":visited", id="visited"),
+        pytest.param(":link", id="link"),
+        pytest.param(":any-link", id="any-link"),
+    ],
+)
+def test_live_state_pseudo_never_matches(selector: str) -> None:
+    # accepted as valid syntax, but a static tree holds no live UA state
+    assert [element.tag for element in parse("<a href='/x'>y</a><input>").select(selector)] == []
+
+
 @pytest.mark.parametrize(
     "selector",
     [
@@ -482,6 +706,19 @@ def test_has_skips_non_element_following_sibling() -> None:
         pytest.param(":nth-child(2n", id="anb-eof-after-n"),
         pytest.param(":nth-child.x", id="functional-without-paren"),
         pytest.param(":nth-child(2n x)", id="anb-trailing-junk"),
+        # state pseudo-classes: non-functional ones reject an argument list, and
+        # :lang()/:dir() require a non-empty argument
+        pytest.param(":checked(x)", id="state-pseudo-with-args"),
+        pytest.param(":scope(x)", id="scope-with-args"),
+        pytest.param(":lang", id="lang-without-args"),
+        pytest.param(":lang()", id="lang-empty-args"),
+        pytest.param(":lang(  )", id="lang-whitespace-args"),
+        pytest.param(":lang(en", id="lang-unterminated"),
+        pytest.param(":dir", id="dir-without-args"),
+        pytest.param(":dir.x", id="dir-name-then-non-paren"),
+        pytest.param(":dir()", id="dir-empty-args"),
+        pytest.param(":dir(ltr", id="dir-unterminated"),
+        pytest.param(":dir(ltr x)", id="dir-junk-after-arg"),
     ],
 )
 def test_invalid_selectors_raise(selector: str) -> None:


### PR DESCRIPTION
The CSS matcher raised `ValueError` on every Selectors-4 pseudo-class beyond the structural and functional sets. This adds the ones a static tree can decide from attributes and structure, and stops raising on the ones it cannot. 🎯

Supported now: the form-state pseudo-classes — `:checked`, `:enabled`/`:disabled` (honoring a disabled `<fieldset>`, its first-`<legend>` exception, and a disabled `<optgroup>`), `:required`/`:optional`, `:read-only`/`:read-write` (including `contenteditable` editing hosts), and `:default` — plus `:scope` (the element the query runs on), `:lang()` (RFC 4647 basic filtering, so `:lang(en)` matches `en-US`), and `:dir(ltr|rtl)`. The live user-interaction set (`:hover`, `:focus`, `:focus-within`, `:active`, `:target`, `:visited`, `:link`, `:any-link`) now parses as valid and resolves to a no-op, since a static document holds no such state.

`:scope` needs the element the query was invoked on, so the per-call `quirks`/`tree` threading is consolidated into a single `sel_match_ctx` that also carries the origin; `select`/`select_one`/`matches` build it from the receiver, and `closest` anchors `:scope` to the receiver rather than each ancestor under test. The form-control checks fold the namespace test into a single `sel_html_atom` lookup so each is one compare, and membership sets are array+loops (not chained `||`) to keep branch coverage stable across clang and gcc.

closes #178