### PR TITLE
✨ feat(select): support :nth-child(An+B of S) selector lists

### DIFF
--- a/docs/changelog/175.feature.rst
+++ b/docs/changelog/175.feature.rst
@@ -1,0 +1,7 @@
+Support the Selectors Level 4 ``of S`` clause on ``:nth-child()`` and ``:nth-last-child()`` (§13.3.1) in
+:meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and
+:meth:`~turbohtml.Node.closest`, instead of rejecting it as invalid. ``:nth-child(An+B of S)`` now counts only the
+inclusive siblings that match the selector list ``S`` -- so ``li:nth-child(2n of .x)`` indexes the ``.x`` items rather
+than every ``li`` -- and an element that does not itself match ``S`` is never selected. The ``of`` keyword is rejected
+on the ``-of-type`` variants, which the grammar does not allow it on, and matching follows the spec and browsers
+(soupsieve's ``of S`` handling is incorrect).

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -189,7 +189,8 @@ The query surface builds on that node model. Navigation covers parents, siblings
 node's children. :meth:`~turbohtml.Node.find` and :meth:`~turbohtml.Node.find_all` filter a chosen
 :class:`~turbohtml.Axis` by tag and attributes, where a filter is a string, regex, callable, or list.
 :meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.select_one` run a native CSS matcher -- type, id, class,
-attribute, the four combinators, the ``:is()``/``:where()``/``:has()``/``:not()`` functional pseudo-classes, and the
+attribute, the four combinators, the structural pseudo-classes (including ``:nth-child(An+B of S)``, which indexes only
+the siblings matching ``S``), the ``:is()``/``:where()``/``:has()``/``:not()`` functional pseudo-classes, and the
 ``:scope``, form/UI (``:checked``, ``:disabled``, ``:default``, ...), ``:lang()`` and ``:dir()`` pseudo-classes that a
 static tree can determine -- and :meth:`~turbohtml.Node.matches` / :meth:`~turbohtml.Node.closest` test a node in place.
 ``:is()`` and ``:where()`` parse their argument as a forgiving selector list (a bad arm is dropped, the rest stay

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -334,8 +334,9 @@ node kind and unpacks the defining field (``tag`` for an :class:`~turbohtml.Elem
 :meth:`~turbohtml.Node.select_one` returns the first or ``None``. The matcher covers type, ``#id``, ``.class``, and
 attribute selectors with the ``=``, ``~=``, ``|=``, ``^=``, ``$=``, ``*=`` operators, the tree-structural pseudo-classes
 (``:root``, ``:empty``, ``:first-child``, ``:last-child``, ``:only-child``, their ``-of-type`` variants, and the
-``:nth-child()`` family with the ``An+B`` microsyntax), joined by the descendant, child (``>``), adjacent (``+``), and
-general-sibling (``~``) combinators, with comma groups:
+``:nth-child()`` family with the ``An+B`` microsyntax, and the Level-4 ``of S`` clause that filters the sibling list by
+a selector), joined by the descendant, child (``>``), adjacent (``+``), and general-sibling (``~``) combinators, with
+comma groups:
 
 .. testcode::
 
@@ -350,6 +351,21 @@ general-sibling (``~``) combinators, with comma groups:
     ['a']
     b
     ['a']
+
+``:nth-child(An+B of S)`` counts only the inclusive siblings that match the selector list ``S``, so ``An+B`` indexes
+that filtered subset rather than every sibling -- here the second ``.row`` item, skipping the separator between them:
+
+.. testcode::
+
+    table = turbohtml.parse(
+        "<ul><li class=row>a</li><li class=sep>-</li>"
+        "<li class=row>b</li><li class=row>c</li></ul>"
+    )
+    print([li.text for li in table.select("li:nth-child(2 of .row)")])
+
+.. testoutput::
+
+    ['b']
 
 The Selectors Level 4 functional pseudo-classes are supported too: ``:is()`` and ``:where()`` match an element against a
 nested selector list (they differ only in specificity, which a tree matcher ignores), ``:has()`` keeps an element when a

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -235,6 +235,18 @@ one alternative does not break the query:
 
     ['h1']
 
+Structural pseudo-classes count positions, and ``:nth-child(An+B of S)`` counts only the siblings matching ``S`` -- here
+the first checked box, ignoring the unchecked ones in between:
+
+.. testcode::
+
+    boxes = turbohtml.parse("<p><input checked><input><input checked></p>")
+    print([e.attrs.get("checked") for e in boxes.select("input:nth-child(1 of [checked])")])
+
+.. testoutput::
+
+    ['']
+
 Because the node types are a sealed hierarchy, structural pattern matching works: each subtype unpacks its defining
 field:
 

--- a/src/turbohtml/selector.h
+++ b/src/turbohtml/selector.h
@@ -591,6 +591,22 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
         if (parser->error) {
             return;
         }
+        /* the Level-4 'of S' clause filters the sibling list by a selector; it is
+           valid only on :nth-child()/:nth-last-child(), not the -of-type variants */
+        if (parser->pos < parser->len && sel_is_ident(parser->src[parser->pos])) {
+            /* the leading character is an identifier char, so sel_ident reads a
+               non-empty run and cannot fail here */
+            const Py_UCS4 *kw;
+            Py_ssize_t kw_len;
+            sel_ident(parser, &kw, &kw_len);
+            if (!sel_kw(kw, kw_len, "of") || (functional != PSEUDO_NTH_CHILD && functional != PSEUDO_NTH_LAST_CHILD)) {
+                parser->error = 1;
+                return;
+            }
+            /* S is a real (non-forgiving) complex-selector-list; this consumes the ')' */
+            sel_parse_alts(parser, &simple->sub, &simple->sub_count, 1, 0, 0);
+            return;
+        }
         if (parser->pos >= parser->len || parser->src[parser->pos] != ')') {
             parser->error = 1;
             return;
@@ -1081,6 +1097,23 @@ static int sel_sibling_index(th_node *node, int from_end, int of_type) {
     return index;
 }
 
+/* The 1-based position of node among its inclusive siblings that match the
+   :nth-child(... of S) selector list (from the end when from_end), or 0 when node
+   itself does not match S, so a non-matching element is never selected. */
+static int sel_nth_of_index(th_node *node, int from_end, const sel_simple *simple, const sel_ctx *ctx) {
+    if (!sel_matches_alts(node, simple->sub, simple->sub_count, ctx)) {
+        return 0;
+    }
+    int index = 1;
+    for (th_node *sibling = from_end ? node->next_sibling : node->prev_sibling; sibling != NULL;
+         sibling = from_end ? sibling->next_sibling : sibling->prev_sibling) {
+        if (sibling->type == TH_NODE_ELEMENT && sel_matches_alts(sibling, simple->sub, simple->sub_count, ctx)) {
+            index++;
+        }
+    }
+    return index;
+}
+
 /* Whether a 1-based index satisfies An+B for some non-negative n. */
 static int sel_nth_matches(int a, int b, int index) {
     if (a == 0) {
@@ -1451,8 +1484,16 @@ static int sel_match_pseudo(th_node *node, const sel_simple *simple, const sel_c
     case PSEUDO_ONLY_OF_TYPE:
         return sel_no_sibling(node, 0, 1) && sel_no_sibling(node, 1, 1);
     case PSEUDO_NTH_CHILD:
+        if (simple->sub != NULL) {
+            int of_index = sel_nth_of_index(node, 0, simple, ctx);
+            return of_index != 0 && sel_nth_matches(simple->nth_a, simple->nth_b, of_index);
+        }
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 0, 0));
     case PSEUDO_NTH_LAST_CHILD:
+        if (simple->sub != NULL) {
+            int of_index = sel_nth_of_index(node, 1, simple, ctx);
+            return of_index != 0 && sel_nth_matches(simple->nth_a, simple->nth_b, of_index);
+        }
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 1, 0));
     case PSEUDO_NTH_OF_TYPE:
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 0, 1));

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -638,8 +638,9 @@ static PyObject *node_css_closest(PyObject *self, PyObject *arg);
 PyDoc_STRVAR(select_doc, "select(selector, /)\n--\n\n"
                          "Return the list of descendant Elements matching the CSS selector, in\n"
                          "document order. The selector grammar covers type, #id, .class, and\n"
-                         "attribute selectors, the four combinators, the structural pseudo-classes,\n"
-                         "the :is(), :where(), :has(), and :not() functional pseudo-classes, and the\n"
+                         "attribute selectors, the four combinators, the structural pseudo-classes\n"
+                         "(including :nth-child(An+B of S)), the :is(), :where(), :has(), and :not()\n"
+                         "functional pseudo-classes, and the\n"
                          ":scope, form/UI, :lang() and :dir() pseudo-classes a static tree can\n"
                          "determine; live-state pseudo-classes (:hover, :focus, ...) match nothing.\n"
                          ":is() and :where() take a forgiving list, so a bad arm is dropped.");

--- a/tests/test_tree_select.py
+++ b/tests/test_tree_select.py
@@ -251,6 +251,40 @@ def test_structural_pseudo_by_text(selector: str, texts: list[str]) -> None:
     assert [element.text for element in parse(_PSEUDO).select(selector)] == texts
 
 
+# a list whose items alternate a class, so An+B applies to the .x-matching subset
+_NTH_OF = "<ul><li class=x>1</li><li>2</li><li class=x>3</li><li>4</li><li class=x>5</li></ul>"
+
+
+@pytest.mark.parametrize(
+    ("selector", "texts"),
+    [
+        # An+B counts only the inclusive siblings matching S (here .x items 1, 3, 5)
+        pytest.param("li:nth-child(1 of .x)", ["1"], id="nth-of-first"),
+        pytest.param("li:nth-child(2n of .x)", ["3"], id="nth-of-even"),
+        pytest.param("li:nth-child(odd of .x)", ["1", "5"], id="nth-of-odd"),
+        pytest.param("li:nth-child(2 of .x)", ["3"], id="nth-of-second"),
+        pytest.param("li:nth-child(-n+2 of .x)", ["1", "3"], id="nth-of-negative-a"),
+        # the of-list filters from the end for :nth-last-child()
+        pytest.param("li:nth-last-child(1 of .x)", ["5"], id="nth-last-of-first"),
+        pytest.param("li:nth-last-child(2 of .x)", ["3"], id="nth-last-of-second"),
+        # S may be a type selector or a compound, and folds 'of' case
+        pytest.param("li:nth-child(2 of li)", ["2"], id="nth-of-type-selector"),
+        pytest.param("li:nth-child(1 of li.x)", ["1"], id="nth-of-compound"),
+        pytest.param("li:NTH-CHILD(1 OF .x)", ["1"], id="nth-of-uppercase"),
+        # an element that does not match S is never selected
+        pytest.param("li:nth-child(1 of .missing)", [], id="nth-of-no-match"),
+    ],
+)
+def test_nth_child_of_selector(selector: str, texts: list[str]) -> None:
+    assert [element.text for element in parse(_NTH_OF).select(selector)] == texts
+
+
+def test_nth_child_of_skips_non_element_siblings() -> None:
+    # a comment between two .x items must not count toward the of-list index
+    doc = "<ul><li class=x>1</li><!--c--><li class=x>2</li></ul>"
+    assert [element.text for element in parse(doc).select("li:nth-child(2 of .x)")] == ["2"]
+
+
 @pytest.mark.parametrize(
     ("selector", "tags"),
     [
@@ -503,6 +537,15 @@ def test_has_skips_non_element_following_sibling() -> None:
         pytest.param(":nth-child(2n", id="anb-eof-after-n"),
         pytest.param(":nth-child.x", id="functional-without-paren"),
         pytest.param(":nth-child(2n x)", id="anb-trailing-junk"),
+        pytest.param(":nth-child(2n*)", id="anb-non-ident-junk"),
+        # the Level-4 'of S' clause: a non-'of' keyword, an empty or unterminated S,
+        # a missing An+B, or 'of' on a pseudo-class that does not take it
+        pytest.param(":nth-child(2n ofx)", id="nth-of-not-of-keyword"),
+        pytest.param(":nth-child(2n of )", id="nth-of-empty-selector"),
+        pytest.param(":nth-child(2n of .x", id="nth-of-unterminated"),
+        pytest.param(":nth-child(of .x)", id="nth-of-without-anb"),
+        pytest.param(":nth-of-type(2n of .x)", id="nth-of-type-rejects-of"),
+        pytest.param(":nth-last-of-type(1 of p)", id="nth-last-of-type-rejects-of"),
     ],
 )
 def test_invalid_selectors_raise(selector: str) -> None:


### PR DESCRIPTION
`:nth-child()` and `:nth-last-child()` accepted the `An+B` microsyntax but rejected the Level-4 `of S` clause that widens it, so `select()` raised on `li:nth-child(2n of .x)` and similar. 🚫

After parsing `An+B`, an optional `of` keyword now introduces a `<complex-selector-list>` `S`, stored on the simple selector's nested-list slot. ✨ Matching counts only the inclusive siblings that match `S` and applies `An+B` to that filtered index, and an element that does not itself match `S` is never selected — so `li:nth-child(2n of .x)` indexes the `.x` items rather than every `li`. The `of` keyword is rejected on the `-of-type` variants, which the grammar does not allow it on.

Matching follows the spec and browsers. soupsieve's `of S` handling is incorrect (for example `:nth-child(1 of .x)` returns every `.x` rather than just the first), so it is not the reference for this behavior. Available through `select`, `select_one`, `matches`, and `closest`.

closes #175