### PR TITLE
✨ feat(compat): html.parser-compatible callback adapter

### DIFF
--- a/docs/changelog/181.feature.rst
+++ b/docs/changelog/181.feature.rst
@@ -1,0 +1,9 @@
+Add :class:`turbohtml.html_parser.HTMLParser`, a drop-in base class for :class:`python:html.parser.HTMLParser`
+subclasses over the streaming tokenizer. It keeps the standard ``handle_starttag``/``handle_startendtag``/
+``handle_endtag``/``handle_data``/``handle_comment``/``handle_decl`` callbacks and the ``feed``/``close``/``reset``/
+``getpos`` methods, so an ``HTMLParser`` subclass migrates by changing its import and base class. Being
+WHATWG-conformant it differs from the standard library only where the standard library does: character references are
+always resolved (so ``handle_entityref``/``handle_charref`` never fire), and a processing instruction or CDATA section
+reaches ``handle_comment`` rather than ``handle_pi``/``unknown_decl``, because the HTML spec treats both as comments.
+The adapter is a Python-layer convenience over the existing token stream, kept out of the core API so the
+one-name-per-concept surface stays bounded.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -128,7 +128,9 @@ Two decisions bound the tokenizer's scope:
 
 Where behavior could drift, more than the suite pins it: a fuzz comparison runs the token stream against html5lib's
 tokenizer, and source positions use the same 1-based-line, 0-based-column convention as :mod:`python:html.parser`, so
-diagnostics line up with what the standard library reports.
+diagnostics line up with what the standard library reports. For code that prefers callbacks to a token stream,
+:class:`turbohtml.html_parser.HTMLParser` re-exposes the stream through ``html.parser``'s subclass-and-override surface,
+so an existing ``HTMLParser`` subclass migrates by swapping its base class.
 
 ****************************
  Tokenizing at native width

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -84,6 +84,37 @@ Unescaping follows the HTML5 rules, including longest-match for references that 
  Migrate from html.parser
 **************************
 
+The quickest port keeps your subclass: :class:`turbohtml.html_parser.HTMLParser` is a drop-in base class with the same
+``handle_*`` callbacks and ``feed``/``close`` methods, over the WHATWG-conformant tokenizer. Change the import and the
+base class and the handlers fire as before:
+
+.. testcode::
+
+    from turbohtml.html_parser import HTMLParser
+
+    class LinkCollector(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.links = []
+
+        def handle_starttag(self, tag, attrs):
+            if tag == "a":
+                self.links += [v for n, v in attrs if n == "href" and v]
+
+    collector = LinkCollector()
+    collector.feed('<a href="/x">x</a> <a href="/y">y</a>')
+    collector.close()
+    print(collector.links)
+
+.. testoutput::
+
+    ['/x', '/y']
+
+It differs from ``html.parser`` only where ``html.parser`` diverges from the WHATWG algorithm: references are always
+resolved (so ``handle_entityref``/``handle_charref`` never fire), and a processing instruction or CDATA section reaches
+``handle_comment`` rather than ``handle_pi``/``unknown_decl``, because the HTML spec treats both as comments.
+
+If you would rather drop the subclass entirely, turbohtml also exposes the raw token stream.
 :class:`python:html.parser.HTMLParser` is callback-driven: you subclass it and override a handler per event. turbohtml
 inverts that into a token stream you iterate, which removes the subclass, the mutable handler state, and the
 per-callback Python call overhead. A typical parser:

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -339,10 +339,11 @@ Pitfalls
     True
     True
 
-In place of subclassing :class:`python:html.parser.HTMLParser` with ``handle_starttag`` and ``handle_data`` callbacks,
-take the token stream from :func:`turbohtml.tokenize` (or :meth:`turbohtml.Tokenizer.feed` for incremental input), or
-skip tokens entirely and :func:`turbohtml.parse` straight to a tree. Unlike ``html.parser``, both are WHATWG-conformant.
-The :doc:`how-to` guide has a worked port.
+To keep an existing :class:`python:html.parser.HTMLParser` subclass, swap its base class for
+:class:`turbohtml.html_parser.HTMLParser`: the same ``handle_*`` callbacks and ``feed``/``close`` methods run over the
+WHATWG-conformant tokenizer. Or drop the subclass and take the token stream from :func:`turbohtml.tokenize` (or
+:meth:`turbohtml.Tokenizer.feed` for incremental input), or skip tokens entirely and :func:`turbohtml.parse` straight to
+a tree. All three are WHATWG-conformant, unlike ``html.parser``. The :doc:`how-to` guide has a worked port.
 
 *****************
  From markupsafe

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -87,3 +87,15 @@ A drop-in for ``bleach.clean`` for projects migrating off bleach. It translates 
 an event handler or a ``javascript:`` URL.
 
 .. autofunction:: clean
+
+***********************
+ turbohtml.html_parser
+***********************
+
+.. module:: turbohtml.html_parser
+
+A drop-in base class for :class:`python:html.parser.HTMLParser` subclasses, over turbohtml's WHATWG-conformant
+tokenizer. Subclass it, override the ``handle_*`` methods, and feed input incrementally as with the standard library.
+
+.. autoclass:: HTMLParser
+    :members:

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -113,9 +113,10 @@ remains:
     ['span']
     []
 
-The incomplete ``<sp`` stayed buffered until the rest of the tag arrived. That is the whole tokenizer API. Head to the
-:doc:`how-to` guides for task-focused recipes, including porting an existing :class:`python:html.parser.HTMLParser`
-subclass, or the :doc:`reference` for the exact signatures.
+The incomplete ``<sp`` stayed buffered until the rest of the tag arrived. That is the whole tokenizer API. If you are
+porting an existing :class:`python:html.parser.HTMLParser` subclass, :class:`turbohtml.html_parser.HTMLParser` keeps the
+same ``handle_*`` callbacks over this tokenizer, so the migration is changing the base class. Head to the :doc:`how-to`
+guides for task-focused recipes or the :doc:`reference` for the exact signatures.
 
 ********************************
  Parsing a document into a tree

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,7 @@ py.install_sources(
         'src/turbohtml/__init__.py',
         'src/turbohtml/_html.pyi',
         'src/turbohtml/bleach_compat.py',
+        'src/turbohtml/html_parser.py',
         'src/turbohtml/linkify.py',
         'src/turbohtml/markup.py',
         'src/turbohtml/sanitizer.py',

--- a/src/turbohtml/html_parser.py
+++ b/src/turbohtml/html_parser.py
@@ -1,0 +1,130 @@
+"""
+An :class:`python:html.parser.HTMLParser`-shaped adapter over the streaming tokenizer.
+
+A drop-in base class for the many ``HTMLParser`` subclasses in the wild: subclass it, override the ``handle_*`` methods,
+and call :meth:`~HTMLParser.feed`/:meth:`~HTMLParser.close` incrementally, exactly as with the standard library, but
+over turbohtml's WHATWG-conformant tokenizer. Migrating is changing the import and the base class.
+
+It is kept apart from the core API (which exposes the token stream and the tree directly) so the drop-in surface stays
+bounded. It differs from the standard library only where the standard library diverges from the WHATWG algorithm
+browsers run:
+
+- Character references are always resolved (as ``convert_charrefs=True``), so :meth:`~HTMLParser.handle_data` receives
+  decoded text and :meth:`~HTMLParser.handle_entityref`/:meth:`~HTMLParser.handle_charref` are never called. The
+  ``convert_charrefs`` argument is accepted for signature compatibility but has no effect.
+- A processing instruction (``<?...>``) and a CDATA section outside foreign content are comments per the HTML spec, so
+  they reach :meth:`~HTMLParser.handle_comment`; :meth:`~HTMLParser.handle_pi` and :meth:`~HTMLParser.unknown_decl` are
+  never called.
+- A valueless attribute's value is the empty string rather than ``None`` (the tokenizer does not tell ``disabled``
+  apart from ``disabled=""``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from ._html import Tokenizer, TokenType
+
+if TYPE_CHECKING:
+    from ._html import Token
+
+__all__ = ["HTMLParser"]
+
+
+class HTMLParser:
+    """A subclass-and-override callback parser over the streaming tokenizer."""
+
+    def __init__(self, *, convert_charrefs: bool = True) -> None:
+        """Create a parser; ``convert_charrefs`` is accepted for compatibility but always behaves as true."""
+        #: Accepted for compatibility; references are always resolved regardless of its value.
+        self.convert_charrefs = convert_charrefs
+        self._tokenizer = Tokenizer()
+        self._lineno = 1
+        self._offset = 0
+
+    def feed(self, data: str) -> None:
+        """Feed a chunk of HTML, dispatching the tokens it completes to the handlers."""
+        for token in self._tokenizer.feed(data):
+            self._dispatch(token)
+
+    def close(self) -> None:
+        """Signal end of input, dispatching any tokens still buffered."""
+        for token in self._tokenizer.close():
+            self._dispatch(token)
+
+    def reset(self) -> None:
+        """Discard the buffered input and position, ready to parse a new document."""
+        self._tokenizer.reset()
+        self._lineno = 1
+        self._offset = 0
+
+    def getpos(self) -> tuple[int, int]:
+        """Return the 1-based line and 0-based column of the token last dispatched."""
+        return (self._lineno, self._offset)
+
+    def _dispatch(self, token: Token) -> None:
+        # the token type guarantees the relevant fields are present, which the Token
+        # API (where every field is optional) cannot express, so they are narrowed here
+        self._lineno = token.line
+        self._offset = token.col
+        kind = token.type
+        if kind is TokenType.START_TAG:
+            tag = cast("str", token.tag)
+            attrs = cast("list[tuple[str, str | None]]", token.attrs or [])
+            if token.self_closing:
+                self.handle_startendtag(tag, attrs)
+            else:
+                self.handle_starttag(tag, attrs)
+        elif kind is TokenType.END_TAG:
+            self.handle_endtag(cast("str", token.tag))
+        elif kind is TokenType.TEXT:
+            self.handle_data(cast("str", token.data))
+        elif kind is TokenType.COMMENT:
+            self.handle_comment(cast("str", token.data))
+        else:  # TokenType.DOCTYPE
+            self.handle_decl(_doctype_decl(token))
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """Handle a start tag; override to act on it."""
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """Handle a self-closing tag; by default fire start then end, like the standard library."""
+        self.handle_starttag(tag, attrs)
+        self.handle_endtag(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        """Handle an end tag; override to act on it."""
+
+    def handle_data(self, data: str) -> None:
+        """Handle a run of text, with character references resolved."""
+
+    def handle_comment(self, data: str) -> None:
+        """Handle a comment (also processing instructions and CDATA, which are comments here)."""
+
+    def handle_decl(self, decl: str) -> None:
+        """Handle a ``<!DOCTYPE ...>`` declaration, with the leading ``<!`` and trailing ``>`` removed."""
+
+    def handle_pi(self, data: str) -> None:
+        """Handle a processing instruction; never called, since PIs are comments in the HTML spec."""
+
+    def handle_entityref(self, name: str) -> None:
+        """Handle a named reference; never called, since references are always resolved."""
+
+    def handle_charref(self, name: str) -> None:
+        """Handle a numeric reference; never called, since references are always resolved."""
+
+    def unknown_decl(self, data: str) -> None:
+        """Handle a CDATA section; never called, since it is a comment outside foreign content."""
+
+
+def _doctype_decl(token: Token) -> str:
+    parts = ["DOCTYPE"]
+    if token.name:
+        parts.append(token.name)
+    if token.public_id is not None:
+        parts.append(f'PUBLIC "{token.public_id}"')
+        if token.system_id is not None:
+            parts.append(f'"{token.system_id}"')
+    elif token.system_id is not None:
+        parts.append(f'SYSTEM "{token.system_id}"')
+    return " ".join(parts)

--- a/tests/test_html_parser.py
+++ b/tests/test_html_parser.py
@@ -1,0 +1,165 @@
+"""The html.parser-compatible callback adapter over the streaming tokenizer."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml.html_parser import HTMLParser
+
+
+class _Recorder(HTMLParser):
+    """Records every callback as a tuple, for asserting the dispatched event stream."""
+
+    def __init__(self, *, convert_charrefs: bool = True) -> None:
+        super().__init__(convert_charrefs=convert_charrefs)
+        self.events: list[tuple[object, ...]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.events.append(("start", tag, attrs))
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.events.append(("startend", tag, attrs))
+
+    def handle_endtag(self, tag: str) -> None:
+        self.events.append(("end", tag))
+
+    def handle_data(self, data: str) -> None:
+        self.events.append(("data", data))
+
+    def handle_comment(self, data: str) -> None:
+        self.events.append(("comment", data))
+
+    def handle_decl(self, decl: str) -> None:
+        self.events.append(("decl", decl))
+
+
+def _events(html: str) -> list[tuple[object, ...]]:
+    parser = _Recorder()
+    parser.feed(html)
+    parser.close()
+    return parser.events
+
+
+@pytest.mark.parametrize(
+    ("html", "events"),
+    [
+        pytest.param("<p>", [("start", "p", [])], id="start-tag"),
+        pytest.param('<p class="x" id=y>', [("start", "p", [("class", "x"), ("id", "y")])], id="start-tag-attrs"),
+        pytest.param("</p>", [("end", "p")], id="end-tag"),
+        pytest.param("<br/>", [("startend", "br", [])], id="self-closing"),
+        pytest.param("text", [("data", "text")], id="text"),
+        pytest.param("<!--c-->", [("comment", "c")], id="comment"),
+        pytest.param("<!doctype html>", [("decl", "DOCTYPE html")], id="doctype"),
+        # references are resolved into the text, so handle_data sees decoded characters
+        pytest.param("a &amp; b &#9731;", [("data", "a & b ☃")], id="charrefs-decoded"),
+        # a valueless attribute's value is the empty string, not None
+        pytest.param("<input disabled>", [("start", "input", [("disabled", "")])], id="valueless-attr"),
+        # processing instructions and CDATA are comments per the HTML spec
+        pytest.param("<?proc?>", [("comment", "?proc?")], id="processing-instruction-is-comment"),
+        pytest.param("<![CDATA[x]]>", [("comment", "[CDATA[x]]")], id="cdata-is-comment"),
+    ],
+)
+def test_dispatch(html: str, events: list[tuple[object, ...]]) -> None:
+    assert _events(html) == events
+
+
+@pytest.mark.parametrize(
+    ("html", "decl"),
+    [
+        pytest.param("<!doctype html>", "DOCTYPE html", id="name-only"),
+        pytest.param("<!doctype>", "DOCTYPE", id="no-name"),
+        pytest.param(
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD//EN" "http://x">',
+            'DOCTYPE html PUBLIC "-//W3C//DTD//EN" "http://x"',
+            id="public-and-system",
+        ),
+        pytest.param('<!DOCTYPE html PUBLIC "pub">', 'DOCTYPE html PUBLIC "pub"', id="public-only"),
+        pytest.param(
+            '<!DOCTYPE html SYSTEM "about:legacy-compat">',
+            'DOCTYPE html SYSTEM "about:legacy-compat"',
+            id="system-only",
+        ),
+    ],
+)
+def test_doctype_decl(html: str, decl: str) -> None:
+    assert _events(html) == [("decl", decl)]
+
+
+def test_full_document_event_stream() -> None:
+    html = "<!doctype html><p class=intro>Tom &amp; Jerry<br/><!--c--></p>"
+    assert _events(html) == [
+        ("decl", "DOCTYPE html"),
+        ("start", "p", [("class", "intro")]),
+        ("data", "Tom & Jerry"),
+        ("startend", "br", []),
+        ("comment", "c"),
+        ("end", "p"),
+    ]
+
+
+def test_incremental_feed_matches_one_shot() -> None:
+    chunks = ["<ul><li>on", "e<li>tw", "o</ul>"]
+    incremental = _Recorder()
+    for chunk in chunks:
+        incremental.feed(chunk)
+    incremental.close()
+    assert incremental.events == _events("".join(chunks))
+
+
+def test_default_startendtag_fires_start_then_end() -> None:
+    # the base handle_startendtag dispatches start then end, like the standard library
+    class StartEnd(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.events: list[tuple[object, ...]] = []
+
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            self.events.append(("start", tag, attrs))
+
+        def handle_endtag(self, tag: str) -> None:
+            self.events.append(("end", tag))
+
+    parser = StartEnd()
+    parser.feed("<br/>")
+    parser.close()
+    assert parser.events == [("start", "br", []), ("end", "br")]
+
+
+def test_default_handlers_are_no_ops() -> None:
+    # the base class ignores every token without raising
+    parser = HTMLParser()
+    parser.feed("<!doctype html><p>x &amp; y<br/><!--c--></p><?pi?>")
+    parser.close()
+    # the never-called compatibility hooks exist and accept their argument
+    parser.handle_pi("x")
+    parser.handle_entityref("amp")
+    parser.handle_charref("9731")
+    parser.unknown_decl("CDATA[x]")
+
+
+def test_reset_clears_buffer_and_position() -> None:
+    parser = _Recorder()
+    parser.feed("<div incomplete")  # an unfinished tag stays buffered, dispatching nothing
+    parser.reset()
+    assert parser.getpos() == (1, 0)
+    assert parser.events == []
+    parser.feed("<p>x</p>")
+    parser.close()
+    assert parser.events == [("start", "p", []), ("data", "x"), ("end", "p")]
+
+
+def test_getpos_tracks_the_last_token() -> None:
+    parser = _Recorder()
+    parser.feed("<p>\n<a>")
+    line, col = parser.getpos()
+    assert line == 2
+    assert col >= 0
+
+
+def test_convert_charrefs_argument_is_accepted_but_inert() -> None:
+    # the argument is kept for signature compatibility; references decode either way
+    parser = _Recorder(convert_charrefs=False)
+    assert parser.convert_charrefs is False
+    parser.feed("a &amp; b")
+    parser.close()
+    assert parser.events == [("data", "a & b")]


### PR DESCRIPTION
The streaming `Tokenizer` already produces exactly the token stream an `HTMLParser` subclass needs, but turbohtml exposed no subclass-and-override callback surface, so an `html.parser.HTMLParser` subclass could not migrate by swapping its base class. 🔌

This adds `turbohtml.html_parser.HTMLParser`, a thin adapter that dispatches each token to the standard `handle_starttag`/`handle_startendtag`/`handle_endtag`/`handle_data`/`handle_comment`/`handle_decl` callbacks and supports incremental `feed()`/`close()`/`reset()`/`getpos()`. ✨ A typical migration is changing the import and the base class. It is a Python-layer convenience over the existing token stream, kept out of the core API so the one-name-per-concept surface stays bounded.

Being WHATWG-conformant it differs from the standard library only where the standard library itself diverges from the algorithm browsers run: character references are always resolved (so `handle_entityref`/`handle_charref` never fire), and a processing instruction or CDATA section reaches `handle_comment` rather than `handle_pi`/`unknown_decl`, because the HTML spec treats both as comments. A valueless attribute's value is the empty string rather than `None`. These deltas are documented in the module, the how-to, and the migration guide.

closes #181