### PR TITLE
✨ feat(query): pyquery-style fluent chaining query API

### DIFF
--- a/docs/changelog/180.feature.rst
+++ b/docs/changelog/180.feature.rst
@@ -1,0 +1,10 @@
+Add :class:`turbohtml.query.Query`, a pyquery-style fluent, chainable query wrapper over the tree and selector engine,
+for code migrating off `pyquery <https://github.com/gawel/pyquery>`_'s jQuery-style chaining. A ``Query`` wraps an
+ordered, duplicate-free set of elements, and its traversal and mutation methods -- ``__call__``/``find``, ``filter``,
+``eq``, ``parent``, ``children``, ``siblings``, ``closest``, ``items``, ``attr``, ``text``, ``html``, ``has_class``,
+``add_class``, ``remove_class``, ``toggle_class`` -- each return a ``Query``, so calls compose. It is a Python-layer
+convenience over the existing tree and selector primitives, kept out of the core API so the chainable surface stays
+optional; the method names are turbohtml's own (``add_class`` rather than pyquery's ``addClass``), so a migration
+adjusts the spelling but keeps the structure. Because the wrapper delegates the real work to the C selector and
+attribute primitives -- and skips a redundant de-duplication when a chain starts from one node -- it runs roughly ten
+times faster than pyquery on the same chain (see the :doc:`performance` page).

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -205,8 +205,10 @@ in a quirks-mode document and compare exactly otherwise, as the Selectors standa
 :meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.xpath_one`, and :meth:`~turbohtml.Node.xpath_iter` evaluate XPath
 1.0 over the same model: a native-C engine compiles each expression once into an immutable, per-tree-cached program,
 resolves name tests to interned atoms, and collapses the ``//`` abbreviation to a single ``descendant`` walk, so the
-structural axes, predicates, operators, unions, and the core function library run at lxml's speed. Output runs back
-through :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and :meth:`~turbohtml.Node.encode`,
+structural axes, predicates, operators, unions, and the core function library run at lxml's speed. The core API stays
+one-name-per-concept and returns plain lists, so the jQuery-style chaining pyquery users expect lives in an optional
+Python-side wrapper, :class:`turbohtml.query.Query`, whose traversal and mutation methods each return a wrapper. Output
+runs back through :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and :meth:`~turbohtml.Node.encode`,
 WHATWG-conformant by default with the escaping selectable through :class:`~turbohtml.Formatter`.
 
 A :class:`~turbohtml.Minify` is a serialization mode on that same conformant tree, and its design rule is that the

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -504,6 +504,27 @@ match) or :meth:`~turbohtml.Node.closest` (the nearest matching self-or-ancestor
     True
     nav
 
+****************************
+ Chain queries like pyquery
+****************************
+
+For code migrating off pyquery's jQuery-style chaining, :class:`turbohtml.query.Query` wraps a set of elements and every
+traversal and mutation method returns a new wrapper, so calls compose. The method names are turbohtml's own (so
+``add_class`` rather than ``addClass``), but the structure carries over:
+
+.. testcode::
+
+    from turbohtml.query import Query
+
+    page = Query("<ul><li class=x>a</li><li>b</li><li class=x>c</li></ul>")
+    print(page("li").filter(".x").eq(0).add_class("first").attr("class"))
+    print(page("li").text())
+
+.. testoutput::
+
+    x first
+    a b c
+
 ******************
  Query with XPath
 ******************

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -9,7 +9,7 @@ source <https://github.com/whatwg/html/blob/main/source>`_, the `ECMAScript spec
 <https://github.com/tc39/ecma262>`_, and a size-weighted sample of `web-platform-tests
 <https://github.com/web-platform-tests/wpt>`_ pages. Reproduce any section with ``tox -e bench <suite>``, where the
 suite is one of ``escape``, ``unescape``, ``tokenize``, ``parse``, ``query``, ``xpath``, ``serialize``, ``build``,
-``edit``, ``markup``, ``linkify``, ``markdown``, or ``sanitize``. Numbers vary with input and hardware.
+``edit``, ``chain``, ``markup``, ``linkify``, ``markdown``, or ``sanitize``. Numbers vary with input and hardware.
 
 **********
  Escaping
@@ -675,3 +675,30 @@ selectolax mutation is limited, so it has no entry.
       - 18.4 µs
       - 40.9 µs
       - 215 µs
+
+*****************
+ Fluent chaining
+*****************
+
+A pyquery-style fluent chain over a pre-parsed tree: select every ``<a>``, keep the linked ones, take the first, tag it,
+and read its ``href`` (turbohtml's :class:`turbohtml.query.Query` against `pyquery <https://github.com/gawel/pyquery>`_,
+whose wrapper delegates to lxml). Both wrappers are thin Python over the underlying engine, so the gap is the engine's:
+turbohtml's selector and attribute primitives run in C, and the wrapper avoids a redundant de-duplication when the chain
+starts from one node, so it runs roughly ten times faster.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 28 36 36
+
+    - - select, filter, tag, read
+      - turbohtml
+      - pyquery
+    - - wpt page (4 kB)
+      - 0.9 µs
+      - 16.0 µs
+    - - wpt page (9.6 kB)
+      - 1.1 µs
+      - 16.5 µs
+    - - wpt page (92 kB)
+      - 21.2 µs
+      - 257 µs

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -99,3 +99,16 @@ tokenizer. Subclass it, override the ``handle_*`` methods, and feed input increm
 
 .. autoclass:: HTMLParser
     :members:
+
+*****************
+ turbohtml.query
+*****************
+
+.. module:: turbohtml.query
+
+A pyquery-style fluent, chainable query wrapper over the tree and selector engine, for code migrating off pyquery's
+jQuery-style chaining. Each traversal and mutation method returns a :class:`Query`, so calls compose.
+
+.. autoclass:: Query
+    :members:
+    :special-members: __call__

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -248,6 +248,9 @@ the first checked box, ignoring the unchecked ones in between:
 
     ['']
 
+If you are coming from pyquery's jQuery-style chaining, :class:`turbohtml.query.Query` wraps these primitives in a
+fluent, chainable surface where each call returns a new wrapper.
+
 Because the node types are a sealed hierarchy, structural pattern matching works: each subtype unpacks its defining
 field:
 

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ py.install_sources(
         'src/turbohtml/html_parser.py',
         'src/turbohtml/linkify.py',
         'src/turbohtml/markup.py',
+        'src/turbohtml/query.py',
         'src/turbohtml/sanitizer.py',
         'src/turbohtml/py.typed',
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ bench = [
   "minify-html>=0.15",
   "nh3>=0.2",
   "pyperf>=2.9",
+  "pyquery>=2",
   "resiliparse>=1.0.8",
   "selectolax>=0.3.30",
   "soupsieve>=2.8",

--- a/src/turbohtml/query.py
+++ b/src/turbohtml/query.py
@@ -1,0 +1,204 @@
+"""
+A pyquery-style fluent, chainable query wrapper over the tree and selector engine.
+
+A thin convenience over the core tree API for code migrating off `pyquery <https://github.com/gawel/pyquery>`_'s
+jQuery-style chaining. A :class:`Query` wraps an ordered, duplicate-free set of elements; the traversal and mutation
+methods each return a :class:`Query`, so calls compose:
+``Query(html)("div").find("a").filter(".x").eq(0).attr("href")``.
+
+It is kept out of the core API (which is one-name-per-concept and not chainable) so the chainable surface stays
+optional. The method names are turbohtml's own -- ``add_class`` rather than pyquery's ``addClass`` -- so a migration
+adjusts the spelling but keeps the structure.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast, overload
+
+from ._html import Document, Element, parse
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+__all__ = ["Query"]
+
+
+def _unique(elements: Iterable[Element]) -> list[Element]:
+    """
+    Return the elements in order, dropping any later duplicate.
+
+    A fresh wrapper is handed out on each tree access, so two wrappers of one node
+    are distinct objects; equality and hashing compare the underlying node, so a
+    set of the elements deduplicates by node identity.
+    """
+    seen: set[Element] = set()
+    out: list[Element] = []
+    for element in elements:
+        if element not in seen:
+            seen.add(element)
+            out.append(element)
+    return out
+
+
+def _class_list(element: Element) -> list[str]:
+    # the tree stores the class attribute tokenized as a list, or omits it (None)
+    value = element.attrs.get("class")
+    return list(value) if isinstance(value, list) else []
+
+
+class Query:  # noqa: PLR0904  # a fluent wrapper mirrors pyquery's broad chainable method set
+    """An ordered, duplicate-free set of elements with chainable traversal and mutation."""
+
+    def __init__(self, source: str | Element | Document | Iterable[Element]) -> None:
+        """Wrap HTML to parse, a single element or document, or an iterable of elements."""
+        if isinstance(source, str):
+            source = parse(source)
+        if isinstance(source, Document):
+            # a parsed document always has an <html> root, though the type admits None
+            self._nodes: list[Element] = [cast("Element", source.root)]
+        elif isinstance(source, Element):
+            self._nodes = [source]
+        else:
+            self._nodes = _unique(source)
+
+    @classmethod
+    def _wrap(cls, nodes: list[Element]) -> Query:
+        """Build a query around an already-unique, document-ordered node list, skipping the dedupe."""
+        query = cls.__new__(cls)
+        query._nodes = nodes  # noqa: SLF001  # a same-class factory setting its own private attribute
+        return query
+
+    def __call__(self, selector: str) -> Query:
+        """Select the descendants of the wrapped elements matching the selector (like ``find``)."""
+        return self.find(selector)
+
+    def find(self, selector: str) -> Query:
+        """Select every descendant of the wrapped elements matching the selector, in document order."""
+        if len(self._nodes) == 1:
+            # the C select() already returns unique results in document order
+            return Query._wrap(self._nodes[0].select(selector))
+        return Query(_unique(match for node in self._nodes for match in node.select(selector)))
+
+    def filter(self, selector: str) -> Query:
+        """Keep the wrapped elements that themselves match the selector."""
+        return Query([node for node in self._nodes if node.matches(selector)])
+
+    def eq(self, index: int) -> Query:
+        """Reduce the set to the element at the given index, or an empty set if it is out of range."""
+        try:
+            return Query([self._nodes[index]])
+        except IndexError:
+            return Query([])
+
+    def parent(self) -> Query:
+        """Select the immediate parent of each wrapped element."""
+        return Query(node.parent for node in self._nodes if isinstance(node.parent, Element))
+
+    def children(self, selector: str | None = None) -> Query:
+        """Select the element children of each wrapped element, optionally filtered by a selector."""
+        children = (child for node in self._nodes for child in node.children if isinstance(child, Element))
+        result = Query(children)
+        return result if selector is None else result.filter(selector)
+
+    def siblings(self, selector: str | None = None) -> Query:
+        """Select the sibling elements of each wrapped element, optionally filtered by a selector."""
+        result = Query(
+            sibling
+            for node in self._nodes
+            if isinstance(node.parent, Element)
+            for sibling in node.parent.children
+            if isinstance(sibling, Element) and sibling != node
+        )
+        return result if selector is None else result.filter(selector)
+
+    def closest(self, selector: str) -> Query:
+        """Select the nearest self-or-ancestor of each wrapped element matching the selector."""
+        return Query(found for node in self._nodes if (found := node.closest(selector)) is not None)
+
+    def items(self) -> Iterator[Query]:
+        """Iterate the wrapped elements, each as its own single-element query."""
+        for node in self._nodes:
+            yield Query([node])
+
+    @overload
+    def attr(self, name: str) -> str | None: ...
+    @overload
+    def attr(self, name: str, value: str) -> Query: ...
+    def attr(self, name: str, value: str | None = None) -> str | Query | None:
+        """Get the attribute from the first element, or set it on every element and return the query."""
+        if value is None:
+            if not self._nodes:
+                return None
+            current = self._nodes[0].attrs.get(name)
+            return " ".join(current) if isinstance(current, list) else current
+        for node in self._nodes:
+            node.attrs[name] = value
+        return self
+
+    @overload
+    def text(self) -> str: ...
+    @overload
+    def text(self, value: str) -> Query: ...
+    def text(self, value: str | None = None) -> str | Query:
+        """Get the combined text of every element, or set each element's text and return the query."""
+        if value is None:
+            return " ".join(node.text for node in self._nodes)
+        for node in self._nodes:
+            node.text = value
+        return self
+
+    def html(self) -> str | None:
+        """Return the inner HTML of the first element, or None when the set is empty."""
+        return self._nodes[0].inner_html if self._nodes else None
+
+    def has_class(self, name: str) -> bool:
+        """Return whether any wrapped element carries the class."""
+        return any(name in _class_list(node) for node in self._nodes)
+
+    def add_class(self, name: str) -> Query:
+        """Add the class to every wrapped element and return the query."""
+        for node in self._nodes:
+            classes = _class_list(node)
+            if name not in classes:
+                classes.append(name)
+                node.attrs["class"] = classes
+        return self
+
+    def remove_class(self, name: str) -> Query:
+        """Remove the class from every wrapped element and return the query."""
+        for node in self._nodes:
+            classes = _class_list(node)
+            if name in classes:
+                node.attrs["class"] = [cls for cls in classes if cls != name]
+        return self
+
+    def toggle_class(self, name: str) -> Query:
+        """Add the class where it is absent and remove it where present, per element."""
+        for node in self._nodes:
+            classes = _class_list(node)
+            node.attrs["class"] = [cls for cls in classes if cls != name] if name in classes else [*classes, name]
+        return self
+
+    def __iter__(self) -> Iterator[Element]:
+        """Iterate the wrapped elements."""
+        return iter(self._nodes)
+
+    def __len__(self) -> int:
+        """Return the number of wrapped elements."""
+        return len(self._nodes)
+
+    def __getitem__(self, index: int) -> Element:
+        """Return the wrapped element at the given index."""
+        return self._nodes[index]
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether other is a query wrapping the same elements in the same order."""
+        return isinstance(other, Query) and self._nodes == other._nodes
+
+    def __hash__(self) -> int:
+        """Hash the wrapped elements by node identity."""
+        return hash(tuple(self._nodes))
+
+    def __repr__(self) -> str:
+        """Return a representation listing the wrapped elements' tags."""
+        return f"Query({[node.tag for node in self._nodes]!r})"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,156 @@
+"""The pyquery-style fluent chaining query wrapper."""
+
+from __future__ import annotations
+
+from turbohtml import Element, parse
+from turbohtml.query import Query
+
+_DOC = "<ul id=list><li class=item>a</li><li class='item on'>b</li><li class=item>c</li></ul><p id=p>after</p>"
+
+
+def _tags(query: Query) -> list[str]:
+    return [element.tag for element in query]
+
+
+def test_construct_from_html_wraps_the_root() -> None:
+    assert _tags(Query("<div></div>")) == ["html"]
+
+
+def test_construct_from_document() -> None:
+    assert _tags(Query(parse("<div></div>"))) == ["html"]
+
+
+def test_construct_from_element() -> None:
+    element = parse(_DOC).select_one("#list")
+    assert element is not None
+    assert _tags(Query(element)) == ["ul"]
+
+
+def test_construct_from_iterable_deduplicates() -> None:
+    doc = parse(_DOC)
+    items = doc.select("li")
+    # the same element passed twice collapses to one, in first-seen order
+    assert len(Query([*items, items[0]])) == 3
+
+
+def test_call_is_find() -> None:
+    query = Query(_DOC)
+    assert _tags(query("li")) == _tags(query.find("li"))
+
+
+def test_find_collects_across_the_set_in_document_order() -> None:
+    assert [e.text for e in Query(_DOC)("li")] == ["a", "b", "c"]
+
+
+def test_find_across_multiple_nodes_deduplicates() -> None:
+    # an outer and an inner div both reach the same <a>, which must appear once
+    doc = parse("<div id=outer><div id=inner><a>x</a></div></div>")
+    divs = Query(doc.select("div"))
+    assert len(divs) == 2
+    assert _tags(divs.find("a")) == ["a"]
+
+
+def test_filter_keeps_matching_elements() -> None:
+    assert [e.text for e in Query(_DOC)("li").filter(".on")] == ["b"]
+
+
+def test_eq_selects_one_or_empty() -> None:
+    items = Query(_DOC)("li")
+    assert items.eq(1)[0].text == "b"
+    assert len(items.eq(99)) == 0
+
+
+def test_parent_deduplicates_and_drops_non_elements() -> None:
+    # the three <li> share one <ul> parent
+    assert _tags(Query(_DOC)("li").parent()) == ["ul"]
+    # the <html> root's parent is the document, not an element, so it is dropped
+    assert len(Query("<p></p>").parent()) == 0
+
+
+def test_children_optionally_filters() -> None:
+    assert [e.text for e in Query(_DOC)("#list").children()] == ["a", "b", "c"]
+    assert [e.text for e in Query(_DOC)("#list").children(".on")] == ["b"]
+
+
+def test_siblings_optionally_filters() -> None:
+    first = Query(_DOC)("li").eq(0)
+    assert [e.text for e in first.siblings()] == ["b", "c"]
+    assert [e.text for e in first.siblings(".on")] == ["b"]
+
+
+def test_closest_finds_or_skips() -> None:
+    assert _tags(Query(_DOC)("li").closest("#list")) == ["ul"]
+    # no ancestor matches, so the element contributes nothing
+    assert len(Query(_DOC)("li").closest("#missing")) == 0
+
+
+def test_items_yields_single_element_queries() -> None:
+    assert [item.attr("class") for item in Query(_DOC)("li").items()] == ["item", "item on", "item"]
+
+
+def test_attr_get_and_set() -> None:
+    query = Query(_DOC)("li")
+    assert query.attr("class") == "item"  # the first element, class joined to a string
+    assert Query(_DOC)("#p").attr("id") == "p"
+    assert query.attr("data-x") is None  # absent attribute
+    assert Query([]).attr("id") is None  # empty set
+    assert query.attr("data-k", "v") is query  # set returns the query for chaining
+    assert all(e.attrs.get("data-k") == "v" for e in query)
+
+
+def test_text_get_and_set() -> None:
+    assert Query(_DOC)("li").text() == "a b c"
+    query = Query("<p>old</p>")("p")
+    assert query.text("new") is query
+    assert query.text() == "new"
+
+
+def test_html_returns_inner_or_none() -> None:
+    assert Query("<div><b>hi</b></div>")("div").html() == "<b>hi</b>"
+    assert Query([]).html() is None
+
+
+def test_class_helpers() -> None:
+    query = Query(_DOC)("li")
+    assert query.has_class("on") is True
+    assert query.has_class("nope") is False
+    assert query.eq(0).add_class("new").attr("class") == "item new"
+    assert query.eq(0).add_class("item").attr("class") == "item new"  # already present, unchanged
+    assert query.eq(1).remove_class("on").attr("class") == "item"
+    assert query.eq(2).remove_class("absent").attr("class") == "item"  # absent, unchanged
+    toggled = Query("<a class=x></a><a></a>")("a")
+    toggled.toggle_class("x")  # removes from the first, adds to the second
+    assert [a.attrs.get("class") for a in toggled] == [[], ["x"]]
+
+
+def test_sequence_protocol() -> None:
+    query = Query(_DOC)("li")
+    assert len(query) == 3
+    assert query[0].text == "a"
+    assert [e.text for e in query] == ["a", "b", "c"]
+
+
+def test_equality_and_hash() -> None:
+    doc = parse(_DOC)
+    one = Query(doc.select("li"))
+    two = Query(doc.select("li"))
+    assert one == two
+    assert hash(one) == hash(two)
+    assert one != Query(doc.select("p"))
+    assert one != object()
+
+
+def test_repr() -> None:
+    assert repr(Query(_DOC)("li")) == "Query(['li', 'li', 'li'])"
+
+
+def test_chaining_example() -> None:
+    # the worked pyquery-style chain from the issue, with turbohtml-native names
+    href = Query(_DOC)("ul").find("li").filter(".on").eq(0).add_class("hot").attr("class")
+    assert href == "item on hot"
+    assert isinstance(Query(_DOC), Query)
+    # construction from a bare Element round-trips through the wrapper
+    element = parse("<span>x</span>").select_one("span")
+    assert element is not None
+    assert Query(element).text() == "x"
+    assert isinstance(element, Element)

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -51,6 +51,7 @@ import w3lib.html
 from bs4 import BeautifulSoup
 from linkify_it import LinkifyIt
 from lxml import html as lxml_html
+from pyquery import PyQuery
 from resiliparse.parse.html import HTMLTree  # ty: ignore[unresolved-import]  # Cython extension, ships no type stubs
 from selectolax.lexbor import LexborHTMLParser
 
@@ -58,6 +59,7 @@ import turbohtml
 from turbohtml import sanitizer as turbo_sanitizer
 from turbohtml.linkify import linkify as turbo_linkify_html
 from turbohtml.markup import escape as turbo_markup_escape
+from turbohtml.query import Query as TurboQuery
 
 _SANITIZER = turbo_sanitizer.Sanitizer(turbo_sanitizer.Policy.relaxed())
 _LXML_CLEANER = lxml_html_clean.Cleaner()
@@ -566,6 +568,63 @@ def print_edit_table(means: dict[str, float], cases: list[str]) -> None:
         row = f"{'edit ' + name:28} {turbo * 1e6:8.1f} us"
         for label in others:
             other = means.get(f"edit {name} [{label}]")
+            row += f" {other * 1e6:8.1f} us {other / turbo:4.1f}x" if other is not None else f"{'-':>18}"
+        print(row)
+
+
+# --- chain suite: a pyquery-style fluent chain over a pre-parsed tree ------- #
+# Each library parses once (outside the timed region), then the timed function
+# runs one fluent chain: select every anchor, keep the linked ones, take the
+# first, tag it, and read its href -- turbohtml.query.Query against pyquery, whose
+# wrapper delegates to lxml. add_class is idempotent, so each pyperf call is equal.
+
+
+def pyquery_tree(text: str) -> PyQuery:
+    """Parse with pyquery (an lxml tree under a jQuery-style wrapper)."""
+    return PyQuery(text)
+
+
+def turbo_chain(doc: Document) -> None:
+    """Run the fluent chain with turbohtml's Query wrapper."""
+    TurboQuery(doc)("a").filter("[href]").eq(0).add_class("seen").attr("href")
+
+
+def pyquery_chain(page: PyQuery) -> None:
+    """Run the same fluent chain with pyquery."""
+    page("a").filter("[href]").eq(0).add_class("seen").attr("href")
+
+
+# Fluent-chain competitors; only turbohtml and pyquery offer jQuery-style chaining.
+CHAIN_LIBS: tuple[tuple[str, Callable[[str], object], Callable[..., None]], ...] = (
+    ("turbohtml", turbo_tree, turbo_chain),
+    ("pyquery", pyquery_tree, pyquery_chain),
+)
+
+
+def run_chain_suite(bench: Callable[[str, object, object], None]) -> list[str]:
+    """Benchmark a pyquery-style fluent chain across every library; return the case names."""
+    names: list[str] = []
+    for name, path, enc in READPATH_CASES:
+        text = corpus_text(path, enc)
+        for label, build, chain in CHAIN_LIBS:
+            bench(f"chain {name} [{label}]", chain, build(text))
+        names.append(name)
+    return names
+
+
+def print_chain_table(means: dict[str, float], cases: list[str]) -> None:
+    """Render turbohtml beside pyquery and its slowdown factor for a fluent chain."""
+    if not cases:
+        return
+    others = [label for label, _, _ in CHAIN_LIBS if label != "turbohtml"]
+    print()
+    header = f"{'chain benchmark':28} {'turbohtml':>11}" + "".join(f"{label:>18}" for label in others)
+    print(header)
+    for name in cases:
+        turbo = means[f"chain {name} [turbohtml]"]
+        row = f"{'chain ' + name:28} {turbo * 1e6:8.1f} us"
+        for label in others:
+            other = means.get(f"chain {name} [{label}]")
             row += f" {other * 1e6:8.1f} us {other / turbo:4.1f}x" if other is not None else f"{'-':>18}"
         print(row)
 
@@ -1280,6 +1339,7 @@ def main() -> None:  # noqa: PLR0914  # one local per suite's collected cases; t
             "serialize",
             "build",
             "edit",
+            "chain",
             "markup",
             "minify",
             "linkify",
@@ -1298,7 +1358,7 @@ def main() -> None:  # noqa: PLR0914  # one local per suite's collected cases; t
     suites = set(
         os.environ.get(
             "TURBOHTML_BENCH_SUITES",
-            "escape,unescape,tokenize,corpus,parse,query,xpath,serialize,build,edit,markup,minify,linkify,markdown,sanitize",
+            "escape,unescape,tokenize,corpus,parse,query,xpath,serialize,build,edit,chain,markup,minify,linkify,markdown,sanitize",
         ).split(",")
     )
     means: dict[str, float] = {}
@@ -1317,6 +1377,7 @@ def main() -> None:  # noqa: PLR0914  # one local per suite's collected cases; t
     serialize_cases = run_readpath_suite(bench, 2, "serialize") if "serialize" in suites else []
     build_cases = run_build_suite(bench) if "build" in suites else []
     edit_cases = run_edit_suite(bench) if "edit" in suites else []
+    chain_cases = run_chain_suite(bench) if "chain" in suites else []
     markup_cases = run_markup_suite(bench) if "markup" in suites else []
     minify_cases = run_minify_suite(bench) if "minify" in suites else []
     if "linkify" in suites:
@@ -1337,6 +1398,7 @@ def main() -> None:  # noqa: PLR0914  # one local per suite's collected cases; t
     print_readpath_table(means, "serialize", serialize_cases)
     print_build_table(means, build_cases)
     print_edit_table(means, edit_cases)
+    print_chain_table(means, chain_cases)
     print_markup_table(means, markup_cases)
     print_minify_table(means, minify_cases)
     print_linkify_table(means, LINKIFY_CASE_NAMES if "linkify" in suites else [])


### PR DESCRIPTION
turbohtml covers pyquery's selection and mutation primitives, but not its jQuery-style **fluent chaining** -- the surface that makes pyquery pyquery -- so a pyquery migration was a rewrite rather than a mechanical change. 🔗

This adds `turbohtml.query.Query`, a thin chainable wrapper over the existing tree and selector primitives. A `Query` holds an ordered, duplicate-free set of elements, and its traversal and mutation methods -- `__call__`/`find`, `filter`, `eq`, `parent`, `children`, `siblings`, `closest`, `items`, `attr`, `text`, `html`, and the class helpers -- each return a `Query`, so calls compose:
`Query(html)("div").find("a").filter(".x").eq(0).add_class("y").attr("href")`. ✨ Deduplication is by node identity, since the tree hands out a fresh wrapper on each access.

It is a Python-layer convenience kept out of the core API so the chainable surface stays optional, and the method names are turbohtml's own (`add_class`, not pyquery's `addClass`), so a migration adjusts the spelling but keeps the structure.

⚡ **Performance.** The wrapper delegates the real work to the C selector/attribute primitives, and skips a redundant de-duplication when a chain starts from one node, so it runs **~11-17× faster than pyquery** on the same chain. A new `chain` suite in the benchmark harness measures it (`tox -e bench chain`), and the performance page records the numbers:

```
chain benchmark                turbohtml           pyquery
chain wpt small (4 kB)            1.1 us     16.1 us 14.4x
chain wpt medium (9.6 kB)         1.1 us     17.5 us 16.6x
chain wpt large (92 kB)          23.3 us    269.1 us 11.5x
```

closes #180