### PR TITLE
📝 docs(migration): add a From parsel guide

### DIFF
--- a/docs/changelog/164.doc.rst
+++ b/docs/changelog/164.doc.rst
@@ -1,0 +1,3 @@
+Add a "From parsel" section to the migration guide, mapping Scrapy parsel's extraction-oriented ``Selector`` API
+(``.css()`` / ``.xpath()`` with ``.get()`` / ``.getall()`` and the ``::text`` / ``::attr()`` pseudo-elements) onto
+turbohtml's node-returning :meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.xpath`.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -351,6 +351,76 @@ Python binding no longer builds on a current toolchain, so there is nothing to p
 gumbo or html5-parser tree maps onto the same :meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.select` read surface
 shown above, with turbohtml supplying the maintained, mutable, typed tree that lineage lacks.
 
+*************
+ From parsel
+*************
+
+`parsel <https://github.com/scrapy/parsel>`_ (Scrapy's selector library) is extraction-oriented: a ``Selector`` query
+returns a ``SelectorList`` and you pull *strings* out of it with ``.get()`` / ``.getall()``, using the ``::text`` and
+``::attr(name)`` pseudo-elements to reach text and attribute values. turbohtml instead returns :class:`~turbohtml.Node`
+objects from :meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.xpath`, and you read
+:attr:`~turbohtml.Node.text`, ``attrs``, or :attr:`~turbohtml.Node.html` off each node -- so the non-standard ``::text``
+/ ``::attr()`` pseudo-elements become ordinary attribute and text access.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - parsel
+      - turbohtml
+    - - ``Selector(text=html)``
+      - ``turbohtml.parse(html)``
+    - - ``sel.css("a")``, ``sel.xpath("//a")``
+      - ``node.select("a")``, ``node.xpath("//a")``
+    - - ``sel.css("a").get()`` (outer HTML)
+      - ``node.select_one("a").html``
+    - - ``sel.css("a::text").get()``, ``.getall()``
+      - ``node.select_one("a").text``, ``[a.text for a in node.select("a")]``
+    - - ``sel.css("a::attr(href)").get()``, ``.getall()``
+      - ``node.select_one("a").attrs.get("href")``, ``[a.attrs.get("href") for a in node.select("a")]``
+    - - ``sel.xpath("//a/@href").getall()``
+      - ``node.xpath("//a/@href")``
+    - - ``sel.attrib``
+      - ``node.attrs``
+    - - ``sel.re(pattern)``, ``sel.re_first(pattern)``
+      - ``re`` over ``node.text`` (use Python's :mod:`re` directly)
+    - - ``sel.root`` (an lxml element)
+      - the :class:`~turbohtml.Node` itself
+
+.. testcode::
+
+    doc = parse('<a href="/x">home</a><a href="/y">about</a>')
+    print([a.attrs.get("href") for a in doc.select("a")])
+    print(doc.select_one("a").text)
+    print(doc.xpath("//a/@href"))
+
+.. testoutput::
+
+    ['/x', '/y']
+    home
+    ['/x', '/y']
+
+Performance
+===========
+
+parsel translates every ``.css()`` query to XPath with `cssselect <https://github.com/scrapy/cssselect>`_ and evaluates
+it on libxml2, building a fresh ``SelectorList`` on each call. turbohtml compiles a selector against the tree once and
+then matches by comparing interned integer atoms, so the same query runs several times faster end to end and an order of
+magnitude faster when it is reused against an already-parsed tree. The :doc:`performance` page's *Querying* table
+measures turbohtml's :meth:`~turbohtml.Node.select` at two to over forty times faster than lxml's ``cssselect`` -- the
+engine parsel itself runs on -- so a parsel-to-turbohtml port keeps that margin and removes parsel's per-call
+``SelectorList`` overhead on top.
+
+Pitfalls
+========
+
+- parsel's ``::text`` and ``::attr()`` pseudo-elements are not CSS standard and turbohtml does not parse them; read
+  :attr:`~turbohtml.Node.text` and ``attrs`` off the selected node instead.
+- ``.get()`` / ``.getall()`` return strings; turbohtml returns nodes, so choose ``.text``, ``.html``, or an attribute
+  explicitly per call.
+- A turbohtml ``xpath("//a/@href")`` already yields the attribute *values* as strings, so there is no ``.getall()`` to
+  chain.
+
 ***************
  From html5lib
 ***************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ bench = [
   "markupsafe>=3",
   "minify-html>=0.15",
   "nh3>=0.2",
+  "parsel>=1.9",
   "pyperf>=2.9",
   "pyquery>=2",
   "resiliparse>=1.0.8",

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -51,6 +51,7 @@ import w3lib.html
 from bs4 import BeautifulSoup
 from linkify_it import LinkifyIt
 from lxml import html as lxml_html
+from parsel import Selector
 from pyquery import PyQuery
 from resiliparse.parse.html import HTMLTree  # ty: ignore[unresolved-import]  # Cython extension, ships no type stubs
 from selectolax.lexbor import LexborHTMLParser
@@ -384,6 +385,21 @@ def lexbor_select(tree: LexborHTMLParser) -> None:
     tree.css(CSS_SELECTOR)
 
 
+def parsel_tree(text: str) -> Selector:
+    """Parse with parsel (Scrapy's selector library), which builds an lxml tree."""
+    return Selector(text=text)
+
+
+def parsel_find(sel: Selector) -> None:
+    """Collect every anchor with parsel's css."""
+    sel.css("a")
+
+
+def parsel_select(sel: Selector) -> None:
+    """Run the CSS selector with parsel's css (cssselect translates it to XPath on libxml2)."""
+    sel.css(CSS_SELECTOR)
+
+
 HAS_SELECTOR = "div:has(a)"  # the :has() relational pseudo-class: a div that contains a link
 
 
@@ -500,11 +516,13 @@ def print_build_table(means: dict[str, float], cases: list[str]) -> None:
 
 
 # Read-path competitors, fastest-first: a tree builder plus the find/select/serialize/:has ops. turbohtml leads each.
-READPATH_LIBS: tuple[tuple[str, Callable[[str], object], tuple[Callable[..., None], ...]], ...] = (
+# A None op means the library does not offer it (parsel has no serializer, and its cssselect cannot compile :has()).
+READPATH_LIBS: tuple[tuple[str, Callable[[str], object], tuple[Callable[..., None] | None, ...]], ...] = (
     ("turbohtml", turbo_tree, (turbo_find, turbo_select, turbo_serialize, turbo_has_select)),
     ("lxml", lxml_tree, (lxml_find, lxml_select, lxml_serialize, lxml_has_select)),
     ("selectolax", lexbor_tree, (lexbor_find, lexbor_select, lexbor_serialize, lexbor_has_select)),
     ("BeautifulSoup", bs4_tree, (bs4_find, bs4_select, bs4_serialize, bs4_has_select)),
+    ("parsel", parsel_tree, (parsel_find, parsel_select, None, None)),
 )
 
 # wpt pages from 4 kB to 92 kB; the multi-MB specs are skipped here since every
@@ -1040,7 +1058,10 @@ def run_readpath_suite(bench: Callable[[str, object, object], None], op_index: i
     for name, path, enc in READPATH_CASES:
         text = corpus_text(path, enc)
         for label, build, ops in READPATH_LIBS:
-            bench(f"{op} {name} [{label}]", ops[op_index], build(text))
+            op_fn = ops[op_index]
+            if op_fn is None:
+                continue  # the library does not offer this operation (e.g. parsel has no serialize/:has)
+            bench(f"{op} {name} [{label}]", op_fn, build(text))
         names.append(name)
     return names
 


### PR DESCRIPTION
The migration guide covered BeautifulSoup, lxml, selectolax, html5lib, the standard library, and the escaping/sanitizing libraries, but not `parsel <https://github.com/scrapy/parsel>`_ — Scrapy's selector library. 📑

This adds a "From parsel" section mapping parsel's extraction-oriented `Selector` API onto turbohtml's node-returning surface. parsel returns a `SelectorList` and you pull strings out with `.get()`/`.getall()`, using the non-standard `::text` and `::attr(name)` pseudo-elements; turbohtml returns `Node` objects from `select()`/`xpath()`, so those pseudo-elements become ordinary `.text` and `.attrs` access. The section follows the existing template (intro, a mapping table, a runnable example, and a pitfalls list) and its example is doctested in the docs build.

closes #164