### PR TITLE
📝 docs(migration): note the encoding-detection boundary

### DIFF
--- a/docs/changelog/168.doc.rst
+++ b/docs/changelog/168.doc.rst
@@ -1,0 +1,4 @@
+Note the encoding-detection boundary in the BeautifulSoup migration guide: turbohtml's WHATWG sniffing (a BOM, the
+``<meta charset>`` prescan, then a ``windows-1252`` fallback) replaces what ``UnicodeDammit`` reads from the markup, but
+not the statistical detectors (``charset-normalizer``, ``chardet``, ``cchardet``) that guess from byte frequency. Reach
+for those when a stream carries no BOM and no declaration.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -45,6 +45,18 @@ Bytes work too; pass the raw response and read the resolved encoding back from :
     café
     windows-1252
 
+Encoding detection
+==================
+
+``parse`` runs the WHATWG sniffing algorithm on bytes: a leading BOM, then a ``<meta charset>`` prescan, then a
+``windows-1252`` fallback. That covers what ``UnicodeDammit`` reads from the markup, and it stops there -- turbohtml
+does not guess an encoding from the byte distribution. ``UnicodeDammit``'s optional statistical pass and the dedicated
+detectors (`charset-normalizer <https://github.com/jawah/charset_normalizer>`_, `chardet
+<https://github.com/chardet/chardet>`_, ``cchardet``) read byte frequency, so a markup-less stream, or a document with
+no BOM and no declaration, lands on ``windows-1252`` here where they would name, say, ``koi8-r``. When there is nothing
+to sniff, detect the encoding with ``charset-normalizer`` first and hand turbohtml the decoded ``str`` (or the bytes
+with an explicit ``encoding=``).
+
 The renames
 ===========
 


### PR DESCRIPTION
A BeautifulSoup user porting byte-input code reaches for `UnicodeDammit`, which combines markup sniffing with an optional statistical guess. turbohtml covers only the first half, and the migration guide should say so plainly rather than let a reader assume full parity and ship a mojibake bug.

This adds an Encoding detection subsection to the BeautifulSoup migration page. turbohtml runs the WHATWG sniffing algorithm on bytes -- a BOM, a `<meta charset>` prescan, then a `windows-1252` fallback -- which is what `UnicodeDammit` reads from the markup. It stops there: it does not guess an encoding from the byte distribution, so a markup-less stream or a document with no BOM and no declaration lands on `windows-1252` where `charset-normalizer`/`chardet`/`cchardet` would name, say, `koi8-r`. The note points a reader at `charset-normalizer` first when there is nothing to sniff, then hand turbohtml the decoded `str` or the bytes with an explicit `encoding=`.

This is a boundary note, not a new feature: the WHATWG sniffing path already exists. It states the limit so the docs do not over-claim.

closes #168