### PR TITLE
📝 docs: compare and migrate w3lib HTML utilities

### DIFF
--- a/docs/changelog/169.doc.rst
+++ b/docs/changelog/169.doc.rst
@@ -1,0 +1,4 @@
+Add a migration entry and a performance comparison for ``w3lib.html``, mapping ``replace_entities`` onto
+:func:`turbohtml.unescape` (now benchmarked side by side) and the tag and comment strippers onto parsing plus
+:attr:`~turbohtml.Node.text`, and scoping the overlap to the HTML subset since the URL and HTTP helpers have no
+equivalent - by :user:`gaborbernat`.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -421,6 +421,47 @@ WHATWG-conformant tokenizer. Or drop the subclass and take the token stream from
 :meth:`turbohtml.Tokenizer.feed` for incremental input), or skip tokens entirely and :func:`turbohtml.parse` straight to
 a tree. All three are WHATWG-conformant, unlike ``html.parser``. The :doc:`how-to` guide has a worked port.
 
+*********************
+ From w3lib (Scrapy)
+*********************
+
+`w3lib <https://github.com/scrapy/w3lib>`_ collects the web utilities Scrapy reuses. Only its ``w3lib.html`` text/entity
+subset overlaps with turbohtml; the URL canonicalization, response-encoding, and HTTP helpers in ``w3lib.url`` and
+elsewhere stay outside turbohtml's scope and have no equivalent here.
+
+``replace_entities`` resolves character references the same way :func:`turbohtml.unescape` does, so it is a drop-in;
+``w3lib.html.replace_entities("caf&eacute; &amp; co")`` returns the same string this prints:
+
+.. testcode::
+
+    from turbohtml import unescape
+    print(unescape("caf&eacute; &amp; co"))
+
+.. testoutput::
+
+    café & co
+
+The tag and comment strippers map onto parsing to a real tree and reading its text. ``remove_tags`` becomes
+:func:`turbohtml.parse` followed by :attr:`~turbohtml.Node.text`, and ``remove_comments`` needs nothing extra because
+comments never appear in ``text``:
+
+.. testcode::
+
+    from turbohtml import parse
+    print(parse("<p>Tom &amp; Jerry <b>says</b> hi</p><!--note-->").text)
+
+.. testoutput::
+
+    Tom & Jerry says hi
+
+The behavior differs in one way worth knowing before migrating: ``remove_tags`` strips angle brackets with a regular
+expression and leaves entities encoded (``Tom &amp; Jerry``), while ``text`` runs the WHATWG tree builder and returns
+decoded characters (``Tom & Jerry``). turbohtml parses malformed and nested markup the way a browser does rather than
+matching ``<...>`` spans, so the two diverge on inputs a regex misreads. ``remove_tags_with_content``, which drops a tag
+together with its subtree, has no single call: select the subtrees to keep with :meth:`~turbohtml.Node.find_all` and
+join their ``text``, the allowlist-style filtering the :doc:`how-to` guide covers, or reach for ``turbohtml.sanitizer``
+when the goal is producing safe HTML rather than plain text.
+
 *****************
  From markupsafe
 *****************

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -219,38 +219,47 @@ builds an lxml tree and a CSS model in Python, where turbohtml does the whole la
  Unescaping
 ************
 
-:func:`turbohtml.unescape` against :func:`python:html.unescape`. It gains the most on entity-heavy input, where the
-standard library pays a Python call per match; turbohtml hops between ``&`` occurrences and bulk-copies the clean spans
-between references.
+:func:`turbohtml.unescape` against :func:`python:html.unescape` and `w3lib <https://github.com/scrapy/w3lib>`_'s
+``replace_entities``, the Scrapy helper that resolves the same references. It gains the most on entity-heavy input,
+where the standard library pays a Python call per match and w3lib runs a regular-expression substitution with a Python
+callback per match; turbohtml hops between ``&`` occurrences in C and bulk-copies the clean spans between references.
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20
+    :widths: 38 20 21 21
 
     - - input
       - turbohtml
       - html.unescape
+      - w3lib
     - - tiny plain (64 B)
       - 0.02 µs
       - 0.03 µs
+      - 0.26 µs
     - - medium dense refs (4 KiB)
-      - 8.26 µs
-      - 69.0 µs
+      - 8.03 µs
+      - 69.5 µs
+      - 116 µs
     - - numeric refs (4 KiB)
-      - 6.00 µs
-      - 78.9 µs
+      - 5.74 µs
+      - 78.7 µs
+      - 93.2 µs
     - - book HTML, real refs (4 MiB)
-      - 2.50 ms
-      - 7.91 ms
+      - 2.46 ms
+      - 7.92 ms
+      - 13.3 ms
     - - escaped book HTML (5 MiB)
       - 1.87 ms
-      - 19.3 ms
+      - 19.5 ms
+      - 35.5 ms
     - - dense refs (4 MiB)
       - 10.1 ms
-      - 73.2 ms
+      - 74.1 ms
+      - 117 ms
     - - UCS-2 refs (4 MiB)
-      - 2.67 ms
-      - 18.0 ms
+      - 2.66 ms
+      - 18.4 ms
+      - 27.5 ms
 
 ************
  Tokenizing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ bench = [
   "resiliparse>=1.0.8",
   "selectolax>=0.3.30",
   "soupsieve>=2.8",
+  "w3lib>=2.3",
   { include-group = "test" },
 ]
 coverage = [

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -7,9 +7,9 @@ Run with ``tox -e bench``; positional arguments pick the suites to run
 ``xpath``, ``serialize``; default all). Remaining arguments are forwarded to
 pyperf (pass ``--help`` to see them). pyperf runs every case in isolated worker
 processes and reports mean and stddev; the parent process then prints a speedup
-table: escape, unescape, and tokenize against the standard library, parse against
-the other HTML tree builders (lxml, selectolax, resiliparse, html5lib, and
-BeautifulSoup), the
+table: escape, unescape, and tokenize against the standard library (unescape also
+against w3lib's replace_entities), parse against the other HTML tree builders
+(lxml, selectolax, resiliparse, html5lib, and BeautifulSoup), the
 read-path query and serialize suites against lxml, selectolax, and BeautifulSoup,
 and the xpath suite against lxml, the only other library with an XPath engine.
 
@@ -47,6 +47,7 @@ import markupsafe
 import minify_html
 import nh3
 import pyperf
+import w3lib.html
 from bs4 import BeautifulSoup
 from linkify_it import LinkifyIt
 from lxml import html as lxml_html
@@ -1183,16 +1184,23 @@ def html5lib_tokenize(text: str) -> None:
         pass
 
 
+def w3lib_unescape(text: str) -> None:
+    """Resolve character references with w3lib's replace_entities, the closest competitor to unescape."""
+    w3lib.html.replace_entities(text)
+
+
 def print_table(means: dict[str, float], rows: list[tuple[str, str]]) -> None:
     """Render the speedup table from the collected per-benchmark means."""
     print()
-    print(f"{'benchmark':40} {'turbohtml':>12} {'stdlib':>12} {'speedup':>8} {'html5lib':>12} {'speedup':>8}")
+    header = f"{'benchmark':40} {'turbohtml':>12} {'stdlib':>12} {'speedup':>8}"
+    print(f"{header} {'html5lib/w3lib':>14} {'speedup':>8}")
     for op, name in rows:
         turbo = means[f"{op} {name} [turbohtml]"]
         stdlib = means[f"{op} {name} [stdlib]"]
         row = f"{op + ' ' + name:40} {turbo * 1e6:9.2f} us {stdlib * 1e6:9.2f} us {stdlib / turbo:7.1f}x"
-        if (five := means.get(f"{op} {name} [html5lib]")) is not None:
-            row += f" {five * 1e6:9.2f} us {five / turbo:7.1f}x"
+        # html5lib (tokenize) and w3lib (unescape) never both apply to one row, so they share the trailing column
+        if (other := means.get(f"{op} {name} [html5lib]") or means.get(f"{op} {name} [w3lib]")) is not None:
+            row += f" {other * 1e6:11.2f} us {other / turbo:7.1f}x"
         print(row)
 
 
@@ -1238,6 +1246,8 @@ def run_string_suites(bench: Callable[[str, object, object], None], suites: set[
         if op in suites:
             bench(f"{op} {name} [turbohtml]", getattr(turbohtml, op), arg)
             bench(f"{op} {name} [stdlib]", getattr(html, op), arg)
+            if op == "unescape":
+                bench(f"unescape {name} [w3lib]", w3lib_unescape, arg)
             rows.append((op, name))
     tokenize_cases = TOKENIZE_CASES if "tokenize" in suites else []
     if "corpus" in suites:


### PR DESCRIPTION
Scrapy projects lean on `w3lib.html` for entity decoding and tag stripping, and the docs neither said which of those jobs turbohtml takes over nor how the speed compares. 📝 This adds a `From w3lib (Scrapy)` migration section and a w3lib column to the unescaping benchmark.

The migration entry maps `replace_entities` onto `turbohtml.unescape` (a drop-in), `remove_tags`/`remove_comments` onto `parse` plus `.text`, and `remove_tags_with_content` onto `find_all` or the sanitizer, scoping the overlap to the HTML subset so the URL and HTTP helpers are not implied to have an equivalent. It documents the one behavioral divergence worth knowing first: `w3lib` strips tags with a regex and leaves entities encoded, while turbohtml runs the WHATWG tree builder and returns decoded text.

The performance page now benchmarks `replace_entities` against `unescape`: its regex substitution with a Python callback per match trails the C span-hopping `unescape` by ten to nineteen times, slower even than the standard library on entity-heavy input. `w3lib` joins the `bench` dependency group.

closes #169