### PR TITLE
📝 docs: compare and migrate resiliparse, note gumbo

### DIFF
--- a/docs/changelog/170.doc.rst
+++ b/docs/changelog/170.doc.rst
@@ -1,0 +1,3 @@
+Add resiliparse to the parsing benchmark, the performance comparison, and the migration guide, and note gumbo, the
+unmaintained WHATWG C parser behind html5-parser, in prose as a read-only alternative turbohtml supersedes - by
+:user:`gaborbernat`.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -275,6 +275,70 @@ Pitfalls
 - selectolax mutation is limited; turbohtml's edit surface (``append``, ``insert``, ``wrap``, ``unwrap``,
   ``replace_with``, and the rest) is full.
 
+******************
+ From resiliparse
+******************
+
+`resiliparse <https://github.com/chatnoir-eu/chatnoir-resiliparse>`_ wraps the same `lexbor <https://lexbor.com>`_
+engine selectolax does, so like turbohtml it builds a WHATWG tree with real text nodes; the move is API surface. Its
+``HTMLTree`` exposes DOM-style traversal and both ``get_element_by_*`` lookups and CSS ``query_selector`` methods, which
+turbohtml folds into the one ``find``/``find_all``/``select`` grammar.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - resiliparse
+      - turbohtml
+    - - ``HTMLTree.parse(html)``
+      - ``turbohtml.parse(html)``
+    - - ``tree.body``, ``tree.head``, ``tree.title``
+      - ``doc.find("body")``, ``doc.find("head")``, ``doc.find("title").text``
+    - - ``node.query_selector("a")``, ``node.query_selector_all("a")``
+      - ``node.select_one("a")``, ``node.select("a")``
+    - - ``node.get_element_by_id("main")``
+      - ``node.find(id="main")``
+    - - ``node.get_elements_by_tag_name("a")``, ``node.get_elements_by_class_name("x")``
+      - ``node.find_all("a")``, ``node.find_all(class_="x")``
+    - - ``node.getattr("href")``, ``node.hasattr("href")``, ``node.setattr(...)``, ``node.delattr(...)``
+      - ``node.attrs.get("href")``, ``"href" in node.attrs``, ``node.attrs[...] = ...``, ``del node.attrs[...]``
+    - - ``node.tag``, ``node.text``, ``node.html``, ``node.class_list``
+      - ``node.tag``, ``node.text``, ``node.html``, ``node.attrs["class"]``
+    - - ``node.parent``, ``node.next_element``, ``node.prev_element``, ``node.first_element_child``
+      - ``node.parent``, ``node.next_sibling``, ``node.previous_sibling``, ``node.first_child``
+    - - ``tree.create_element("div")``, ``node.append_child(...)``, ``node.decompose()``
+      - ``Element("div")``, ``node.append(...)``, ``node.decompose()``
+    - - ``extract_plain_text(html)`` (from ``resiliparse.extract``)
+      - ``node.to_text()`` for layout, ``node.text`` for the raw concatenation
+
+.. testcode::
+
+    doc = parse("<div id=main><p class=x>Hi <a href='/u'>link</a></p></div>")
+    print(doc.select_one("#main a").attrs["href"])
+    print(doc.find(id="main").find("p").text)
+
+.. testoutput::
+
+    /u
+    Hi link
+
+Pitfalls
+========
+
+- resiliparse's boilerplate and main-content extraction, language detection, and the encoding and archive utilities it
+  ships for web-crawl processing have no turbohtml equivalent; the overlap is parsing and DOM access only.
+- turbohtml compares nodes by value, not identity, so ``find("p") == find("p")`` is ``False`` where resiliparse returns
+  the same wrapped node; compare serializations or walk the tree instead.
+
+A note on gumbo
+===============
+
+`gumbo <https://github.com/google/gumbo-parser>`_, the C WHATWG parser behind `html5-parser
+<https://html5-parser.readthedocs.io>`_, has no migration table here. It is read-oriented and archived upstream, and its
+Python binding no longer builds on a current toolchain, so there is nothing to port from in practice. Code that read a
+gumbo or html5-parser tree maps onto the same :meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.select` read surface
+shown above, with turbohtml supplying the maintained, mutable, typed tree that lineage lacks.
+
 ***************
  From html5lib
 ***************

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -317,69 +317,87 @@ times faster.
 *********
 
 :func:`turbohtml.parse` builds a full WHATWG document tree, against the other Python tree builders: `lxml
-<https://lxml.de>`_, `selectolax <https://github.com/rushter/selectolax>`_ (`lexbor <https://lexbor.com>`_),
-`BeautifulSoup <https://www.crummy.com/software/BeautifulSoup/bs4/doc/>`_ over ``html.parser``, and html5lib. turbohtml
-runs roughly two to five times faster than the C parsers and 30 to 80 times faster than the pure-Python ones, while
-building the WHATWG tree that lxml's libxml2 does not.
+<https://lxml.de>`_, `selectolax <https://github.com/rushter/selectolax>`_ and `resiliparse
+<https://github.com/chatnoir-eu/chatnoir-resiliparse>`_ (both wrapping `lexbor <https://lexbor.com>`_), `BeautifulSoup
+<https://www.crummy.com/software/BeautifulSoup/bs4/doc/>`_ over ``html.parser``, and html5lib. turbohtml runs on par
+with resiliparse, two to four times faster than lxml and selectolax, and 30 to 80 times faster than the pure-Python
+builders, while building the WHATWG tree that lxml's libxml2 does not.
+
+resiliparse reaches turbohtml's throughput because its ``HTMLTree.parse`` is a thin call straight into lexbor's native
+tree, while selectolax wraps that same engine behind a heavier object layer; the comparison here is parsing only.
+resiliparse's wider toolkit, boilerplate and main-content extraction, language detection, and the encoding and archive
+utilities it ships for large-scale web-crawl processing, sits outside turbohtml's scope. `gumbo
+<https://github.com/google/gumbo-parser>`_, the C WHATWG parser Google released and the engine behind `html5-parser
+<https://html5-parser.readthedocs.io>`_, has no row: it is read-oriented, archived upstream, and its Python binding no
+longer builds on a current toolchain. turbohtml is the maintained, mutable, typed alternative to that lineage.
 
 .. list-table::
     :header-rows: 1
-    :widths: 26 13 12 12 14 12
+    :widths: 26 12 11 11 12 13 11
 
     - - input
       - turbohtml
       - lxml
       - selectolax
+      - resiliparse
       - BeautifulSoup
       - html5lib
     - - wpt page (0.6 kB)
       - 1.3 µs
       - 3.3 µs
-      - 6.8 µs
+      - 7.0 µs
+      - 3.9 µs
       - 61.3 µs
       - 101 µs
     - - wpt page (4 kB)
-      - 10.6 µs
-      - 27.1 µs
-      - 42.0 µs
-      - 438 µs
+      - 10.9 µs
+      - 27.2 µs
+      - 42.3 µs
+      - 12.9 µs
+      - 435 µs
       - 615 µs
     - - wpt page (9.6 kB)
-      - 27.5 µs
-      - 73.2 µs
-      - 106 µs
-      - 836 µs
+      - 28.2 µs
+      - 72.8 µs
+      - 107 µs
+      - 28.0 µs
+      - 840 µs
       - 1.45 ms
     - - wpt page (92 kB)
-      - 254 µs
+      - 269 µs
       - 633 µs
-      - 917 µs
-      - 15.1 ms
-      - 16.6 ms
+      - 919 µs
+      - 282 µs
+      - 15.2 ms
+      - 16.7 ms
     - - wpt page, CJK (124 kB)
-      - 505 µs
+      - 536 µs
       - 1.43 ms
       - 2.29 ms
-      - 20.7 ms
-      - 29.5 ms
+      - 538 µs
+      - 21.8 ms
+      - 29.3 ms
     - - whatwg spec (235 kB)
-      - 498 µs
-      - 1.23 ms
-      - 1.78 ms
-      - 25.3 ms
-      - 31.0 ms
+      - 510 µs
+      - 1.24 ms
+      - 1.77 ms
+      - 505 µs
+      - 25.2 ms
+      - 30.9 ms
     - - ecmascript spec (3 MB)
-      - 4.31 ms
-      - 17.4 ms
+      - 4.48 ms
+      - 17.5 ms
       - 15.7 ms
-      - 193 ms
+      - 5.30 ms
+      - 192 ms
       - 260 ms
     - - whatwg spec source (7.9 MB)
-      - 26.8 ms
-      - 83.1 ms
-      - 94.0 ms
-      - 1.63 s
-      - 1.55 s
+      - 28.4 ms
+      - 84.1 ms
+      - 93.9 ms
+      - 30.0 ms
+      - 1.60 s
+      - 1.51 s
 
 **********
  Querying

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ bench = [
   "minify-html>=0.15",
   "nh3>=0.2",
   "pyperf>=2.9",
+  "resiliparse>=1.0.8",
   "selectolax>=0.3.30",
   "soupsieve>=2.8",
   { include-group = "test" },

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -8,7 +8,8 @@ Run with ``tox -e bench``; positional arguments pick the suites to run
 pyperf (pass ``--help`` to see them). pyperf runs every case in isolated worker
 processes and reports mean and stddev; the parent process then prints a speedup
 table: escape, unescape, and tokenize against the standard library, parse against
-the other HTML tree builders (lxml, selectolax, html5lib, and BeautifulSoup), the
+the other HTML tree builders (lxml, selectolax, resiliparse, html5lib, and
+BeautifulSoup), the
 read-path query and serialize suites against lxml, selectolax, and BeautifulSoup,
 and the xpath suite against lxml, the only other library with an XPath engine.
 
@@ -47,6 +48,7 @@ import pyperf
 from bs4 import BeautifulSoup
 from linkify_it import LinkifyIt
 from lxml import html as lxml_html
+from resiliparse.parse.html import HTMLTree  # ty: ignore[unresolved-import]  # Cython extension, ships no type stubs
 from selectolax.lexbor import LexborHTMLParser
 
 import turbohtml
@@ -280,6 +282,11 @@ def lxml_parse(text: str) -> None:
     lxml_html.document_fromstring(text)
 
 
+def resiliparse_parse(text: str) -> None:
+    """Parse with resiliparse, which wraps the same lexbor engine selectolax does."""
+    HTMLTree.parse(text)
+
+
 def html5lib_parse(text: str) -> None:
     """Parse with html5lib, the pure-Python WHATWG reference implementation."""
     html5lib.parse(text)
@@ -295,6 +302,7 @@ def soup_parse(text: str) -> None:
 PARSE_COMPETITORS: tuple[tuple[str, Callable[[str], None]], ...] = (
     ("lxml", lxml_parse),
     ("selectolax", lexbor_parse),
+    ("resiliparse", resiliparse_parse),
     ("BeautifulSoup", soup_parse),
     ("html5lib", html5lib_parse),
 )


### PR DESCRIPTION
The parser comparison raced turbohtml against lxml, selectolax, BeautifulSoup, and html5lib, leaving out the two projects in the same fast-WHATWG-parser niche. 📝 This adds `resiliparse` to the parse benchmark and the migration guide, and covers `gumbo` in prose.

The benchmark surfaces something worth showing: `resiliparse` wraps the same `lexbor` engine `selectolax` does, but its thin `HTMLTree.parse` lands on par with turbohtml while `selectolax`'s heavier object layer trails three to four times behind. The migration section maps its DOM and query surface onto `find`/`select` and flags the archive-extraction extras as out of scope. `resiliparse` joins the `bench` dependency group.

`gumbo`, the archived C parser behind `html5-parser`, gets a prose note rather than a row or table: it is read-oriented and its Python binding no longer builds on a current toolchain, so turbohtml stands as the maintained, mutable, typed alternative to that lineage. The lone `ty: ignore` on the resiliparse import is unavoidable because the package ships a compiled extension with no type stubs.

closes #170