### PR TITLE
🔒 fix(sanitizer): scheme-check ping and srcset URL lists

### DIFF
--- a/docs/changelog/215.feature.rst
+++ b/docs/changelog/215.feature.rst
@@ -1,0 +1,2 @@
+Scheme-check the ``ping`` attribute and the ``srcset``/``imagesrcset`` URL lists in the sanitizer, so a disallowed
+scheme can no longer ride in on ``<a ping>`` or an ``<img srcset>`` candidate - by :user:`gaborbernat`.

--- a/src/turbohtml/sanitize.c
+++ b/src/turbohtml/sanitize.c
@@ -86,7 +86,8 @@ static int is_url_attr(const char *name, Py_ssize_t len) {
     case 3:
         return memcmp(name, "src", 3) == 0;
     case 4:
-        return memcmp(name, "href", 4) == 0 || memcmp(name, "cite", 4) == 0 || memcmp(name, "data", 4) == 0;
+        return memcmp(name, "href", 4) == 0 || memcmp(name, "cite", 4) == 0 || memcmp(name, "data", 4) == 0 ||
+               memcmp(name, "ping", 4) == 0;
     case 6:
         return memcmp(name, "action", 6) == 0 || memcmp(name, "poster", 6) == 0;
     case 8:
@@ -153,6 +154,60 @@ static int scheme_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t len) {
         started = 1;
     }
     return s->allow_relative; /* no colon: a relative URL */
+}
+
+/* The ASCII whitespace that separates srcset candidates, minus CR: the WHATWG input preprocessor converts CR to LF, so
+   a parsed attribute value never carries a 0x0D. An array+loop keeps the branch count stable when clang inlines this
+   into srcset_allowed's two call sites. */
+static int is_ascii_ws(Py_UCS4 c) {
+    static const Py_UCS4 whitespace[] = {0x09, 0x0A, 0x0C, 0x20};
+    for (size_t index = 0; index < sizeof(whitespace) / sizeof(whitespace[0]); index++) {
+        if (c == whitespace[index]) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* srcset and imagesrcset hold a comma-separated list of "URL descriptor" candidates. Each candidate's leading URL is
+   scheme-checked; the whole attribute is rejected if any candidate carries a disallowed scheme. Splitting on commas
+   can over-segment a URL that contains one, but that only adds scheme checks of schemeless tails (read as relative),
+   so it never lets a disallowed scheme through. Returns 1 allow, 0 drop, -1 error. */
+static int srcset_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t len) {
+    Py_ssize_t pos = 0;
+    while (pos < len) {
+        while (pos < len && (value[pos] == ',' || is_ascii_ws(value[pos]))) {
+            pos++; /* skip separators before the candidate URL */
+        }
+        Py_ssize_t start = pos;
+        while (pos < len && value[pos] != ',' && !is_ascii_ws(value[pos])) {
+            pos++; /* the URL runs up to a descriptor (whitespace) or the next candidate (comma) */
+        }
+        if (pos > start) {
+            int ok = scheme_allowed(s, value + start, pos - start);
+            if (ok < 0) {  /* GCOVR_EXCL_BR_LINE: scheme_allowed only fails on allocation failure */
+                return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            if (!ok) {
+                return 0;
+            }
+        }
+        while (pos < len && value[pos] != ',') {
+            pos++; /* skip the candidate's descriptor */
+        }
+    }
+    return 1;
+}
+
+/* srcset-valued attributes, matched on the interned name bytes. */
+static int is_srcset_attr(const char *name, Py_ssize_t len) {
+    if (len == 6) {
+        return memcmp(name, "srcset", 6) == 0;
+    }
+    if (len == 11) {
+        return memcmp(name, "imagesrcset", 11) == 0;
+    }
+    return 0;
 }
 
 /* Is `name` allowed on element `tag` by the policy? A "*" inside an attribute set allows every attribute name.
@@ -236,23 +291,32 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             }
             drop = !allowed;
         }
+        int url_disallowed = 0;
         if (!drop && is_url_attr(name, name_len)) {
             int ok = scheme_allowed(s, attr->value, attr->value_len);
             if (ok < 0) {  /* GCOVR_EXCL_BR_LINE: scheme_allowed only fails on allocation failure */
                 return -1; /* GCOVR_EXCL_LINE */
             }
-            if (!ok) {
-                /* A duplicate URL attribute desyncs the per-value scheme check from the
-                   single value a re-parsing browser keeps (WHATWG keeps the first): dropping
-                   only this occurrence deletes the first match by name, which may be a benign
-                   sibling, leaving the disallowed value as the lone attribute. Drop every
-                   occurrence of the name so no disallowed scheme survives, then rescan from
-                   the start because removing an earlier slot shifts the rest down. */
-                while (th_node_attr_del(s->tree, element, name, name_len)) {
-                }
-                index = 0;
-                continue;
+            url_disallowed = !ok;
+        }
+        if (!drop && is_srcset_attr(name, name_len)) {
+            int ok = srcset_allowed(s, attr->value, attr->value_len);
+            if (ok < 0) {  /* GCOVR_EXCL_BR_LINE: srcset_allowed only fails on allocation failure */
+                return -1; /* GCOVR_EXCL_LINE */
             }
+            url_disallowed = !ok;
+        }
+        if (url_disallowed) {
+            /* A duplicate URL attribute desyncs the per-value scheme check from the
+               single value a re-parsing browser keeps (WHATWG keeps the first): dropping
+               only this occurrence deletes the first match by name, which may be a benign
+               sibling, leaving the disallowed value as the lone attribute. Drop every
+               occurrence of the name so no disallowed scheme survives, then rescan from
+               the start because removing an earlier slot shifts the rest down. */
+            while (th_node_attr_del(s->tree, element, name, name_len)) {
+            }
+            index = 0;
+            continue;
         }
         if (drop) {
             th_node_attr_del(s->tree, element, name, name_len);

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -25,7 +25,7 @@ _VOID_CASES = [
     ("param", "<param>"), ("source", "<source>"), ("track", "<track>"), ("wbr", "<wbr>"),
 ]  # fmt: skip
 _URL_ATTRS = [
-    "href", "src", "cite", "data", "action", "poster", "longdesc", "formaction", "background", "xlink:href",
+    "href", "src", "cite", "data", "ping", "action", "poster", "longdesc", "formaction", "background", "xlink:href",
 ]  # fmt: skip
 
 
@@ -144,6 +144,37 @@ def test_every_url_attribute_is_scheme_checked(attr: str) -> None:
     assert sanitize(f'<x {attr}="javascript:alert(1)">t</x>', policy) == "<x>t</x>"
 
 
+@pytest.mark.parametrize("attr", ["srcset", "imagesrcset"])
+@pytest.mark.parametrize(
+    ("value", "kept"),
+    [
+        pytest.param("a.jpg 1x, b.jpg 2x", True, id="relative-candidates"),
+        pytest.param("https://ok/a.jpg 1x, https://ok/b.jpg 2x", True, id="allowed-scheme"),
+        pytest.param("a.jpg", True, id="single-no-descriptor"),
+        pytest.param("", True, id="empty"),
+        pytest.param("a.jpg,", True, id="trailing-comma"),
+        pytest.param("  ,  a.jpg 1x", True, id="leading-separators"),
+        pytest.param("a.jpg\t1x,\nb.jpg\x0c2x", True, id="ascii-whitespace-separators"),
+        pytest.param("javascript:alert(1) 1x", False, id="first-candidate-script"),
+        pytest.param("a.jpg 1x, javascript:alert(1) 2x", False, id="later-candidate-script"),
+        pytest.param("https://ok/a.jpg 1x, vbscript:msgbox(1) 2x", False, id="later-candidate-vbscript"),
+    ],
+)
+def test_srcset_candidate_schemes_are_checked(attr: str, value: str, kept: bool) -> None:  # noqa: FBT001
+    # a srcset is a comma-separated list of "URL descriptor" candidates; every candidate's scheme is
+    # checked and the whole attribute is dropped if any candidate carries a disallowed scheme.
+    out = sanitize(f'<img {attr}="{value}">', _allow_all({"img"}, {attr}))
+    assert (attr in out) is kept
+
+
+def test_eleven_char_non_srcset_attribute_is_not_url_checked() -> None:
+    # placeholder is eleven characters but is not imagesrcset, so its value is never scheme-checked.
+    policy = _allow_all({"x"}, {"placeholder"})
+    assert (
+        sanitize('<x placeholder="javascript:not-a-url">t</x>', policy) == '<x placeholder="javascript:not-a-url">t</x>'
+    )
+
+
 @pytest.mark.parametrize(
     ("html", "expected"),
     [
@@ -170,6 +201,12 @@ def test_duplicate_url_attribute_keeps_only_the_first() -> None:
 def test_non_url_attribute_value_is_not_scheme_checked() -> None:
     policy = _allow_all({"x"}, {"title"})
     assert sanitize('<x title="javascript:not-a-url">t</x>', policy) == '<x title="javascript:not-a-url">t</x>'
+
+
+def test_four_char_non_url_attribute_is_not_scheme_checked() -> None:
+    # type is four characters but is none of href/cite/data/ping, so its value is never scheme-checked.
+    policy = _allow_all({"x"}, {"type"})
+    assert sanitize('<x type="javascript:not-a-url">t</x>', policy) == '<x type="javascript:not-a-url">t</x>'
 
 
 def test_ten_char_non_url_attribute_is_not_scheme_checked() -> None:


### PR DESCRIPTION
The sanitizer's URL-scheme allowlist already guards `href`, `src`, `cite`, `data`, `action`, `formaction`, `poster`, `longdesc`, `background`, and `xlink:href`, and its obfuscation normalization already defeats `java\tscript:`-style tricks. 🔒 But two modern URL-bearing locations slipped through: the `ping` attribute (`<a ping="javascript:...">`, fired on click) and the `srcset`/`imagesrcset` candidate lists (`<img srcset="javascript:... 1x">`). A disallowed scheme could survive on either.

`ping` is a single URL, so it joins `is_url_attr` and rides the existing scheme check. `srcset`/`imagesrcset` are comma-separated `URL descriptor` lists, which the single-value `scheme_allowed` cannot read, so a list-aware pass walks each candidate, scheme-checks its leading URL, and drops the whole attribute if any candidate carries a disallowed scheme. Splitting on commas can over-segment a URL that contains one, but that only adds scheme checks of schemeless tails, so it never lets a disallowed scheme through.

The adversarial sanitizer suite gains `ping` and a `srcset`/`imagesrcset` matrix (allowed schemes kept, `javascript:`/`vbscript:` in any candidate drops the attribute); `sanitize.c` stays at 100% line and branch coverage. This is the URL-attribute half of the gap analysis; SVG presentation `url()` references are a separate follow-up.

closes #215