### PR TITLE
✨ feat(sanitizer): add Policy.remove_with_content

### DIFF
--- a/docs/changelog/216.feature.rst
+++ b/docs/changelog/216.feature.rst
@@ -1,0 +1,3 @@
+Add ``Policy.remove_with_content`` to the sanitizer: disallowed tags named in it (e.g. ``script``/``style``) have their
+whole subtree dropped instead of escaped or stripped, so their text never leaks into the output - by
+:user:`gaborbernat`.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -892,10 +892,11 @@ Porting inverts the model. Instead of switching dangerous things off, declare th
     <p>Hi&lt;script&gt;x()&lt;/script&gt; <a>l</a></p>
 
 The ``javascript:`` URL is gone because ``http``/``https``/``mailto`` are the only schemes the policy admits, and the
-``<script>`` is escaped rather than executed. ``Cleaner``'s ``host_whitelist`` and ``kill_tags``/``allow_tags`` lists
-fold into ``Policy.tags`` and ``attribute_filter``; its ``add_nofollow`` maps to ``Policy.add_link_rel``. The CSS
-scrubbing ``Cleaner`` does for ``style`` is not ported, and ``Cleaner`` rewrites a disallowed scheme to an empty
-``href`` where turbohtml drops the attribute outright.
+``<script>`` is escaped rather than executed. ``Cleaner``'s ``host_whitelist`` and ``allow_tags`` lists fold into
+``Policy.tags`` and ``attribute_filter``, its ``kill_tags`` (drop the element together with its content) maps to
+``Policy.remove_with_content``, and its ``add_nofollow`` maps to ``Policy.add_link_rel``. The CSS scrubbing ``Cleaner``
+does for ``style`` is not ported, and ``Cleaner`` rewrites a disallowed scheme to an empty ``href`` where turbohtml
+drops the attribute outright.
 
 *********************
  From html-sanitizer

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -34,6 +34,7 @@ def _sanitize(
     add_link_rel: str | None,
     attribute_filter: Callable[[str, str, str], str | None] | None,
     set_attributes: Mapping[str, Mapping[str, str]],
+    remove_with_content: frozenset[str],
     /,
 ) -> None: ...
 

--- a/src/turbohtml/sanitize.c
+++ b/src/turbohtml/sanitize.c
@@ -26,6 +26,7 @@ typedef struct {
     PyObject *add_link_rel;     /* str to set as an <a> rel, or None */
     PyObject *attribute_filter; /* callable (tag, name, value) -> str | None, or None */
     PyObject *set_attributes;   /* dict[str, dict[str, str]]: per-tag attribute values to force-set on kept elements */
+    PyObject *remove_with_content; /* frozenset[str]: disallowed tags whose whole subtree is dropped, not escaped */
     int allow_relative;
     int on_disallowed;
     int strip_comments;
@@ -512,13 +513,17 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
     if (allowed > 0 && !is_html && !parent_kept) {
         allowed = 0;
     }
+    /* only disallowed elements consult remove_with_content, so a kept element never pays the set lookup */
+    int remove_content = allowed > 0 ? 0 : PySet_Contains(s->remove_with_content, tag);
     int status = 0;
-    if (allowed < 0) { /* GCOVR_EXCL_BR_LINE: PySet_Contains only fails on a non-hashable member, impossible here */
-        status = -1;   /* GCOVR_EXCL_LINE */
+    if (allowed < 0 || remove_content < 0) { /* GCOVR_EXCL_BR_LINE: PySet_Contains never fails on a str key */
+        status = -1;                         /* GCOVR_EXCL_LINE */
     } else if (allowed) {
         status = sanitize_attributes(s, element, tag) < 0 ? -1 : sanitize_children(s, element, 1);
-    } else if (s->on_disallowed == ON_REMOVE || (s->on_disallowed == ON_STRIP && !is_html)) {
-        th_node_remove(element); /* foreign content is removed rather than unwrapped, to avoid namespace confusion */
+    } else if (remove_content || s->on_disallowed == ON_REMOVE || (s->on_disallowed == ON_STRIP && !is_html)) {
+        /* drop the whole subtree: a content-removal tag (e.g. script/style, so its text never leaks), REMOVE mode, or
+           foreign content under STRIP (unwrapping it would invite namespace confusion) */
+        th_node_remove(element);
     } else if (s->on_disallowed == ON_STRIP) {
         if ((status = sanitize_children(s, element, 0)) == 0) {
             hoist_children(element);
@@ -553,13 +558,14 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
 }
 
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
-   attribute_filter, set_attributes) -> None. Filters the parsed fragment in place; sanitizer.py serializes it. */
+   attribute_filter, set_attributes, remove_with_content) -> None. Filters the fragment in place; sanitizer.py
+   serializes it. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+    if (!PyArg_ParseTuple(args, "OOOOpipOOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
-                          &s.set_attributes)) {
+                          &s.set_attributes, &s.remove_with_content)) {
         return NULL;
     }
     th_node *root;

--- a/src/turbohtml/sanitizer.py
+++ b/src/turbohtml/sanitizer.py
@@ -76,8 +76,10 @@ class Policy:
     the allowlist for URL-bearing attributes; ``attribute_filter`` is an optional last word over every surviving
     attribute, returning a replacement value or ``None`` to drop it. ``set_attributes`` maps a tag to attribute values
     forced onto every kept instance of it (added if absent, overwritten if present) -- the one thing
-    ``attribute_filter`` cannot do, since it only sees attributes already there. The baseline-unsafe set and the
-    event-handler and bad-scheme stripping are not configurable, so any policy is safe.
+    ``attribute_filter`` cannot do, since it only sees attributes already there. ``remove_with_content`` names
+    disallowed tags whose whole subtree is dropped (e.g. ``script``/``style``) rather than escaped or stripped, so their
+    text never leaks into the output. The baseline-unsafe set and the event-handler and bad-scheme stripping are not
+    configurable, so any policy is safe.
     """
 
     tags: frozenset[str] = DEFAULT_TAGS
@@ -90,6 +92,7 @@ class Policy:
     add_link_rel: frozenset[str] = frozenset()
     attribute_filter: Callable[[str, str, str], str | None] | None = None
     set_attributes: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
+    remove_with_content: frozenset[str] = frozenset()
 
     @classmethod
     def strict(cls) -> Policy:
@@ -136,6 +139,7 @@ class Sanitizer:
             self._link_rel,
             policy.attribute_filter,
             self._set_attributes,
+            policy.remove_with_content,
         )
         return root.inner_html
 

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -153,6 +153,39 @@ def test_set_attributes_skips_disallowed_elements() -> None:
     assert "rel=" not in sanitize("<a>t</a><script>z</script>", policy)
 
 
+def test_script_text_leaks_without_remove_with_content() -> None:
+    # baseline: under the default ESCAPE mode a disallowed <script> is escaped, so its text stays visible
+    out = sanitize("<b>ok</b><script>alert(1)</script>", Policy(tags=frozenset({"b"})))
+    assert "alert(1)" in out
+
+
+def test_remove_with_content_deletes_disallowed_subtree() -> None:
+    # naming the tag in remove_with_content drops the tag and its whole subtree, so the text never leaks
+    policy = Policy(tags=frozenset({"b"}), remove_with_content=frozenset({"script", "style"}))
+    assert sanitize("<b>ok</b><script>alert(1)</script><style>x{}</style>", policy) == "<b>ok</b>"
+
+
+def test_remove_with_content_does_not_drop_allowed_tags() -> None:
+    # an allowlisted tag is kept even when it also appears in remove_with_content
+    policy = Policy(tags=frozenset({"b"}), remove_with_content=frozenset({"b"}))
+    assert sanitize("<b>kept</b>", policy) == "<b>kept</b>"
+
+
+def test_remove_with_content_leaves_other_disallowed_tags_to_the_mode() -> None:
+    # a disallowed tag that is not in the set still follows on_disallowed (escaped here)
+    policy = Policy(tags=frozenset({"b"}), remove_with_content=frozenset({"script"}))
+    assert "&lt;unknown&gt;" in sanitize("<b>ok</b><unknown>x</unknown>", policy)
+
+
+@pytest.mark.parametrize("mode", [OnDisallowed.ESCAPE, OnDisallowed.STRIP, OnDisallowed.REMOVE])
+def test_remove_with_content_overrides_every_disposition(mode: OnDisallowed) -> None:
+    # content removal happens before the escape/strip/remove dispatch, so it wins in every mode
+    policy = Policy(tags=frozenset({"b"}), on_disallowed_tag=mode, remove_with_content=frozenset({"script"}))
+    out = sanitize("<b>ok</b><script>alert(1)</script>", policy)
+    assert "alert(1)" not in out
+    assert "<b>ok</b>" in out
+
+
 @pytest.mark.parametrize(
     ("url", "kept"),
     [
@@ -395,7 +428,7 @@ def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
     with pytest.raises(TypeError):
-        _sanitize("not an element", frozenset(), {}, frozenset(), True, 0, True, None, None, {})  # ty: ignore[invalid-argument-type]  # noqa: FBT003
+        _sanitize("not an element", frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset())  # ty: ignore[invalid-argument-type]  # noqa: FBT003
 
 
 def test_sanitize_rejects_wrong_arguments() -> None:


### PR DESCRIPTION
A disallowed tag was handled by a single global disposition (escape, strip, or remove), so under the default `ESCAPE` mode a disallowed `<script>` was escaped and its body text leaked into the output as visible content. There was no way to say "delete these tags and their content outright" while letting other disallowed tags still escape or strip — the capability nh3 exposes as `clean_content_tags` and lxml-html-clean as `kill_tags`.

`Policy.remove_with_content` is a frozenset of tag names whose entire subtree is dropped before the escape/strip/remove dispatch, so their text never reaches the output. It wins over the global mode (in every disposition), but an allowlisted tag still wins over it — a tag in both `tags` and `remove_with_content` is kept. The membership check runs only for already-disallowed elements, so the allowed-element hot path is untouched.

The filtering stays in C: the new set is threaded through `_sanitize` and consulted in `sanitize_element`. `sanitize.c` keeps 100% line and branch coverage, and the adversarial suite gains content-removal cases across all three dispositions. The migration guide's lxml-html-clean section now maps `kill_tags` to this field.

closes #216