### PR TITLE
✨ feat(sanitizer): add Policy.set_attributes

### DIFF
--- a/docs/changelog/217.feature.rst
+++ b/docs/changelog/217.feature.rst
@@ -1,0 +1,3 @@
+Add ``Policy.set_attributes`` to the sanitizer: a per-tag mapping of attribute values forced onto every kept element
+(added if absent, overwritten if present), covering what ``attribute_filter`` cannot since it only sees attributes
+already present - by :user:`gaborbernat`.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -851,9 +851,10 @@ bleach feature parity: it has no escape-instead-of-strip mode, no attribute-rewr
     sanitize(text, Policy(tags=frozenset({"a"}), attributes={"a": frozenset({"href"})}))
 
 nh3's ``link_rel`` maps to ``Policy.add_link_rel``, its ``url_schemes`` to ``url_schemes``, and its ``attribute_filter``
-to ``attribute_filter`` (turbohtml's may rewrite a value, not only drop it). turbohtml escapes disallowed tags by
-default (``OnDisallowed.ESCAPE``), the mode ammonia blocked upstream; pass ``OnDisallowed.STRIP`` or
-``OnDisallowed.REMOVE`` for nh3-style dropping.
+to ``attribute_filter`` (turbohtml's may rewrite a value, not only drop it). Its ``set_tag_attribute_values`` (force an
+attribute onto matching tags) maps to ``Policy.set_attributes``. turbohtml escapes disallowed tags by default
+(``OnDisallowed.ESCAPE``), the mode ammonia blocked upstream; pass ``OnDisallowed.STRIP`` or ``OnDisallowed.REMOVE`` for
+nh3-style dropping.
 
 **********************
  From lxml-html-clean

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -33,6 +33,7 @@ def _sanitize(
     strip_comments: bool,
     add_link_rel: str | None,
     attribute_filter: Callable[[str, str, str], str | None] | None,
+    set_attributes: Mapping[str, Mapping[str, str]],
     /,
 ) -> None: ...
 

--- a/src/turbohtml/sanitize.c
+++ b/src/turbohtml/sanitize.c
@@ -25,6 +25,7 @@ typedef struct {
     PyObject *star;             /* the interned "*" string, for the any-name wildcard */
     PyObject *add_link_rel;     /* str to set as an <a> rel, or None */
     PyObject *attribute_filter; /* callable (tag, name, value) -> str | None, or None */
+    PyObject *set_attributes;   /* dict[str, dict[str, str]]: per-tag attribute values to force-set on kept elements */
     int allow_relative;
     int on_disallowed;
     int strip_comments;
@@ -277,6 +278,37 @@ static int run_attribute_filter(sanitizer *s, th_node *element, PyObject *tag, c
 }
 
 /* Strip every attribute the policy rejects from an allowed element, then add the configured link rel. */
+/* Force-set the policy's per-tag attribute values on a kept element, adding the attribute if absent and overwriting it
+   if present (what attribute_filter cannot do, since it only sees attributes already there). */
+static int apply_set_attributes(sanitizer *s, th_node *element, PyObject *tag) {
+    PyObject *per_tag = PyDict_GetItemWithError(s->set_attributes, tag);
+    if (per_tag == NULL) {
+        if (PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: PyDict_GetItemWithError only errors on a non-hashable key */
+            return -1;          /* GCOVR_EXCL_LINE: error path */
+        }
+        return 0; /* no forced attributes for this tag */
+    }
+    PyObject *name, *value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(per_tag, &pos, &name, &value)) {
+        Py_ssize_t name_len = 0;
+        const char *name_bytes = PyUnicode_AsUTF8AndSize(name, &name_len);
+        if (name_bytes == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;            /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        Py_UCS4 *points = PyUnicode_AsUCS4Copy(value);
+        if (points == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;        /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        int status = th_node_attr_set(s->tree, element, name_bytes, name_len, points, PyUnicode_GET_LENGTH(value), 1);
+        PyMem_Free(points);
+        if (status < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;    /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    return 0;
+}
+
 static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
     Py_ssize_t index = 0;
     while (index < element->attr_count) {
@@ -343,6 +375,9 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
         if (status < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return -1;    /* GCOVR_EXCL_LINE: allocation-failure path */
         }
+    }
+    if (apply_set_attributes(s, element, tag) < 0) { /* GCOVR_EXCL_BR_LINE: only on allocation failure */
+        return -1;                                   /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     return 0;
 }
@@ -518,13 +553,13 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
 }
 
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
-   attribute_filter) -> None. Filters the parsed fragment in place; sanitizer.py serializes the result. */
+   attribute_filter, set_attributes) -> None. Filters the parsed fragment in place; sanitizer.py serializes it. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
-                          &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel,
-                          &s.attribute_filter)) {
+    if (!PyArg_ParseTuple(args, "OOOOpipOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+                          &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
+                          &s.set_attributes)) {
         return NULL;
     }
     th_node *root;

--- a/src/turbohtml/sanitizer.py
+++ b/src/turbohtml/sanitizer.py
@@ -74,8 +74,10 @@ class Policy:
     Build one and reuse it across threads. ``tags`` is the allowed element set and ``attributes`` maps a tag (or
     ``"*"`` for every tag) to its allowed attribute names (a ``"*"`` inside a set allows every name). ``url_schemes`` is
     the allowlist for URL-bearing attributes; ``attribute_filter`` is an optional last word over every surviving
-    attribute, returning a replacement value or ``None`` to drop it. The baseline-unsafe set and the event-handler and
-    bad-scheme stripping are not configurable, so any policy is safe.
+    attribute, returning a replacement value or ``None`` to drop it. ``set_attributes`` maps a tag to attribute values
+    forced onto every kept instance of it (added if absent, overwritten if present) -- the one thing
+    ``attribute_filter`` cannot do, since it only sees attributes already there. The baseline-unsafe set and the
+    event-handler and bad-scheme stripping are not configurable, so any policy is safe.
     """
 
     tags: frozenset[str] = DEFAULT_TAGS
@@ -87,6 +89,7 @@ class Policy:
     strip_comments: bool = True
     add_link_rel: frozenset[str] = frozenset()
     attribute_filter: Callable[[str, str, str], str | None] | None = None
+    set_attributes: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
 
     @classmethod
     def strict(cls) -> Policy:
@@ -116,6 +119,7 @@ class Sanitizer:
         self.policy = policy if policy is not None else Policy()
         self._attributes = dict(self.policy.attributes)
         self._link_rel = " ".join(sorted(self.policy.add_link_rel)) or None
+        self._set_attributes = {tag: dict(values) for tag, values in self.policy.set_attributes.items()}
 
     def sanitize(self, html: str) -> str:
         """Sanitize an HTML fragment and return safe HTML."""
@@ -131,6 +135,7 @@ class Sanitizer:
             policy.strip_comments,
             self._link_rel,
             policy.attribute_filter,
+            self._set_attributes,
         )
         return root.inner_html
 

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -115,6 +115,44 @@ def test_allowlisted_foreign_script_is_still_escaped() -> None:
     assert "<script>" not in out
 
 
+def test_set_attributes_adds_absent_attributes() -> None:
+    # set_attributes forces attributes onto kept elements even when the allowlist would not admit them
+    policy = Policy(
+        tags=frozenset({"a"}),
+        attributes={"a": frozenset({"href"})},
+        set_attributes={"a": {"target": "_blank", "rel": "noopener"}},
+    )
+    out = sanitize('<a href="http://x">t</a>', policy)
+    assert 'target="_blank"' in out
+    assert 'rel="noopener"' in out
+
+
+def test_set_attributes_overwrites_present_attribute() -> None:
+    policy = Policy(
+        tags=frozenset({"a"}),
+        attributes={"a": frozenset({"href", "target"})},
+        set_attributes={"a": {"target": "_blank"}},
+    )
+    out = sanitize('<a href="http://x" target="_self">t</a>', policy)
+    assert 'target="_blank"' in out
+    assert "_self" not in out
+
+
+def test_set_attributes_only_touches_named_tag() -> None:
+    # a kept element whose tag is not in set_attributes is left alone
+    policy = Policy(
+        tags=frozenset({"a", "b"}), attributes={"a": frozenset({"href"})}, set_attributes={"a": {"rel": "x"}}
+    )
+    out = sanitize('<a href="http://x">t</a><b>y</b>', policy)
+    assert out.count("rel=") == 1
+
+
+def test_set_attributes_skips_disallowed_elements() -> None:
+    # a disallowed tag is escaped, so its set_attributes entry is never applied
+    policy = Policy(tags=frozenset({"a"}), set_attributes={"script": {"rel": "x"}})
+    assert "rel=" not in sanitize("<a>t</a><script>z</script>", policy)
+
+
 @pytest.mark.parametrize(
     ("url", "kept"),
     [
@@ -357,7 +395,7 @@ def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
     with pytest.raises(TypeError):
-        _sanitize("not an element", frozenset(), {}, frozenset(), True, 0, True, None, None)  # ty: ignore[invalid-argument-type]  # noqa: FBT003
+        _sanitize("not an element", frozenset(), {}, frozenset(), True, 0, True, None, None, {})  # ty: ignore[invalid-argument-type]  # noqa: FBT003
 
 
 def test_sanitize_rejects_wrong_arguments() -> None:


### PR DESCRIPTION
`attribute_filter` is only invoked for attributes that are already present, so it can rewrite or drop a value but cannot *add* one that is absent — there was no way to force, say, `rel="noopener"` or `target="_blank"` onto every kept `<a>` that lacks it. `add_link_rel` covered only the `rel` case on anchors.

`Policy.set_attributes` is a per-tag mapping (`{tag: {attr: value}}`) of attribute values forced onto every kept element: added when absent, overwritten when present. It runs after the attribute-allowlist filter, so the forced value survives even when the attribute is not itself allowlisted, and the per-tag lookup only happens for elements being kept, so the hot path is untouched. It maps nh3's `set_tag_attribute_values`.

The injection stays in C (threaded through `_sanitize`, applied in `sanitize_attributes`). `sanitize.c` keeps 100% line and branch coverage, and the suite gains add/overwrite/scope cases. Note: this branches on the merged #215 and will rebase cleanly against #216's `_sanitize` signature once that lands.

closes #217