### PR TITLE
✨ feat(sanitizer): scrub the style attribute against a CSS property allowlist

### DIFF
--- a/docs/changelog/214.feature.rst
+++ b/docs/changelog/214.feature.rst
@@ -1,0 +1,3 @@
+Scrub the ``style`` attribute in the sanitizer: when ``style`` is an allowed attribute, each CSS declaration whose
+property name is not in ``Policy.css_properties`` (a safe default set) is dropped, so dangerous inline CSS cannot ride
+in on a kept ``style`` - by :user:`gaborbernat`.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -828,7 +828,10 @@ frozen, thread-safe policy (bleach's ``clean`` had a documented thread-safety fo
 an ``attribute_filter`` that rewrites or drops a value where bleach's callable only returned a bool. One difference is
 deliberate and load-bearing: turbohtml's safety baseline (``<script>``, ``on*`` handlers, ``javascript:`` URLs) is not
 configurable, so even a permissive ``attributes`` callable cannot re-admit them, where bleach faithfully kept whatever
-you allowed. CSS sanitizing (bleach's ``css_sanitizer``) is not yet ported; ``clean`` raises if you pass it.
+you allowed. The native sanitizer scrubs the ``style`` attribute against ``Policy.css_properties`` (the safe set
+bleach's ``css_sanitizer`` defaults to), so an allowed ``style`` keeps only allowlisted declarations; the
+bleach-compatible ``clean`` shim does not yet take a ``css_sanitizer`` argument (it raises), and ``<style>`` element
+contents are dropped rather than scrubbed.
 
 **********
  From nh3
@@ -894,9 +897,10 @@ Porting inverts the model. Instead of switching dangerous things off, declare th
 The ``javascript:`` URL is gone because ``http``/``https``/``mailto`` are the only schemes the policy admits, and the
 ``<script>`` is escaped rather than executed. ``Cleaner``'s ``host_whitelist`` and ``allow_tags`` lists fold into
 ``Policy.tags`` and ``attribute_filter``, its ``kill_tags`` (drop the element together with its content) maps to
-``Policy.remove_with_content``, and its ``add_nofollow`` maps to ``Policy.add_link_rel``. The CSS scrubbing ``Cleaner``
-does for ``style`` is not ported, and ``Cleaner`` rewrites a disallowed scheme to an empty ``href`` where turbohtml
-drops the attribute outright.
+``Policy.remove_with_content``, and its ``add_nofollow`` maps to ``Policy.add_link_rel``. turbohtml scrubs a kept
+``style`` attribute against ``Policy.css_properties``, though it drops ``<style>`` elements where ``Cleaner`` scrubs
+their text too, and ``Cleaner`` rewrites a disallowed scheme to an empty ``href`` where turbohtml drops the attribute
+outright.
 
 *********************
  From html-sanitizer

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -35,6 +35,7 @@ def _sanitize(
     attribute_filter: Callable[[str, str, str], str | None] | None,
     set_attributes: Mapping[str, Mapping[str, str]],
     remove_with_content: frozenset[str],
+    css_properties: frozenset[str],
     /,
 ) -> None: ...
 

--- a/src/turbohtml/sanitize.c
+++ b/src/turbohtml/sanitize.c
@@ -27,6 +27,7 @@ typedef struct {
     PyObject *attribute_filter; /* callable (tag, name, value) -> str | None, or None */
     PyObject *set_attributes;   /* dict[str, dict[str, str]]: per-tag attribute values to force-set on kept elements */
     PyObject *remove_with_content; /* frozenset[str]: disallowed tags whose whole subtree is dropped, not escaped */
+    PyObject *css_properties;      /* frozenset[str]: CSS property names kept when scrubbing a `style` attribute */
     int allow_relative;
     int on_disallowed;
     int strip_comments;
@@ -310,6 +311,147 @@ static int apply_set_attributes(sanitizer *s, th_node *element, PyObject *tag) {
     return 0;
 }
 
+/* A CSS property name is ASCII letters, digits, and '-', so an ASCII lowercase is enough to look it up. Returns 1
+   allow, 0 drop, -1 error. */
+static int css_property_allowed(sanitizer *s, const Py_UCS4 *name, Py_ssize_t len) {
+    char lowered[64];
+    if (len == 0 || len >= (Py_ssize_t)sizeof(lowered)) {
+        return 0; /* empty, or longer than any real property name */
+    }
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 c = name[index];
+        lowered[index] = (char)((c >= 'A' && c <= 'Z') ? (c | 0x20) : c);
+    }
+    PyObject *key = PyUnicode_FromStringAndSize(lowered, len);
+    if (key == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int allowed = PySet_Contains(s->css_properties, key);
+    Py_DECREF(key);
+    return allowed;
+}
+
+/* Append the declaration `value[start:end)` to `out` if the property name (the part before `colon`) is allowlisted,
+   trimming surrounding whitespace and joining kept declarations with "; ". Returns 0, or -1 on error. */
+static int css_flush_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_ssize_t colon,
+                                 Py_UCS4 *out, Py_ssize_t *out_len) {
+    if (colon < start) {
+        return 0; /* no property:value split in this declaration, so drop it */
+    }
+    Py_ssize_t name_start = start;
+    Py_ssize_t name_end = colon;
+    while (name_start < name_end && is_ascii_ws(value[name_start])) {
+        name_start++;
+    }
+    while (name_end > name_start && is_ascii_ws(value[name_end - 1])) {
+        name_end--;
+    }
+    int allowed = css_property_allowed(s, value + name_start, name_end - name_start);
+    if (allowed < 0) { /* GCOVR_EXCL_BR_LINE: css_property_allowed only fails on allocation failure */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    if (!allowed) {
+        return 0;
+    }
+    /* output from the trimmed name start to the value's last non-whitespace byte (the leading whitespace was already
+       trimmed into name_start, so a kept declaration is emitted without its surrounding whitespace) */
+    Py_ssize_t decl_end = end;
+    while (decl_end > colon + 1 && is_ascii_ws(value[decl_end - 1])) {
+        decl_end--;
+    }
+    if (*out_len > 0) {
+        out[(*out_len)++] = ';';
+        out[(*out_len)++] = ' ';
+    }
+    for (Py_ssize_t index = name_start; index < decl_end; index++) {
+        out[(*out_len)++] = value[index];
+    }
+    return 0;
+}
+
+/* Scrub a kept `style` attribute: keep only declarations whose property name is allowlisted. The value is a CSS
+   declaration list; split it on top-level ';' and ':' while skipping strings, comments, and parenthesised groups so a
+   separator inside url()/quotes/comments is not mistaken for one. Rewrites the attribute, deleting it if nothing
+   survives. Returns 0 on success, -1 on error. */
+static int sanitize_style(sanitizer *s, th_node *element, th_node_attr *attr) {
+    const Py_UCS4 *value = attr->value;
+    Py_ssize_t len = attr->value_len;
+    Py_UCS4 *out = PyMem_Malloc((size_t)(2 * len + 2) * sizeof(Py_UCS4));
+    if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    Py_ssize_t out_len = 0;
+    Py_ssize_t decl_start = 0;
+    Py_ssize_t colon = -1;
+    int mode = 0; /* 0 normal, 1 string, 2 comment */
+    Py_UCS4 quote = 0;
+    int depth = 0;
+    for (Py_ssize_t index = 0; index <= len; index++) {
+        int boundary = index == len; /* the end of the value flushes the final declaration */
+        Py_UCS4 c = boundary ? 0 : value[index];
+        if (!boundary && mode == 2) {
+            if (c == '*' && index + 1 < len && value[index + 1] == '/') {
+                mode = 0;
+                index++;
+            }
+            continue;
+        }
+        if (!boundary && mode == 1) {
+            if (c == '\\') {
+                index++; /* a backslash escapes the next byte, even a quote */
+            } else if (c == quote) {
+                mode = 0;
+            }
+            continue;
+        }
+        if (!boundary) {
+            if (c == '/' && index + 1 < len && value[index + 1] == '*') {
+                mode = 2;
+                index++;
+                continue;
+            }
+            if (c == '"' || c == '\'') {
+                mode = 1;
+                quote = c;
+                continue;
+            }
+            if (c == '(') {
+                depth++;
+                continue;
+            }
+            if (c == ')') {
+                depth -= depth > 0;
+                continue;
+            }
+            if (depth > 0) {
+                continue;
+            }
+            if (c == ':' && colon < 0) {
+                colon = index;
+                continue;
+            }
+            if (c != ';') {
+                continue;
+            }
+        }
+        int flushed = css_flush_declaration(s, value, decl_start, index, colon, out, &out_len);
+        if (flushed < 0) {   /* GCOVR_EXCL_BR_LINE: css_flush_declaration only fails on allocation failure */
+            PyMem_Free(out); /* GCOVR_EXCL_LINE: allocation-failure path */
+            return -1;       /* GCOVR_EXCL_LINE */
+        }
+        decl_start = index + 1;
+        colon = -1;
+    }
+    if (out_len == 0) {
+        th_node_attr_del(s->tree, element, "style", 5);
+        PyMem_Free(out);
+        return 0;
+    }
+    int result = th_node_attr_set(s->tree, element, "style", 5, out, out_len, 1);
+    PyMem_Free(out);
+    return result;
+}
+
 static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
     Py_ssize_t index = 0;
     while (index < element->attr_count) {
@@ -354,6 +496,15 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
         if (drop) {
             th_node_attr_del(s->tree, element, name, name_len);
             continue; /* the next attribute shifted into this slot */
+        }
+        if (name_len == 5 && memcmp(name, "style", 5) == 0) {
+            Py_ssize_t before = element->attr_count;
+            if (sanitize_style(s, element, attr) < 0) { /* GCOVR_EXCL_BR_LINE: only on allocation failure */
+                return -1;                              /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            if (element->attr_count < before) {
+                continue; /* the style scrubbed to empty and was deleted */
+            }
         }
         if (s->attribute_filter != Py_None) {
             Py_ssize_t before = element->attr_count;
@@ -558,14 +709,14 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
 }
 
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
-   attribute_filter, set_attributes, remove_with_content) -> None. Filters the fragment in place; sanitizer.py
-   serializes it. */
+   attribute_filter, set_attributes, remove_with_content, css_properties) -> None. Filters the fragment in place;
+   sanitizer.py serializes it. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+    if (!PyArg_ParseTuple(args, "OOOOpipOOOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
-                          &s.set_attributes, &s.remove_with_content)) {
+                          &s.set_attributes, &s.remove_with_content, &s.css_properties)) {
         return NULL;
     }
     th_node *root;

--- a/src/turbohtml/sanitizer.py
+++ b/src/turbohtml/sanitizer.py
@@ -48,6 +48,17 @@ DEFAULT_ATTRIBUTES: Mapping[str, frozenset[str]] = MappingProxyType({
 })
 #: bleach's default URL schemes.
 DEFAULT_SCHEMES = frozenset({"http", "https", "mailto"})
+#: bleach's default allowed CSS properties (CSS 2.1 safe set plus SVG paint), for scrubbing a ``style`` attribute.
+DEFAULT_CSS_PROPERTIES = frozenset({
+    "azimuth", "background-color", "border-bottom-color", "border-collapse", "border-color", "border-left-color",
+    "border-right-color", "border-top-color", "clear", "color", "cursor", "direction", "display", "elevation",
+    "float", "font", "font-family", "font-size", "font-style", "font-variant", "font-weight", "height",
+    "letter-spacing", "line-height", "overflow", "pause", "pause-after", "pause-before", "pitch", "pitch-range",
+    "richness", "speak", "speak-header", "speak-numeral", "speak-punctuation", "speech-rate", "stress", "text-align",
+    "text-decoration", "text-indent", "unicode-bidi", "vertical-align", "voice-family", "volume", "white-space",
+    "width", "fill", "fill-opacity", "fill-rule", "stroke", "stroke-width", "stroke-linecap", "stroke-linejoin",
+    "stroke-opacity",
+})  # fmt: skip
 
 # A roomier set for the relaxed preset: typical user-generated content (headings, tables, images, figures).
 _RELAXED_TAGS = DEFAULT_TAGS | {
@@ -78,8 +89,10 @@ class Policy:
     forced onto every kept instance of it (added if absent, overwritten if present) -- the one thing
     ``attribute_filter`` cannot do, since it only sees attributes already there. ``remove_with_content`` names
     disallowed tags whose whole subtree is dropped (e.g. ``script``/``style``) rather than escaped or stripped, so their
-    text never leaks into the output. The baseline-unsafe set and the event-handler and bad-scheme stripping are not
-    configurable, so any policy is safe.
+    text never leaks into the output. When ``style`` is an allowed attribute, its value is scrubbed against
+    ``css_properties``: each declaration whose property name is not in the set is dropped, so dangerous CSS cannot ride
+    in on a kept ``style``. The baseline-unsafe set and the event-handler and bad-scheme stripping are not configurable,
+    so any policy is safe.
     """
 
     tags: frozenset[str] = DEFAULT_TAGS
@@ -93,6 +106,7 @@ class Policy:
     attribute_filter: Callable[[str, str, str], str | None] | None = None
     set_attributes: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
     remove_with_content: frozenset[str] = frozenset()
+    css_properties: frozenset[str] = DEFAULT_CSS_PROPERTIES
 
     @classmethod
     def strict(cls) -> Policy:
@@ -140,6 +154,7 @@ class Sanitizer:
             policy.attribute_filter,
             self._set_attributes,
             policy.remove_with_content,
+            policy.css_properties,
         )
         return root.inner_html
 
@@ -151,6 +166,7 @@ def sanitize(html: str, policy: Policy | None = None) -> str:
 
 __all__ = [
     "DEFAULT_ATTRIBUTES",
+    "DEFAULT_CSS_PROPERTIES",
     "DEFAULT_SCHEMES",
     "DEFAULT_TAGS",
     "OnDisallowed",

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from turbohtml.sanitizer import (
     DEFAULT_ATTRIBUTES,
+    DEFAULT_CSS_PROPERTIES,
     DEFAULT_SCHEMES,
     DEFAULT_TAGS,
     OnDisallowed,
@@ -11,6 +14,24 @@ from turbohtml.sanitizer import (
     Sanitizer,
     sanitize,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _style_policy(
+    *,
+    css_properties: frozenset[str] = DEFAULT_CSS_PROPERTIES,
+    attribute_filter: Callable[[str, str, str], str | None] | None = None,
+) -> Policy:
+    """A policy that allows <p style="...">, for exercising CSS scrubbing."""
+    return Policy(
+        tags=frozenset({"p"}),
+        attributes={"p": frozenset({"style"})},
+        css_properties=css_properties,
+        attribute_filter=attribute_filter,
+    )
+
 
 # frame and frameset are absent: the parser drops them outside a frameset document, so a fragment never contains one.
 _UNSAFE_TAGS = [
@@ -184,6 +205,95 @@ def test_remove_with_content_overrides_every_disposition(mode: OnDisallowed) -> 
     out = sanitize("<b>ok</b><script>alert(1)</script>", policy)
     assert "alert(1)" not in out
     assert "<b>ok</b>" in out
+
+
+def test_style_dropped_when_not_allowed() -> None:
+    # style is not in the default allowed attributes, so it is dropped without CSS scrubbing
+    assert sanitize('<a href="http://x" style="color: red">t</a>') == '<a href="http://x">t</a>'
+
+
+@pytest.mark.parametrize(
+    ("style", "expected"),
+    [
+        pytest.param("color: red", 'style="color: red"', id="keep-allowed"),
+        pytest.param("position: fixed", None, id="drop-disallowed"),
+        pytest.param("COLOR: red", 'style="COLOR: red"', id="uppercase-name"),
+        pytest.param("color: red; width: 5px", 'style="color: red; width: 5px"', id="two-kept-joined"),
+        pytest.param("color: red; position: fixed", 'style="color: red"', id="keep-one-drop-one"),
+        pytest.param("  color : red  ", 'style="color : red"', id="surrounding-whitespace-trimmed"),
+        pytest.param("color: red; /* ; : x */ width: 1px", 'style="color: red', id="comment-holds-separators"),
+        pytest.param("font-family: 'a;b:c'; color: red", "font-family: 'a;b:c'", id="string-holds-separators"),
+        pytest.param("font-family: 'a\\'b'; color: red", "color: red", id="string-escaped-quote"),
+        pytest.param("cursor: url(a;b:c); color: red", "cursor: url(a;b:c)", id="url-holds-separators"),
+        pytest.param("cursor: url((nested)); color: red", "color: red", id="nested-parens"),
+        pytest.param("color: red)", 'style="color: red)"', id="stray-close-paren"),
+        pytest.param("color:", 'style="color:"', id="empty-value"),
+        pytest.param("color: a:b", 'style="color: a:b"', id="value-has-second-colon"),
+        pytest.param("no-colon-declaration", None, id="declaration-without-colon"),
+        pytest.param(": red; color: blue", 'style="color: blue"', id="empty-property-name"),
+        pytest.param("", None, id="empty-value"),
+        pytest.param(";;; color: red ;;;", 'style="color: red"', id="extra-semicolons"),
+        pytest.param("position: fixed; z-index: 9", None, id="all-dropped-removes-attribute"),
+        pytest.param(("a" * 70) + ": red; color: blue", 'style="color: blue"', id="property-name-too-long"),
+    ],
+)
+def test_style_scrubbing(style: str, expected: str | None) -> None:
+    out = sanitize(f'<p style="{style}">x</p>', _style_policy())
+    if expected is None:
+        assert "style=" not in out
+    else:
+        assert expected in out
+
+
+def test_style_unterminated_string_is_safe() -> None:
+    # an unterminated string runs to the end; the declaration's property still gates it
+    out = sanitize('<p style="color: red; font-family: \'unterminated">x</p>', _style_policy())
+    assert "color: red" in out
+    assert sanitize(out, _style_policy()) == out  # idempotent
+
+
+def test_style_unterminated_comment_is_safe() -> None:
+    out = sanitize('<p style="color: red; width: 1px /* unterminated">x</p>', _style_policy())
+    assert "color: red" in out
+    assert sanitize(out, _style_policy()) == out
+
+
+def test_style_empty_property_set_drops_all_css() -> None:
+    out = sanitize('<p style="color: red">x</p>', _style_policy(css_properties=frozenset()))
+    assert "style=" not in out
+
+
+def test_style_scrubbed_before_attribute_filter_sees_it() -> None:
+    seen: list[str] = []
+
+    def record(_tag: str, name: str, value: str) -> str:
+        seen.append(f"{name}={value}")
+        return value
+
+    sanitize('<p style="color: red; position: fixed">x</p>', _style_policy(attribute_filter=record))
+    assert seen == ["style=color: red"]  # the filter sees the already-scrubbed value
+
+
+def test_style_comment_with_lone_asterisk() -> None:
+    # a '*' inside a comment that is not the closing '*/' must not end the comment early
+    assert "color: red" in sanitize('<p style="color: red /* a*b */">x</p>', _style_policy())
+
+
+def test_style_unterminated_comment_ending_in_asterisk() -> None:
+    # a '*' as the final byte of an unterminated comment has no following '/'
+    assert "color: red" in sanitize('<p style="color: red /* x *">x</p>', _style_policy())
+
+
+def test_style_slash_not_starting_a_comment() -> None:
+    # a '/' not followed by '*' is an ordinary character, including one at the very end
+    assert "color: 1/2" in sanitize('<p style="color: 1/2">x</p>', _style_policy())
+    assert "color: red/" in sanitize('<p style="color: red/">x</p>', _style_policy())
+
+
+def test_style_double_quoted_css_string() -> None:
+    # a double-quoted CSS string (in a single-quoted attribute) holds separators safely
+    out = sanitize("<p style='font-family: \"a;b:c\"; color: red'>x</p>", _style_policy())
+    assert "color: red" in out
 
 
 @pytest.mark.parametrize(
@@ -427,8 +537,10 @@ def test_strip_propagates_a_child_filter_error() -> None:
 def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
+    # the eleven policy arguments after the element; only the non-element first argument matters to this guard
+    policy_args = (frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset(), frozenset())
     with pytest.raises(TypeError):
-        _sanitize("not an element", frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset())  # ty: ignore[invalid-argument-type]  # noqa: FBT003
+        _sanitize("not an element", *policy_args)  # ty: ignore[invalid-argument-type]
 
 
 def test_sanitize_rejects_wrong_arguments() -> None:


### PR DESCRIPTION
A kept `style` attribute previously passed its inline CSS through verbatim, so a policy that allowed `style` had no way to stop a dangerous declaration — it was all-or-nothing. 🔐 bleach (`css_sanitizer`) and nh3 (`filter_style_properties`) both solve this by keeping only an allowlist of CSS *property names*; turbohtml lacked any middle ground.

When `style` is an allowed attribute, its value is now parsed as a CSS declaration list and each declaration whose property name is not in `Policy.css_properties` is dropped. `css_properties` defaults to the safe CSS 2.1 set bleach ships (plus SVG paint), which excludes the URL-bearing properties (`background`, `background-image`, ...), so `url(javascript:...)` cannot ride in. The declaration parser splits on top-level `;` and `:` while skipping strings, comments, and parenthesised groups, so a separator inside `url()` or a quoted string is never mistaken for one. It runs in C, before `attribute_filter` so the filter stays the last word, and an empty result drops the attribute entirely.

The whole walk stays in C and `sanitize.c` keeps 100% line and branch coverage, with an adversarial CSS suite covering comments/strings/`url()` holding separators, escaped quotes, unterminated comments and strings, stray parens, and the empty/no-colon/too-long edge cases. The migration guide's bleach, nh3, and lxml-html-clean sections are updated.

One deliberate limit, called out in the commit and docs: `<style>` *element* contents are still dropped rather than scrubbed, because `<style>` is in the non-configurable baseline-unsafe set; un-baselining it to scrub its stylesheet is a distinct, more security-sensitive change tracked as a follow-up. This branches on the merged #215/#217 and will rebase cleanly against #216's `_sanitize` signature.

closes #214