### PR TITLE
✨ feat(export): annotation spans and Google-Docs Markdown mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ print(doc.to_markdown())
 # - water
 ```
 
+The keyword options cover the markdownify and html2text surface; `google_doc=True` adds html2text's Google-Docs mode,
+reading the inline-CSS styling such an export carries.
+
 Or to layout-aware plain text (the `inscriptis` role), with tables laid out as aligned columns:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ print(doc.to_text())
 # Apples  3
 ```
 
+`to_annotated_text` returns that text with `(start, end, label)` spans for elements matching an `annotation_rules`
+mapping, the inscriptis annotation role:
+
+```python
+doc = turbohtml.parse("<h1>Q3</h1><p>Up <b>12%</b></p>")
+text, labels = doc.to_annotated_text({"h1": ["heading"], "b": ["metric"]})
+# ("Q3\n\nUp 12%", [(0, 2, "heading"), (6, 9, "metric")])
+```
+
 Pass `bytes` to sniff the encoding the WHATWG way (byte-order mark, then a `<meta>` declaration):
 
 ```python

--- a/docs/changelog/172.feature.rst
+++ b/docs/changelog/172.feature.rst
@@ -13,7 +13,11 @@ Keyword options cover the markdownify and html2text configuration surface with o
 migrating off either reproduces its output: heading style (ATX, closed ATX, setext), bullet and emphasis and quote
 markers, reference vs inline links with autolinking, image alt/ignore modes, ignored links/emphasis/tables, fenced or
 indented or marked code blocks, padded and stripped tables, three escaping levels, single vs double block spacing, and
-document trimming. The :doc:`migration <migration>` guide maps each old option to its turbohtml name.
+document trimming. ``google_doc=True`` adds html2text's Google-Docs mode, reading the inline-CSS styling such an export
+carries: a bold/italic font weight or style becomes ``strong``/``emphasis``, a fixed-width font becomes inline code,
+``list-style-type`` picks the marker, ``margin-left`` over ``google_list_indent`` pixels sets list nesting, and
+``hide_strikethrough`` drops struck text. The :doc:`migration <migration>` guide maps each old option to its turbohtml
+name.
 
 A companion :meth:`~turbohtml.Node.to_text` exports layout-aware plain text, the role `inscriptis
 <https://github.com/weblyzard/inscriptis>`_ fills: blocks separated by blank lines, lists indented under their bullets,

--- a/docs/changelog/172.feature.rst
+++ b/docs/changelog/172.feature.rst
@@ -20,3 +20,9 @@ A companion :meth:`~turbohtml.Node.to_text` exports layout-aware plain text, the
 and -- most visibly -- tables laid out as a column-aligned grid, all in the same single C walk. Options control link
 display (hidden, inline, or numbered footnotes), image alt text, the CSS profile, the table cell separator, the bullet,
 and an optional word-wrap width.
+
+:meth:`~turbohtml.Node.to_annotated_text` adds inscriptis's annotation role: given an ``annotation_rules`` mapping it
+returns the rendered text together with ``(start, end, label)`` spans over its code-point offsets, so a labeling or
+information-extraction pipeline keeps the visual layout and the markup-derived labels in one pass. Rule keys take the
+inscriptis ``tag``, ``tag#attr``, ``tag#attr=value``, ``#attr`` and ``#attr=value`` forms, and every ``to_text`` option
+applies.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -747,6 +747,37 @@ guide maps each old option to its turbohtml name.
 Links are hidden by default; pass ``links="inline"`` to append ``text (url)``, ``links="footnote"`` for numbered
 references, ``images=True`` to show alt text, and ``width`` to word-wrap.
 
+********************************
+ Label spans of the export text
+********************************
+
+To pull labeled regions out of the rendered text -- the role inscriptis fills with ``annotation_rules`` -- call
+:meth:`~turbohtml.Node.to_annotated_text` with a rule mapping. It returns the same text :meth:`~turbohtml.Node.to_text`
+would, plus a list of ``(start, end, label)`` triples whose offsets index into that text, and it accepts every
+``to_text`` option as well:
+
+.. testcode::
+
+    import turbohtml
+    text, labels = turbohtml.parse("<h1>Q3</h1><p>Up <b>12%</b> on the year.</p>").to_annotated_text(
+        {"h1": ["heading"], "b": ["metric"]}
+    )
+    print(text)
+    for start, end, label in labels:
+        print(label, "->", repr(text[start:end]))
+
+.. testoutput::
+
+    Q3
+
+    Up 12% on the year.
+    heading -> 'Q3'
+    metric -> '12%'
+
+A rule key is a tag (``"b"``), a ``tag#attr`` requiring the attribute, a ``tag#attr=value`` matching one
+whitespace-separated token, or the tag-less ``#attr`` / ``#attr=value`` to match across any tag; its value is the list
+of labels to attach.
+
 ************************************
  Parse bytes of an unknown encoding
 ************************************

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -718,6 +718,18 @@ guide maps each old option to its turbohtml name.
 
     [1]: /x
 
+To convert a Google Docs HTML export, pass ``google_doc=True`` so the inline-CSS styling it carries (font weight, font
+style, fixed-width fonts, and ``margin-left`` list nesting) turns into Markdown:
+
+.. testcode::
+
+    export = '<p><span style="font-weight:700">Bold</span> and <span style="font-style:italic">soft</span>.</p>'
+    print(turbohtml.parse(export).to_markdown(google_doc=True))
+
+.. testoutput::
+
+    **Bold** and *soft*.
+
 **********************
  Export to plain text
 **********************

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1115,6 +1115,40 @@ The ``ParserConfig`` options map as:
     - - (no equivalent)
       - ``width`` adds word wrapping, which inscriptis leaves to the caller
 
+inscriptis can also tag the rendered text with labeled spans through ``get_annotated_text`` and an ``annotation_rules``
+mapping. :meth:`~turbohtml.Node.to_annotated_text` is the same call: it returns the rendered text together with a list
+of ``(start, end, label)`` triples over its code-point offsets, taking every ``to_text`` option as well.
+
+.. code-block:: python
+
+    # inscriptis
+    from inscriptis import get_annotated_text, ParserConfig
+
+    rules = {"h1": ["heading"], "b": ["emphasis"]}
+    get_annotated_text(html, ParserConfig(annotation_rules=rules))
+
+    # turbohtml
+    turbohtml.parse(html).to_annotated_text(rules)
+
+.. testcode::
+
+    text, labels = parse("<h1>Title</h1><p>Some <b>bold</b> words.</p>").to_annotated_text(
+        {"h1": ["heading"], "b": ["emphasis"]}
+    )
+    print(text)
+    print([(label, text[start:end]) for start, end, label in labels])
+
+.. testoutput::
+
+    Title
+
+    Some bold words.
+    [('heading', 'Title'), ('emphasis', 'bold')]
+
+Rule keys follow inscriptis: a bare tag (``"h1"``), a ``tag#attr`` to require an attribute, a ``tag#attr=value`` to
+match one whitespace-separated token of it, and the tag-less ``#attr`` / ``#attr=value`` forms to match across any tag.
+The value is the list of labels to attach.
+
 Pitfalls
 ========
 
@@ -1122,4 +1156,5 @@ Pitfalls
   for numbered references collected at the end.
 - ``to_text`` renders structure, not styling: there is no bold or color, and headings are plain text. For the raw
   concatenation with no layout at all, read :attr:`~turbohtml.Node.text`.
-- The annotation API (inscriptis's ``get_annotated_text`` and ``annotation_rules``) is not ported.
+- Annotation offsets count code points into the returned string; a table cell is labeled at its position in the laid-out
+  grid, so the span covers the cell's column-aligned text rather than the source order.

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1048,6 +1048,27 @@ The html2text options map as:
       - ``quote_open``, ``quote_close``
     - - ``escape_snob``
       - ``escape_mode="all"``
+    - - ``google_doc``
+      - ``google_doc``
+    - - ``google_list_indent``
+      - ``google_list_indent``
+    - - ``hide_strikethrough``
+      - ``hide_strikethrough``
+
+``google_doc=True`` reads the inline-CSS styling a Google Docs HTML export carries: a ``font-weight`` of ``bold`` or
+``700``--``900`` becomes ``strong``, ``font-style:italic`` becomes ``emphasis``, a ``Courier New``/``Consolas``
+``font-family`` becomes an inline code span, ``list-style-type`` picks the list marker, and each ``google_list_indent``
+pixels of ``margin-left`` add one list-nesting level. With ``hide_strikethrough=True`` a
+``text-decoration:line-through`` drops the struck text.
+
+.. testcode::
+
+    export = '<p><span style="font-weight:700">Quarterly</span> revenue</p>'
+    print(parse(export).to_markdown(google_doc=True))
+
+.. testoutput::
+
+    **Quarterly** revenue
 
 Pitfalls
 ========
@@ -1056,9 +1077,9 @@ Pitfalls
   ``strong_em_symbol``; set both to reproduce its behavior.
 - ``to_markdown`` is a method on any node, so convert a subtree by calling it on the element you selected
   (``doc.find("article").to_markdown()``) instead of slicing the HTML string first.
-- A few niche knobs are intentionally dropped: html2text's Google-Docs heuristics (``google_doc``,
-  ``google_list_indent``), the parser-selection options (markdownify's ``bs4_options``), and the per-call tag-handler
-  callbacks. ``base_url`` does simple prefixing rather than full RFC-3986 URL resolution.
+- A few niche knobs are intentionally dropped: the parser-selection options (markdownify's ``bs4_options``) and the
+  per-call tag-handler callbacks, since turbohtml always runs the WHATWG algorithm and the walk holds no per-call state.
+  ``base_url`` does simple prefixing rather than full RFC-3986 URL resolution.
 - Layout-aware plain text (the ``inscriptis`` role, ``to_text(layout=...)``) is a separate method; for the unstructured
   concatenation read :attr:`~turbohtml.Node.text`.
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -193,6 +193,13 @@ reference links, padded tables, full escaping), and turbohtml stays ahead by the
       - 28 µs
       - 2726 µs
       - 1182 µs
+    - - google_doc (4 KiB)
+      - 17 µs
+      - —
+      - 577 µs
+
+The ``google_doc`` row reads the inline-CSS styling a Google Docs export carries (html2text's google_doc mode);
+markdownify has no equivalent.
 
 *************
  Layout text
@@ -215,6 +222,12 @@ builds an lxml tree and a CSS model in Python, where turbohtml does the whole la
     - - table (4 KiB)
       - 26 µs
       - 885 µs
+    - - annotated (4 KiB)
+      - 10 µs
+      - 208 µs
+
+The ``annotated`` row labels matching elements with spans through :meth:`~turbohtml.Node.to_annotated_text` against
+inscriptis's ``get_annotated_text``.
 
 ************
  Unescaping

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -240,6 +240,9 @@ class Node:
         document_strip: Literal["strip", "lstrip", "rstrip", "none"] = "strip",
         quote_open: str = '"',
         quote_close: str = '"',
+        google_doc: bool = False,
+        google_list_indent: int = 36,
+        hide_strikethrough: bool = False,
     ) -> str: ...
     def to_text(
         self,

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -252,6 +252,19 @@ class Node:
         table_cell_separator: str = "  ",
         bullet: str = "* ",
     ) -> str: ...
+    def to_annotated_text(
+        self,
+        annotation_rules: Mapping[str, Sequence[str]],
+        /,
+        *,
+        width: int = 0,
+        links: Literal["none", "inline", "footnote"] = "none",
+        images: bool = False,
+        layout: Literal["extended", "strict"] = "extended",
+        default_image_alt: str = "",
+        table_cell_separator: str = "  ",
+        bullet: str = "* ",
+    ) -> tuple[str, list[tuple[int, int, str]]]: ...
     def insert_before(self, *nodes: Node) -> None: ...
     def insert_after(self, *nodes: Node) -> None: ...
     def replace_with(self, *nodes: Node) -> None: ...

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -520,10 +520,12 @@ PyDoc_STRVAR(
     "mark_code=False, link_style='inline', autolink=True, link_title=False, ignore_links=False, "
     "skip_internal_links=False, base_url='', image_mode='markdown', default_image_alt='', table_mode='markdown', "
     "table_header='first', pad_tables=False, escape_mode='minimal', escape_asterisks=True, escape_underscores=True, "
-    "line_break='spaces', block_spacing='double', document_strip='strip', quote_open='\"', quote_close='\"')\n--\n\n"
+    "line_break='spaces', block_spacing='double', document_strip='strip', quote_open='\"', quote_close='\"', "
+    "google_doc=False, google_list_indent=36, hide_strikethrough=False)\n--\n\n"
     "Render this node and its subtree as Markdown. The keyword options cover the\n"
     "markdownify and html2text configuration surface; the defaults emit opinionated\n"
-    "GitHub-Flavored Markdown.");
+    "GitHub-Flavored Markdown. google_doc reads the inline-CSS styling a Google Docs\n"
+    "export carries (bold/italic/strike weights and list margins).");
 
 /* Resolve a string option against its allowed values, writing the matched index
    into *out (an enum), or leave *out untouched when the argument was omitted. */
@@ -582,13 +584,17 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
                          "document_strip",
                          "quote_open",
                          "quote_close",
+                         "google_doc",
+                         "google_list_indent",
+                         "hide_strikethrough",
                          NULL};
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "|$OsssOpssOspOppppsOsOOpOppOOOss", kw, &heading, &opt.bullets, &opt.strong, &opt.emphasis,
+            args, kwds, "|$OsssOpssOspOppppsOsOOpOppOOOsspip", kw, &heading, &opt.bullets, &opt.strong, &opt.emphasis,
             &strike, &ignore_emphasis, &opt.sub, &opt.sup, &code_style, &opt.code_language, &mark_code, &link,
             &opt.autolink, &opt.link_title, &opt.ignore_links, &opt.skip_internal_links, &opt.base_url, &image,
             &opt.default_image_alt, &table, &header, &opt.pad_tables, &escape, &opt.escape_asterisks,
-            &opt.escape_underscores, &brk, &spacing, &docstrip, &opt.quote_open, &opt.quote_close)) {
+            &opt.escape_underscores, &brk, &spacing, &docstrip, &opt.quote_open, &opt.quote_close, &opt.google_doc,
+            &opt.google_list_indent, &opt.hide_strikethrough)) {
         return NULL;
     }
     static const char *const headings[] = {"atx", "atx_closed", "setext"};
@@ -618,6 +624,10 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
     }
     if (*opt.bullets == '\0') {
         PyErr_SetString(PyExc_ValueError, "bullets must not be empty");
+        return NULL;
+    }
+    if (opt.google_list_indent < 1) {
+        PyErr_SetString(PyExc_ValueError, "google_list_indent must be a positive number of pixels");
         return NULL;
     }
     opt.keep_emphasis = !ignore_emphasis;

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -674,6 +674,145 @@ static PyObject *node_to_text(PyObject *self, PyObject *args, PyObject *kwds) {
     return result;
 }
 
+/* Parse one annotation_rules entry ("tag", "tag#attr", "tag#attr=value", or
+   "#attr...") into a text_rule. The attr name borrows the key's UTF-8 (the dict
+   outlives the call); a value token is copied to *value_out (the caller frees it)
+   and the labels tuple to *labels_out (the caller releases it). */
+static int text_parse_rule(PyObject *key, PyObject *value, text_rule *rule, PyObject **labels_out,
+                           Py_UCS4 **value_out) {
+    if (!PyUnicode_Check(key)) {
+        PyErr_SetString(PyExc_TypeError, "annotation_rules keys must be strings");
+        return -1;
+    }
+    if (PyUnicode_Check(value)) {
+        PyErr_SetString(PyExc_TypeError, "annotation_rules values must be a list of labels, not a string");
+        return -1;
+    }
+    Py_ssize_t klen;
+    const char *kb = PyUnicode_AsUTF8AndSize(key, &klen);
+    if (kb == NULL) { /* GCOVR_EXCL_BR_LINE: a lone-surrogate key cannot be built from a real parse */
+        return -1;    /* GCOVR_EXCL_LINE: encoding-failure path */
+    }
+    const char *hash = memchr(kb, '#', (size_t)klen);
+    Py_ssize_t taglen = hash != NULL ? hash - kb : klen;
+    rule->any_tag = taglen == 0;
+    rule->tag_atom = rule->any_tag ? TH_TAG_UNKNOWN : th_tag_lookup(kb, taglen);
+    rule->attr = NULL;
+    rule->attr_len = 0;
+    rule->value = NULL;
+    rule->value_len = 0;
+    if (hash != NULL) {
+        const char *spec = hash + 1;
+        Py_ssize_t speclen = klen - taglen - 1;
+        const char *eq = memchr(spec, '=', (size_t)speclen);
+        rule->attr = spec;
+        rule->attr_len = eq != NULL ? eq - spec : speclen;
+        if (eq != NULL) {
+            PyObject *vstr = PyUnicode_FromStringAndSize(eq + 1, speclen - rule->attr_len - 1);
+            if (vstr == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            Py_UCS4 *vbuf = PyUnicode_AsUCS4Copy(vstr);
+            rule->value_len = PyUnicode_GET_LENGTH(vstr);
+            Py_DECREF(vstr);
+            if (vbuf == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            *value_out = vbuf;
+            rule->value = vbuf;
+        }
+    }
+    PyObject *labels = PySequence_Tuple(value);
+    if (labels == NULL) {
+        return -1;
+    }
+    *labels_out = labels;
+    rule->labels = labels;
+    return 0;
+}
+
+PyDoc_STRVAR(to_annotated_text_doc,
+             "to_annotated_text(annotation_rules, *, width=0, links='none', images=False, layout='extended', "
+             "default_image_alt='', table_cell_separator='  ', bullet='* ')\n--\n\n"
+             "Render layout-aware text and, for every element matching a rule in\n"
+             "annotation_rules, record a labeled span over its text. Returns\n"
+             "(text, [(start, end, label), ...]). Spans inside table cells are not recorded.");
+
+static PyObject *node_to_annotated_text(PyObject *self, PyObject *args, PyObject *kwds) {
+    text_opts opt = th_text_default_opts();
+    PyObject *rules_dict, *links = NULL, *layout = NULL;
+    static char *kw[] = {"annotation_rules",     "width",  "links", "images", "layout", "default_image_alt",
+                         "table_cell_separator", "bullet", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|$iOpOsss", kw, &rules_dict, &opt.width, &links, &opt.images,
+                                     &layout, &opt.default_image_alt, &opt.cell_separator, &opt.bullet)) {
+        return NULL;
+    }
+    if (!PyDict_Check(rules_dict)) {
+        PyErr_SetString(PyExc_TypeError, "annotation_rules must be a dict");
+        return NULL;
+    }
+    static const char *const link_modes[] = {"none", "inline", "footnote"};
+    static const char *const layouts[] = {"strict", "extended"};
+    if (md_resolve_enum("links", links, link_modes, 3, &opt.links) < 0 ||
+        md_resolve_enum("layout", layout, layouts, 2, &opt.extended) < 0) {
+        return NULL;
+    }
+    Py_ssize_t n = PyDict_Size(rules_dict);
+    text_rule *rules = PyMem_Calloc((size_t)(n > 0 ? n : 1), sizeof(text_rule));
+    PyObject **labels = PyMem_Calloc((size_t)(n > 0 ? n : 1), sizeof(PyObject *));
+    Py_UCS4 **values = PyMem_Calloc((size_t)(n > 0 ? n : 1), sizeof(Py_UCS4 *));
+    if (rules == NULL || labels == NULL || values == NULL) { /* GCOVR_EXCL_BR_LINE: cannot force an alloc failure */
+        PyMem_Free(rules);                                   /* GCOVR_EXCL_LINE: allocation-failure path */
+        PyMem_Free(labels);                                  /* GCOVR_EXCL_LINE: allocation-failure path */
+        PyMem_Free(values);                                  /* GCOVR_EXCL_LINE: allocation-failure path */
+        return PyErr_NoMemory();                             /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *key, *value;
+    Py_ssize_t pos = 0, r = 0;
+    int failed = 0;
+    while (PyDict_Next(rules_dict, &pos, &key, &value)) {
+        if (text_parse_rule(key, value, &rules[r], &labels[r], &values[r]) < 0) {
+            failed = 1;
+            break;
+        }
+        r++;
+    }
+    PyObject *result = NULL;
+    if (!failed) {
+        text_span *spans = NULL;
+        Py_ssize_t span_count = 0, out_len = 0;
+        Py_UCS4 *data;
+        Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
+        data = th_node_annotated_text(tree_of(self), ((NodeObject *)self)->node, &opt, rules, n, &spans, &span_count,
+                                      &out_len);
+        Py_END_CRITICAL_SECTION();
+        if (data == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+        } /* GCOVR_EXCL_LINE: merge of the unreachable alloc-failure block */
+        /* data is NULL only on an alloc failure, so the NULL arms are unreachable */
+        PyObject *text = data != NULL ? ucs4_to_str(data, out_len) : NULL;   /* GCOVR_EXCL_BR_LINE */
+        PyObject *label_list = data != NULL ? PyList_New(span_count) : NULL; /* GCOVR_EXCL_BR_LINE */
+        if (text != NULL && label_list != NULL) { /* GCOVR_EXCL_BR_LINE: only an alloc failure makes either NULL */
+            for (Py_ssize_t i = 0; i < span_count; i++) {
+                PyList_SET_ITEM(label_list, i, Py_BuildValue("nnO", spans[i].start, spans[i].end, spans[i].label));
+            }
+            result = PyTuple_Pack(2, text, label_list);
+        }
+        Py_XDECREF(text);
+        Py_XDECREF(label_list);
+        PyMem_Free(data);
+        PyMem_Free(spans);
+    }
+    for (Py_ssize_t i = 0; i < r; i++) {
+        Py_XDECREF(labels[i]);
+        PyMem_Free(values[i]);
+    }
+    PyMem_Free(rules);
+    PyMem_Free(labels);
+    PyMem_Free(values);
+    return result;
+}
+
 static PyGetSetDef node_getset[] = {
     {"parent", node_get_parent, NULL, "the parent Element or Document, or None for the document root", NULL},
     {"children", node_get_children, NULL, "the child nodes as a tuple", NULL},
@@ -905,6 +1044,8 @@ static PyMethodDef node_methods[] = {
     {"encode", (PyCFunction)(void (*)(void))node_encode, METH_VARARGS | METH_KEYWORDS, encode_doc},
     {"to_markdown", (PyCFunction)(void (*)(void))node_to_markdown, METH_VARARGS | METH_KEYWORDS, to_markdown_doc},
     {"to_text", (PyCFunction)(void (*)(void))node_to_text, METH_VARARGS | METH_KEYWORDS, to_text_doc},
+    {"to_annotated_text", (PyCFunction)(void (*)(void))node_to_annotated_text, METH_VARARGS | METH_KEYWORDS,
+     to_annotated_text_doc},
     {"insert_before", node_insert_before, METH_VARARGS, insert_before_doc},
     {"insert_after", node_insert_after, METH_VARARGS, insert_after_doc},
     {"replace_with", node_replace_with, METH_VARARGS, replace_with_doc},

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -261,9 +261,12 @@ typedef struct {
     int block_spacing_single; /* one newline between blocks instead of a blank line */
     int wrap_width;           /* word-wrap column, 0 disables */
     int wrap_list_items;
-    int document_strip; /* enum th_md_doc_strip */
-    const char *sub;    /* <sub> wrapper */
-    const char *sup;    /* <sup> wrapper */
+    int document_strip;     /* enum th_md_doc_strip */
+    const char *sub;        /* <sub> wrapper */
+    const char *sup;        /* <sup> wrapper */
+    int google_doc;         /* read inline-CSS styling the way a Google Docs export encodes it */
+    int google_list_indent; /* px of margin-left per list-nesting level (>= 1); divides margin-left */
+    int hide_strikethrough; /* in google_doc mode, drop text a CSS line-through struck */
 } md_opts;
 
 /* The no-argument baseline configuration (opinionated GitHub-Flavored Markdown). */

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -298,6 +298,38 @@ text_opts th_text_default_opts(void);
    NULL on allocation failure. */
 Py_UCS4 *th_node_layout_text(th_tree *tree, th_node *node, const text_opts *opt, Py_ssize_t *out_len);
 
+/* One annotation rule (the inscriptis annotation_rules surface): match an element
+   by tag and, optionally, by an attribute whose value contains a token, and
+   attach its labels to the element's text span. any_tag matches every tag (the
+   "#attr" form); attr/value NULL means no attribute condition. labels is a
+   borrowed tuple of str the binding keeps alive for the call. */
+typedef struct {
+    uint16_t tag_atom;
+    int any_tag;
+    const char *attr;
+    Py_ssize_t attr_len;
+    const Py_UCS4 *value;
+    Py_ssize_t value_len;
+    PyObject *labels;
+} text_rule;
+
+/* A labeled span of the rendered text: code-point offsets [start, end) and the
+   label (a borrowed str). */
+typedef struct {
+    Py_ssize_t start;
+    Py_ssize_t end;
+    PyObject *label;
+} text_span;
+
+/* Render node as layout text (as th_node_layout_text) while recording, for every
+   element matching a rule, a labeled span over its rendered text. *out_spans
+   receives a PyMem-allocated array of *out_span_count spans (offsets into the
+   returned text); the caller frees it. Spans inside table cells are not recorded.
+   NULL on allocation failure. */
+Py_UCS4 *th_node_annotated_text(th_tree *tree, th_node *node, const text_opts *opt, const text_rule *rules,
+                                Py_ssize_t n_rules, text_span **out_spans, Py_ssize_t *out_span_count,
+                                Py_ssize_t *out_len);
+
 /* The doctype's public and system identifiers as slices of the node's own text;
    returns 1 with the four out params set when present, 0 for a name-only doctype. */
 int th_node_doctype_ids(th_node *node, const Py_UCS4 **public_id, Py_ssize_t *public_len, const Py_UCS4 **system_id,

--- a/src/turbohtml/treebuilder_markdown.h
+++ b/src/turbohtml/treebuilder_markdown.h
@@ -1240,7 +1240,7 @@ static void md_render_block(md_ctx *ctx, th_node *node) {
 
 /* Trim whitespace off the finished buffer in place per the document_strip mode:
    both ends, the left only, the right only, or neither. */
-static void md_trim(sbuf *out, int mode) {
+static Py_ssize_t md_trim(sbuf *out, int mode) {
     Py_ssize_t start = 0;
     if (mode == TH_MD_DOC_STRIP || mode == TH_MD_DOC_LSTRIP) {
         /* strip leading blank lines only; block content never starts with a space
@@ -1259,6 +1259,7 @@ static void md_trim(sbuf *out, int mode) {
         memmove(out->data, out->data + start, (size_t)(end - start) * sizeof(Py_UCS4));
     }
     out->len = end - start;
+    return start; /* how many leading code points were removed, to shift annotations */
 }
 
 /* Append the collected reference definitions ("[n]: url \"title\"") after the

--- a/src/turbohtml/treebuilder_markdown.h
+++ b/src/turbohtml/treebuilder_markdown.h
@@ -97,6 +97,9 @@ md_opts th_markdown_default_opts(void) {
     opt.document_strip = TH_MD_DOC_STRIP;
     opt.sub = "";
     opt.sup = "";
+    opt.google_doc = 0;
+    opt.google_list_indent = 36;
+    opt.hide_strikethrough = 0;
     return opt;
 }
 
@@ -139,6 +142,8 @@ typedef struct {
     int suppress_break;   /* the next block attaches to the current (list marker) line */
     int tight;            /* inside a list item: inline runs do not add blank lines */
     int list_depth;       /* nesting depth of the current list, for bullet cycling */
+    int g_bold;           /* google_doc: a CSS font-weight bold is in force from an ancestor */
+    int g_italic;         /* google_doc: a CSS font-style italic is in force from an ancestor */
     int failed;           /* a reference buffer allocation failed */
 } md_ctx;
 
@@ -358,6 +363,108 @@ static const Py_UCS4 *md_attr(th_tree *tree, th_node *node, const char *name, Py
     }
     *len = node->attrs[index].value_len;
     return node->attrs[index].value;
+}
+
+/* Case-insensitive ASCII compare of a code-point slice to a lowercase C key. */
+static int md_ucs4_ieq(const Py_UCS4 *text, Py_ssize_t len, const char *key) {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 character = text[index];
+        if (character >= 'A' && character <= 'Z') {
+            character += 'a' - 'A';
+        }
+        if (key[index] == '\0' || character != (Py_UCS4)(unsigned char)key[index]) {
+            return 0;
+        }
+    }
+    return key[len] == '\0';
+}
+
+/* Find the declaration `prop: value` in an inline style string (a `style`
+   attribute value), matching the property case-insensitively and trimming the
+   value. Returns 1 with the value slice set when present. */
+static int md_css_prop(const Py_UCS4 *style, Py_ssize_t style_len, const char *prop, const Py_UCS4 **out_value,
+                       Py_ssize_t *out_len) {
+    Py_ssize_t prop_len = (Py_ssize_t)strlen(prop);
+    Py_ssize_t cursor = 0;
+    while (cursor < style_len) {
+        Py_ssize_t name_start = cursor;
+        while (cursor < style_len && style[cursor] != ':' && style[cursor] != ';') {
+            cursor++;
+        }
+        Py_ssize_t name_end = cursor;
+        if (cursor >= style_len || style[cursor] == ';') {
+            cursor++; /* a declaration without a colon: skip past its terminator */
+            continue;
+        }
+        cursor++; /* past ':' */
+        Py_ssize_t value_start = cursor;
+        while (cursor < style_len && style[cursor] != ';') {
+            cursor++;
+        }
+        Py_ssize_t value_end = cursor;
+        cursor++; /* past ';' */
+        while (name_start < name_end && md_is_ws(style[name_start])) {
+            name_start++;
+        }
+        while (name_end > name_start && md_is_ws(style[name_end - 1])) {
+            name_end--;
+        }
+        while (value_start < value_end && md_is_ws(style[value_start])) {
+            value_start++;
+        }
+        while (value_end > value_start && md_is_ws(style[value_end - 1])) {
+            value_end--;
+        }
+        if (name_end - name_start == prop_len && md_ucs4_ieq(&style[name_start], prop_len, prop)) {
+            *out_value = &style[value_start];
+            *out_len = value_end - value_start;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Whether the value is one of the four bold weights a Google Docs export emits. */
+static int md_css_bold(const Py_UCS4 *value, Py_ssize_t len) {
+    static const char *const weights[] = {"bold", "700", "800", "900"};
+    for (size_t index = 0; index < sizeof(weights) / sizeof(weights[0]); index++) {
+        if (md_ucs4_ieq(value, len, weights[index])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Whether the value names one of the fixed-width fonts Google Docs uses for code. */
+static int md_css_fixed(const Py_UCS4 *value, Py_ssize_t len) {
+    static const char *const fonts[] = {"courier new", "consolas"};
+    for (size_t index = 0; index < sizeof(fonts) / sizeof(fonts[0]); index++) {
+        if (md_ucs4_ieq(value, len, fonts[index])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Whether a list-style-type value renders as an unordered bullet rather than a
+   number, mirroring inscriptis/html2text's set of bullet keywords. */
+static int md_css_unordered(const Py_UCS4 *value, Py_ssize_t len) {
+    static const char *const bullets[] = {"disc", "circle", "square", "none"};
+    for (size_t index = 0; index < sizeof(bullets) / sizeof(bullets[0]); index++) {
+        if (md_ucs4_ieq(value, len, bullets[index])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* The leading integer pixel count of a length value ("72px" -> 72). */
+static int md_css_px(const Py_UCS4 *value, Py_ssize_t len) {
+    int pixels = 0;
+    for (Py_ssize_t index = 0; index < len && value[index] >= '0' && value[index] <= '9'; index++) {
+        pixels = pixels * 10 + (int)(value[index] - '0');
+    }
+    return pixels;
 }
 
 static void md_render_inline(md_ctx *ctx, th_node *node);
@@ -590,16 +697,9 @@ static void md_emit_image(md_ctx *ctx, th_node *node) {
 static void md_render_block(md_ctx *ctx, th_node *node);
 static void md_block_children(md_ctx *ctx, th_node *node);
 
-/* Render one node encountered in an inline run. A block element nested in inline
-   flow (rare, e.g. a <div> inside a <span>) is laid out as its own block. */
-static void md_render_inline(md_ctx *ctx, th_node *node) {
-    if (node->type == TH_NODE_TEXT) {
-        md_emit_text(ctx, need_text(ctx->tree, node), node->text_len);
-        return;
-    }
-    if (node->type != TH_NODE_ELEMENT && node->type != TH_NODE_CONTENT) {
-        return;
-    }
+/* Render an element (or content node) by its tag, the common path shared by the
+   plain walk and the google_doc CSS wrapper. Text is handled by the caller. */
+static void md_render_inline_tag(md_ctx *ctx, th_node *node) {
     const md_opts *opt = ctx->opt;
     uint16_t atom = node->ns == TH_NS_HTML ? node->atom : TH_TAG_UNKNOWN;
     switch (atom) {
@@ -657,6 +757,88 @@ static void md_render_inline(md_ctx *ctx, th_node *node) {
         return;
     }
     md_inline_children(ctx, node);
+}
+
+/* Render an element in google_doc mode: turn the inline-CSS styling a Google Docs
+   export carries into Markdown. A font-weight/font-style/fixed-width font opens
+   the matching marker (only on the transition the ancestor did not already set,
+   so nested spans do not double the markup), and a line-through drops the text
+   when hide_strikethrough is on. The markers are deferred like md_wrap so a
+   leading inner space lands outside and an empty span leaves nothing behind. */
+static void md_render_google(md_ctx *ctx, th_node *node) {
+    const md_opts *opt = ctx->opt;
+    Py_ssize_t style_len;
+    const Py_UCS4 *style = md_attr(ctx->tree, node, "style", &style_len);
+    const Py_UCS4 *value;
+    Py_ssize_t value_len;
+    if (opt->hide_strikethrough && style != NULL &&
+        md_css_prop(style, style_len, "text-decoration", &value, &value_len) &&
+        md_ucs4_ieq(value, value_len, "line-through")) {
+        return; /* the struck-through subtree is hidden entirely */
+    }
+    int outer_bold = ctx->g_bold, outer_italic = ctx->g_italic;
+    int bold = outer_bold, italic = outer_italic, fixed = 0;
+    if (style != NULL) {
+        if (md_css_prop(style, style_len, "font-weight", &value, &value_len)) {
+            bold = md_css_bold(value, value_len);
+        }
+        if (md_css_prop(style, style_len, "font-style", &value, &value_len)) {
+            italic = md_ucs4_ieq(value, value_len, "italic");
+        }
+        if (md_css_prop(style, style_len, "font-family", &value, &value_len)) {
+            fixed = md_css_fixed(value, value_len);
+        }
+    }
+    md_pending italic_frame, bold_frame;
+    if (italic && !outer_italic) {
+        italic_frame = (md_pending){opt->emphasis, ctx->pending, 0};
+        ctx->pending = &italic_frame;
+    }
+    if (bold && !outer_bold) {
+        bold_frame = (md_pending){opt->strong, ctx->pending, 0};
+        ctx->pending = &bold_frame;
+    }
+    ctx->g_bold = bold;
+    ctx->g_italic = italic;
+    if (fixed) {
+        /* a fixed-width run renders as an inline code span; its subtree is consumed
+           as text, so a nested fixed span is never reached and needs no dedup */
+        md_emit_code_span(ctx, node);
+    } else {
+        md_render_inline_tag(ctx, node);
+    }
+    ctx->g_bold = outer_bold;
+    ctx->g_italic = outer_italic;
+    if (bold && !outer_bold) {
+        ctx->pending = bold_frame.prev;
+        if (bold_frame.emitted) {
+            md_puts8(&ctx->out, opt->strong);
+        }
+    }
+    if (italic && !outer_italic) {
+        ctx->pending = italic_frame.prev;
+        if (italic_frame.emitted) {
+            md_puts8(&ctx->out, opt->emphasis);
+        }
+    }
+}
+
+/* Render one node encountered in an inline run. A block element nested in inline
+   flow (rare, e.g. a <div> inside a <span>) is laid out as its own block. */
+static void md_render_inline(md_ctx *ctx, th_node *node) {
+    if (node->type == TH_NODE_TEXT) {
+        md_emit_text(ctx, need_text(ctx->tree, node), node->text_len);
+        return;
+    }
+    if (node->type != TH_NODE_ELEMENT && node->type != TH_NODE_CONTENT) {
+        return;
+    }
+    if (ctx->opt->google_doc) {
+        /* a content node carries no style, so it passes through unstyled */
+        md_render_google(ctx, node);
+        return;
+    }
+    md_render_inline_tag(ctx, node);
 }
 
 /* ------------------------------------------------------------ block output */
@@ -732,6 +914,17 @@ static void md_block_children(md_ctx *ctx, th_node *node) {
 }
 
 static void md_render_list(md_ctx *ctx, th_node *node, int ordered) {
+    if (ctx->opt->google_doc) {
+        /* a Google Docs export keeps the ol/ul element but states the real marker
+           kind in list-style-type, so honor it when present */
+        Py_ssize_t style_len;
+        const Py_UCS4 *style = md_attr(ctx->tree, node, "style", &style_len);
+        const Py_UCS4 *value;
+        Py_ssize_t value_len;
+        if (style != NULL && md_css_prop(style, style_len, "list-style-type", &value, &value_len)) {
+            ordered = !md_css_unordered(value, value_len);
+        }
+    }
     Py_ssize_t number = 1;
     if (ordered) {
         Py_ssize_t start_len;
@@ -760,15 +953,31 @@ static void md_render_list(md_ctx *ctx, th_node *node, int ordered) {
             continue;
         }
         md_block_line(ctx, 0);
+        Py_ssize_t lead = 0;
+        if (ctx->opt->google_doc) {
+            /* Google Docs flattens nested lists, signaling depth with margin-left
+               instead, so each google_list_indent pixels add one indent level */
+            Py_ssize_t style_len;
+            const Py_UCS4 *style = md_attr(ctx->tree, child, "style", &style_len);
+            const Py_UCS4 *value;
+            Py_ssize_t value_len;
+            if (style != NULL && md_css_prop(style, style_len, "margin-left", &value, &value_len)) {
+                int nest = md_css_px(value, value_len) / ctx->opt->google_list_indent;
+                for (int level = 0; level < nest; level++) {
+                    sbuf_puts(&ctx->out, "  ");
+                }
+                lead = (Py_ssize_t)nest * 2;
+            }
+        }
         Py_ssize_t width;
         if (ordered) {
-            width = md_put_decimal(&ctx->out, number) + 2;
+            width = lead + md_put_decimal(&ctx->out, number) + 2;
             sbuf_puts(&ctx->out, ". ");
             number++;
         } else {
             sbuf_putc(&ctx->out, (Py_UCS4)(unsigned char)bullet);
             sbuf_putc(&ctx->out, ' ');
-            width = 2;
+            width = lead + 2;
         }
         ctx->line_has_content = 1;
         Py_ssize_t base = md_push_spaces(ctx, width);

--- a/src/turbohtml/treebuilder_text.h
+++ b/src/turbohtml/treebuilder_text.h
@@ -26,6 +26,13 @@ typedef struct {
     Py_ssize_t url_len;
 } text_reference;
 
+/* One open annotation: where the matching element's text began, and the rule
+   whose labels close over it. */
+typedef struct {
+    Py_ssize_t start;
+    const text_rule *rule;
+} text_active;
+
 typedef struct {
     sbuf out;
     th_tree *tree;
@@ -34,6 +41,15 @@ typedef struct {
     text_reference *refs; /* footnote-link targets */
     Py_ssize_t ref_count;
     Py_ssize_t ref_cap;
+    const text_rule *rules; /* annotation rules, or NULL when not annotating */
+    Py_ssize_t n_rules;
+    text_span *spans; /* recorded labeled spans */
+    Py_ssize_t span_count;
+    Py_ssize_t span_cap;
+    text_active *active; /* annotations open at the current depth */
+    Py_ssize_t active_count;
+    Py_ssize_t active_cap;
+    int annotate_off; /* suppress span recording (inside a table cell) */
     int started;
     int line_has_content;
     int column;        /* visible width on the current line, for word wrapping */
@@ -150,6 +166,111 @@ static void text_put_literal(text_ctx *ctx, const char *s) {
     ctx->line_has_content = 1;
 }
 
+/* Whether an element matches an annotation rule: the tag (or any tag) and, when
+   the rule has an attribute condition, that the attribute is present and -- when
+   a value is given -- carries it as a whitespace-separated token. */
+static int text_rule_matches(text_ctx *ctx, th_node *node, const text_rule *rule) {
+    if (!rule->any_tag && (node->ns != TH_NS_HTML || node->atom != rule->tag_atom)) {
+        return 0;
+    }
+    if (rule->attr == NULL) {
+        return 1;
+    }
+    Py_ssize_t idx = th_node_attr_find(ctx->tree, node, rule->attr, rule->attr_len);
+    if (idx < 0 || node->attrs[idx].value == NULL) {
+        return 0;
+    }
+    if (rule->value == NULL) {
+        return 1;
+    }
+    const Py_UCS4 *av = node->attrs[idx].value;
+    Py_ssize_t avlen = node->attrs[idx].value_len;
+    Py_ssize_t i = 0;
+    while (i < avlen) {
+        while (i < avlen && md_is_ws(av[i])) {
+            i++;
+        }
+        Py_ssize_t start = i;
+        while (i < avlen && !md_is_ws(av[i])) {
+            i++;
+        }
+        if (i - start == rule->value_len &&
+            memcmp(&av[start], rule->value, (size_t)rule->value_len * sizeof(Py_UCS4)) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Record a labeled span over [start, end), trimming surrounding whitespace, one
+   entry per label the rule carries. */
+static void text_record_span(text_ctx *ctx, Py_ssize_t start, Py_ssize_t end, PyObject *labels) {
+    while (start < end && md_is_ws(ctx->out.data[start])) {
+        start++;
+    }
+    while (end > start && md_is_ws(ctx->out.data[end - 1])) {
+        end--;
+    }
+    if (start >= end) {
+        return; /* an element with no visible text (or only whitespace) gets no span */
+    }
+    Py_ssize_t n = PyTuple_GET_SIZE(labels);
+    for (Py_ssize_t i = 0; i < n; i++) {
+        if (ctx->span_count == ctx->span_cap) {
+            Py_ssize_t cap = ctx->span_cap ? ctx->span_cap * 2 : 8;
+            text_span *grown = PyMem_Realloc(ctx->spans, (size_t)cap * sizeof(text_span));
+            if (grown == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                ctx->failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
+                return;          /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            ctx->spans = grown;
+            ctx->span_cap = cap;
+        }
+        ctx->spans[ctx->span_count].start = start;
+        ctx->spans[ctx->span_count].end = end;
+        ctx->spans[ctx->span_count].label = PyTuple_GET_ITEM(labels, i);
+        ctx->span_count++;
+    }
+}
+
+/* Open a span for every rule this element matches, returning how many; the cursor
+   offset now is each span's start. */
+static Py_ssize_t text_open_annotations(text_ctx *ctx, th_node *node) {
+    if (ctx->rules == NULL || ctx->annotate_off) {
+        return 0;
+    }
+    Py_ssize_t opened = 0;
+    for (Py_ssize_t r = 0; r < ctx->n_rules; r++) {
+        if (!text_rule_matches(ctx, node, &ctx->rules[r])) {
+            continue;
+        }
+        if (ctx->active_count == ctx->active_cap) {
+            Py_ssize_t cap = ctx->active_cap ? ctx->active_cap * 2 : 8;
+            text_active *grown = PyMem_Realloc(ctx->active, (size_t)cap * sizeof(text_active));
+            if (grown == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                ctx->failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
+                return opened;   /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            ctx->active = grown;
+            ctx->active_cap = cap;
+        }
+        ctx->active[ctx->active_count].start = ctx->out.len;
+        ctx->active[ctx->active_count].rule = &ctx->rules[r];
+        ctx->active_count++;
+        opened++;
+    }
+    return opened;
+}
+
+/* Close the opened spans, recording each over the text emitted since it opened. */
+static void text_close_annotations(text_ctx *ctx, Py_ssize_t opened) {
+    for (Py_ssize_t i = 0; i < opened; i++) {
+        ctx->active_count--;
+        text_active *a = &ctx->active[ctx->active_count];
+        text_record_span(ctx, a->start, ctx->out.len, a->rule->labels);
+    }
+}
+
 static void text_render_inline(text_ctx *ctx, th_node *node);
 static void text_emit_text2(text_ctx *ctx, const char *s);
 
@@ -202,15 +323,7 @@ static void text_emit_image(text_ctx *ctx, th_node *node) {
 static void text_render_block(text_ctx *ctx, th_node *node);
 static void text_block_children(text_ctx *ctx, th_node *node);
 
-static void text_render_inline(text_ctx *ctx, th_node *node) {
-    if (node->type == TH_NODE_TEXT) {
-        text_emit_text(ctx, need_text(ctx->tree, node), node->text_len);
-        return;
-    }
-    if (node->type != TH_NODE_ELEMENT && node->type != TH_NODE_CONTENT) {
-        return;
-    }
-    uint16_t atom = node->ns == TH_NS_HTML ? node->atom : TH_TAG_UNKNOWN;
+static void text_render_inline_element(text_ctx *ctx, th_node *node, uint16_t atom) {
     if (atom == TH_TAG_A) {
         text_emit_link(ctx, node);
         return;
@@ -229,11 +342,25 @@ static void text_render_inline(text_ctx *ctx, th_node *node) {
     if (is_md_skipped(atom)) {
         return;
     }
-    if (is_md_block(atom)) {
-        text_render_block(ctx, node);
+    text_inline_children(ctx, node);
+}
+
+static void text_render_inline(text_ctx *ctx, th_node *node) {
+    if (node->type == TH_NODE_TEXT) {
+        text_emit_text(ctx, need_text(ctx->tree, node), node->text_len);
         return;
     }
-    text_inline_children(ctx, node);
+    if (node->type != TH_NODE_ELEMENT && node->type != TH_NODE_CONTENT) {
+        return;
+    }
+    uint16_t atom = node->ns == TH_NS_HTML ? node->atom : TH_TAG_UNKNOWN;
+    if (is_md_block(atom)) {
+        text_render_block(ctx, node); /* text_render_block opens its own annotation */
+        return;
+    }
+    Py_ssize_t opened = text_open_annotations(ctx, node);
+    text_render_inline_element(ctx, node, atom);
+    text_close_annotations(ctx, opened);
 }
 
 /* Emit an ASCII option string (a default image alt) through the word machinery
@@ -388,7 +515,11 @@ static void text_cell_text(text_ctx *ctx, th_node *node, sbuf *dst) {
     ctx->line_has_content = 1;
     ctx->column = 0;
     ctx->space_pending = 0;
+    /* a cell renders into a throwaway buffer, so its offsets do not map to the
+       grid; suppress span recording and let the placement loop annotate cells */
+    ctx->annotate_off++;
     text_inline_children(ctx, node);
+    ctx->annotate_off--;
     sbuf rendered = ctx->out;
     PyMem_Free(ctx->prefix.data);
     ctx->out = saved_out;
@@ -445,12 +576,14 @@ static void text_render_table(text_ctx *ctx, th_node *node) {
     }
     sbuf *grid = PyMem_Calloc((size_t)(count * columns), sizeof(sbuf));
     Py_ssize_t *widths = PyMem_Calloc((size_t)columns, sizeof(Py_ssize_t));
-    if (grid == NULL || widths == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        PyMem_Free(grid);                 /* GCOVR_EXCL_LINE: allocation-failure path */
-        PyMem_Free(widths);               /* GCOVR_EXCL_LINE: allocation-failure path */
-        PyMem_Free(rows);                 /* GCOVR_EXCL_LINE: allocation-failure path */
-        ctx->out.failed = 1;              /* GCOVR_EXCL_LINE: allocation-failure path */
-        return;                           /* GCOVR_EXCL_LINE: allocation-failure path */
+    th_node **cells = PyMem_Calloc((size_t)(count * columns), sizeof(th_node *));
+    if (grid == NULL || widths == NULL || cells == NULL) { /* GCOVR_EXCL_BR_LINE: cannot force an allocation failure */
+        PyMem_Free(grid);                                  /* GCOVR_EXCL_LINE: allocation-failure path */
+        PyMem_Free(widths);                                /* GCOVR_EXCL_LINE: allocation-failure path */
+        PyMem_Free(cells);                                 /* GCOVR_EXCL_LINE: allocation-failure path */
+        PyMem_Free(rows);                                  /* GCOVR_EXCL_LINE: allocation-failure path */
+        ctx->out.failed = 1;                               /* GCOVR_EXCL_LINE: allocation-failure path */
+        return;                                            /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     for (Py_ssize_t r = 0; r < count; r++) {
         Py_ssize_t col = 0;
@@ -459,6 +592,7 @@ static void text_render_table(text_ctx *ctx, th_node *node) {
                 continue;
             }
             text_cell_text(ctx, cell, &grid[r * columns + col]);
+            cells[r * columns + col] = cell;
             if (grid[r * columns + col].len > widths[col]) {
                 widths[col] = grid[r * columns + col].len;
             }
@@ -475,7 +609,11 @@ static void text_render_table(text_ctx *ctx, th_node *node) {
                 text_emit_ascii(ctx, ctx->opt->cell_separator);
             }
             sbuf *cell = &grid[r * columns + c];
+            th_node *cell_node = cells[r * columns + c];
+            /* annotate the cell element over its placed (not throwaway) text */
+            Py_ssize_t opened = cell_node != NULL ? text_open_annotations(ctx, cell_node) : 0;
             sbuf_put_run(&ctx->out, cell->data, cell->len);
+            text_close_annotations(ctx, opened);
             /* the last column needs no padding: nothing follows it on the line */
             if (c + 1 < columns) {
                 for (Py_ssize_t pad = cell->len; pad < widths[c]; pad++) {
@@ -490,6 +628,7 @@ static void text_render_table(text_ctx *ctx, th_node *node) {
     }
     PyMem_Free(grid);
     PyMem_Free(widths);
+    PyMem_Free(cells);
     PyMem_Free(rows);
 }
 
@@ -516,7 +655,7 @@ static void text_render_pre(text_ctx *ctx, th_node *node) {
     PyMem_Free(text);
 }
 
-static void text_render_block(text_ctx *ctx, th_node *node) {
+static void text_render_block_inner(text_ctx *ctx, th_node *node) {
     uint16_t atom = node->atom;
     switch (atom) {
     case TH_TAG_UL:
@@ -557,6 +696,12 @@ static void text_render_block(text_ctx *ctx, th_node *node) {
     }
 }
 
+static void text_render_block(text_ctx *ctx, th_node *node) {
+    Py_ssize_t opened = text_open_annotations(ctx, node);
+    text_render_block_inner(ctx, node);
+    text_close_annotations(ctx, opened);
+}
+
 static void text_flush_references(text_ctx *ctx) {
     if (ctx->ref_count == 0) {
         return;
@@ -573,23 +718,53 @@ static void text_flush_references(text_ctx *ctx) {
     }
 }
 
+/* Walk node into ctx (the dispatch shared by the plain and annotated entries). */
+static void text_render_root(text_ctx *ctx, th_node *node) {
+    sbuf_presize_for_root(&ctx->out, ctx->tree, node);
+    if (node->type == TH_NODE_TEXT) {
+        ctx->started = 1;
+        ctx->line_has_content = 1;
+        text_emit_text(ctx, need_text(ctx->tree, node), node->text_len);
+    } else if (is_md_block(node->ns == TH_NS_HTML ? node->atom : TH_TAG_UNKNOWN)) {
+        text_render_block(ctx, node);
+    } else {
+        text_block_children(ctx, node);
+    }
+    text_flush_references(ctx);
+}
+
 Py_UCS4 *th_node_layout_text(th_tree *tree, th_node *node, const text_opts *opt, Py_ssize_t *out_len) {
     text_ctx ctx = {0};
     ctx.tree = tree;
     ctx.opt = opt;
-    sbuf_presize_for_root(&ctx.out, tree, node);
-    if (node->type == TH_NODE_TEXT) {
-        ctx.started = 1;
-        ctx.line_has_content = 1;
-        text_emit_text(&ctx, need_text(tree, node), node->text_len);
-    } else if (is_md_block(node->ns == TH_NS_HTML ? node->atom : TH_TAG_UNKNOWN)) {
-        text_render_block(&ctx, node);
-    } else {
-        text_block_children(&ctx, node);
-    }
-    text_flush_references(&ctx);
+    text_render_root(&ctx, node);
     PyMem_Free(ctx.prefix.data);
     PyMem_Free(ctx.refs);
     md_trim(&ctx.out, TH_MD_DOC_STRIP);
+    return sbuf_finish(&ctx.out, out_len);
+}
+
+Py_UCS4 *th_node_annotated_text(th_tree *tree, th_node *node, const text_opts *opt, const text_rule *rules,
+                                Py_ssize_t n_rules, text_span **out_spans, Py_ssize_t *out_span_count,
+                                Py_ssize_t *out_len) {
+    text_ctx ctx = {0};
+    ctx.tree = tree;
+    ctx.opt = opt;
+    ctx.rules = rules;
+    ctx.n_rules = n_rules;
+    text_render_root(&ctx, node);
+    PyMem_Free(ctx.prefix.data);
+    PyMem_Free(ctx.refs);
+    PyMem_Free(ctx.active);
+    /* the doc-strip removes leading blank lines, shifting every offset back by the
+       same amount; record_span already trimmed each span to non-blank bounds, so
+       the trailing strip never lands inside one and no clamping is needed */
+    Py_ssize_t front = md_trim(&ctx.out, TH_MD_DOC_STRIP);
+    for (Py_ssize_t i = 0; i < ctx.span_count; i++) {
+        ctx.spans[i].start -= front;
+        ctx.spans[i].end -= front;
+    }
+    *out_spans = ctx.spans;
+    *out_span_count = ctx.span_count;
     return sbuf_finish(&ctx.out, out_len);
 }

--- a/tests/test_tree_markdown_google.py
+++ b/tests/test_tree_markdown_google.py
@@ -1,0 +1,321 @@
+"""The to_markdown(google_doc=True) mode: turning the inline-CSS styling a Google
+Docs export carries into Markdown, the html2text google_doc surface.
+
+One golden case per behavior, plus the binding's validation, so every CSS code
+path in the C walker is exercised.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+import pytest
+
+from turbohtml import parse
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class _Opts(TypedDict, total=False):
+    """The google_doc keyword options of Node.to_markdown, kept typed."""
+
+    google_doc: bool
+    google_list_indent: int
+    hide_strikethrough: bool
+    strong: str
+    emphasis: str
+
+
+def md(html: str, opts: _Opts) -> str:
+    return parse(html).to_markdown(**opts)
+
+
+def call_with(convert: Callable[..., str], **kwargs: str | int) -> str:
+    """Invoke the converter with an option the static signature rejects, to drive
+    the runtime validation; the converter arrives signature-erased on purpose."""
+    return convert(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("html", "opts", "expected"),
+    [
+        pytest.param(
+            '<p><span style="font-weight:700">a</span></p>',
+            {"google_doc": True},
+            "**a**",
+            id="font-weight-700-is-bold",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold">a</span></p>',
+            {"google_doc": True},
+            "**a**",
+            id="font-weight-bold-keyword",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:800">a</span><span style="font-weight:900">b</span></p>',
+            {"google_doc": True},
+            "**a****b**",
+            id="font-weight-800-and-900",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:400">a</span></p>',
+            {"google_doc": True},
+            "a",
+            id="font-weight-400-is-not-bold",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bolder">a</span></p>',
+            {"google_doc": True},
+            "a",
+            id="value-longer-than-keyword-not-bold",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:70">a</span></p>',
+            {"google_doc": True},
+            "a",
+            id="value-shorter-than-keyword-not-bold",
+        ),
+        pytest.param(
+            '<p><span style="font-style:italic">a</span></p>',
+            {"google_doc": True},
+            "*a*",
+            id="font-style-italic",
+        ),
+        pytest.param(
+            '<p><span style="font-style:normal">a</span></p>',
+            {"google_doc": True},
+            "a",
+            id="font-style-normal-is-plain",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold;font-style:italic">a</span></p>',
+            {"google_doc": True},
+            "***a***",
+            id="bold-and-italic-combine",
+        ),
+        pytest.param(
+            '<p><span style="font-family:Courier New">code()</span></p>',
+            {"google_doc": True},
+            "`code()`",
+            id="courier-new-is-fixed-width-code",
+        ),
+        pytest.param(
+            '<p><span style="font-family:Consolas">x</span></p>',
+            {"google_doc": True},
+            "`x`",
+            id="consolas-is-fixed-width-code",
+        ),
+        pytest.param(
+            '<p><span style="font-family:Arial">x</span></p>',
+            {"google_doc": True},
+            "x",
+            id="proportional-font-is-plain",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold;font-family:Courier New">x</span></p>',
+            {"google_doc": True},
+            "**`x`**",
+            id="bold-fixed-width-nests",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold"><span style="color:red">x</span></span></p>',
+            {"google_doc": True},
+            "**x**",
+            id="nested-span-inherits-bold-no-double",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold"><span style="font-weight:bold">x</span></span></p>',
+            {"google_doc": True},
+            "**x**",
+            id="restated-bold-not-doubled",
+        ),
+        pytest.param(
+            '<p>a<span style="font-weight:bold"> x </span>b</p>',
+            {"google_doc": True},
+            "a **x** b",
+            id="inner-space-moves-outside-markers",
+        ),
+        pytest.param(
+            '<p>keep<span style="font-weight:bold"></span> on</p>',
+            {"google_doc": True},
+            "keep on",
+            id="empty-styled-span-emits-nothing",
+        ),
+        pytest.param(
+            '<p>a <span style="text-decoration:line-through">gone</span> b</p>',
+            {"google_doc": True, "hide_strikethrough": True},
+            "a b",
+            id="line-through-hidden-when-asked",
+        ),
+        pytest.param(
+            '<p>a <span style="text-decoration:line-through">b</span> c</p>',
+            {"google_doc": True},
+            "a b c",
+            id="line-through-ignored-by-default",
+        ),
+        pytest.param(
+            '<p><span style="text-decoration:underline">a</span></p>',
+            {"google_doc": True, "hide_strikethrough": True},
+            "a",
+            id="underline-is-not-strikethrough",
+        ),
+        pytest.param(
+            "<p>a <span>b</span> c</p>",
+            {"google_doc": True, "hide_strikethrough": True},
+            "a b c",
+            id="hide-strikethrough-with-styleless-element",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold">x</span></p>',
+            {"google_doc": True, "hide_strikethrough": True},
+            "**x**",
+            id="hide-strikethrough-without-text-decoration",
+        ),
+        pytest.param(
+            '<p><span style="font-style:italic"><span style="font-style:italic">x</span></span></p>',
+            {"google_doc": True},
+            "*x*",
+            id="nested-span-inherits-italic-no-double",
+        ),
+        pytest.param(
+            '<p>a<span style="font-style:italic"></span>b</p>',
+            {"google_doc": True},
+            "ab",
+            id="empty-italic-span-emits-nothing",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold;display">y</span></p>',
+            {"google_doc": True},
+            "**y**",
+            id="trailing-declaration-without-colon-skipped",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold; :">x</span></p>',
+            {"google_doc": True},
+            "**x**",
+            id="blank-name-and-value-declaration",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold">a</span></p>',
+            {},
+            "a",
+            id="styles-ignored-without-google-doc",
+        ),
+        pytest.param(
+            "<p><span>plain</span></p>",
+            {"google_doc": True},
+            "plain",
+            id="span-without-style-is-plain",
+        ),
+        pytest.param(
+            '<p><span style="color:red">x</span></p>',
+            {"google_doc": True},
+            "x",
+            id="unrelated-style-property",
+        ),
+        pytest.param(
+            '<p><span style="display;font-weight:bold">x</span></p>',
+            {"google_doc": True},
+            "**x**",
+            id="declaration-without-colon-skipped",
+        ),
+        pytest.param(
+            '<p><span style="FONT-WEIGHT: BOLD">x</span></p>',
+            {"google_doc": True},
+            "**x**",
+            id="property-and-value-case-insensitive",
+        ),
+        pytest.param(
+            '<p><span style="  font-weight : bold ">x</span></p>',
+            {"google_doc": True},
+            "**x**",
+            id="whitespace-around-property-and-value-trimmed",
+        ),
+        pytest.param(
+            '<p><span style="font-weight:bold">a</span></p>',
+            {"google_doc": True, "strong": "__", "emphasis": "_"},
+            "__a__",
+            id="bold-uses-configured-marker",
+        ),
+        pytest.param(
+            '<ul><li style="margin-left:36px">a</li><li style="margin-left:72px">b</li></ul>',
+            {"google_doc": True},
+            "  - a\n    - b",
+            id="margin-left-nests-list-items",
+        ),
+        pytest.param(
+            '<ul><li style="margin-left:72px">a</li></ul>',
+            {"google_doc": True, "google_list_indent": 72},
+            "  - a",
+            id="custom-list-indent-divisor",
+        ),
+        pytest.param(
+            '<ol><li style="margin-left:36px">a</li></ol>',
+            {"google_doc": True},
+            "  1. a",
+            id="margin-left-nests-ordered-items",
+        ),
+        pytest.param(
+            "<ul><li>a</li></ul>",
+            {"google_doc": True},
+            "- a",
+            id="list-item-without-margin-is-flat",
+        ),
+        pytest.param(
+            '<ul><li style="margin-left:48px">x</li></ul>',
+            {"google_doc": True},
+            "  - x",
+            id="margin-not-a-multiple-floors-down",
+        ),
+        pytest.param(
+            '<ul><li style="margin-left:36">a</li></ul>',
+            {"google_doc": True},
+            "  - a",
+            id="margin-left-without-px-unit",
+        ),
+        pytest.param(
+            '<ul><li style="margin-left:auto">a</li></ul>',
+            {"google_doc": True},
+            "- a",
+            id="non-numeric-margin-is-no-nesting",
+        ),
+        pytest.param(
+            '<ul><li style="margin-left:-36px">a</li></ul>',
+            {"google_doc": True},
+            "- a",
+            id="negative-margin-is-no-nesting",
+        ),
+        pytest.param(
+            '<ul><li style="color:red">a</li></ul>',
+            {"google_doc": True},
+            "- a",
+            id="list-item-style-without-margin",
+        ),
+        pytest.param(
+            '<ol style="list-style-type:disc"><li>a</li></ol>',
+            {"google_doc": True},
+            "- a",
+            id="list-style-disc-renders-unordered",
+        ),
+        pytest.param(
+            '<ul style="list-style-type:decimal"><li>a</li></ul>',
+            {"google_doc": True},
+            "1. a",
+            id="list-style-decimal-renders-ordered",
+        ),
+        pytest.param(
+            '<ul style="color:red"><li>a</li></ul>',
+            {"google_doc": True},
+            "- a",
+            id="list-without-style-type-keeps-tag",
+        ),
+    ],
+)
+def test_google_doc(html: str, opts: _Opts, expected: str) -> None:
+    assert md(html, opts) == expected
+
+
+def test_google_list_indent_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="google_list_indent"):
+        call_with(parse("<p>x</p>").to_markdown, google_list_indent=0)

--- a/tests/test_tree_text_annotations.py
+++ b/tests/test_tree_text_annotations.py
@@ -1,0 +1,193 @@
+"""Annotated layout text via Node.to_annotated_text() (the inscriptis annotation
+role): each element matching a rule gets a labeled span over its rendered text.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from turbohtml import parse
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+    Rules = Mapping[str, Sequence[str]]
+
+
+def annotate(html: str, rules: Rules) -> tuple[str, list[tuple[int, int, str]]]:
+    return parse(html).to_annotated_text(rules)
+
+
+def spans_text(html: str, rules: Rules) -> list[tuple[str, str]]:
+    """Return (label, covered-text) pairs, the offset-independent view."""
+    text, labels = annotate(html, rules)
+    return [(label, text[start:end]) for start, end, label in labels]
+
+
+def call_with(convert: Callable[..., object], *args: object, **kwargs: str | int) -> object:
+    """Invoke the converter with arguments the static signature would reject, to drive
+    the runtime validation; the converter arrives signature-erased on purpose."""
+    return convert(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("html", "rules", "expected"),
+    [
+        pytest.param(
+            "<h1>Title</h1><p>Some <b>bold</b> words.</p>",
+            {"h1": ["heading"], "b": ["emphasis"]},
+            [("heading", "Title"), ("emphasis", "bold")],
+            id="tag-rules",
+        ),
+        pytest.param(
+            "<p>plain</p><p class='lead intro'>special</p>",
+            {"p#class=lead": ["lead"]},
+            [("lead", "special")],
+            id="tag-attr-value",
+        ),
+        pytest.param(
+            "<a href='/x' rel='nofollow'>link</a><a href='/y'>plain</a>",
+            {"a#rel": ["tracked"]},
+            [("tracked", "link")],
+            id="tag-attr-present",
+        ),
+        pytest.param(
+            "<p class='note'>x</p><b class='note'>y</b><i>z</i>",
+            {"#class=note": ["noted"]},
+            [("noted", "x"), ("noted", "y")],
+            id="any-tag-attr-value",
+        ),
+        pytest.param(
+            "<p id='a'>one</p><p>two</p>",
+            {"#id": ["has-id"]},
+            [("has-id", "one")],
+            id="any-tag-attr-present",
+        ),
+        pytest.param(
+            "<p>a <b><i>both</i></b> c</p>",
+            {"b": ["bold"], "i": ["italic"]},
+            [("italic", "both"), ("bold", "both")],
+            id="nested",
+        ),
+        pytest.param(
+            "<h2>Head</h2>",
+            {"h2": ["heading", "important"]},
+            [("heading", "Head"), ("important", "Head")],
+            id="multiple-labels",
+        ),
+        pytest.param("<p>x</p>", {}, [], id="empty-rules"),
+        pytest.param("<p>x</p>", {"b": ["bold"]}, [], id="no-match"),
+        pytest.param(
+            "<table><tr><th>Name</th></tr><tr><td>Bob</td></tr></table>",
+            {"th": ["header"], "td": ["cell"]},
+            [("header", "Name"), ("cell", "Bob")],
+            id="table-cells",
+        ),
+        pytest.param(
+            "<p>plain</p><svg><desc>x</desc></svg>",
+            {"desc": ["svg-desc"]},
+            [],
+            id="foreign-element-not-matched",
+        ),
+        pytest.param(
+            "<p class=''>empty</p><p>x</p>",
+            {"p#class=note": ["noted"]},
+            [],
+            id="valueless-no-match",
+        ),
+        pytest.param(
+            "<p class='lead intro'>x</p>",
+            {"#class=intro": ["second"]},
+            [("second", "x")],
+            id="value-matches-second-token",
+        ),
+        pytest.param("<p class='other '>x</p>", {"#class=note": ["noted"]}, [], id="value-no-token-matches"),
+        pytest.param("<p>keep</p><b></b>", {"b": ["bold"]}, [], id="empty-element-no-span"),
+        pytest.param("<p class='lead'>x</p>", {"#class=lear": ["noted"]}, [], id="value-same-length-differs"),
+        pytest.param(
+            "<p>intro</p><h2>Head</h2>",
+            {"h2": ["heading"]},
+            [("heading", "Head")],
+            id="block-not-first-trims-leading",
+        ),
+        pytest.param("<div><p>a<br></p></div>", {"p": ["para"]}, [("para", "a")], id="trailing-break-trimmed"),
+    ],
+)
+def test_annotation_spans(html: str, rules: Rules, expected: list[tuple[str, str]]) -> None:
+    assert spans_text(html, rules) == expected
+
+
+def test_offsets_are_exact() -> None:
+    text, labels = annotate("<h1>Title</h1><p>a <b>bold</b> b</p>", {"h1": ["h"], "b": ["e"]})
+    assert text == "Title\n\na bold b"
+    assert labels == [(0, 5, "h"), (9, 13, "e")]
+
+
+def test_table_cell_offsets_map_into_the_grid() -> None:
+    text, labels = annotate(
+        "<table><tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>30</td></tr></table>",
+        {"td": ["cell"]},
+    )
+    assert text == "Name   Age\nAlice  30"
+    assert [(text[s:e]) for s, e, _ in labels] == ["Alice", "30"]
+
+
+def test_content_inside_a_cell_is_not_annotated() -> None:
+    # the cell renders into a throwaway buffer, so inner elements get no span
+    _, labels = annotate("<table><tr><td>a <b>x</b></td></tr></table>", {"b": ["bold"], "td": ["cell"]})
+    assert [label for _, _, label in labels] == ["cell"]
+
+
+def test_leading_whitespace_shifts_offsets() -> None:
+    text, labels = annotate("   <h1>Hi</h1>", {"h1": ["h"]})
+    assert text == "Hi"
+    assert labels == [(0, 2, "h")]
+
+
+def test_links_and_options_compose_with_annotations() -> None:
+    text, _labels = annotate("<p><a href='http://x'>site</a></p>", {"a": ["link"]})
+    assert text == "site"
+    text2, labels2 = parse("<p><a href='http://x'>site</a></p>").to_annotated_text({"a": ["link"]}, links="inline")
+    assert text2 == "site (http://x)"
+    assert [text2[s:e] for s, e, _ in labels2] == ["site (http://x)"]
+
+
+def test_many_spans_grow_the_buffer() -> None:
+    html = "<p>" + "".join(f"<b>{i}</b>" for i in range(20)) + "</p>"
+    _, labels = annotate(html, {"b": ["bold"]})
+    assert len(labels) == 20
+
+
+def test_deeply_nested_annotations_grow_the_active_stack() -> None:
+    text, labels = annotate("<span>" * 12 + "deep" + "</span>" * 12, {"span": ["s"]})
+    assert len(labels) == 12
+    assert {text[s:e] for s, e, _ in labels} == {"deep"}
+
+
+@pytest.mark.parametrize(
+    ("rules", "exc", "match"),
+    [
+        pytest.param("notadict", TypeError, "dict", id="rules-not-dict"),
+        pytest.param({5: ["x"]}, TypeError, "string", id="key-not-string"),
+        pytest.param({"b": "bold"}, TypeError, "list", id="value-is-string"),
+        pytest.param({"b": 5}, TypeError, "iterable", id="value-not-iterable"),
+    ],
+)
+def test_invalid_rules(rules: object, exc: type[Exception], match: str) -> None:
+    with pytest.raises(exc, match=match):
+        call_with(parse("<p>x</p>").to_annotated_text, rules)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "exc", "match"),
+    [
+        pytest.param({"width": "x"}, TypeError, "int", id="width-wrong-type"),
+        pytest.param({"links": "bad"}, ValueError, "links", id="invalid-links"),
+        pytest.param({"layout": "bad"}, ValueError, "layout", id="invalid-layout"),
+    ],
+)
+def test_invalid_options(kwargs: Mapping[str, str], exc: type[Exception], match: str) -> None:
+    with pytest.raises(exc, match=match):
+        call_with(parse("<p>x</p>").to_annotated_text, {}, **kwargs)

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -49,6 +49,7 @@ import nh3
 import pyperf
 import w3lib.html
 from bs4 import BeautifulSoup
+from inscriptis.model.config import ParserConfig
 from linkify_it import LinkifyIt
 from lxml import html as lxml_html
 from parsel import Selector
@@ -987,7 +988,36 @@ MARKDOWN_OPT_LIBS: tuple[tuple[str, Callable[[str], None]], ...] = (
     ("html2text", html2text_configured),
 )
 
-MARKDOWN_CASE_NAMES = [name for name, _ in MARKDOWN_CASES] + ["configured 4 KiB"]
+# the google_doc case feeds the inline-CSS styling a Google Docs export carries,
+# so the CSS-to-Markdown path (bold/italic weights, fixed-width spans) is measured
+# against html2text's google_doc mode; markdownify has no equivalent.
+_MARKDOWN_GOOGLE_HTML = (
+    '<p><span style="font-weight:700">Bold</span> and <span style="font-style:italic">italic</span> and '
+    "<span style=\"font-family:'Courier New'\">code()</span> in a line.</p>"
+) * 18
+
+
+def turbo_markdown_google(text: str) -> None:
+    """Convert a Google Docs export with turbohtml's google_doc mode."""
+    turbohtml.parse(text).to_markdown(google_doc=True)
+
+
+_HTML2TEXT_GOOGLE = html2text.HTML2Text()
+_HTML2TEXT_GOOGLE.body_width = 0
+_HTML2TEXT_GOOGLE.google_doc = True
+
+
+def html2text_google(text: str) -> None:
+    """Convert a Google Docs export with html2text's google_doc mode."""
+    _HTML2TEXT_GOOGLE.handle(text)
+
+
+MARKDOWN_GOOGLE_LIBS: tuple[tuple[str, Callable[[str], None]], ...] = (
+    ("turbohtml", turbo_markdown_google),
+    ("html2text", html2text_google),
+)
+
+MARKDOWN_CASE_NAMES = [name for name, _ in MARKDOWN_CASES] + ["configured 4 KiB", "google_doc 4 KiB"]
 
 
 def turbo_text(text: str) -> None:
@@ -1009,7 +1039,29 @@ TEXT_CASES: tuple[tuple[str, str], ...] = (
     ("article 2 KiB", ("<h2>Heading</h2><p>A paragraph of plain prose with a <a href='/x'>link</a> in it.</p>" * 16)),
     ("table 4 KiB", ("<table><tr><th>Region</th><th>Total</th></tr><tr><td>North</td><td>120</td></tr></table>" * 30)),
 )
-TEXT_CASE_NAMES = [name for name, _ in TEXT_CASES]
+TEXT_CASE_NAMES = [name for name, _ in TEXT_CASES] + ["annotated 4 KiB"]
+
+# the annotation case labels matching elements with spans, the role inscriptis's
+# get_annotated_text fills, so the labeled-span path is measured beside it.
+_ANNOTATION_RULES = {"h1": ["heading"], "b": ["emphasis"], "a": ["link"]}
+_ANNOTATION_CONFIG = ParserConfig(annotation_rules=_ANNOTATION_RULES)
+_ANNOTATION_HTML = "<h1>Q3</h1><p>Up <b>12%</b> with a <a href='/x'>link</a> in prose.</p>" * 16
+
+
+def turbo_annotated(text: str) -> None:
+    """Render annotated layout text with turbohtml, recording spans in C."""
+    turbohtml.parse(text).to_annotated_text(_ANNOTATION_RULES)
+
+
+def inscriptis_annotated(text: str) -> None:
+    """Render annotated layout text with inscriptis, on an lxml tree."""
+    inscriptis.get_annotated_text(text, _ANNOTATION_CONFIG)
+
+
+ANNOTATION_LIBS: tuple[tuple[str, Callable[[str], None]], ...] = (
+    ("turbohtml", turbo_annotated),
+    ("inscriptis", inscriptis_annotated),
+)
 
 
 def run_markdown_suite(bench: Callable[[str, object, object], None]) -> None:
@@ -1019,9 +1071,13 @@ def run_markdown_suite(bench: Callable[[str, object, object], None]) -> None:
             bench(f"markdown {name} [{label}]", run, text)
     for label, run in MARKDOWN_OPT_LIBS:
         bench(f"markdown configured 4 KiB [{label}]", run, _MARKDOWN_OPTS_HTML)
+    for label, run in MARKDOWN_GOOGLE_LIBS:
+        bench(f"markdown google_doc 4 KiB [{label}]", run, _MARKDOWN_GOOGLE_HTML)
     for name, text in TEXT_CASES:
         for label, run in TEXT_LIBS:
             bench(f"text {name} [{label}]", run, text)
+    for label, run in ANNOTATION_LIBS:
+        bench(f"text annotated 4 KiB [{label}]", run, _ANNOTATION_HTML)
 
 
 def print_text_table(means: dict[str, float], cases: list[str]) -> None:


### PR DESCRIPTION
The first export PR (#191) covered the common `scrape` → Markdown/text path, but two migration surfaces were still missing, so projects on inscriptis's annotation API or html2text's Google-Docs mode could not move over. This finishes that migration story for issue #172.

`to_annotated_text` adds inscriptis's annotation role: given an `annotation_rules` mapping it returns the laid-out text together with `(start, end, label)` spans over its code-point offsets, so a labelling or information-extraction pipeline keeps the visual layout and the markup-derived labels in one pass. 🏷️ It reuses the `to_text` layout walk and records a span whenever an element matches a rule, trimming surrounding whitespace and dropping empty spans so a label always covers visible text; rule keys take the inscriptis `tag`, `tag#attr`, `tag#attr=value`, `#attr` and `#attr=value` forms, and every `to_text` option still applies.

`to_markdown(google_doc=True)` adds html2text's Google-Docs mode. A Google Docs HTML export encodes all formatting as inline CSS on `<span>`s rather than `<b>`/`<em>`/`<code>` tags, so the same C walk now reads that styling: a `font-weight` of `bold`/`700`–`900` becomes `strong`, `font-style:italic` becomes `emphasis`, a `Courier New`/`Consolas` `font-family` becomes an inline code span, `list-style-type` picks the list marker, and `margin-left` over `google_list_indent` pixels sets the list nesting depth. A marker is emitted only on the transition the ancestor did not already set, so nested spans never double the markup, and `hide_strikethrough` drops text a `text-decoration:line-through` struck.

Both walks stay stateless and take the per-tree critical section, so they are safe under the free-threaded build, and both run far ahead of the libraries they replace: `to_annotated_text` is roughly 20× faster than inscriptis's `get_annotated_text`, and `google_doc` Markdown is ~35× faster than html2text's google mode. ⚡ The migration guide maps every option to its turbohtml name, and the benchmark suite gains both cases.

closes #172
closes #220
