### PR TITLE
feat(serialize): attribute order and meta-charset options

### DIFF
--- a/docs/changelog/221.feature.rst
+++ b/docs/changelog/221.feature.rst
@@ -1,0 +1,4 @@
+Add two output options to :meth:`~turbohtml.Node.serialize` and :meth:`~turbohtml.Node.encode`: ``sort_attributes``
+emits each start tag's attributes in ascending name order for deterministic diffs, and ``meta_charset`` ensures the
+document ``<head>`` declares the output encoding, normalizing an existing ``<meta charset>`` or injecting one. Both
+compose with every ``formatter`` and ``layout`` - by :user:`gaborbernat`.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -667,6 +667,41 @@ Whitespace-significant elements (``pre``, ``textarea``, ``listing``) and raw-tex
 their content verbatim, and a tag is never dropped when omitting it would let the reparse reconstruct a formatting
 element across the boundary.
 
+***********************************
+ Normalize attributes and encoding
+***********************************
+
+Two more keyword options on ``serialize`` and ``encode`` normalize the output without touching the tree, and compose
+with any ``formatter`` or ``layout``. ``sort_attributes`` emits each start tag's attributes in ascending name order, so
+two serializations of equal trees diff cleanly:
+
+.. testcode::
+
+    import turbohtml
+    node = turbohtml.parse("<p id=main class=lead data-x=1>hi</p>").select_one("p")
+    print(node.serialize(sort_attributes=True))
+
+.. testoutput::
+
+    <p class="lead" data-x="1" id="main">hi</p>
+
+``meta_charset`` makes the document ``<head>`` declare the output encoding: an existing ``<meta charset>`` (or ``<meta
+http-equiv="content-type">``) is normalized in place, and a head that declares none gets a ``<meta charset>`` injected
+as its first child — never a duplicate. ``serialize`` declares ``utf-8`` (the encoding of the returned ``str``), while
+``encode`` declares the encoding it writes:
+
+.. testcode::
+
+    import turbohtml
+    doc = turbohtml.parse("<title>Hi</title>")
+    print(doc.serialize(meta_charset=True))
+    print(doc.encode("iso-8859-1", meta_charset=True))
+
+.. testoutput::
+
+    <html><head><meta charset="utf-8"><title>Hi</title></head><body></body></html>
+    b'<html><head><meta charset="iso-8859-1"><title>Hi</title></head><body></body></html>'
+
 ********************
  Export to Markdown
 ********************

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -205,9 +205,22 @@ class Node:
     ) -> Element | str | None: ...
     def matches(self, selector: str, /) -> bool: ...
     def closest(self, selector: str, /) -> Element | None: ...
-    def serialize(self, *, formatter: Formatter = ..., layout: Indent | Minify | None = ...) -> str: ...
+    def serialize(
+        self,
+        *,
+        formatter: Formatter = ...,
+        layout: Indent | Minify | None = ...,
+        sort_attributes: bool = ...,
+        meta_charset: bool = ...,
+    ) -> str: ...
     def encode(
-        self, encoding: str = "utf-8", *, formatter: Formatter = ..., layout: Indent | Minify | None = ...
+        self,
+        encoding: str = "utf-8",
+        *,
+        formatter: Formatter = ...,
+        layout: Indent | Minify | None = ...,
+        sort_attributes: bool = ...,
+        meta_charset: bool = ...,
     ) -> bytes: ...
     def to_markdown(
         self,

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -980,15 +980,21 @@ PyDoc_STRVAR(closest_doc, "closest(selector, /)\n--\n\n"
 static PyObject *node_serialize(PyObject *self, PyObject *args, PyObject *kwds);
 static PyObject *node_encode(PyObject *self, PyObject *args, PyObject *kwds);
 
-PyDoc_STRVAR(serialize_doc, "serialize(*, formatter=Formatter.WHATWG, layout=None)\n--\n\n"
-                            "Serialize this node and its subtree to a str. formatter chooses the escape\n"
-                            "policy. layout chooses the whitespace: None gives the compact WHATWG form,\n"
-                            "an Indent pretty-prints (adding whitespace, so it does not preserve\n"
-                            "meaning), and a Minify shrinks the output while reparsing to the same tree.");
+PyDoc_STRVAR(serialize_doc,
+             "serialize(*, formatter=Formatter.WHATWG, layout=None, sort_attributes=False, meta_charset=False)\n--\n\n"
+             "Serialize this node and its subtree to a str. formatter chooses the escape\n"
+             "policy. layout chooses the whitespace: None gives the compact WHATWG form,\n"
+             "an Indent pretty-prints (adding whitespace, so it does not preserve\n"
+             "meaning), and a Minify shrinks the output while reparsing to the same tree.\n"
+             "sort_attributes emits each start tag's attributes in ascending name order.\n"
+             "meta_charset ensures the document <head> declares <meta charset=\"utf-8\">,\n"
+             "normalizing an existing charset declaration or injecting one.");
 
-PyDoc_STRVAR(encode_doc, "encode(encoding='utf-8', *, formatter=Formatter.WHATWG, layout=None)\n--\n\n"
-                         "Serialize this node and its subtree to bytes in the named encoding,\n"
-                         "with the same formatter and layout controls as serialize().");
+PyDoc_STRVAR(encode_doc, "encode(encoding='utf-8', *, formatter=Formatter.WHATWG, layout=None, sort_attributes=False, "
+                         "meta_charset=False)\n--\n\n"
+                         "Serialize this node and its subtree to bytes in the named encoding, with the\n"
+                         "same formatter, layout, and sort_attributes controls as serialize(). When\n"
+                         "meta_charset is set the injected/normalized <meta charset> names encoding.");
 
 PyDoc_STRVAR(find_doc, "find(tag=None, /, *, axis=Axis.DESCENDANTS, attrs=None, class_=None, **filters)\n--\n\n"
                        "Return the first Element along axis matching the tag filter and every\n"
@@ -3129,10 +3135,14 @@ static int resolve_layout(module_state *state, PyObject *layout_obj, enum th_lay
     return -1;
 }
 
-/* Serialize self to a str under the given Formatter member and layout mode. */
-static PyObject *node_serialize_str(PyObject *self, PyObject *formatter_obj, PyObject *layout_obj) {
-    int formatter;
-    if (resolve_formatter(state_of(self), formatter_obj, &formatter) < 0) {
+/* Serialize self to a str under the given Formatter member, layout mode, and the
+   two output normalizations. charset is the label the meta_charset option writes
+   (the str output is conceptually UTF-8 for serialize, the target encoding for
+   encode); it is borrowed only for the duration of the call. */
+static PyObject *node_serialize_str(PyObject *self, PyObject *formatter_obj, PyObject *layout_obj, int sort_attributes,
+                                    int meta_charset, const char *charset) {
+    th_serialize_opts opts = {0, sort_attributes, meta_charset, charset, (Py_ssize_t)strlen(charset)};
+    if (resolve_formatter(state_of(self), formatter_obj, &opts.formatter) < 0) {
         return NULL;
     }
     enum th_layout_mode mode;
@@ -3148,10 +3158,10 @@ static PyObject *node_serialize_str(PyObject *self, PyObject *formatter_obj, PyO
        mutate cannot rewire it mid-walk (a no-op on the GIL build) */
     Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
     if (mode == TH_LAYOUT_MINIFY) {
-        data = th_node_minify(tree_of(self), ((NodeObject *)self)->node, &minify_opts, formatter, &out_len);
+        data = th_node_minify(tree_of(self), ((NodeObject *)self)->node, &minify_opts, &opts, &out_len);
     } else {
         const Py_UCS4 *indent = mode == TH_LAYOUT_INDENT ? indent_unit : NULL;
-        data = th_node_serialize(tree_of(self), ((NodeObject *)self)->node, formatter, indent, indent_len, &out_len);
+        data = th_node_serialize(tree_of(self), ((NodeObject *)self)->node, &opts, indent, indent_len, &out_len);
     }
     Py_END_CRITICAL_SECTION();
     if (data == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -3163,24 +3173,30 @@ static PyObject *node_serialize_str(PyObject *self, PyObject *formatter_obj, PyO
 }
 
 static PyObject *node_serialize(PyObject *self, PyObject *args, PyObject *kwds) {
-    static char *keywords[] = {"formatter", "layout", NULL};
+    static char *keywords[] = {"formatter", "layout", "sort_attributes", "meta_charset", NULL};
     PyObject *formatter_obj = NULL;
     PyObject *layout_obj = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|$OO", keywords, &formatter_obj, &layout_obj)) {
+    int sort_attributes = 0;
+    int meta_charset = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|$OOpp", keywords, &formatter_obj, &layout_obj, &sort_attributes,
+                                     &meta_charset)) {
         return NULL;
     }
-    return node_serialize_str(self, formatter_obj, layout_obj);
+    return node_serialize_str(self, formatter_obj, layout_obj, sort_attributes, meta_charset, "utf-8");
 }
 
 static PyObject *node_encode(PyObject *self, PyObject *args, PyObject *kwds) {
-    static char *keywords[] = {"encoding", "formatter", "layout", NULL};
+    static char *keywords[] = {"encoding", "formatter", "layout", "sort_attributes", "meta_charset", NULL};
     const char *encoding = "utf-8";
     PyObject *formatter_obj = NULL;
     PyObject *layout_obj = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s$OO", keywords, &encoding, &formatter_obj, &layout_obj)) {
+    int sort_attributes = 0;
+    int meta_charset = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s$OOpp", keywords, &encoding, &formatter_obj, &layout_obj,
+                                     &sort_attributes, &meta_charset)) {
         return NULL;
     }
-    PyObject *text = node_serialize_str(self, formatter_obj, layout_obj);
+    PyObject *text = node_serialize_str(self, formatter_obj, layout_obj, sort_attributes, meta_charset, encoding);
     if (text == NULL) {
         return NULL;
     }

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -195,12 +195,22 @@ Py_UCS4 *th_node_html(th_tree *tree, th_node *node, Py_ssize_t *out_len);
    compact. PyMem-allocated; *out_len receives the length. NULL on failure. */
 Py_UCS4 *th_node_inner_html(th_tree *tree, th_node *node, Py_ssize_t *out_len);
 
-/* Serialize node and its subtree under a chosen escape formatter (0 WHATWG,
-   1 minimal, 2 named entities). When indent is non-NULL it is the per-level
-   whitespace unit for pretty output; NULL emits the compact form. PyMem-
+/* Output-shaping options shared by serialize() and encode(): the escape formatter
+   plus two opt-in normalizations that leave the tree untouched. Every field is
+   off (zero / NULL) by default, so the common serialize costs nothing. */
+typedef struct {
+    int formatter;       /* escape policy: 0 WHATWG, 1 minimal, 2 named entities */
+    int sort_attributes; /* emit each start tag's attributes in ascending name order */
+    int inject_meta;     /* ensure <head> declares <meta charset=charset> */
+    const char *charset; /* ASCII encoding label for the injected/normalized meta */
+    Py_ssize_t charset_len;
+} th_serialize_opts;
+
+/* Serialize node and its subtree under opts. When indent is non-NULL it is the
+   per-level whitespace unit for pretty output; NULL emits the compact form. PyMem-
    allocated; *out_len receives the length. NULL on failure. */
-Py_UCS4 *th_node_serialize(th_tree *tree, th_node *node, int formatter, const Py_UCS4 *indent, Py_ssize_t indent_len,
-                           Py_ssize_t *out_len);
+Py_UCS4 *th_node_serialize(th_tree *tree, th_node *node, const th_serialize_opts *opts, const Py_UCS4 *indent,
+                           Py_ssize_t indent_len, Py_ssize_t *out_len);
 
 /* The minification transforms serialize(minify=...) toggles, each round-trip safe
    (the minified bytes reparse to the same tree). */
@@ -211,9 +221,10 @@ typedef struct {
     int strip_comments;      /* skip comment nodes */
 } th_minify_opts;
 
-/* Serialize node and its subtree minified under opts and the escape formatter.
+/* Serialize node and its subtree minified under minify and the output options.
    PyMem-allocated; *out_len receives the length. NULL on failure. */
-Py_UCS4 *th_node_minify(th_tree *tree, th_node *node, const th_minify_opts *opts, int formatter, Py_ssize_t *out_len);
+Py_UCS4 *th_node_minify(th_tree *tree, th_node *node, const th_minify_opts *minify, const th_serialize_opts *opts,
+                        Py_ssize_t *out_len);
 
 /* The Markdown export configuration, a union of the markdownify and html2text
    knobs with one name per concept. The Python binding fills it from keyword

--- a/src/turbohtml/treebuilder_minify.h
+++ b/src/turbohtml/treebuilder_minify.h
@@ -108,16 +108,24 @@ static int mini_attr_unquotable(const Py_UCS4 *value, Py_ssize_t len) {
 }
 
 /* Write an element's start tag, dropping redundant attribute quotes and writing a
-   valueless/empty attribute as just its name when unquoting is enabled. */
-static void mini_open_tag(sbuf *out, th_tree *tree, th_node *node, int formatter, int unquote) {
+   valueless/empty attribute as just its name when unquoting is enabled. Attribute
+   order and charset normalization come from the shared output options (a normalized
+   charset value always keeps its quotes). */
+static void mini_open_tag(sbuf *out, th_tree *tree, th_node *node, const th_serialize_opts *opts, int unquote) {
     sbuf_putc(out, '<');
     sbuf_put_ucs4(out, node->text, node->text_len);
-    for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-        th_node_attr *attr = &node->attrs[index];
+    Py_ssize_t stack_order[MAX_SORTED_ATTRS];
+    Py_ssize_t *order = ser_attr_order(tree, node, opts->sort_attributes, stack_order);
+    int charset_kind = opts->inject_meta ? ser_meta_charset_kind(tree, node) : 0;
+    for (Py_ssize_t position = 0; position < node->attr_count; position++) {
+        th_node_attr *attr = &node->attrs[order != NULL ? order[position] : position];
         sbuf_putc(out, ' ');
         Py_ssize_t name_len;
         const char *name = th_attr_name(tree, attr->name_atom, &name_len);
         sbuf_put_utf8(out, name, name_len);
+        if (ser_put_charset_value(out, opts, charset_kind, name, name_len)) {
+            continue;
+        }
         if (unquote && attr->value_len == 0) {
             continue; /* an empty value reparses identically as a bare attribute name */
         }
@@ -126,10 +134,11 @@ static void mini_open_tag(sbuf *out, th_tree *tree, th_node *node, int formatter
             sbuf_put_run(out, attr->value, attr->value_len); /* unquotable means no character needs escaping */
         } else {
             sbuf_puts(out, "=\"");
-            sbuf_put_text(out, attr->value, attr->value_len, 1, formatter);
+            sbuf_put_text(out, attr->value, attr->value_len, 1, opts->formatter);
             sbuf_putc(out, '"');
         }
     }
+    ser_attr_order_free(order, stack_order);
     sbuf_putc(out, '>');
 }
 
@@ -334,7 +343,8 @@ static int mini_omit_start_tag(th_tree *tree, th_node *node, int strip_comments)
    descending through first_child and ascending through parent pointers, with a
    preserve counter so text inside pre/textarea/listing skips whitespace
    collapsing. */
-static void serialize_minify(sbuf *out, th_tree *tree, th_node *root, const th_minify_opts *opts, int formatter) {
+static void serialize_minify(sbuf *out, th_tree *tree, th_node *root, const th_minify_opts *opts,
+                             const th_serialize_opts *st) {
     th_node *node = root;
     int preserve = 0;
     int formatting = 0;
@@ -348,8 +358,9 @@ static void serialize_minify(sbuf *out, th_tree *tree, th_node *root, const th_m
             /* the serialization root is what the caller asked to serialize, so its own tags
                always render (matching the plain serializer); only inner tags may be omitted */
             if (!(opts->omit_optional_tags && node != root && mini_omit_start_tag(tree, node, opts->strip_comments))) {
-                mini_open_tag(out, tree, node, formatter, opts->unquote_attributes);
+                mini_open_tag(out, tree, node, st, opts->unquote_attributes);
             }
+            ser_inject_head_meta(out, tree, node, st);
             if (node->ns == TH_NS_HTML && is_serialize_void_atom(node->atom)) {
                 break; /* void elements have no children or end tag */
             }
@@ -377,9 +388,9 @@ static void serialize_minify(sbuf *out, th_tree *tree, th_node *root, const th_m
             break;
         case TH_NODE_TEXT:
             if (opts->collapse_whitespace && preserve == 0) {
-                mini_put_collapsed_text(out, need_text(tree, node), node->text_len, formatter, &last_was_space);
+                mini_put_collapsed_text(out, need_text(tree, node), node->text_len, st->formatter, &last_was_space);
             } else {
-                sbuf_put_text(out, need_text(tree, node), node->text_len, 0, formatter);
+                sbuf_put_text(out, need_text(tree, node), node->text_len, 0, st->formatter);
                 last_was_space = 0;
             }
             break;
@@ -445,9 +456,10 @@ static void serialize_minify(sbuf *out, th_tree *tree, th_node *root, const th_m
     }
 }
 
-Py_UCS4 *th_node_minify(th_tree *tree, th_node *node, const th_minify_opts *opts, int formatter, Py_ssize_t *out_len) {
+Py_UCS4 *th_node_minify(th_tree *tree, th_node *node, const th_minify_opts *minify, const th_serialize_opts *opts,
+                        Py_ssize_t *out_len) {
     sbuf out = {NULL, 0, 0, 0};
     sbuf_presize_for_root(&out, tree, node);
-    serialize_minify(&out, tree, node, opts, formatter);
+    serialize_minify(&out, tree, node, minify, opts);
     return sbuf_finish(&out, out_len);
 }

--- a/src/turbohtml/treebuilder_serialize.h
+++ b/src/turbohtml/treebuilder_serialize.h
@@ -468,21 +468,173 @@ static int ser_needs_leading_newline(th_tree *tree, th_node *node) {
     return first != NULL && first->type == TH_NODE_TEXT && need_text(tree, first)[0] == '\n';
 }
 
-/* Write an element's start tag, "<tag attrs...>", with attributes in source order
-   and double-quoted values escaped under the formatter. */
-static void ser_open_tag(sbuf *out, th_tree *tree, th_node *node, int formatter) {
+/* ASCII case-insensitive compare of a UCS-4 attribute value against a lowercase
+   literal: the value matches when it has the same length and folds to the same
+   bytes (only A-Z fold, the only case mapping the labels here need). */
+static int ser_value_iequals(const Py_UCS4 *value, Py_ssize_t len, const char *ascii) {
+    Py_ssize_t index = 0;
+    for (; index < len && ascii[index] != '\0'; index++) {
+        Py_UCS4 character = value[index];
+        if (character >= 'A' && character <= 'Z') {
+            character += 'a' - 'A';
+        }
+        if (character != (Py_UCS4)(unsigned char)ascii[index]) {
+            return 0;
+        }
+    }
+    return index == len && ascii[index] == '\0';
+}
+
+/* How a <meta> element declares the document encoding, for the meta_charset
+   normalizer: 1 a `charset` attribute, 2 an http-equiv="content-type" with a
+   `content` attribute, 0 neither (or not an HTML <meta>). */
+static int ser_meta_charset_kind(th_tree *tree, const th_node *node) {
+    if (node->ns != TH_NS_HTML || node->atom != TH_TAG_META) {
+        return 0;
+    }
+    if (th_node_attr_find(tree, (th_node *)node, "charset", 7) >= 0) {
+        return 1;
+    }
+    Py_ssize_t equiv = th_node_attr_find(tree, (th_node *)node, "http-equiv", 10);
+    if (equiv >= 0 && th_node_attr_find(tree, (th_node *)node, "content", 7) >= 0 &&
+        ser_value_iequals(node->attrs[equiv].value, node->attrs[equiv].value_len, "content-type")) {
+        return 2;
+    }
+    return 0;
+}
+
+/* Whether head already declares a charset through a direct <meta> child, so the
+   meta_charset option normalizes that one in place instead of injecting another. */
+static int ser_head_has_charset_meta(th_tree *tree, const th_node *head) {
+    for (th_node *child = head->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type == TH_NODE_ELEMENT && ser_meta_charset_kind(tree, child) != 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Emit a fresh charset declaration, <meta charset="LABEL">. */
+static void ser_emit_meta_charset(sbuf *out, const th_serialize_opts *opts) {
+    sbuf_puts(out, "<meta charset=\"");
+    sbuf_put_utf8(out, opts->charset, opts->charset_len);
+    sbuf_puts(out, "\">");
+}
+
+/* Lexicographic compare of two interned attribute names by bytes, the shorter
+   name ordering first on a shared prefix (the html5lib alphabetical-attributes
+   order over the stored, parser-lowercased name). */
+static int ser_name_cmp(const char *left, Py_ssize_t left_len, const char *right, Py_ssize_t right_len) {
+    Py_ssize_t min_len = left_len < right_len ? left_len : right_len;
+    int order = memcmp(left, right, (size_t)min_len);
+    if (order != 0) {
+        return order;
+    }
+    return left_len < right_len ? -1 : left_len > right_len;
+}
+
+/* Insertion-sort order[0..count) into ascending attribute-name order. Counts are
+   tiny, so the quadratic sort beats any setup an asymptotically faster one needs. */
+static void ser_sort_order(th_tree *tree, const th_node *node, Py_ssize_t *order, Py_ssize_t count) {
+    for (Py_ssize_t index = 0; index < count; index++) {
+        order[index] = index;
+    }
+    for (Py_ssize_t index = 1; index < count; index++) {
+        Py_ssize_t key = order[index];
+        Py_ssize_t key_len;
+        const char *key_name = th_attr_name(tree, node->attrs[key].name_atom, &key_len);
+        Py_ssize_t prev = index - 1;
+        while (prev >= 0) {
+            Py_ssize_t prev_len;
+            const char *prev_name = th_attr_name(tree, node->attrs[order[prev]].name_atom, &prev_len);
+            if (ser_name_cmp(prev_name, prev_len, key_name, key_len) <= 0) {
+                break;
+            }
+            order[prev + 1] = order[prev];
+            prev--;
+        }
+        order[prev + 1] = key;
+    }
+}
+
+/* The order to emit node's attributes in: NULL means source order (sorting off, or
+   fewer than two attributes), otherwise a filled index array — the caller's stack
+   buffer for up to MAX_SORTED_ATTRS attributes, else a heap block freed through
+   ser_attr_order_free. */
+static Py_ssize_t *ser_attr_order(th_tree *tree, const th_node *node, int sort, Py_ssize_t *stack) {
+    if (!sort || node->attr_count < 2) {
+        return NULL;
+    }
+    Py_ssize_t *order =
+        node->attr_count <= MAX_SORTED_ATTRS ? stack : PyMem_Malloc((size_t)node->attr_count * sizeof(Py_ssize_t));
+    if (order == NULL) { /* GCOVR_EXCL_BR_LINE: only the heap path can fail, and OOM is unforceable */
+        return NULL;     /* GCOVR_EXCL_LINE: degrade to source order on allocation failure */
+    }
+    ser_sort_order(tree, node, order, node->attr_count);
+    return order;
+}
+
+static void ser_attr_order_free(Py_ssize_t *order, const Py_ssize_t *stack) {
+    if (order != NULL && order != stack) {
+        PyMem_Free(order);
+    }
+}
+
+/* Under meta_charset, rewrite a charset meta's declaration to the target label:
+   charset="LABEL" (kind 1) or content="text/html; charset=LABEL" (kind 2). Returns
+   1 when it emitted the attribute, 0 when the caller should emit the stored value.
+   The element is an HTML <meta>, whose attribute names the parser has lowercased,
+   so a byte compare against the lowercase spelling is exact. */
+static int ser_put_charset_value(sbuf *out, const th_serialize_opts *opts, int kind, const char *name,
+                                 Py_ssize_t name_len) {
+    if (kind == 1 && name_len == 7 && memcmp(name, "charset", 7) == 0) {
+        sbuf_puts(out, "=\"");
+        sbuf_put_utf8(out, opts->charset, opts->charset_len);
+        sbuf_putc(out, '"');
+        return 1;
+    }
+    if (kind == 2 && name_len == 7 && memcmp(name, "content", 7) == 0) {
+        sbuf_puts(out, "=\"text/html; charset=");
+        sbuf_put_utf8(out, opts->charset, opts->charset_len);
+        sbuf_putc(out, '"');
+        return 1;
+    }
+    return 0;
+}
+
+/* When meta_charset is on and node is a <head> that declares no charset of its own,
+   emit the <meta charset> as its first child so the output names the encoding. The
+   atom guard means this is a no-op for every element but the document head. */
+static void ser_inject_head_meta(sbuf *out, th_tree *tree, const th_node *node, const th_serialize_opts *opts) {
+    if (opts->inject_meta && node->ns == TH_NS_HTML && node->atom == TH_TAG_HEAD &&
+        !ser_head_has_charset_meta(tree, node)) {
+        ser_emit_meta_charset(out, opts);
+    }
+}
+
+/* Write an element's start tag, "<tag attrs...>": attributes in source order, or in
+   name order when opts asks; values double-quoted and escaped under the formatter,
+   with a charset meta's declaration normalized when meta_charset is on. */
+static void ser_open_tag(sbuf *out, th_tree *tree, th_node *node, const th_serialize_opts *opts) {
     sbuf_putc(out, '<');
     sbuf_put_ucs4(out, node->text, node->text_len);
-    for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-        th_node_attr *attr = &node->attrs[index];
+    Py_ssize_t stack_order[MAX_SORTED_ATTRS];
+    Py_ssize_t *order = ser_attr_order(tree, node, opts->sort_attributes, stack_order);
+    int charset_kind = opts->inject_meta ? ser_meta_charset_kind(tree, node) : 0;
+    for (Py_ssize_t position = 0; position < node->attr_count; position++) {
+        th_node_attr *attr = &node->attrs[order != NULL ? order[position] : position];
         sbuf_putc(out, ' ');
         Py_ssize_t name_len;
         const char *name = th_attr_name(tree, attr->name_atom, &name_len);
         sbuf_put_utf8(out, name, name_len);
+        if (ser_put_charset_value(out, opts, charset_kind, name, name_len)) {
+            continue;
+        }
         sbuf_puts(out, "=\"");
-        sbuf_put_text(out, attr->value, attr->value_len, 1, formatter);
+        sbuf_put_text(out, attr->value, attr->value_len, 1, opts->formatter);
         sbuf_putc(out, '"');
     }
+    ser_attr_order_free(order, stack_order);
     sbuf_putc(out, '>');
 }
 
@@ -496,13 +648,14 @@ static void ser_close_tag(sbuf *out, th_node *node) {
    algorithm), parameterized by the escape formatter. The walk is iterative,
    descending through first_child and ascending through parent pointers, so a
    tree of any depth serializes without recursing one C stack frame per level. */
-static void serialize_compact(sbuf *out, th_tree *tree, th_node *root, int formatter) {
+static void serialize_compact(sbuf *out, th_tree *tree, th_node *root, const th_serialize_opts *opts) {
     th_node *node = root;
     while (1) {
         th_node *descend = NULL;
         switch (node->type) { /* GCOVR_EXCL_BR_LINE: th_node_type is exhaustive; the implicit default is unreachable */
         case TH_NODE_ELEMENT:
-            ser_open_tag(out, tree, node, formatter);
+            ser_open_tag(out, tree, node, opts);
+            ser_inject_head_meta(out, tree, node, opts);
             if (node->ns == TH_NS_HTML && is_serialize_void_atom(node->atom)) {
                 break; /* void elements have no children or end tag */
             }
@@ -524,7 +677,7 @@ static void serialize_compact(sbuf *out, th_tree *tree, th_node *root, int forma
             }
             break;
         case TH_NODE_TEXT:
-            sbuf_put_text(out, need_text(tree, node), node->text_len, 0, formatter);
+            sbuf_put_text(out, need_text(tree, node), node->text_len, 0, opts->formatter);
             break;
         case TH_NODE_COMMENT:
             sbuf_puts(out, "<!--");
@@ -572,9 +725,10 @@ static void serialize_compact(sbuf *out, th_tree *tree, th_node *root, int forma
     }
 }
 
-/* Indentation context for the pretty form: the per-level unit and the formatter. */
+/* Indentation context for the pretty form: the output options plus the per-level
+   unit the layout's Indent supplies. */
 typedef struct {
-    int formatter;
+    const th_serialize_opts *out;
     const Py_UCS4 *indent;
     Py_ssize_t indent_len;
 } ser_opts;
@@ -598,7 +752,7 @@ static void serialize_pretty(sbuf *out, th_tree *tree, th_node *root, const ser_
         th_node *descend = NULL;
         switch (node->type) { /* GCOVR_EXCL_BR_LINE: th_node_type is exhaustive; the implicit default is unreachable */
         case TH_NODE_ELEMENT: {
-            ser_open_tag(out, tree, node, opts->formatter);
+            ser_open_tag(out, tree, node, opts->out);
             if (node->ns == TH_NS_HTML && is_serialize_void_atom(node->atom)) {
                 break;
             }
@@ -617,13 +771,26 @@ static void serialize_pretty(sbuf *out, th_tree *tree, th_node *root, const ser_
                     if (raw && child->type == TH_NODE_TEXT) { /* GCOVR_EXCL_BR_LINE */
                         sbuf_put_ucs4(out, need_text(tree, child), child->text_len);
                     } else {
-                        serialize_compact(out, tree, child, opts->formatter);
+                        serialize_compact(out, tree, child, opts->out);
                     }
                 }
                 ser_close_tag(out, node);
                 break;
             }
+            /* meta_charset injects the declaration as head's first child, on its own
+               indented line (head is never a preserve/raw element, so this is reached) */
+            int inject = opts->out->inject_meta && node->ns == TH_NS_HTML && node->atom == TH_TAG_HEAD &&
+                         !ser_head_has_charset_meta(tree, node);
+            if (node->first_child == NULL && !inject) {
+                ser_close_tag(out, node);
+                break;
+            }
+            if (inject) {
+                ser_newline_indent(out, opts, depth + 1);
+                ser_emit_meta_charset(out, opts->out);
+            }
             if (node->first_child == NULL) {
+                ser_newline_indent(out, opts, depth);
                 ser_close_tag(out, node);
                 break;
             }
@@ -632,7 +799,7 @@ static void serialize_pretty(sbuf *out, th_tree *tree, th_node *root, const ser_
             break;
         }
         case TH_NODE_TEXT:
-            sbuf_put_text(out, need_text(tree, node), node->text_len, 0, opts->formatter);
+            sbuf_put_text(out, need_text(tree, node), node->text_len, 0, opts->out->formatter);
             break;
         case TH_NODE_COMMENT:
             sbuf_puts(out, "<!--");
@@ -780,30 +947,34 @@ static void sbuf_presize_for_root(sbuf *out, th_tree *tree, th_node *node) {
     }
 }
 
+/* The WHATWG-conformant defaults the html/inner_html accessors serialize under:
+   minimal escaping, source attribute order, no charset injection. */
+static const th_serialize_opts ser_default_opts = {TH_FMT_WHATWG, 0, 0, NULL, 0};
+
 Py_UCS4 *th_node_html(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
     sbuf out = {NULL, 0, 0, 0};
     sbuf_presize_for_root(&out, tree, node);
-    serialize_compact(&out, tree, node, TH_FMT_WHATWG);
+    serialize_compact(&out, tree, node, &ser_default_opts);
     return sbuf_finish(&out, out_len);
 }
 
 Py_UCS4 *th_node_inner_html(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
     sbuf out = {NULL, 0, 0, 0};
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        serialize_compact(&out, tree, child, TH_FMT_WHATWG);
+        serialize_compact(&out, tree, child, &ser_default_opts);
     }
     return sbuf_finish(&out, out_len);
 }
 
-Py_UCS4 *th_node_serialize(th_tree *tree, th_node *node, int formatter, const Py_UCS4 *indent, Py_ssize_t indent_len,
-                           Py_ssize_t *out_len) {
+Py_UCS4 *th_node_serialize(th_tree *tree, th_node *node, const th_serialize_opts *opts, const Py_UCS4 *indent,
+                           Py_ssize_t indent_len, Py_ssize_t *out_len) {
     sbuf out = {NULL, 0, 0, 0};
     sbuf_presize_for_root(&out, tree, node);
     if (indent == NULL) {
-        serialize_compact(&out, tree, node, formatter);
+        serialize_compact(&out, tree, node, opts);
     } else {
-        ser_opts opts = {formatter, indent, indent_len};
-        serialize_pretty(&out, tree, node, &opts, 0);
+        ser_opts pretty = {opts, indent, indent_len};
+        serialize_pretty(&out, tree, node, &pretty, 0);
     }
     return sbuf_finish(&out, out_len);
 }

--- a/tests/test_serialize_output_options.py
+++ b/tests/test_serialize_output_options.py
@@ -1,0 +1,246 @@
+"""The serialize()/encode() output options: sort_attributes and meta_charset."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Element, Formatter, Indent, Minify, parse
+
+# ----------------------------------------------------------------- sort_attributes
+
+
+@pytest.mark.parametrize(
+    ("markup", "selector", "expected"),
+    [
+        pytest.param("<p z=1 a=2 m=3>x", "p", '<p a="2" m="3" z="1">x</p>', id="three-attrs"),
+        pytest.param("<p a=1>x", "p", '<p a="1">x</p>', id="single-attr-unchanged"),
+        pytest.param("<p>x", "p", "<p>x</p>", id="no-attrs-unchanged"),
+        pytest.param("<input name=q value=1>", "input", '<input name="q" value="1">', id="void-element"),
+    ],
+)
+def test_sort_attributes_orders_by_name(markup: str, selector: str, expected: str) -> None:
+    node = parse(markup).select_one(selector)
+    assert node is not None
+    assert node.serialize(sort_attributes=True) == expected
+
+
+def test_sort_attributes_off_keeps_source_order() -> None:
+    node = parse("<p z=1 a=2>x").select_one("p")
+    assert node is not None
+    assert node.serialize() == '<p z="1" a="2">x</p>'
+
+
+@pytest.mark.parametrize(
+    ("attrs", "expected"),
+    [
+        pytest.param({"ab": "1", "a": "2"}, '<x a="2" ab="1"></x>', id="prefix-name-after-longer"),
+        pytest.param({"a": "1", "ab": "2"}, '<x a="1" ab="2"></x>', id="prefix-name-before-longer"),
+    ],
+)
+def test_sort_attributes_orders_prefix_names(attrs: dict[str, str], expected: str) -> None:
+    assert Element("x", attrs).serialize(sort_attributes=True) == expected
+
+
+def test_sort_attributes_beyond_stack_buffer_uses_heap() -> None:
+    names = [f"a{index:02d}" for index in range(70)]
+    element = Element("x", {name: "" for name in reversed(names)})
+    expected = "<x " + " ".join(f'{name}=""' for name in names) + "></x>"
+    assert element.serialize(sort_attributes=True) == expected
+
+
+def test_sort_attributes_composes_with_indent() -> None:
+    node = parse("<p z=1 a=2>x").select_one("p")
+    assert node is not None
+    assert node.serialize(layout=Indent(2), sort_attributes=True).splitlines()[0] == '<p a="2" z="1">'
+
+
+def test_sort_attributes_composes_with_minify() -> None:
+    node = parse("<p z=1 a=2>x").select_one("p")
+    assert node is not None
+    assert node.serialize(layout=Minify(), sort_attributes=True) == "<p a=2 z=1>x</p>"
+
+
+# ------------------------------------------------------------------- meta_charset
+
+
+def test_meta_charset_injects_into_empty_head() -> None:
+    out = parse("<p>x").serialize(meta_charset=True)
+    assert out == '<html><head><meta charset="utf-8"></head><body><p>x</p></body></html>'
+
+
+def test_meta_charset_injects_before_existing_head_content() -> None:
+    out = parse("<link rel=icon>").serialize(meta_charset=True)
+    assert out == '<html><head><meta charset="utf-8"><link rel="icon"></head><body></body></html>'
+
+
+def test_meta_charset_normalizes_existing_charset_meta() -> None:
+    out = parse("<meta charset=ascii>").serialize(meta_charset=True)
+    assert out == '<html><head><meta charset="utf-8"></head><body></body></html>'
+
+
+def test_meta_charset_keeps_other_attributes_on_charset_meta() -> None:
+    out = parse("<meta charset=ascii id=enc>").serialize(meta_charset=True)
+    assert out == '<html><head><meta charset="utf-8" id="enc"></head><body></body></html>'
+
+
+def test_meta_charset_normalizes_http_equiv_content_type() -> None:
+    out = parse('<meta http-equiv=content-type content="text/html; charset=ascii">').serialize(meta_charset=True)
+    expected = '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8">'
+    assert out.startswith(expected)
+    assert out.count("charset=") == 1
+
+
+def test_meta_charset_matches_mixed_case_http_equiv_value() -> None:
+    out = parse('<meta http-equiv="Content-Type" content="text/html; charset=ascii">').serialize(meta_charset=True)
+    expected = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8">'
+    assert out.startswith(expected)
+    assert out.count("charset=") == 1
+
+
+def test_meta_charset_ignores_unrelated_http_equiv() -> None:
+    out = parse('<meta http-equiv=refresh content="5">').serialize(meta_charset=True)
+    assert out.startswith('<html><head><meta charset="utf-8"><meta http-equiv="refresh" content="5">')
+
+
+def test_meta_charset_ignores_http_equiv_content_type_without_content() -> None:
+    out = parse("<meta http-equiv=content-type>").serialize(meta_charset=True)
+    assert out.startswith('<html><head><meta charset="utf-8"><meta http-equiv="content-type">')
+
+
+@pytest.mark.parametrize(
+    "equiv",
+    [
+        pytest.param("content", id="shorter-prefix"),
+        pytest.param("content-type-x", id="longer-than-label"),
+    ],
+)
+def test_meta_charset_http_equiv_label_mismatch_injects(equiv: str) -> None:
+    out = parse(f'<meta http-equiv="{equiv}" content="x">').serialize(meta_charset=True)
+    assert out.startswith('<html><head><meta charset="utf-8">')
+
+
+def test_meta_charset_ignores_meta_without_charset_or_http_equiv() -> None:
+    out = parse('<meta name=viewport content="width=1">').serialize(meta_charset=True)
+    assert out.startswith('<html><head><meta charset="utf-8"><meta name="viewport" content="width=1">')
+
+
+def test_meta_charset_keeps_seven_char_attr_on_charset_meta() -> None:
+    out = parse('<meta charset=ascii content="x">').serialize(meta_charset=True)
+    assert out.startswith('<html><head><meta charset="utf-8" content="x">')
+
+
+def test_meta_charset_keeps_seven_char_attr_on_content_type_meta() -> None:
+    out = parse('<meta http-equiv=content-type content="text/html" enabled="x">').serialize(meta_charset=True)
+    assert out.startswith('<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8" enabled="x">')
+
+
+def test_meta_charset_with_indent_leaves_foreign_element() -> None:
+    out = parse("<svg></svg>").serialize(layout=Indent(2), meta_charset=True)
+    assert '<meta charset="utf-8">' in out
+    assert "<svg></svg>" in out
+
+
+def test_meta_charset_skips_non_element_head_children() -> None:
+    out = parse("<head><!--note--><title>t").serialize(meta_charset=True)
+    assert out == (
+        '<html><head><meta charset="utf-8"><!--note--><title>t</title></head><body></body></html>'
+    )
+
+
+def test_meta_charset_off_injects_nothing() -> None:
+    assert parse("<p>x").serialize() == "<html><head></head><body><p>x</p></body></html>"
+
+
+def test_meta_charset_no_head_is_a_no_op() -> None:
+    node = parse("<p id=a>x").select_one("p")
+    assert node is not None
+    assert node.serialize(meta_charset=True) == '<p id="a">x</p>'
+
+
+def test_meta_charset_leaves_foreign_elements_untouched() -> None:
+    node = parse("<svg><circle r=5></circle></svg>").select_one("svg")
+    assert node is not None
+    assert node.serialize(meta_charset=True) == '<svg><circle r="5"></circle></svg>'
+
+
+def test_meta_charset_reparses_to_one_declaration() -> None:
+    out = parse("<title>t").serialize(meta_charset=True)
+    metas = parse(out).select("meta")
+    assert len(metas) == 1
+    assert metas[0].attrs["charset"] == "utf-8"
+
+
+# ------------------------------------------------------------- meta_charset layouts
+
+
+def test_meta_charset_with_indent_indents_injected_meta() -> None:
+    out = parse("<p>x").serialize(layout=Indent(2), meta_charset=True)
+    assert out == (
+        "<html>\n"
+        "  <head>\n"
+        '    <meta charset="utf-8">\n'
+        "  </head>\n"
+        "  <body>\n"
+        "    <p>\n"
+        "      x\n"
+        "    </p>\n"
+        "  </body>\n"
+        "</html>"
+    )
+
+
+def test_meta_charset_with_indent_non_empty_head() -> None:
+    out = parse("<link rel=icon>").serialize(layout=Indent(2), meta_charset=True)
+    assert out == (
+        "<html>\n"
+        "  <head>\n"
+        '    <meta charset="utf-8">\n'
+        '    <link rel="icon">\n'
+        "  </head>\n"
+        "  <body></body>\n"
+        "</html>"
+    )
+
+
+def test_meta_charset_with_indent_normalizes_existing_meta() -> None:
+    out = parse("<meta charset=ascii>").serialize(layout=Indent(2), meta_charset=True)
+    assert out == (
+        "<html>\n"
+        "  <head>\n"
+        '    <meta charset="utf-8">\n'
+        "  </head>\n"
+        "  <body></body>\n"
+        "</html>"
+    )
+
+
+def test_meta_charset_with_minify_injects() -> None:
+    out = parse("<title>t").serialize(layout=Minify(), meta_charset=True)
+    assert out.startswith('<meta charset="utf-8">')
+    metas = parse(out).select("meta")
+    assert len(metas) == 1
+    assert metas[0].attrs["charset"] == "utf-8"
+
+
+def test_meta_charset_with_minify_normalizes_existing_meta() -> None:
+    out = parse("<meta charset=ascii><title>t").serialize(layout=Minify(), meta_charset=True)
+    metas = parse(out).select("meta")
+    assert len(metas) == 1
+    assert metas[0].attrs["charset"] == "utf-8"
+    assert 'charset="utf-8"' in out
+
+
+# ------------------------------------------------------------------- encode wiring
+
+
+def test_encode_meta_charset_uses_target_encoding() -> None:
+    out = parse("<p>x").encode("iso-8859-1", meta_charset=True)
+    assert out == (
+        '<html><head><meta charset="iso-8859-1"></head><body><p>x</p></body></html>'.encode("latin-1")
+    )
+
+
+def test_encode_sort_attributes() -> None:
+    node = parse("<p z=1 a=2>x").select_one("p")
+    assert node is not None
+    assert node.encode(sort_attributes=True) == b'<p a="2" z="1">x</p>'

--- a/tests/test_serialize_output_options.py
+++ b/tests/test_serialize_output_options.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from turbohtml import Element, Formatter, Indent, Minify, parse
+from turbohtml import Element, Indent, Minify, parse
 
 # ----------------------------------------------------------------- sort_attributes
 
@@ -43,7 +43,7 @@ def test_sort_attributes_orders_prefix_names(attrs: dict[str, str], expected: st
 
 def test_sort_attributes_beyond_stack_buffer_uses_heap() -> None:
     names = [f"a{index:02d}" for index in range(70)]
-    element = Element("x", {name: "" for name in reversed(names)})
+    element = Element("x", dict.fromkeys(reversed(names), ""))
     expected = "<x " + " ".join(f'{name}=""' for name in names) + "></x>"
     assert element.serialize(sort_attributes=True) == expected
 
@@ -142,9 +142,7 @@ def test_meta_charset_with_indent_leaves_foreign_element() -> None:
 
 def test_meta_charset_skips_non_element_head_children() -> None:
     out = parse("<head><!--note--><title>t").serialize(meta_charset=True)
-    assert out == (
-        '<html><head><meta charset="utf-8"><!--note--><title>t</title></head><body></body></html>'
-    )
+    assert out == ('<html><head><meta charset="utf-8"><!--note--><title>t</title></head><body></body></html>')
 
 
 def test_meta_charset_off_injects_nothing() -> None:
@@ -192,26 +190,13 @@ def test_meta_charset_with_indent_indents_injected_meta() -> None:
 def test_meta_charset_with_indent_non_empty_head() -> None:
     out = parse("<link rel=icon>").serialize(layout=Indent(2), meta_charset=True)
     assert out == (
-        "<html>\n"
-        "  <head>\n"
-        '    <meta charset="utf-8">\n'
-        '    <link rel="icon">\n'
-        "  </head>\n"
-        "  <body></body>\n"
-        "</html>"
+        '<html>\n  <head>\n    <meta charset="utf-8">\n    <link rel="icon">\n  </head>\n  <body></body>\n</html>'
     )
 
 
 def test_meta_charset_with_indent_normalizes_existing_meta() -> None:
     out = parse("<meta charset=ascii>").serialize(layout=Indent(2), meta_charset=True)
-    assert out == (
-        "<html>\n"
-        "  <head>\n"
-        '    <meta charset="utf-8">\n'
-        "  </head>\n"
-        "  <body></body>\n"
-        "</html>"
-    )
+    assert out == ('<html>\n  <head>\n    <meta charset="utf-8">\n  </head>\n  <body></body>\n</html>')
 
 
 def test_meta_charset_with_minify_injects() -> None:
@@ -235,9 +220,7 @@ def test_meta_charset_with_minify_normalizes_existing_meta() -> None:
 
 def test_encode_meta_charset_uses_target_encoding() -> None:
     out = parse("<p>x").encode("iso-8859-1", meta_charset=True)
-    assert out == (
-        '<html><head><meta charset="iso-8859-1"></head><body><p>x</p></body></html>'.encode("latin-1")
-    )
+    assert out == ('<html><head><meta charset="iso-8859-1"></head><body><p>x</p></body></html>'.encode("latin-1"))
 
 
 def test_encode_sort_attributes() -> None:


### PR DESCRIPTION
Adds two opt-in, fully-typed keyword options to Node.serialize and Node.encode, integrating with the existing formatter/layout surface (one clean modern name per concept, no parallel filter pipeline).

API: serialize and encode gain sort_attributes and meta_charset (both bool, default False).

- sort_attributes emits each start tag attributes in ascending interned-name order for deterministic diffs. Composes with every Formatter and with Indent/Minify.
- meta_charset ensures the document head declares the output encoding. An existing meta charset (or meta http-equiv=content-type) is normalized in place; a head with none gets a meta charset injected as its first child. Never a duplicate. The label is utf-8 for serialize and the encoding argument for encode.

Implementation: a new th_serialize_opts {formatter, sort_attributes, inject_meta, charset, charset_len} in treebuilder.h replaces the bare int formatter on th_node_serialize/th_node_minify; off-by-default fields cost nothing. ser_open_tag and mini_open_tag share ser_attr_order (insertion sort into a stack buffer, heap only past 64 attributes) and a charset-value rewrite, reusing the existing atom/arena/SIMD paths with no per-call allocation when the options are off. A single ser_inject_head_meta hook fires once at the head element across the compact, Indent, and Minify walkers. Serialization stays read-only under the existing per-tree critical section, so it is free-threading ready.

Validation: new fully-typed tests in tests/test_serialize_output_options.py; how-to docs and a changelog fragment. Gates pass locally: fix, type, 3.14 (100% line + branch on Python and C, gcc + llvm-cov), and docs including the doctest build.

closes #221