### PR TITLE
feat(markdown): per-tag converter hook for to_markdown

### DIFF
--- a/docs/changelog/218.feature.rst
+++ b/docs/changelog/218.feature.rst
@@ -1,0 +1,5 @@
+Add a ``converters`` keyword to :meth:`~turbohtml.Node.to_markdown`: a mapping from a lowercased tag name to a
+``callable(element, content) -> str`` that replaces how that tag renders. The callable receives the
+:class:`~turbohtml.Element` and the already-converted Markdown of its children and returns the element's Markdown, so a
+custom element or a one-off rule needs no subclass. It is the clean-break answer to ``markdownify``'s ``convert_<tag>``
+handlers, dispatched entirely in C and free unless a tag is registered.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -253,6 +253,15 @@ exporting two trees never interfere, and the binding takes the same per-tree cri
 mid-walk (a no-op under the GIL build). Where Go's ``html-to-markdown`` reaches for a mutex, the stateless visitor needs
 none.
 
+Where ``markdownify`` makes extensibility a subclass with a ``convert_<tag>`` method per tag, turbohtml exposes the same
+power as a ``converters`` mapping: tag name to ``callable(element, content) -> str``. The C walk checks it only on an
+element and only when the mapping is present -- one ``NULL`` test on the no-hook path -- so the dispatch is free unless
+a tag is actually registered. When one matches, the engine renders that element's children into a sub-buffer (sharing
+the document's reference-link accumulator), hands the callable a real :class:`~turbohtml.Element` and that inner
+Markdown, and splices the result back into the stream with block or inline framing from the tag. The callable runs
+inside the walk's critical section, so reading the element is safe; CPython suspends and resumes the section around any
+reentrant tree access the callable makes, so it cannot deadlock.
+
 *******************
  Mutating the tree
 *******************

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -730,6 +730,29 @@ style, fixed-width fonts, and ``margin-left`` list nesting) turns into Markdown:
 
     **Bold** and *soft*.
 
+When an option cannot express the rule you need -- a custom element, or a tag that should render its own way -- pass
+``converters``: a mapping from a lowercased tag name to a ``callable(element, content) -> str``. The callable receives
+the :class:`~turbohtml.Element` and the already-converted Markdown of its children, and returns the Markdown for that
+element. A registered tag's built-in rendering is replaced; every other tag is untouched, and the hook costs nothing
+when the mapping is omitted.
+
+.. testcode::
+
+    html = '<p>Watch <video src="/clip.mp4">a clip</video> and <abbr title="Markdown">MD</abbr>.</p>'
+    converters = {
+        "video": lambda el, content: f"[{content}]({el.attrs['src']})",
+        "abbr": lambda el, content: f"{content} ({el.attrs['title']})",
+    }
+    print(turbohtml.parse(html).to_markdown(converters=converters))
+
+.. testoutput::
+
+    Watch [a clip](/clip.mp4) and MD (Markdown).
+
+Return ``""`` to drop an element, or return ``content`` unchanged to unwrap it. A registered block-level tag is laid out
+on its own line; any other tag flows inline. The callable runs inside the same per-tree lock the walk holds, so it may
+read the element's attributes and subtree freely.
+
 **********************
  Export to plain text
 **********************

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -245,6 +245,7 @@ class Node:
         google_doc: bool = False,
         google_list_indent: int = 36,
         hide_strikethrough: bool = False,
+        converters: Mapping[str, Callable[[Element, str], str]] | None = None,
     ) -> str: ...
     def to_text(
         self,

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -521,11 +521,13 @@ PyDoc_STRVAR(
     "skip_internal_links=False, base_url='', image_mode='markdown', default_image_alt='', table_mode='markdown', "
     "table_header='first', pad_tables=False, escape_mode='minimal', escape_asterisks=True, escape_underscores=True, "
     "line_break='spaces', block_spacing='double', document_strip='strip', quote_open='\"', quote_close='\"', "
-    "google_doc=False, google_list_indent=36, hide_strikethrough=False)\n--\n\n"
+    "google_doc=False, google_list_indent=36, hide_strikethrough=False, converters=None)\n--\n\n"
     "Render this node and its subtree as Markdown. The keyword options cover the\n"
     "markdownify and html2text configuration surface; the defaults emit opinionated\n"
     "GitHub-Flavored Markdown. google_doc reads the inline-CSS styling a Google Docs\n"
-    "export carries (bold/italic/strike weights and list margins).");
+    "export carries (bold/italic/strike weights and list margins). converters maps a\n"
+    "lowercased tag name to a callable(element, content) -> str that replaces how\n"
+    "that tag renders, receiving the element and its already-converted child Markdown.");
 
 /* Resolve a string option against its allowed values, writing the matched index
    into *out (an enum), or leave *out untouched when the argument was omitted. */
@@ -549,10 +551,47 @@ static int md_resolve_enum(const char *name, PyObject *value, const char *const 
     return -1;
 }
 
+/* The state a to_markdown converter hook needs to turn a th_node back into an
+   Element for the callback: the module's types and the tree handle to keep alive. */
+typedef struct {
+    module_state *state;
+    PyObject *handle;
+} md_wrap_ctx;
+
+static PyObject *md_wrap_node(void *wrap_ctx, th_node *node) {
+    md_wrap_ctx *ctx = wrap_ctx;
+    return node_wrap(ctx->state, ctx->handle, node);
+}
+
+/* Coerce the converters argument to a plain dict the C walker can look up in: a
+   dict is borrowed as-is, any other mapping is copied once. An empty mapping
+   yields NULL so the walk keeps its zero-overhead no-hook path. */
+static PyObject *md_converters_dict(PyObject *converters) {
+    PyObject *dict;
+    if (PyDict_Check(converters)) {
+        dict = Py_NewRef(converters);
+    } else {
+        dict = PyDict_New();
+        if (dict == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        if (PyDict_Update(dict, converters) < 0) {
+            Py_DECREF(dict);
+            return NULL;
+        }
+    }
+    if (PyDict_GET_SIZE(dict) == 0) {
+        Py_DECREF(dict);
+        Py_RETURN_NONE;
+    }
+    return dict;
+}
+
 static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds) {
     md_opts opt = th_markdown_default_opts();
     PyObject *heading = NULL, *strike = NULL, *code_style = NULL, *link = NULL, *image = NULL, *table = NULL;
     PyObject *header = NULL, *escape = NULL, *brk = NULL, *spacing = NULL, *docstrip = NULL;
+    PyObject *converters = NULL;
     int ignore_emphasis = 0, mark_code = 0;
     static char *kw[] = {"heading_style",
                          "bullets",
@@ -587,14 +626,15 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
                          "google_doc",
                          "google_list_indent",
                          "hide_strikethrough",
+                         "converters",
                          NULL};
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "|$OsssOpssOspOppppsOsOOpOppOOOsspip", kw, &heading, &opt.bullets, &opt.strong, &opt.emphasis,
+            args, kwds, "|$OsssOpssOspOppppsOsOOpOppOOOsspipO", kw, &heading, &opt.bullets, &opt.strong, &opt.emphasis,
             &strike, &ignore_emphasis, &opt.sub, &opt.sup, &code_style, &opt.code_language, &mark_code, &link,
             &opt.autolink, &opt.link_title, &opt.ignore_links, &opt.skip_internal_links, &opt.base_url, &image,
             &opt.default_image_alt, &table, &header, &opt.pad_tables, &escape, &opt.escape_asterisks,
             &opt.escape_underscores, &brk, &spacing, &docstrip, &opt.quote_open, &opt.quote_close, &opt.google_doc,
-            &opt.google_list_indent, &opt.hide_strikethrough)) {
+            &opt.google_list_indent, &opt.hide_strikethrough, &converters)) {
         return NULL;
     }
     static const char *const headings[] = {"atx", "atx_closed", "setext"};
@@ -637,12 +677,33 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
         opt.code_mark_open = "[code]";
         opt.code_mark_close = "[/code]";
     }
+    PyObject *conv = NULL;
+    md_wrap_ctx wrap_ctx;
+    if (converters != NULL && converters != Py_None) {
+        conv = md_converters_dict(converters);
+        if (conv == NULL) {
+            return NULL;
+        }
+        if (conv != Py_None) {
+            wrap_ctx.state = state_of(self);
+            wrap_ctx.handle = ((NodeObject *)self)->handle;
+            opt.converters = conv;
+            opt.wrap_node = md_wrap_node;
+            opt.wrap_node_ctx = &wrap_ctx;
+        }
+    }
     Py_ssize_t out_len;
     Py_UCS4 *data;
     Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
     data = th_node_markdown(tree_of(self), ((NodeObject *)self)->node, &opt, &out_len);
     Py_END_CRITICAL_SECTION();
-    if (data == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+    Py_XDECREF(conv);
+    if (data == NULL) {
+        /* a converter that raised or returned a non-str leaves the exception set;
+           a bare NULL with no exception is the unforceable allocation failure */
+        if (PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: the no-exception NULL is an unforceable allocation failure */
+            return NULL;
+        }
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     PyObject *result = ucs4_to_str(data, out_len);

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -267,6 +267,12 @@ typedef struct {
     int google_doc;         /* read inline-CSS styling the way a Google Docs export encodes it */
     int google_list_indent; /* px of margin-left per list-nesting level (>= 1); divides margin-left */
     int hide_strikethrough; /* in google_doc mode, drop text a CSS line-through struck */
+    /* Per-tag converter hook: a registered tag's built-in rendering is replaced by a
+       Python callable receiving the element and its rendered child Markdown. The
+       engine builds the element through wrap_node so it need not know the binding. */
+    PyObject *converters;                                       /* borrowed dict {tag name: callable}; NULL disables */
+    PyObject *(*wrap_node)(void *wrap_node_ctx, th_node *node); /* build an Element for a node; new ref or NULL */
+    void *wrap_node_ctx;                                        /* opaque, handed to wrap_node */
 } md_opts;
 
 /* The no-argument baseline configuration (opinionated GitHub-Flavored Markdown). */

--- a/src/turbohtml/treebuilder_markdown.h
+++ b/src/turbohtml/treebuilder_markdown.h
@@ -100,6 +100,9 @@ md_opts th_markdown_default_opts(void) {
     opt.google_doc = 0;
     opt.google_list_indent = 36;
     opt.hide_strikethrough = 0;
+    opt.converters = NULL;
+    opt.wrap_node = NULL;
+    opt.wrap_node_ctx = NULL;
     return opt;
 }
 
@@ -468,6 +471,7 @@ static int md_css_px(const Py_UCS4 *value, Py_ssize_t len) {
 }
 
 static void md_render_inline(md_ctx *ctx, th_node *node);
+static int md_apply_converter(md_ctx *ctx, th_node *node);
 
 static void md_inline_children(md_ctx *ctx, th_node *node) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
@@ -833,6 +837,9 @@ static void md_render_inline(md_ctx *ctx, th_node *node) {
     if (node->type != TH_NODE_ELEMENT && node->type != TH_NODE_CONTENT) {
         return;
     }
+    if (md_apply_converter(ctx, node)) {
+        return;
+    }
     if (ctx->opt->google_doc) {
         /* a content node carries no style, so it passes through unstyled */
         md_render_google(ctx, node);
@@ -911,6 +918,149 @@ static void md_block_children(md_ctx *ctx, th_node *node) {
         }
         md_render_inline(ctx, child);
     }
+}
+
+/* Render a node's children into a standalone Markdown string for a converter to
+   wrap. The walk runs on the live ctx with a swapped-in buffer and a reset layout
+   state, so the inner content carries no outer prefix, but the reference-link
+   accumulator stays shared so a link inside the subtree still registers globally.
+   The walk never begins a block with whitespace, so only a trailing line break is
+   trimmed off. NULL (with no Python error) only on allocation failure. */
+static PyObject *md_children_markdown(md_ctx *ctx, th_node *node) {
+    sbuf saved_out = ctx->out;
+    sbuf saved_prefix = ctx->prefix;
+    md_pending *saved_pending = ctx->pending;
+    int saved_started = ctx->started, saved_line = ctx->line_has_content, saved_column = ctx->column;
+    int saved_space = ctx->space_pending, saved_drop = ctx->drop_space, saved_loose = ctx->pending_loose;
+    int saved_suppress = ctx->suppress_break, saved_tight = ctx->tight, saved_list_depth = ctx->list_depth;
+    int saved_bold = ctx->g_bold, saved_italic = ctx->g_italic;
+    ctx->out = (sbuf){0};
+    ctx->prefix = (sbuf){0};
+    ctx->pending = NULL;
+    ctx->started = 0;
+    ctx->line_has_content = 0;
+    ctx->column = 0;
+    ctx->space_pending = 0;
+    ctx->drop_space = 1;
+    ctx->pending_loose = 0;
+    ctx->suppress_break = 0;
+    ctx->tight = 0;
+    ctx->list_depth = 0;
+    ctx->g_bold = 0;
+    ctx->g_italic = 0;
+    md_block_children(ctx, node);
+    Py_UCS4 *data = ctx->out.data;
+    Py_ssize_t end = ctx->out.len;
+    while (end > 0 && md_is_ws(data[end - 1])) {
+        end--;
+    }
+    PyObject *content = NULL;
+    if (!ctx->out.failed) { /* GCOVR_EXCL_BR_LINE: the sub-buffer fails only on an unforceable allocation */
+        content = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, data, end);
+    }
+    PyMem_Free(data);
+    PyMem_Free(ctx->prefix.data);
+    ctx->out = saved_out;
+    ctx->prefix = saved_prefix;
+    ctx->pending = saved_pending;
+    ctx->started = saved_started;
+    ctx->line_has_content = saved_line;
+    ctx->column = saved_column;
+    ctx->space_pending = saved_space;
+    ctx->drop_space = saved_drop;
+    ctx->pending_loose = saved_loose;
+    ctx->suppress_break = saved_suppress;
+    ctx->tight = saved_tight;
+    ctx->list_depth = saved_list_depth;
+    ctx->g_bold = saved_bold;
+    ctx->g_italic = saved_italic;
+    return content;
+}
+
+/* Splice a converter's returned Markdown into the output at the element's position:
+   a registered block tag opens its own block line, anything else flows inline. A
+   newline inside the string starts a fresh continuation line so an outer list or
+   blockquote prefix keeps applying; every other code point is copied verbatim,
+   since the converter already produced final Markdown. An empty result emits
+   nothing, leaving no stray blank line behind. */
+static void md_emit_converted(md_ctx *ctx, th_node *node, PyObject *text) {
+    Py_ssize_t len = PyUnicode_GET_LENGTH(text);
+    if (len == 0) {
+        return;
+    }
+    if (node->ns == TH_NS_HTML && is_md_block(node->atom)) {
+        md_block_line(ctx, 1);
+    } else {
+        md_before_visible(ctx);
+    }
+    int kind = PyUnicode_KIND(text);
+    const void *data = PyUnicode_DATA(text);
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 character = PyUnicode_READ(kind, data, index);
+        if (character == '\n') {
+            md_newline(ctx);
+        } else {
+            sbuf_putc(&ctx->out, character);
+            ctx->line_has_content = 1;
+        }
+    }
+}
+
+/* Run the per-tag converter hook for an element. Returns 1 when the element was
+   handled (its built-in rendering replaced, or the walk aborted by an error that
+   leaves ctx->failed and a Python exception set), 0 when no converter applies and
+   the caller should render the element normally. */
+static int md_apply_converter(md_ctx *ctx, th_node *node) {
+    if (ctx->opt->converters == NULL || node->type != TH_NODE_ELEMENT) {
+        return 0;
+    }
+    PyObject *tag = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, node->text, node->text_len);
+    if (tag == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        ctx->failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
+        return 1;        /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *converter = PyDict_GetItemWithError(ctx->opt->converters, tag); /* borrowed */
+    if (converter == NULL) {
+        Py_DECREF(tag);
+        if (PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: a str key never raises on lookup */
+            ctx->failed = 1;    /* GCOVR_EXCL_LINE: unreachable hash-error path */
+            return 1;           /* GCOVR_EXCL_LINE: unreachable hash-error path */
+        }
+        return 0;
+    }
+    PyObject *content = md_children_markdown(ctx, node);
+    if (content == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(tag);    /* GCOVR_EXCL_LINE: allocation-failure path */
+        ctx->failed = 1;   /* GCOVR_EXCL_LINE: allocation-failure path */
+        return 1;          /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *element = ctx->opt->wrap_node(ctx->opt->wrap_node_ctx, node);
+    if (element == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(tag);     /* GCOVR_EXCL_LINE: allocation-failure path */
+        Py_DECREF(content); /* GCOVR_EXCL_LINE: allocation-failure path */
+        ctx->failed = 1;    /* GCOVR_EXCL_LINE: allocation-failure path */
+        return 1;           /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *result = PyObject_CallFunctionObjArgs(converter, element, content, NULL);
+    Py_DECREF(element);
+    Py_DECREF(content);
+    if (result == NULL) {
+        Py_DECREF(tag);
+        ctx->failed = 1;
+        return 1;
+    }
+    if (!PyUnicode_Check(result)) {
+        PyErr_Format(PyExc_TypeError, "to_markdown converter for <%U> must return a str, not %.200s", tag,
+                     Py_TYPE(result)->tp_name);
+        Py_DECREF(tag);
+        Py_DECREF(result);
+        ctx->failed = 1;
+        return 1;
+    }
+    Py_DECREF(tag);
+    md_emit_converted(ctx, node, result);
+    Py_DECREF(result);
+    return 1;
 }
 
 static void md_render_list(md_ctx *ctx, th_node *node, int ordered) {
@@ -1352,6 +1502,9 @@ static void md_render_pre(md_ctx *ctx, th_node *node) {
 }
 
 static void md_render_block(md_ctx *ctx, th_node *node) {
+    if (md_apply_converter(ctx, node)) {
+        return;
+    }
     /* only an HTML element is ever classified as a block, so the namespace check
        the callers already made guarantees node is HTML here */
     uint16_t atom = node->atom;
@@ -1503,6 +1656,8 @@ Py_UCS4 *th_node_markdown(th_tree *tree, th_node *node, const md_opts *opt, Py_s
         ctx.started = 1;
         ctx.line_has_content = 1;
         md_emit_text(&ctx, need_text(tree, node), node->text_len);
+    } else if (md_apply_converter(&ctx, node)) {
+        /* a converter registered for the root element renders it whole */
     } else if (is_md_block(node->ns == TH_NS_HTML ? node->atom : TH_TAG_UNKNOWN)) {
         md_render_block(&ctx, node);
     } else {
@@ -1511,6 +1666,10 @@ Py_UCS4 *th_node_markdown(th_tree *tree, th_node *node, const md_opts *opt, Py_s
     md_flush_references(&ctx);
     PyMem_Free(ctx.prefix.data);
     PyMem_Free(ctx.refs);
+    if (ctx.failed) {
+        PyMem_Free(ctx.out.data);
+        return NULL;
+    }
     md_trim(&ctx.out, opt->document_strip);
     return sbuf_finish(&ctx.out, out_len);
 }

--- a/tests/test_tree_markdown_converters.py
+++ b/tests/test_tree_markdown_converters.py
@@ -101,7 +101,7 @@ def test_block_converter_multiline_keeps_prefix() -> None:
 
 def test_empty_converter_result_emits_nothing() -> None:
     out = parse("<section><div>x</div></section>").to_markdown(converters={"div": lambda _e, _t: ""})
-    assert out == ""
+    assert not out
 
 
 def test_converter_on_root_element() -> None:

--- a/tests/test_tree_markdown_converters.py
+++ b/tests/test_tree_markdown_converters.py
@@ -2,7 +2,7 @@
 
 A registered tag's built-in rendering is replaced by a callable that receives the
 element and its already-converted child Markdown and returns the element's
-Markdown. The cases pin the splice behaviour (inline vs block framing, dropping,
+Markdown. The cases pin the splice behavior (inline vs block framing, dropping,
 unwrapping, custom elements) and the binding's argument handling and errors.
 """
 

--- a/tests/test_tree_markdown_converters.py
+++ b/tests/test_tree_markdown_converters.py
@@ -1,0 +1,185 @@
+"""The per-tag converter hook of Node.to_markdown().
+
+A registered tag's built-in rendering is replaced by a callable that receives the
+element and its already-converted child Markdown and returns the element's
+Markdown. The cases pin the splice behaviour (inline vs block framing, dropping,
+unwrapping, custom elements) and the binding's argument handling and errors.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+import pytest
+
+from turbohtml import Element, parse
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from pytest_mock import MockerFixture
+
+    Converter = Callable[[Element, str], str]
+
+
+def wrap(marker: str) -> Converter:
+    """A converter that surrounds the rendered child Markdown with a marker."""
+    return lambda _element, content: f"{marker}{content}{marker}"
+
+
+@pytest.mark.parametrize(
+    ("html", "tag", "converter", "expected"),
+    [
+        pytest.param(
+            "<p>see <a href='https://x.test'>the site</a> now</p>",
+            "a",
+            lambda _el, text: f"[{text}]",
+            "see [the site] now",
+            id="inline-wrap",
+        ),
+        pytest.param("<p>a<b>x</b>b</p>", "b", wrap("=="), "a==x==b", id="inline-marker"),
+        pytest.param("<p>a<span>x</span>b</p>", "span", lambda _e, _t: "", "ab", id="inline-drop"),
+        pytest.param("<p>a<u>keep</u>b</p>", "u", lambda _e, text: text, "akeepb", id="inline-unwrap"),
+        pytest.param("<p>only <i>italic</i></p>", "i", wrap("/"), "only /italic/", id="inline-trailing"),
+    ],
+)
+def test_inline_converter(html: str, tag: str, converter: Converter, expected: str) -> None:
+    assert parse(html).to_markdown(converters={tag: converter}) == expected
+
+
+def test_inner_trailing_break_is_trimmed() -> None:
+    # the <br> leaves a trailing "  \n" in the rendered child Markdown that the hook strips
+    out = parse("<p>go <a href='https://x.test'>x<br></a> on</p>").to_markdown(converters={"a": wrap("|")})
+    assert out == "go |x| on"
+
+
+def test_inner_all_whitespace_trims_to_empty() -> None:
+    # a child that renders to only a break trims away entirely, so the hook sees ""
+    out = parse("<p>a<i><br></i>b</p>").to_markdown(converters={"i": lambda _e, content: f"[{content}]"})
+    assert out == "a[]b"
+
+
+def test_custom_element_with_attribute() -> None:
+    html = "<p>play <video src='m.mp4'>fallback</video> here</p>"
+    out = parse(html).to_markdown(converters={"video": lambda el, _t: f"[{el.attrs['src']}]"})
+    assert out == "play [m.mp4] here"
+
+
+def test_converter_on_foreign_element() -> None:
+    # a non-HTML (SVG) element matches by tag name and flows inline, never as a block
+    out = parse("<p>see <svg><title>chart</title></svg> now</p>").to_markdown(converters={"title": wrap("@")})
+    assert out == "see @chart@ now"
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param(
+            "<section><p>a</p><div>x</div><p>b</p></section>",
+            "a\n\n<<x>>\n\nb",
+            id="block-between-paragraphs",
+        ),
+        pytest.param("<ul><li>one<div>x</div></li></ul>", "- one\n  <<x>>", id="block-in-list-item"),
+        pytest.param(
+            "<blockquote><div>x</div></blockquote>",
+            "> <<x>>",
+            id="block-in-blockquote",
+        ),
+    ],
+)
+def test_block_converter(html: str, expected: str) -> None:
+    assert parse(html).to_markdown(converters={"div": lambda _e, text: f"<<{text}>>"}) == expected
+
+
+def test_block_converter_multiline_keeps_prefix() -> None:
+    out = parse("<ul><li>one<div>x</div></li></ul>").to_markdown(
+        converters={"div": lambda _e, _t: "line1\nline2"},
+    )
+    assert out == "- one\n  line1\n  line2"
+
+
+def test_empty_converter_result_emits_nothing() -> None:
+    out = parse("<section><div>x</div></section>").to_markdown(converters={"div": lambda _e, _t: ""})
+    assert out == ""
+
+
+def test_converter_on_root_element() -> None:
+    section = parse("<section>hi <b>there</b></section>").find("section")
+    assert section is not None
+    out = section.to_markdown(converters={"section": lambda _e, text: f"S[{text}]"})
+    assert out == "S[hi **there**]"
+
+
+def test_reference_link_inside_converter_registers() -> None:
+    html = "<div><a href='https://e.test'>e</a></div>"
+    out = parse(html).to_markdown(link_style="reference", converters={"div": wrap("|")})
+    assert out == "|[e][1]|\n\n[1]: https://e.test"
+
+
+def test_converter_receives_element_and_content(mocker: MockerFixture) -> None:
+    converter = mocker.MagicMock(return_value="X")
+    out = parse("<p><b>hi <i>there</i></b></p>").to_markdown(converters={"b": converter})
+    assert out == "X"
+    converter.assert_called_once()
+    element, content = converter.call_args.args
+    assert isinstance(element, Element)
+    assert element.tag == "b"
+    assert content == "hi *there*"
+
+
+def test_unregistered_tag_renders_normally() -> None:
+    out = parse("<p><b>x</b><i>y</i></p>").to_markdown(converters={"b": wrap("@")})
+    assert out == "@x@*y*"
+
+
+def test_content_node_passes_through_with_converters() -> None:
+    out = parse("<p>a<template>b</template>c</p>").to_markdown(converters={"unused": wrap("@")})
+    assert out == "abc"
+
+
+@pytest.mark.parametrize(
+    "converters",
+    [
+        pytest.param({}, id="empty-dict"),
+        pytest.param(None, id="none"),
+        pytest.param(MappingProxyType({}), id="empty-mapping"),
+    ],
+)
+def test_no_op_converters_match_default(converters: Mapping[str, Converter] | None) -> None:
+    html = "<p><b>x</b></p>"
+    assert parse(html).to_markdown(converters=converters) == parse(html).to_markdown()
+
+
+def test_non_dict_mapping_is_accepted() -> None:
+    out = parse("<p><b>x</b></p>").to_markdown(converters=MappingProxyType({"b": wrap("__")}))
+    assert out == "__x__"
+
+
+def test_non_str_return_raises_type_error() -> None:
+    def convert(_element: Element, _content: str) -> str:
+        return 123  # ty: ignore[invalid-return-type]  # a non-str on purpose, to exercise the runtime check
+
+    with pytest.raises(TypeError, match=r"converter for <b> must return a str, not int"):
+        parse("<p><b>x</b></p>").to_markdown(converters={"b": convert})
+
+
+def test_converter_exception_propagates() -> None:
+    def boom(_element: Element, _content: str) -> str:
+        msg = "boom"
+        raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        parse("<p><b>x</b></p>").to_markdown(converters={"b": boom})
+
+
+def test_non_callable_value_raises() -> None:
+    with pytest.raises(TypeError):
+        # a non-callable value on purpose, to exercise the runtime call failure
+        parse("<p><b>x</b></p>").to_markdown(converters={"b": "not callable"})  # ty: ignore[invalid-argument-type]
+
+
+def test_non_mapping_argument_raises() -> None:
+    with pytest.raises((TypeError, AttributeError)):
+        # a non-mapping on purpose, to exercise the binding's argument coercion
+        parse("<p><b>x</b></p>").to_markdown(converters=42)  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Summary

Adds a `converters` keyword to `Node.to_markdown` — a per-tag converter hook, the clean-break answer to markdownify's `convert_<tag>` handler subclasses.

```python
node.to_markdown(converters={
    "video": lambda el, content: f"[{content}]({el.attrs['src']})",
    "abbr":  lambda el, content: f"{content} ({el.attrs['title']})",
})
```

`converters` maps a lowercased tag name to a `callable(element, content) -> str`. When the Markdown walk reaches an element whose tag is registered, its built-in rendering is replaced: the element's children render to Markdown (`content`), the callable receives the live `Element` and that inner Markdown, and its return value is spliced into the output. Return `""` to drop an element, or `content` to unwrap it. A registered block-level tag is laid out on its own line; any other tag flows inline. Works for any tag, including custom/unknown elements.

## Design

All logic stays in C; the Python surface is one typed keyword in the stub.

- `md_opts` gains `converters` (borrowed dict, `NULL` = disabled) plus a `wrap_node` function pointer + opaque ctx, so the engine in `treebuilder.c` builds an `Element` without depending on `tree_type.c`.
- `md_apply_converter()` in `treebuilder_markdown.h` is checked once per element in `md_render_inline`, `md_render_block`, and the entry point. Zero overhead when `converters is None` (one `NULL` test); a single dict lookup keyed by the node's tag-name run otherwise. The callback fires only for a registered tag.
- Inner content renders through the existing walk into a swapped-in sub-buffer that shares the document's reference-link accumulator, so a reference link inside a converter's subtree still registers globally.
- Free-threading: the callback runs inside the existing per-tree `Py_BEGIN_CRITICAL_SECTION(handle)` that already guards the walk; CPython suspends/resumes the section around any reentrant tree access, so no deadlock and no extra lock.
- A callback that raises or returns a non-`str` aborts the walk and propagates the exception.

Design discussion: https://github.com/tox-dev/turbohtml/issues/218#issuecomment-4756493574

## Tests, docs, gates

- New `tests/test_tree_markdown_converters.py`: inline/block framing, custom and foreign-namespace elements, drop/unwrap, attribute access, reference-link registration, whitespace trimming, root-element conversion, and the argument/error paths (non-mapping, non-callable value, non-`str` return, raised exception). 100% line + branch coverage on the new C.
- How-to and explanation sections, plus a changelog fragment.
- `tox r -e fix`, `tox r -e type`, `tox r -e docs`, and `tox r -e 3.14` (Python and C coverage, llvm-cov) all pass locally.

closes #218
