### PR TITLE
feat(markdown): add to_markdown strip/convert filters

### DIFF
--- a/docs/changelog/248.feature.rst
+++ b/docs/changelog/248.feature.rst
@@ -1,0 +1,4 @@
+Add ``strip`` and ``convert`` keywords to :meth:`~turbohtml.Node.to_markdown`, the mutually exclusive tag filters
+``markdownify`` exposes under the same names: ``strip`` names tags whose markup is dropped while their text stays, and
+``convert`` names the only tags to keep markup for, dropping every other tag's. A name outside the tag table is ignored,
+and ``<script>``/``<style>``/``<head>`` still vanish whole - by :user:`gaborbernat`.

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -288,6 +288,12 @@ Markdown, and splices the result back into the stream with block or inline frami
 inside the walk's critical section, so reading the element is safe; CPython suspends and resumes the section around any
 reentrant tree access the callable makes, so it cannot deadlock.
 
+A lighter knob unwraps whole tags without a callable: ``strip`` (a denylist) and ``convert`` (an allowlist), the same
+pair ``markdownify`` carries. Both compile to one 256-bit set indexed by the interned tag atom, so the per-element test
+is a constant-time bit lookup with no bound check -- a stripped element simply renders its children in place of its own
+markup. The interning is what makes a name the tag table does not know fold to no entry, mirroring how ``markdownify``
+ignores a tag it has no converter for.
+
 *******************
  Mutating the tree
 *******************

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -984,6 +984,22 @@ Return ``""`` to drop an element, or return ``content`` unchanged to unwrap it. 
 on its own line; any other tag flows inline. The callable runs inside the same per-tree lock the walk holds, so it may
 read the element's attributes and subtree freely.
 
+To unwrap whole tags without a callable, pass ``strip`` or ``convert`` -- the two mutually exclusive filters
+``markdownify`` exposes under the same names. ``strip`` names tags whose markup is dropped while their text keeps
+flowing; ``convert`` names the only tags to keep markup for, so every other tag is unwrapped. A name the tag table does
+not know is ignored, and ``<script>``, ``<style>``, and ``<head>`` still vanish whole regardless:
+
+.. testcode::
+
+    doc = turbohtml.parse('<p>see <a href="/x">the docs</a> and <b>note</b> this</p>')
+    print(doc.to_markdown(strip=["a"]))
+    print(doc.to_markdown(convert=["b"]))
+
+.. testoutput::
+
+    see the docs and **note** this
+    see the docs and **note** this
+
 **********************
  Export to plain text
 **********************

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1082,6 +1082,8 @@ libraries with one name per concept. The markdownify options map as:
       - ``document_strip`` (``"strip"``/``"lstrip"``/``"rstrip"``/``"none"``)
     - - ``code_language``
       - ``code_language``
+    - - ``strip``, ``convert``
+      - ``strip``, ``convert`` (mutually exclusive tag filters)
 
 The html2text options map as:
 

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -279,6 +279,8 @@ class Node:
         google_doc: bool = False,
         google_list_indent: int = 36,
         hide_strikethrough: bool = False,
+        strip: Iterable[str] | None = None,
+        convert: Iterable[str] | None = None,
         converters: Mapping[str, Callable[[Element, str], str]] | None = None,
     ) -> str: ...
     def to_text(

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -638,7 +638,8 @@ static PyObject *md_converters_dict(PyObject *converters) {
    Returns -1 with an exception set on a non-string element or an iteration error. */
 static int md_build_tag_filter(PyObject *seq, md_opts *opt, int mode) {
     if (PyUnicode_Check(seq)) {
-        PyErr_SetString(PyExc_TypeError, "to_markdown strip/convert must be an iterable of tag names, not a single str");
+        PyErr_SetString(PyExc_TypeError,
+                        "to_markdown strip/convert must be an iterable of tag names, not a single str");
         return -1;
     }
     PyObject *iter = PyObject_GetIter(seq);

--- a/src/turbohtml/tree_type.c
+++ b/src/turbohtml/tree_type.c
@@ -560,15 +560,18 @@ PyDoc_STRVAR(
     "table_header='first', pad_tables=False, escape_mode='minimal', escape_asterisks=True, escape_underscores=True, "
     "line_break='spaces', block_spacing='double', wrap_width=0, wrap_list_items=False, wrap_links=True, "
     "transliterate=False, document_strip='strip', quote_open='\"', quote_close='\"', "
-    "google_doc=False, google_list_indent=36, hide_strikethrough=False, converters=None)\n--\n\n"
+    "google_doc=False, google_list_indent=36, hide_strikethrough=False, strip=None, convert=None, "
+    "converters=None)\n--\n\n"
     "Render this node and its subtree as Markdown. The keyword options cover the\n"
     "markdownify and html2text configuration surface; the defaults emit opinionated\n"
     "GitHub-Flavored Markdown. wrap_width word-wraps prose at a column (0 disables);\n"
     "image_mode='html' and table_mode='html' pass the element through verbatim;\n"
     "transliterate folds common non-ASCII typography in prose to ASCII. google_doc\n"
-    "reads the inline-CSS styling a Google Docs export carries. converters maps a\n"
-    "lowercased tag name to a callable(element, content) -> str that replaces how\n"
-    "that tag renders, receiving the element and its already-converted child Markdown.");
+    "reads the inline-CSS styling a Google Docs export carries. strip names tags\n"
+    "whose markup is dropped (their text stays); convert names the only tags to keep\n"
+    "markup for; the two are mutually exclusive. converters maps a lowercased tag\n"
+    "name to a callable(element, content) -> str that replaces how that tag renders,\n"
+    "receiving the element and its already-converted child Markdown.");
 
 /* Resolve a string option against its allowed values, writing the matched index
    into *out (an enum), or leave *out untouched when the argument was omitted. */
@@ -628,11 +631,58 @@ static PyObject *md_converters_dict(PyObject *converters) {
     return dict;
 }
 
+/* Mark every tag named in seq in opt->filter_tags and switch opt to the given
+   filter mode. Each name is matched as a lowercased atom, so a name outside the
+   tag table matches nothing and is skipped, the way markdownify ignores a tag it
+   has no converter for. A bare str is rejected so it never iterates per character.
+   Returns -1 with an exception set on a non-string element or an iteration error. */
+static int md_build_tag_filter(PyObject *seq, md_opts *opt, int mode) {
+    if (PyUnicode_Check(seq)) {
+        PyErr_SetString(PyExc_TypeError, "to_markdown strip/convert must be an iterable of tag names, not a single str");
+        return -1;
+    }
+    PyObject *iter = PyObject_GetIter(seq);
+    if (iter == NULL) {
+        return -1;
+    }
+    PyObject *item;
+    while ((item = PyIter_Next(iter)) != NULL) {
+        if (!PyUnicode_Check(item)) {
+            PyErr_Format(PyExc_TypeError, "to_markdown strip/convert tags must be str, not %.200s",
+                         Py_TYPE(item)->tp_name);
+            Py_DECREF(item);
+            Py_DECREF(iter);
+            return -1;
+        }
+        Py_ssize_t utf8_len;
+        const char *utf8 = PyUnicode_AsUTF8AndSize(item, &utf8_len);
+        char lowered[64];
+        if (utf8 != NULL && utf8_len <= (Py_ssize_t)sizeof(lowered)) {
+            for (Py_ssize_t byte = 0; byte < utf8_len; byte++) {
+                lowered[byte] = utf8[byte] >= 'A' && utf8[byte] <= 'Z' ? (char)(utf8[byte] + 32) : utf8[byte];
+            }
+            uint16_t atom = th_tag_lookup(lowered, utf8_len);
+            if (atom != TH_TAG_UNKNOWN) {
+                opt->filter_tags[atom >> 6] |= (uint64_t)1 << (atom & 63);
+            }
+        } else {
+            PyErr_Clear(); /* a surrogate or over-long name matches no known tag */
+        }
+        Py_DECREF(item);
+    }
+    Py_DECREF(iter);
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+    opt->tag_filter = mode;
+    return 0;
+}
+
 static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds) {
     md_opts opt = th_markdown_default_opts();
     PyObject *heading = NULL, *strike = NULL, *code_style = NULL, *link = NULL, *image = NULL, *table = NULL;
     PyObject *header = NULL, *escape = NULL, *brk = NULL, *spacing = NULL, *docstrip = NULL;
-    PyObject *converters = NULL;
+    PyObject *converters = NULL, *strip = NULL, *convert = NULL;
     int ignore_emphasis = 0, mark_code = 0;
     static char *kw[] = {"heading_style",
                          "bullets",
@@ -671,16 +721,18 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
                          "google_doc",
                          "google_list_indent",
                          "hide_strikethrough",
+                         "strip",
+                         "convert",
                          "converters",
                          NULL};
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "|$OsssOpssOspOppppsOsOOpOppOOipppOsspipO", kw, &heading, &opt.bullets, &opt.strong,
+            args, kwds, "|$OsssOpssOspOppppsOsOOpOppOOipppOsspipOOO", kw, &heading, &opt.bullets, &opt.strong,
             &opt.emphasis, &strike, &ignore_emphasis, &opt.sub, &opt.sup, &code_style, &opt.code_language, &mark_code,
             &link, &opt.autolink, &opt.link_title, &opt.ignore_links, &opt.skip_internal_links, &opt.base_url, &image,
             &opt.default_image_alt, &table, &header, &opt.pad_tables, &escape, &opt.escape_asterisks,
             &opt.escape_underscores, &brk, &spacing, &opt.wrap_width, &opt.wrap_list_items, &opt.wrap_links,
             &opt.transliterate, &docstrip, &opt.quote_open, &opt.quote_close, &opt.google_doc, &opt.google_list_indent,
-            &opt.hide_strikethrough, &converters)) {
+            &opt.hide_strikethrough, &strip, &convert, &converters)) {
         return NULL;
     }
     static const char *const headings[] = {"atx", "atx_closed", "setext"};
@@ -726,6 +778,18 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
     if (mark_code) {
         opt.code_mark_open = "[code]";
         opt.code_mark_close = "[/code]";
+    }
+    int has_strip = strip != NULL && strip != Py_None;
+    int has_convert = convert != NULL && convert != Py_None;
+    if (has_strip && has_convert) {
+        PyErr_SetString(PyExc_ValueError, "strip and convert are mutually exclusive");
+        return NULL;
+    }
+    if (has_strip && md_build_tag_filter(strip, &opt, TH_MD_FILTER_STRIP) < 0) {
+        return NULL;
+    }
+    if (has_convert && md_build_tag_filter(convert, &opt, TH_MD_FILTER_CONVERT) < 0) {
+        return NULL;
     }
     PyObject *conv = NULL;
     md_wrap_ctx wrap_ctx;

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -310,19 +310,19 @@ typedef struct {
     int escape_mode; /* enum th_md_escape */
     int escape_asterisks;
     int escape_underscores;
-    int line_break;           /* enum th_md_break */
-    int block_spacing_single; /* one newline between blocks instead of a blank line */
-    int wrap_width;           /* word-wrap column, 0 disables */
-    int wrap_list_items;      /* extend word wrapping into list-item text */
-    int wrap_links;           /* 0 keeps a link/image construct unbroken across a wrap */
-    int transliterate;        /* fold common non-ASCII typography in prose to ASCII */
-    int document_strip;       /* enum th_md_doc_strip */
-    const char *sub;          /* <sub> wrapper */
-    const char *sup;          /* <sup> wrapper */
-    int google_doc;           /* read inline-CSS styling the way a Google Docs export encodes it */
-    int google_list_indent;   /* px of margin-left per list-nesting level (>= 1); divides margin-left */
-    int hide_strikethrough;   /* in google_doc mode, drop text a CSS line-through struck */
-    int tag_filter;           /* enum th_md_filter selecting how filter_tags reads */
+    int line_break;                           /* enum th_md_break */
+    int block_spacing_single;                 /* one newline between blocks instead of a blank line */
+    int wrap_width;                           /* word-wrap column, 0 disables */
+    int wrap_list_items;                      /* extend word wrapping into list-item text */
+    int wrap_links;                           /* 0 keeps a link/image construct unbroken across a wrap */
+    int transliterate;                        /* fold common non-ASCII typography in prose to ASCII */
+    int document_strip;                       /* enum th_md_doc_strip */
+    const char *sub;                          /* <sub> wrapper */
+    const char *sup;                          /* <sup> wrapper */
+    int google_doc;                           /* read inline-CSS styling the way a Google Docs export encodes it */
+    int google_list_indent;                   /* px of margin-left per list-nesting level (>= 1); divides margin-left */
+    int hide_strikethrough;                   /* in google_doc mode, drop text a CSS line-through struck */
+    int tag_filter;                           /* enum th_md_filter selecting how filter_tags reads */
     uint64_t filter_tags[TH_MD_FILTER_WORDS]; /* atoms named by strip (denylist) or convert (allowlist) */
     /* Per-tag converter hook: a registered tag's built-in rendering is replaced by a
        Python callable receiving the element and its rendered child Markdown. The

--- a/src/turbohtml/treebuilder.h
+++ b/src/turbohtml/treebuilder.h
@@ -274,6 +274,13 @@ enum th_md_escape { TH_MD_ESCAPE_MINIMAL, TH_MD_ESCAPE_ALL };
 enum th_md_break { TH_MD_BREAK_SPACES, TH_MD_BREAK_BACKSLASH };
 enum th_md_doc_strip { TH_MD_DOC_STRIP, TH_MD_DOC_LSTRIP, TH_MD_DOC_RSTRIP, TH_MD_DOC_NONE };
 enum th_md_table_header { TH_MD_HEADER_FIRST, TH_MD_HEADER_DETECT, TH_MD_HEADER_NONE };
+/* No filter, a strip denylist (listed tags lose their markup), or a convert
+   allowlist (only listed tags keep their markup). */
+enum th_md_filter { TH_MD_FILTER_NONE, TH_MD_FILTER_STRIP, TH_MD_FILTER_CONVERT };
+
+/* Words in the tag-filter bitset: 256 bits cover every interned tag atom (there
+   are ~150, all < 256) with headroom, so a set membership test needs no bound. */
+#define TH_MD_FILTER_WORDS 4
 
 typedef struct {
     int heading_style;          /* enum th_md_heading */
@@ -315,6 +322,8 @@ typedef struct {
     int google_doc;           /* read inline-CSS styling the way a Google Docs export encodes it */
     int google_list_indent;   /* px of margin-left per list-nesting level (>= 1); divides margin-left */
     int hide_strikethrough;   /* in google_doc mode, drop text a CSS line-through struck */
+    int tag_filter;           /* enum th_md_filter selecting how filter_tags reads */
+    uint64_t filter_tags[TH_MD_FILTER_WORDS]; /* atoms named by strip (denylist) or convert (allowlist) */
     /* Per-tag converter hook: a registered tag's built-in rendering is replaced by a
        Python callable receiving the element and its rendered child Markdown. The
        engine builds the element through wrap_node so it need not know the binding. */

--- a/src/turbohtml/treebuilder_markdown.h
+++ b/src/turbohtml/treebuilder_markdown.h
@@ -67,6 +67,18 @@ static int is_md_skipped(uint16_t atom) {
     return atom == TH_TAG_HEAD || atom == TH_TAG_SCRIPT || atom == TH_TAG_STYLE;
 }
 
+/* Whether an element's own Markdown markup is dropped under the strip/convert
+   filter, leaving its children to render transparently in the surrounding flow.
+   A strip set names the tags to drop; a convert set names the only tags to keep,
+   so every tag outside it is dropped. */
+static int md_tag_filtered(const md_opts *opt, uint16_t atom) {
+    if (opt->tag_filter == TH_MD_FILTER_NONE) {
+        return 0;
+    }
+    int present = (opt->filter_tags[atom >> 6] >> (atom & 63)) & 1;
+    return opt->tag_filter == TH_MD_FILTER_STRIP ? present : !present;
+}
+
 /* ----------------------------------------------------------------- options */
 
 md_opts th_markdown_default_opts(void) {
@@ -104,6 +116,7 @@ md_opts th_markdown_default_opts(void) {
     opt.google_doc = 0;
     opt.google_list_indent = 36;
     opt.hide_strikethrough = 0;
+    opt.tag_filter = TH_MD_FILTER_NONE;
     opt.converters = NULL;
     opt.wrap_node = NULL;
     opt.wrap_node_ctx = NULL;
@@ -950,6 +963,13 @@ static void md_render_inline(md_ctx *ctx, th_node *node) {
     if (md_apply_converter(ctx, node)) {
         return;
     }
+    uint16_t atom = node->ns == TH_NS_HTML ? node->atom : TH_TAG_UNKNOWN;
+    if (md_tag_filtered(ctx->opt, atom) && !is_md_skipped(atom)) {
+        /* drop this tag's markup but keep its inline content (a skipped tag, e.g.
+           <script>, still vanishes whole, so it falls through to the no-op below) */
+        md_inline_children(ctx, node);
+        return;
+    }
     if (ctx->opt->google_doc) {
         /* a content node carries no style, so it passes through unstyled */
         md_render_google(ctx, node);
@@ -1630,6 +1650,11 @@ static void md_render_block(md_ctx *ctx, th_node *node) {
     /* only an HTML element is ever classified as a block, so the namespace check
        the callers already made guarantees node is HTML here */
     uint16_t atom = node->atom;
+    if (md_tag_filtered(ctx->opt, atom)) {
+        /* drop the block's own markup but keep laying its children out as blocks */
+        md_block_children(ctx, node);
+        return;
+    }
     switch (atom) {
     case TH_TAG_H1:
     case TH_TAG_H2:

--- a/tests/test_tree_markdown_filters.py
+++ b/tests/test_tree_markdown_filters.py
@@ -1,0 +1,185 @@
+"""The strip/convert tag filters of Node.to_markdown().
+
+``strip`` names tags whose markup is dropped while their text stays; ``convert``
+names the only tags to keep markup for, so every other tag is dropped. The two
+are mutually exclusive. The cases pin the inline and block unwrapping, the
+allowlist/denylist semantics, and the binding's argument handling and errors.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from turbohtml import parse
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from turbohtml import Document
+
+
+@pytest.mark.parametrize(
+    ("html", "strip", "expected"),
+    [
+        pytest.param(
+            '<p>visit <a href="https://e.test">the site</a> today</p>',
+            ["a"],
+            "visit the site today",
+            id="link-loses-markup",
+        ),
+        pytest.param("<p>a <b>bold</b> and <i>soft</i></p>", ["b"], "a bold and *soft*", id="one-of-two"),
+        pytest.param("<p>a <b>bold</b> and <i>soft</i></p>", ["b", "i"], "a bold and soft", id="both"),
+        pytest.param("<p>a <b>bold</b> and <i>soft</i></p>", ["i"], "a **bold** and soft", id="other-kept"),
+    ],
+)
+def test_strip_inline(html: str, strip: list[str], expected: str) -> None:
+    assert parse(html).to_markdown(strip=strip) == expected
+
+
+@pytest.mark.parametrize(
+    ("html", "convert", "expected"),
+    [
+        pytest.param(
+            '<p>a <b>bold</b> and <a href="https://e.test">link</a></p>',
+            ["a"],
+            "a bold and [link](https://e.test)",
+            id="only-link-kept",
+        ),
+        pytest.param(
+            '<p>a <b>bold</b> and <a href="https://e.test">link</a></p>',
+            ["b"],
+            "a **bold** and link",
+            id="only-bold-kept",
+        ),
+        pytest.param("<p>a <b>bold</b> and <i>soft</i></p>", ["b", "i"], "a **bold** and *soft*", id="both-kept"),
+    ],
+)
+def test_convert_inline(html: str, convert: list[str], expected: str) -> None:
+    assert parse(html).to_markdown(convert=convert) == expected
+
+
+def test_convert_empty_drops_all_markup() -> None:
+    # an empty allowlist keeps markup for nothing, so only the text survives
+    out = parse('<p><b>x</b> <a href="https://e.test">y</a></p>').to_markdown(convert=[])
+    assert out == "x y"
+
+
+def test_strip_block_keeps_children() -> None:
+    out = parse("<blockquote><p>quoted</p></blockquote>").to_markdown(strip=["blockquote"])
+    assert out == "quoted"
+
+
+def test_strip_heading_unwraps_to_prose() -> None:
+    out = parse("<h2>Heading</h2><p>Body text.</p>").to_markdown(strip=["h2"])
+    assert out == "Heading\n\nBody text."
+
+
+def test_convert_block_drops_outer_block() -> None:
+    out = parse("<blockquote><p>kept</p></blockquote>").to_markdown(convert=["p"])
+    assert out == "kept"
+
+
+def test_strip_leaves_foreign_element_untouched() -> None:
+    # an SVG element has no HTML atom, so it is never named by a filter and renders normally
+    out = parse("<p>a <svg><title>chart</title></svg> b</p>").to_markdown(strip=["b"])
+    assert out == "a chart b"
+
+
+@pytest.mark.parametrize(
+    "render",
+    [
+        pytest.param(lambda doc: doc.to_markdown(strip=["script"]), id="strip"),
+        pytest.param(lambda doc: doc.to_markdown(convert=["b"]), id="convert"),
+    ],
+)
+def test_skipped_tag_inside_kept_inline_vanishes_whole(render: Callable[[Document], str]) -> None:
+    # a <script> nested in a kept inline parent is reached by the inline walk, yet still
+    # drops content-and-all rather than unwrapping the way the filter unwraps other tags
+    assert render(parse("<p>a <b><script>var x = 1</script>keep</b> b</p>")) == "a **keep** b"
+
+
+def test_uppercase_tag_name_is_lowercased() -> None:
+    # a tag name is matched case-insensitively, exercising the ASCII lowercasing
+    out = parse("<p><b>x</b></p>").to_markdown(strip=["B"])
+    assert out == "x"
+
+
+def test_unknown_tag_name_is_ignored() -> None:
+    html = "<p><b>x</b></p>"
+    assert parse(html).to_markdown(strip=["nosuchtag"]) == parse(html).to_markdown()
+
+
+def test_overlong_tag_name_is_ignored() -> None:
+    html = "<p><b>x</b></p>"
+    assert parse(html).to_markdown(strip=["z" * 65]) == parse(html).to_markdown()
+
+
+def test_surrogate_tag_name_is_ignored() -> None:
+    html = "<p><b>x</b></p>"
+    assert parse(html).to_markdown(strip=["\ud800"]) == parse(html).to_markdown()
+
+
+@pytest.mark.parametrize(
+    "render",
+    [
+        pytest.param(lambda doc: doc.to_markdown(strip=None), id="strip-none"),
+        pytest.param(lambda doc: doc.to_markdown(convert=None), id="convert-none"),
+        pytest.param(lambda doc: doc.to_markdown(strip=[]), id="strip-empty"),
+    ],
+)
+def test_no_op_filters_match_default(render: Callable[[Document], str]) -> None:
+    html = "<p><b>x</b> <i>y</i></p>"
+    assert render(parse(html)) == parse(html).to_markdown()
+
+
+def test_non_str_iterable_accepted() -> None:
+    out = parse("<p><b>x</b></p>").to_markdown(strip=(tag for tag in ["b"]))
+    assert out == "x"
+
+
+def test_strip_and_convert_are_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="strip and convert are mutually exclusive"):
+        parse("<p><b>x</b></p>").to_markdown(strip=["b"], convert=["b"])
+
+
+@pytest.mark.parametrize(
+    "render",
+    [
+        pytest.param(lambda doc: doc.to_markdown(strip="b"), id="strip"),
+        pytest.param(lambda doc: doc.to_markdown(convert="a"), id="convert"),
+    ],
+)
+def test_single_str_rejected(render: Callable[[Document], str]) -> None:
+    with pytest.raises(TypeError, match="iterable of tag names, not a single str"):
+        render(parse("<p><b>x</b></p>"))
+
+
+@pytest.mark.parametrize(
+    "render",
+    [
+        # a non-iterable on purpose, to exercise the binding's iterator coercion
+        pytest.param(lambda doc: doc.to_markdown(strip=42), id="strip"),
+        pytest.param(lambda doc: doc.to_markdown(convert=42), id="convert"),
+    ],
+)
+def test_non_iterable_rejected(render: Callable[[Document], str]) -> None:
+    with pytest.raises(TypeError):
+        render(parse("<p><b>x</b></p>"))
+
+
+def test_non_str_tag_rejected() -> None:
+    with pytest.raises(TypeError, match="tags must be str, not int"):
+        # a non-str element on purpose, to exercise the per-item type check
+        parse("<p><b>x</b></p>").to_markdown(strip=["b", 5])  # ty: ignore[invalid-argument-type]
+
+
+def test_iterator_error_propagates() -> None:
+    def tags() -> Iterator[str]:
+        yield "b"
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        parse("<p><b>x</b></p>").to_markdown(strip=tags())


### PR DESCRIPTION
Add the mutually exclusive `strip` and `convert` keywords to `Node.to_markdown`, the tag filters `markdownify` exposes under the same names.

- `strip` names tags whose markup is dropped while their text keeps flowing.
- `convert` names the only tags to keep markup for, so every other tag is unwrapped.

Both compile to one 256-bit set indexed by the interned tag atom, so the per-element test is a constant-time bit lookup with no bound check. A name the tag table does not know folds to no entry (mirroring how `markdownify` ignores an unknown tag), and `<script>`/`<style>`/`<head>` still vanish whole.

Docs (how-to, explanation, migration markdownify row) and a changelog fragment are included. Coverage is 100% line+branch on the changed files under both llvm-cov and gcc-16.

closes #248