### PR TITLE
docs(changelog): rewrite entries as concise end-user release notes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,25 +13,22 @@
 Features - 0.4.0
 ================
 
-- Build and edit the tree, not just read it. Construct ``Element``, ``Text``, and ``Comment`` nodes and assemble them
-  with ``append``, ``extend``, ``insert``, ``wrap``, ``unwrap``, ``insert_before``, ``insert_after``, ``replace_with``,
-  ``extract``, ``decompose``, and ``normalize``. ``element.attrs`` is a live mapping you assign to and delete from, and
-  ``Text``/``Comment`` take a ``.data`` setter while ``Element`` takes a ``.text`` setter. Nodes move within their tree
-  and are copied when adopted into another, and ``copy.copy``, ``copy.deepcopy``, and ``pickle`` duplicate a subtree
-  exactly. Invalid names and cycles raise ``ValueError`` - by :user:`gaborbernat`. (:issue:`19`)
-- Round out the node model: :class:`~turbohtml.ProcessingInstruction` and :class:`~turbohtml.CData` join the hierarchy
-  for building, :class:`~turbohtml.Doctype` exposes its ``public_id`` and ``system_id``, and every node type now
-  supports structural pattern matching - by :user:`gaborbernat`. (:issue:`22`)
+- Build and edit the tree, not just read it: construct ``Element``, ``Text``, and ``Comment`` nodes and rearrange them
+  with the full set of insert, wrap, extract, and normalize methods, with ``attrs`` and ``.text``/``.data`` as live
+  setters. ``copy``, ``deepcopy``, and ``pickle`` duplicate a subtree - by :user:`gaborbernat`. (:issue:`19`)
+- Round out the node model: :class:`~turbohtml.ProcessingInstruction` and :class:`~turbohtml.CData` join the hierarchy,
+  :class:`~turbohtml.Doctype` exposes its ``public_id`` and ``system_id``, and every node type supports structural
+  pattern matching - by :user:`gaborbernat`. (:issue:`22`)
 
 Improved documentation - 0.4.0
 ==============================
 
-- Document and benchmark the write path: tutorial, how-to, and explanation coverage for building and editing a tree,
-  plus ``build`` and ``edit`` benchmark suites showing turbohtml builds and rewrites trees about twice as fast as lxml
-  and an order of magnitude faster than BeautifulSoup - by :user:`gaborbernat`. (:issue:`19`)
-- Add migration guides from every library turbohtml replaces - BeautifulSoup, lxml, selectolax, html5lib, and the
-  standard library - each mapping its idioms to the turbohtml equivalent and calling out the behavior differences a
-  porting user hits - by :user:`gaborbernat`. (:issue:`23`)
+- Learn the write path through new tutorial, how-to, and explanation docs, backed by benchmarks showing turbohtml builds
+  and rewrites trees about twice as fast as lxml and an order of magnitude faster than BeautifulSoup - by
+  :user:`gaborbernat`. (:issue:`19`)
+- Port to turbohtml with migration guides from BeautifulSoup, lxml, selectolax, html5lib, and the standard library, each
+  mapping the source library's idioms to their turbohtml equivalents and flagging behavior differences - by
+  :user:`gaborbernat`. (:issue:`23`)
 
 *********************
  v0.3.0 (2026-06-16)
@@ -40,38 +37,27 @@ Improved documentation - 0.4.0
 Features - 0.3.0
 ================
 
-- Add ``select()`` and ``select_one()`` to every node: a native CSS matcher over the common selector subset - type,
-  universal, ``#id``, ``.class``, and attribute selectors with the ``=``, ``~=``, ``|=``, ``^=``, ``$=``, ``*=``
-  operators (plus the ``i``/``s`` case-sensitivity flag), combined into compounds and joined by the descendant, child
-  (``>``), adjacent (``+``), and general-sibling (``~``) combinators, with comma groups returned in document order.
-  Selectors compile against the tree so names resolve to interned atoms, making each match an integer compare. An
-  invalid selector raises ``ValueError`` - by :user:`gaborbernat`. (:issue:`14`)
-- Rework ``find()`` and ``find_all()`` into a filter grammar over a search axis. A filter is a ``str``, a compiled
-  regex, a ``bool``, a callable, or a list of those, applied to the tag and to attribute filters (keyword arguments, the
-  ``attrs`` mapping, or ``class_``, which matches the class tokens). The ``axis`` keyword (an ``Axis`` member) selects
-  descendants, children, ancestors, siblings, or document-order following/preceding. ``find_all`` takes a ``limit`` and
-  now returns a ``list`` - by :user:`gaborbernat`. (:issue:`15`)
-- Add ``matches()`` and ``closest()`` to every node. ``matches()`` returns whether the node is an Element satisfying a
-  CSS selector, evaluated against its real ancestors and siblings; ``closest()`` returns the nearest Element matching
-  the selector, testing the node itself and then each ancestor, or ``None``. Both reuse the ``select()`` matcher, so an
-  invalid selector raises ``ValueError`` - by :user:`gaborbernat`. (:issue:`16`)
-- Add traversal-axis iterators to every node: ``next_siblings``, ``previous_siblings``, ``following`` (document order,
-  excluding the node's own subtree), and ``preceding`` (reverse document order, excluding the node's ancestors), plus
-  the ``strings`` and ``stripped_strings`` text iterators - by :user:`gaborbernat`. (:issue:`17`)
-- Expose the HTML token-list attributes (``class``, ``rel``, ``rev``, ``headers``, ``accesskey``, ``dropzone``,
-  ``sizes``, ``sandbox``, ``archive``, ``accept-charset``) as a ``list[str]`` in ``Element.attrs``, split on ASCII
-  whitespace. Every other attribute stays a string and a valueless attribute stays ``None`` - by :user:`gaborbernat`.
-  (:issue:`18`)
-- Give every node a controllable serializer. ``inner_html`` returns the children only; ``serialize(formatter=...,
-  indent=...)`` and ``encode(encoding=..., formatter=..., indent=...)`` expose the escape policy through the
-  ``Formatter`` enum (``WHATWG`` minimal-conformant, ``MINIMAL`` structural-only, ``NAMED_ENTITIES`` HTML names) and a
-  pretty form keyed on ``indent`` (an int or string). The default ``html`` output stays WHATWG-conformant: minimal
-  escaping, source-order double-quoted attributes, void elements without an end tag, raw-text content verbatim, and a
-  restored leading newline in ``pre``/``textarea``/``listing`` - by :user:`gaborbernat`. (:issue:`20`)
-- ``parse()`` now accepts ``bytes``. The encoding is sniffed with the WHATWG algorithm: a byte-order mark, then the
-  ``encoding`` argument, then a ``<meta>`` charset prescan, then windows-1252. The bytes are decoded with the resolved
-  codec, replacing malformed sequences with U+FFFD, and ``Document.encoding`` reports the encoding used (``None`` for
-  ``str`` input). Validated against the html5lib-tests encoding suite - by :user:`gaborbernat`. (:issue:`21`)
+- Query any node with CSS through ``select()`` and ``select_one()``, a native matcher covering type, universal, ``#id``,
+  ``.class``, and attribute selectors (all operators plus the case-sensitivity flag) across the descendant, child,
+  adjacent, and sibling combinators, returning comma groups in document order. An invalid selector raises ``ValueError``
+  - by :user:`gaborbernat`. (:issue:`14`)
+- Search with a richer ``find()`` and ``find_all()`` filter grammar: match the tag and attributes by string, regex,
+  bool, callable, or list (including ``class_`` and the ``attrs`` mapping), and choose the search direction with the
+  ``axis`` keyword. ``find_all`` takes a ``limit`` and returns a ``list`` - by :user:`gaborbernat`. (:issue:`15`)
+- Test a node against a selector with ``matches()`` and ``closest()``: ``matches()`` reports whether the node satisfies
+  a CSS selector in context, and ``closest()`` returns the nearest matching ancestor (or the node itself), or ``None`` -
+  by :user:`gaborbernat`. (:issue:`16`)
+- Walk the tree by axis with new iterators: ``next_siblings``, ``previous_siblings``, document-order ``following`` and
+  ``preceding``, plus the ``strings`` and ``stripped_strings`` text iterators - by :user:`gaborbernat`. (:issue:`17`)
+- Read HTML token-list attributes (``class``, ``rel``, ``headers``, ``sizes``, ``sandbox``, and the rest) as a
+  ``list[str]`` in ``Element.attrs``, split on ASCII whitespace; other attributes stay strings and valueless ones stay
+  ``None`` - by :user:`gaborbernat`. (:issue:`18`)
+- Control serialization on any node: ``inner_html`` returns the children, while ``serialize()`` and ``encode()`` take a
+  ``formatter`` (the ``Formatter`` enum picks the escape policy) and an ``indent`` for pretty output. The default stays
+  WHATWG-conformant HTML - by :user:`gaborbernat`. (:issue:`20`)
+- Parse ``bytes`` directly: ``parse()`` sniffs the encoding with the WHATWG algorithm (BOM, ``encoding`` argument,
+  ``<meta>`` charset, then windows-1252), decodes with U+FFFD replacement, and reports the result in
+  ``Document.encoding`` - by :user:`gaborbernat`. (:issue:`21`)
 
 *********************
  v0.2.0 (2026-06-11)
@@ -80,21 +66,12 @@ Features - 0.3.0
 Features - 0.2.0
 ================
 
-- Add a WHATWG-conformant HTML tokenizer: :func:`turbohtml.tokenize` for whole strings, the streaming
-  :class:`turbohtml.Tokenizer`, and the :class:`turbohtml.Token` / :class:`turbohtml.TokenType` types. The C state
-  machine is validated against the html5lib-tests tokenizer conformance suite and bulk-scans text runs the way html5ever
-  does. (:issue:`6`)
-- Speed up ``escape`` and ``unescape``. ``escape`` classifies one-byte strings sixteen bytes at a time with NEON or
-  SSE2, or a SWAR word elsewhere (on NEON, a single low-nibble table lookup matches all five specials at once). The
-  sizing pass accumulates growth without branches, the writing pass copies clean stretches in bulk and rewrites only the
-  positions a match bitmask singles out, and one SWAR pass probes UCS-2 / UCS-4 text for every special character instead
-  of running one ``PyUnicode_FindChar`` sweep per character (UCS-4 uses a four-lane NEON vector). ``unescape`` hops
-  between ``&`` occurrences and bulk-copies the clean spans instead of routing every character through a per-code-point
-  emit, keeps output staging at the input's width until a reference widens it, and resolves the entities ``html.escape``
-  emits with one comparison rather than the full binary search, so unescaping escaped real HTML runs about three times
-  faster than the general lookup path alone. The benchmark now uses `pyperf <https://pyperf.readthedocs.io>`_ with
-  multi-MiB real documents referenced as pinned git submodules under ``tools/bench-data`` - by :user:`gaborbernat`.
-  (:issue:`7`)
+- Tokenize HTML directly with a WHATWG-conformant tokenizer: :func:`turbohtml.tokenize` for whole strings, the streaming
+  :class:`turbohtml.Tokenizer`, and the :class:`turbohtml.Token` / :class:`turbohtml.TokenType` types, validated against
+  the html5lib-tests tokenizer conformance suite. (:issue:`6`)
+- Run ``escape`` and ``unescape`` faster: vectorized scanning and bulk copying speed up both calls, with unescaping of
+  real escaped HTML about three times faster than the general lookup path. The benchmark now uses `pyperf
+  <https://pyperf.readthedocs.io>`_ over multi-MiB real documents - by :user:`gaborbernat`. (:issue:`7`)
 
 *********************
  v0.1.1 (2026-06-09)
@@ -103,8 +80,8 @@ Features - 0.2.0
 Packaging updates - 0.1.1
 =========================
 
-- Publish each wheel artifact in its own job so PEP 740 attestations finish within the Sigstore signing identity's
-  lifetime, fixing the ``sigstore.oidc.ExpiredIdentity`` failure that blocked the first PyPI upload - by
+- Install reliably from PyPI again: publishing each wheel in its own job keeps PEP 740 attestations within the Sigstore
+  identity's lifetime, fixing the ``sigstore.oidc.ExpiredIdentity`` failure that blocked the first upload - by
   :user:`gaborbernat`. (:issue:`4`)
 
 *********************
@@ -114,23 +91,20 @@ Packaging updates - 0.1.1
 Features - 0.1.0
 ================
 
-- Add C-accelerated :func:`turbohtml.escape` and :func:`turbohtml.unescape`, matching :func:`python:html.escape` and
-  :func:`python:html.unescape` byte for byte, with free-threading support and per-interpreter wheels for CPython 3.10
+- Speed up entity handling with C-accelerated :func:`turbohtml.escape` and :func:`turbohtml.unescape`, drop-in
+  replacements for :func:`python:html.escape` and :func:`python:html.unescape`, shipped as wheels for CPython 3.10
   through 3.15 - by :user:`gaborbernat`. (:issue:`1`)
-- Speed up ``escape`` of non-ASCII (UCS-2/UCS-4) text that needs no escaping by probing for special characters with a
-  vectorized scan instead of a scalar one, making it several times faster and ahead of :func:`python:html.escape` - by
-  :user:`gaborbernat`. (:issue:`3`)
+- Escape non-ASCII text that needs no escaping several times faster with a vectorized special-character scan, ahead of
+  :func:`python:html.escape` - by :user:`gaborbernat`. (:issue:`3`)
 
 Improved documentation - 0.1.0
 ==============================
 
-- Document the measured ``escape``/``unescape`` speedups over the standard library in the README and the docs, add a
-  reproducible benchmark behind ``tox -e bench``, and give the API reference typed signatures with intersphinx links -
-  by :user:`gaborbernat`. (:issue:`2`)
+- See the measured ``escape``/``unescape`` speedups in the README and docs, reproduce them with ``tox -e bench``, and
+  browse a typed API reference with intersphinx links - by :user:`gaborbernat`. (:issue:`2`)
 
 Miscellaneous internal changes - 0.1.0
 ======================================
 
-- Automate releases the tox-dev way: git-tag-derived versioning, a towncrier-managed changelog, and a manual
-  prepare-release workflow that tags and triggers the trusted-publishing wheel build - by :user:`gaborbernat`.
-  (:issue:`1`)
+- Automate releases with git-tag-derived versioning, a towncrier-managed changelog, and a prepare-release workflow that
+  tags and triggers the trusted-publishing wheel build - by :user:`gaborbernat`. (:issue:`1`)

--- a/docs/changelog/11.feature.rst
+++ b/docs/changelog/11.feature.rst
@@ -1,7 +1,4 @@
-Escape untrusted text for HTML with ``turbohtml.migration.markupsafe``, a drop-in for markupsafe's public surface:
-``Markup``, ``escape``, ``escape_silent``, ``soft_str``, and ``EscapeFormatter``. A Jinja2, WTForms, or Werkzeug project
+Escape untrusted text for HTML with ``turbohtml.migration.markupsafe``, a drop-in for markupsafe's public surface
+(``Markup``, ``escape``, ``escape_silent``, ``soft_str``, ``EscapeFormatter``). A Jinja2, WTForms, or Werkzeug project
 migrates by changing the import, and ``escape`` runs two to four times faster on the small strings autoescaping
-interpolates while every ``Markup`` method runs faster than markupsafe's. ``Markup`` overrides the full ``str`` method
-surface so a result stays safe through template filters, ``Markup.striptags`` and ``Markup.unescape`` run on turbohtml's
-own parser and reference resolution, and a migration test renders Jinja2 templates with markupsafe swapped for
-``turbohtml.migration.markupsafe``.
+interpolates.

--- a/docs/changelog/162.feature.rst
+++ b/docs/changelog/162.feature.rst
@@ -1,8 +1,3 @@
-Accelerate the read path with two per-tree caches that ``find``, ``find_all``, ``select``, and ``select_one`` build
-lazily and reuse. A lazy element index, bucketed by tag atom, lets a whole-document tag or type-subject query enumerate
-just the matching tag's bucket instead of walking every node, and a move-to-front compiled-selector cache reuses a
-parsed selector across repeated calls on the same tree instead of recompiling it each time. The index drops on any
-structural mutation and the selector cache invalidates against the tree's attribute generation, so results stay correct.
-Together they run whole-document ``find``/``select`` two to roughly six times faster on large pages and repeated
-small-document ``select`` calls several times faster, while a query rooted at a subtree or with an unknown subject falls
-back to the original pre-order walk.
+Run whole-document ``find``, ``find_all``, ``select``, and ``select_one`` two to roughly six times faster on large
+pages, and repeated small-document ``select`` calls several times faster, thanks to per-tree element-index and
+compiled-selector caches that build lazily and invalidate on mutation, so results stay correct.

--- a/docs/changelog/163.doc.rst
+++ b/docs/changelog/163.doc.rst
@@ -1,3 +1,2 @@
-Add a "From html5-parser" migration guide mapping ``html5_parser.parse`` onto :func:`turbohtml.parse`, porting the lxml
-element accessors and noting XPath has no equivalent (CSS only), and cross-linking the parser comparison since
-html5-parser sits in the same native-gumbo tier - by :user:`gaborbernat`.
+A new "From html5-parser" migration guide maps ``html5_parser.parse`` onto :func:`turbohtml.parse` and ports the lxml
+element accessors, so html5-parser users have a step-by-step path across - by :user:`gaborbernat`.

--- a/docs/changelog/164.doc.rst
+++ b/docs/changelog/164.doc.rst
@@ -1,4 +1,3 @@
-Add a "From parsel" section to the migration guide, mapping Scrapy parsel's extraction-oriented ``Selector`` API
-(``.css()`` / ``.xpath()`` with ``.get()`` / ``.getall()`` and the ``::text`` / ``::attr()`` pseudo-elements) onto
-turbohtml's node-returning :meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.xpath`. The benchmark suite now
-races parsel in the query comparison, and the performance page's *Querying* table reports it alongside the others.
+A new "From parsel" migration section maps Scrapy parsel's ``Selector`` API onto turbohtml's node-returning
+:meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.xpath`, and the performance page now reports parsel in the
+*Querying* comparison.

--- a/docs/changelog/165.doc.rst
+++ b/docs/changelog/165.doc.rst
@@ -1,3 +1,2 @@
-Add a "From pyquery" migration guide mapping the jQuery-style chaining idiom onto :class:`turbohtml.query.Query`, which
-shares the ``filter``/``eq``/``attr``/``add_class`` surface, and cross-linking the fluent-chaining benchmark - by
-:user:`gaborbernat`.
+A new "From pyquery" migration guide maps the jQuery-style chaining idiom onto :class:`turbohtml.query.Query`, so
+pyquery users have a path to the fluent-chaining API - by :user:`gaborbernat`.

--- a/docs/changelog/166.doc.rst
+++ b/docs/changelog/166.doc.rst
@@ -1,3 +1,3 @@
-Add ``lxml-html-clean`` and ``html-sanitizer`` to the sanitizer comparison and the migration guide, alongside the
-allowlist-versus-blocklist safety argument: turbohtml's allowlist drops anything unlisted, where ``lxml-html-clean``'s
-blocklist passes any dangerous construct it does not enumerate - by :user:`gaborbernat`.
+The sanitizer comparison and migration guide now cover ``lxml-html-clean`` and ``html-sanitizer``, explaining why
+turbohtml's allowlist is safer than a blocklist that passes any dangerous construct it does not enumerate - by
+:user:`gaborbernat`.

--- a/docs/changelog/167.doc.rst
+++ b/docs/changelog/167.doc.rst
@@ -1,3 +1,2 @@
-Expand the standard-library migration guide with the ``html.parser`` SAX callback to token-loop mapping, noting that
-character references are always resolved (no ``convert_charrefs`` switch) and cross-linking the tokenizing benchmark -
-by :user:`gaborbernat`.
+The standard-library migration guide now maps the ``html.parser`` SAX callbacks onto turbohtml's token loop, noting that
+character references are always resolved, so ``html.parser`` users have a path across - by :user:`gaborbernat`.

--- a/docs/changelog/168.doc.rst
+++ b/docs/changelog/168.doc.rst
@@ -1,4 +1,3 @@
-Note the encoding-detection boundary in the BeautifulSoup migration guide: turbohtml's WHATWG sniffing (a BOM, the
-``<meta charset>`` prescan, then a ``windows-1252`` fallback) replaces what ``UnicodeDammit`` reads from the markup, but
-not the statistical detectors (``charset-normalizer``, ``chardet``, ``cchardet``) that guess from byte frequency. Reach
-for those when a stream carries no BOM and no declaration.
+The BeautifulSoup migration guide now documents the encoding-detection boundary: turbohtml's WHATWG sniffing replaces
+``UnicodeDammit``'s markup reading, but reach for ``charset-normalizer``, ``chardet``, or ``cchardet`` when a stream
+carries no BOM and no declaration.

--- a/docs/changelog/169.doc.rst
+++ b/docs/changelog/169.doc.rst
@@ -1,4 +1,3 @@
-Add a migration entry and a performance comparison for ``w3lib.html``, mapping ``replace_entities`` onto
-:func:`turbohtml.unescape` (now benchmarked side by side) and the tag and comment strippers onto parsing plus
-:attr:`~turbohtml.Node.text`, and scoping the overlap to the HTML subset since the URL and HTTP helpers have no
-equivalent - by :user:`gaborbernat`.
+A new migration entry and performance comparison for ``w3lib.html`` map ``replace_entities`` onto
+:func:`turbohtml.unescape` and the tag and comment strippers onto parsing plus :attr:`~turbohtml.Node.text`, so w3lib
+users have a path for the HTML helpers - by :user:`gaborbernat`.

--- a/docs/changelog/170.doc.rst
+++ b/docs/changelog/170.doc.rst
@@ -1,3 +1,2 @@
-Add resiliparse to the parsing benchmark, the performance comparison, and the migration guide, and note gumbo, the
-unmaintained WHATWG C parser behind html5-parser, in prose as a read-only alternative turbohtml supersedes - by
-:user:`gaborbernat`.
+The parsing benchmark, performance comparison, and migration guide now cover resiliparse, giving its users a documented
+path to turbohtml - by :user:`gaborbernat`.

--- a/docs/changelog/171.breaking.rst
+++ b/docs/changelog/171.breaking.rst
@@ -1,4 +1,3 @@
-Replace the ``indent`` argument of :meth:`~turbohtml.Node.serialize` and :meth:`~turbohtml.Node.encode` with a single
-``layout`` argument that holds one serialization mode, so the pretty and minify modes are mutually exclusive by
-construction rather than by a runtime check. Pretty-printing now takes ``layout=`` an :class:`~turbohtml.Indent` (an int
-for that many spaces, or a string used verbatim); ``serialize(indent=2)`` becomes ``serialize(layout=Indent(2))``.
+:meth:`~turbohtml.Node.serialize` and :meth:`~turbohtml.Node.encode` replace the ``indent`` argument with a single
+``layout`` argument that selects one serialization mode. Pretty-printing now passes ``layout=`` an
+:class:`~turbohtml.Indent`: ``serialize(indent=2)`` becomes ``serialize(layout=Indent(2))``.

--- a/docs/changelog/171.feature.rst
+++ b/docs/changelog/171.feature.rst
@@ -1,5 +1,4 @@
-Add an HTML minification mode to the serializer: :meth:`~turbohtml.Node.serialize` and :meth:`~turbohtml.Node.encode`
-take ``layout=`` a :class:`~turbohtml.Minify` options object whose four flags fold insignificant whitespace, omit the
-start/end tags the WHATWG rules make optional, drop redundant attribute quotes, and strip comments. Every transform is
-round-trip safe -- the minified output reparses to the same tree -- so turbohtml can replace ``minify-html`` and
-``htmlmin`` without a serialize-then-reparse changing the document.
+Minify HTML by passing ``layout=`` a :class:`~turbohtml.Minify` options object to :meth:`~turbohtml.Node.serialize` and
+:meth:`~turbohtml.Node.encode`, which folds insignificant whitespace, omits optional tags, drops redundant attribute
+quotes, and strips comments. Every transform is round-trip safe: the output reparses to the same tree, so turbohtml
+replaces ``minify-html`` and ``htmlmin``.

--- a/docs/changelog/172.feature.rst
+++ b/docs/changelog/172.feature.rst
@@ -1,32 +1,5 @@
-Export a node and its subtree as GitHub-Flavored Markdown with :meth:`~turbohtml.Node.to_markdown`, a single C tree walk
-that covers the common ``scrape`` → ``Markdown`` pipeline without a second dependency. It maps headings, paragraphs,
-ordered and unordered (and nested) lists, links, images, ``*``/``**`` emphasis and ``~~`` strikethrough, inline code and
-fenced code blocks (with the language from a ``language-*`` class), blockquotes, horizontal rules, line breaks, and pipe
-tables, collapsing runs of whitespace the way CSS normal flow does. Whitespace is settled with a deferred-space rule and
-the emphasis markers are deferred too, so a space inside ``<b> bold </b>`` lands outside the ``**`` instead of producing
-invalid Markdown; plain prose is bulk-copied after its first character. Three things the reference converters get wrong
-are correct here: an inline code span grows its backtick fence past any backticks in the content, a ``|`` inside a table
-cell is escaped, and a nested ordered list keeps its own counter. The walk holds no state outside its stack frame and
-takes the per-tree critical section, so it is safe under the free-threaded build.
-
-Keyword options cover the markdownify and html2text configuration surface with one name per concept, so a project
-migrating off either reproduces its output: heading style (ATX, closed ATX, setext), bullet and emphasis and quote
-markers, reference vs inline links with autolinking, image alt/ignore modes, ignored links/emphasis/tables, fenced or
-indented or marked code blocks, padded and stripped tables, three escaping levels, single vs double block spacing, and
-document trimming. ``google_doc=True`` adds html2text's Google-Docs mode, reading the inline-CSS styling such an export
-carries: a bold/italic font weight or style becomes ``strong``/``emphasis``, a fixed-width font becomes inline code,
-``list-style-type`` picks the marker, ``margin-left`` over ``google_list_indent`` pixels sets list nesting, and
-``hide_strikethrough`` drops struck text. The :doc:`migration <migration>` guide maps each old option to its turbohtml
-name.
-
-A companion :meth:`~turbohtml.Node.to_text` exports layout-aware plain text, the role `inscriptis
-<https://github.com/weblyzard/inscriptis>`_ fills: blocks separated by blank lines, lists indented under their bullets,
-and -- most visibly -- tables laid out as a column-aligned grid, all in the same single C walk. Options control link
-display (hidden, inline, or numbered footnotes), image alt text, the CSS profile, the table cell separator, the bullet,
-and an optional word-wrap width.
-
-:meth:`~turbohtml.Node.to_annotated_text` adds inscriptis's annotation role: given an ``annotation_rules`` mapping it
-returns the rendered text together with ``(start, end, label)`` spans over its code-point offsets, so a labeling or
-information-extraction pipeline keeps the visual layout and the markup-derived labels in one pass. Rule keys take the
-inscriptis ``tag``, ``tag#attr``, ``tag#attr=value``, ``#attr`` and ``#attr=value`` forms, and every ``to_text`` option
-applies.
+Export a node to GitHub-Flavored Markdown (:meth:`~turbohtml.Node.to_markdown`), layout-aware plain text
+(:meth:`~turbohtml.Node.to_text`), or annotated text with ``(start, end, label)`` spans
+(:meth:`~turbohtml.Node.to_annotated_text`). The three methods cover the markdownify, html2text, and inscriptis use
+cases without an extra dependency. ``to_markdown`` accepts the markdownify/html2text options (including
+``google_doc=True``); the :doc:`migration <migration>` guide maps each - by :user:`gaborbernat`.

--- a/docs/changelog/173.feature.rst
+++ b/docs/changelog/173.feature.rst
@@ -1,7 +1,4 @@
-Match the Selectors Level 4 negation pseudo-class ``:not()`` in :meth:`~turbohtml.Node.select`,
-:meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and :meth:`~turbohtml.Node.closest`, instead of
-rejecting it as invalid. ``:not()`` takes a full ``<complex-selector-list>``, so it negates compound and complex
-selectors -- ``p:not(.a, .b)`` and ``p:not(div p)`` -- and nests with the other functional pseudo-classes, making the
-spec example ``section:not(:has(h1))`` and compositions such as ``ul:has(:not(a))`` work. The argument list is
-non-forgiving: a syntactically invalid arm invalidates the whole selector, and matching agrees with soupsieve and
-lexbor.
+Use the Selectors Level 4 ``:not()`` negation pseudo-class in :meth:`~turbohtml.Node.select`,
+:meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and :meth:`~turbohtml.Node.closest`. It takes a
+full complex-selector list, so ``p:not(.a, .b)`` and ``section:not(:has(h1))`` work and nest with the other functional
+pseudo-classes, matching soupsieve and lexbor.

--- a/docs/changelog/174.bugfix.rst
+++ b/docs/changelog/174.bugfix.rst
@@ -1,8 +1,3 @@
-Parse the ``:is()`` and ``:where()`` arguments as a Selectors Level 4 forgiving selector list (§16.1) in
-:meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and
-:meth:`~turbohtml.Node.closest`. An arm that fails to parse -- an unsupported pseudo-class, a malformed compound, or an
-empty arm from a stray comma -- is now dropped so the remaining arms stay usable, instead of invalidating the whole
-selector, and an all-dropped list (including ``:is()``) is valid and matches nothing. ``:not()`` and ``:has()`` keep
-their non-forgiving real-list semantics, where a bad arm is still an error, and the top-level selector list stays
-non-forgiving as the standard requires. Recovery skips delimiters inside strings and balanced brackets, so a comma in a
-dropped arm's ``[attr="a, b"]`` does not split it.
+``:is()`` and ``:where()`` now parse as Selectors Level 4 forgiving selector lists in :meth:`~turbohtml.Node.select`,
+:meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and :meth:`~turbohtml.Node.closest`, so an
+unsupported or malformed arm is dropped and the remaining arms stay usable instead of invalidating the whole selector.

--- a/docs/changelog/175.feature.rst
+++ b/docs/changelog/175.feature.rst
@@ -1,7 +1,4 @@
-Support the Selectors Level 4 ``of S`` clause on ``:nth-child()`` and ``:nth-last-child()`` (§13.3.1) in
+Use the Selectors Level 4 ``of S`` clause on ``:nth-child()`` and ``:nth-last-child()`` in
 :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and
-:meth:`~turbohtml.Node.closest`, instead of rejecting it as invalid. ``:nth-child(An+B of S)`` now counts only the
-inclusive siblings that match the selector list ``S`` -- so ``li:nth-child(2n of .x)`` indexes the ``.x`` items rather
-than every ``li`` -- and an element that does not itself match ``S`` is never selected. The ``of`` keyword is rejected
-on the ``-of-type`` variants, which the grammar does not allow it on, and matching follows the spec and browsers
-(soupsieve's ``of S`` handling is incorrect).
+:meth:`~turbohtml.Node.closest`, so ``li:nth-child(2n of .x)`` indexes the ``.x`` items rather than every ``li``,
+matching the spec and browsers.

--- a/docs/changelog/176.bugfix.rst
+++ b/docs/changelog/176.bugfix.rst
@@ -1,5 +1,3 @@
-Match ``#id`` and ``.class`` selectors ASCII case-insensitively in a quirks-mode document (one parsed with no doctype),
-as `Selectors-4 §6.1 <https://www.w3.org/TR/selectors-4/#class-html>`_ and `§6.2
-<https://www.w3.org/TR/selectors-4/#id-selectors>`_ require. ``select(".foo")`` now finds ``<div class=FOO>`` in a
-quirks document, while a standards-mode document (with a doctype) keeps the case-sensitive comparison. The fold reaches
-class and ID selectors nested in ``:is()``, ``:where()``, and ``:has()``.
+``#id`` and ``.class`` selectors now match ASCII case-insensitively in a quirks-mode document (parsed with no doctype),
+as Selectors-4 requires, so ``select(".foo")`` finds ``<div class=FOO>``; standards-mode documents keep the
+case-sensitive comparison.

--- a/docs/changelog/177.bugfix.rst
+++ b/docs/changelog/177.bugfix.rst
@@ -1,4 +1,2 @@
-Match elements that contain only document white space with ``:empty``, following `Selectors-4 §13.2
-<https://www.w3.org/TR/selectors-4/#the-empty-pseudo>`_. The matcher previously used the Level 3 rule that rejected any
-text child, so ``select("p:empty")`` missed ``<p> </p>``. Comment-only elements still match, and a non-breaking space
-(U+00A0, which is not white space) still counts as content.
+``:empty`` now matches elements containing only white space, as Selectors-4 §13.2 requires, so ``select("p:empty")``
+finds ``<p> </p>``; it previously used the Level 3 rule that rejected any text child.

--- a/docs/changelog/178.feature.rst
+++ b/docs/changelog/178.feature.rst
@@ -1,11 +1,5 @@
-Match the Selectors Level 4 ``:scope`` (§6.6), input/UI (§12), ``:lang()`` and ``:dir()`` (§11) pseudo-classes in
+Match the Selectors Level 4 ``:scope``, input/UI, ``:lang()``, and ``:dir()`` pseudo-classes in
 :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and
-:meth:`~turbohtml.Node.closest`, instead of rejecting them as invalid. The attribute- and structure-determinable set --
-``:checked``, ``:disabled`` / ``:enabled`` (with ``fieldset`` and ``optgroup`` inheritance and the first-``legend``
-exception), ``:required`` / ``:optional``, ``:read-only`` / ``:read-write``, ``:default`` (including a form's first
-submit button), ``:scope`` (the query root), ``:lang()`` (nearest ``lang`` with BCP47 hyphen-prefix ranges) and
-``:dir()`` (resolving ``auto`` and ``bdi`` from the content's first strong character) -- now matches, in agreement with
-soupsieve and browsers. The live UA/interaction and navigation pseudo-classes (``:hover``, ``:focus``,
-``:focus-within``, ``:focus-visible``, ``:active``, ``:target``, ``:target-within``, ``:visited``, ``:link``,
-``:any-link``) parse as valid selectors but match nothing, since a static tree has no such state, so they compose inside
-``:is()`` and ``:not()`` rather than raising.
+:meth:`~turbohtml.Node.closest`. The attribute- and structure-determinable set (``:checked``, ``:disabled``,
+``:required``, ``:default``, and more) matches as soupsieve and browsers do; live UA-state pseudo-classes (``:hover``,
+``:focus``, ``:target``, ...) parse as valid but match nothing.

--- a/docs/changelog/179.feature.rst
+++ b/docs/changelog/179.feature.rst
@@ -1,7 +1,4 @@
-Evaluate XPath 1.0 expressions with :meth:`~turbohtml.Node.xpath` (a list of results, or the matching ``float`` /
-``str`` / ``bool`` for a scalar expression), :meth:`~turbohtml.Node.xpath_one` (the first result or ``None``), and
-:meth:`~turbohtml.Node.xpath_iter` (an iterator). A native-C engine compiles each expression once into an immutable,
-per-tree-cached program and evaluates it over the tree: the structural axes, the ``name`` / ``*`` / ``node()`` /
-``text()`` / ``comment()`` node tests, predicates, the boolean, relational, and arithmetic operators, unions, and the
-core function library, including the namespace axis. The ``//`` abbreviation collapses to a single ``descendant`` walk,
-so ``//a`` matches lxml's speed. ``lxml``, ``parsel``, and ``pyquery`` users keep their XPath when they migrate.
+Evaluate XPath 1.0 expressions with :meth:`~turbohtml.Node.xpath` (a list of results, or a scalar ``float`` / ``str`` /
+``bool``), :meth:`~turbohtml.Node.xpath_one` (the first result or ``None``), and :meth:`~turbohtml.Node.xpath_iter` (an
+iterator), covering the structural axes, node tests, predicates, operators, unions, and the core function library, so
+``lxml``, ``parsel``, and ``pyquery`` users keep their XPath when they migrate.

--- a/docs/changelog/180.feature.rst
+++ b/docs/changelog/180.feature.rst
@@ -1,10 +1,4 @@
-Add :class:`turbohtml.query.Query`, a pyquery-style fluent, chainable query wrapper over the tree and selector engine,
-for code migrating off `pyquery <https://github.com/gawel/pyquery>`_'s jQuery-style chaining. A ``Query`` wraps an
-ordered, duplicate-free set of elements, and its traversal and mutation methods -- ``__call__``/``find``, ``filter``,
-``eq``, ``parent``, ``children``, ``siblings``, ``closest``, ``items``, ``attr``, ``text``, ``html``, ``has_class``,
-``add_class``, ``remove_class``, ``toggle_class`` -- each return a ``Query``, so calls compose. It is a Python-layer
-convenience over the existing tree and selector primitives, kept out of the core API so the chainable surface stays
-optional; the method names are turbohtml's own (``add_class`` rather than pyquery's ``addClass``), so a migration
-adjusts the spelling but keeps the structure. Because the wrapper delegates the real work to the C selector and
-attribute primitives -- and skips a redundant de-duplication when a chain starts from one node -- it runs roughly ten
-times faster than pyquery on the same chain (see the :doc:`performance` page).
+Chain queries fluently with :class:`turbohtml.query.Query`, a pyquery-style wrapper over the tree and selector engine
+whose traversal and mutation methods (``find``, ``filter``, ``eq``, ``parent``, ``children``, ``attr``, ``add_class``,
+and the rest) each return a ``Query`` so calls compose. It runs roughly ten times faster than pyquery on the same chain
+(see the :doc:`performance` page).

--- a/docs/changelog/181.feature.rst
+++ b/docs/changelog/181.feature.rst
@@ -1,9 +1,4 @@
-Add :class:`turbohtml.migration.stdlib.HTMLParser`, a drop-in base class for :class:`python:html.parser.HTMLParser`
-subclasses over the streaming tokenizer. It keeps the standard ``handle_starttag``/``handle_startendtag``/
-``handle_endtag``/``handle_data``/``handle_comment``/``handle_decl`` callbacks and the ``feed``/``close``/``reset``/
-``getpos`` methods, so an ``HTMLParser`` subclass migrates by changing its import and base class. Being
-WHATWG-conformant it differs from the standard library only where the standard library does: character references are
-always resolved (so ``handle_entityref``/``handle_charref`` never fire), and a processing instruction or CDATA section
-reaches ``handle_comment`` rather than ``handle_pi``/``unknown_decl``, because the HTML spec treats both as comments.
-The adapter is a Python-layer convenience over the existing token stream, kept out of the core API so the
-one-name-per-concept surface stays bounded.
+Migrate a :class:`python:html.parser.HTMLParser` subclass by changing its import and base class to
+:class:`turbohtml.migration.stdlib.HTMLParser`, a drop-in over the streaming tokenizer that keeps the standard
+``handle_*`` callbacks and the ``feed``/``close``/``reset``/``getpos`` methods. Being WHATWG-conformant, it resolves
+character references always and routes processing instructions and CDATA to ``handle_comment``.

--- a/docs/changelog/182.feature.rst
+++ b/docs/changelog/182.feature.rst
@@ -1,7 +1,4 @@
-Add an opt-in content-based encoding detection step to :func:`turbohtml.parse`: ``parse(data, detect_encoding=True)``
-guesses the encoding of a declaration-less byte stream the way Firefox's ``chardetng`` does. It runs strictly after the
-WHATWG sniffing steps (a BOM, the ``encoding`` argument, then the ``<meta>`` prescan) and only when those yield no
-encoding, so a declared, ``<meta>``, or BOM encoding always wins and the default behavior is unchanged. Detection covers
-UTF-8, the legacy single-byte families (Latin, Cyrillic, Greek, Arabic, Hebrew, Baltic, Thai), and the CJK multi-byte
-encodings (GBK, Big5, Shift_JIS, EUC-JP, EUC-KR, ISO-2022-JP). This closes the last gap for replacing BeautifulSoup's
-``UnicodeDammit`` without a separate ``charset-normalizer``/``chardet`` install.
+Detect the encoding of a declaration-less byte stream with :func:`turbohtml.parse` and ``detect_encoding=True``, which
+guesses the way Firefox's ``chardetng`` does. It runs only after the WHATWG sniffing steps yield no encoding, so a
+declared, ``<meta>``, or BOM encoding always wins. Detection covers UTF-8, the legacy single-byte families, and the CJK
+multi-byte encodings. It replaces BeautifulSoup's ``UnicodeDammit`` without a separate install.

--- a/docs/changelog/189.bugfix.rst
+++ b/docs/changelog/189.bugfix.rst
@@ -1,5 +1,3 @@
-Treat a present-but-empty DOCTYPE system identifier the same as a missing one when deciding quirks mode for the
-``-//W3C//DTD HTML 4.01 Frameset//`` and ``-//W3C//DTD HTML 4.01 Transitional//`` public identifiers, as the WHATWG
-initial insertion mode requires ("the system identifier is missing or the empty string"). ``<!DOCTYPE html PUBLIC
-"-//W3C//DTD HTML 4.01 Frameset//EN" "">`` now enters quirks mode; only a non-empty system identifier downgrades these
-to limited-quirks.
+A DOCTYPE with an empty system identifier now triggers quirks mode for the HTML 4.01 Frameset and Transitional public
+identifiers, as the WHATWG spec requires, so ``<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "">`` enters
+quirks mode; only a non-empty system identifier downgrades to limited-quirks.

--- a/docs/changelog/194.feature.rst
+++ b/docs/changelog/194.feature.rst
@@ -1,23 +1,5 @@
-Complete the XPath 1.0 core function library with ``id()``, ``namespace-uri()``, and ``lang()``. On an HTML document
-``lang()`` honors the HTML ``lang`` attribute and ``namespace-uri()`` reports the SVG and MathML namespace for foreign
-content, where ``lxml``'s legacy HTML parser returns nothing for both.
-
-Bind ``$name`` variables by passing them as keyword arguments to :meth:`~turbohtml.Node.xpath`,
-:meth:`~turbohtml.Node.xpath_one`, and :meth:`~turbohtml.Node.xpath_iter` (a ``str``, ``int``, ``float``, or ``bool``
-each), so ``doc.xpath("//a[@href=$url]", url=target)`` keeps the value out of the expression string the way ``lxml`` and
-``parsel`` do.
-
-Support the EXSLT regular-expression functions ``re:test`` and ``re:replace`` that ``parsel`` and ``scrapy`` enable by
-default, so a predicate like ``//a[re:test(@href, '\\d+$', 'i')]`` ports across. The ``re:`` prefix dispatches to
-Python's :mod:`re`, with the EXSLT flag letters (``i``, ``m``, ``s``, ``x``, and ``g`` for a global replace) honored.
-
-Pass ``smart_strings=True`` to get :class:`~turbohtml.XPathString` results, ``str`` subclasses that remember the element
-an attribute or ``text()`` value came from, the way ``lxml``'s smart strings do: ``result.getparent()`` returns the
-element and ``result.is_attribute`` / ``result.attrname`` identify the source. The default stays a plain ``str`` (the
-fast path ``parsel`` also chooses).
-
-Register custom XPath functions with ``extensions={(None, name): callable}``, like ``lxml``. The callable receives a
-context whose ``context_node`` is the current element and the evaluated arguments (a node-set as a list of elements, a
-string/number/boolean as the matching Python value), and returns a ``str``, number, or ``bool``. Calling a Python
-function from the evaluator runs outside the all-C fast path, so reserve it for what the built-in library cannot
-express.
+Round out the XPath engine: the core library gains ``id()``, ``namespace-uri()``, and ``lang()``; bind ``$name``
+variables as keyword arguments to :meth:`~turbohtml.Node.xpath` (and its ``_one``/``_iter`` siblings); use the EXSLT
+``re:test``/``re:replace`` functions parsel and scrapy enable; opt into ``lxml``-style :class:`~turbohtml.XPathString`
+smart strings with ``smart_strings=True``; and register custom functions with ``extensions={(None, name): callable}``.
+The ``lxml`` and ``parsel`` expressions port across.

--- a/docs/changelog/208.doc.rst
+++ b/docs/changelog/208.doc.rst
@@ -1,4 +1,3 @@
-Benchmark :class:`turbohtml.migration.stdlib.HTMLParser` against the standard library's
-:class:`python:html.parser.HTMLParser`. A new ``htmlparser`` suite in the benchmark harness (``tox -e bench
-htmlparser``) drives both through the same minimal handler, and the performance page records the result: the adapter
-runs three to four times faster on the same callback-driven workload.
+The performance page now benchmarks :class:`turbohtml.migration.stdlib.HTMLParser` against the standard library's
+:class:`python:html.parser.HTMLParser`, recording that the adapter runs three to four times faster on the same
+callback-driven workload.

--- a/docs/changelog/210.feature.rst
+++ b/docs/changelog/210.feature.rst
@@ -1,5 +1,4 @@
-Add :class:`turbohtml.IncrementalParser`, a push parser that builds a :class:`~turbohtml.Document` from chunks fed with
-``feed`` and finished with ``close``. A chunk is ``str`` or ``bytes`` (decoded through a stateful incremental codec for
-the parser's ``encoding``, so a multi-byte character split across a chunk boundary decodes correctly), and the resulting
-tree is identical to parsing the joined input with :func:`turbohtml.parse`. The tokenizer reclaims the input it has
-consumed on every feed, so a document arriving over a stream never has to be held whole in memory.
+Parse a document arriving over a stream with :class:`turbohtml.IncrementalParser`, a push parser that builds a
+:class:`~turbohtml.Document` from ``str`` or ``bytes`` chunks fed with ``feed`` and finished with ``close``. The tree is
+identical to :func:`turbohtml.parse` on the joined input, and consumed input is reclaimed each feed so the document
+never has to be held whole in memory.

--- a/docs/changelog/211.feature.rst
+++ b/docs/changelog/211.feature.rst
@@ -1,6 +1,4 @@
-Surface the WHATWG parse errors the recovery algorithm used to swallow. :func:`~turbohtml.parse` now records each error
-it recovered from on :attr:`~turbohtml.Document.errors`, a list of :class:`~turbohtml.ParseError` carrying the spec
-``code`` and the source position (1-based ``line``, 0-based ``col``, as for :class:`~turbohtml.Token`). Collection costs
-nothing on well-formed input and leaves the standalone :func:`~turbohtml.tokenize`/:class:`~turbohtml.Tokenizer` stream
-untouched. Passing ``strict=True`` raises the first error as :class:`~turbohtml.HTMLParseError` -- with the
-``ParseError`` on its ``error`` attribute -- instead of returning a recovered tree.
+Inspect the WHATWG parse errors recovery used to swallow: :func:`~turbohtml.parse` records each on
+:attr:`~turbohtml.Document.errors` as a :class:`~turbohtml.ParseError` carrying the spec ``code`` and source position.
+Collection costs nothing on well-formed input, and ``strict=True`` instead raises the first as
+:class:`~turbohtml.HTMLParseError`.

--- a/docs/changelog/212.feature.rst
+++ b/docs/changelog/212.feature.rst
@@ -1,12 +1,5 @@
-Every parsed element now records where its start tag began in the source, read through
-:attr:`~turbohtml.Node.source_line`, :attr:`~turbohtml.Node.source_col`, and the :attr:`~turbohtml.Node.position` pair,
-so error locators, linters, and source-mapping tools can point back at the original markup the way ``lxml``'s
-``sourceline`` and ``BeautifulSoup``'s ``sourceline``/``sourcepos`` do. The line is 1-based and the column 0-based,
-matching :meth:`python:html.parser.HTMLParser.getpos` and the existing
-:attr:`turbohtml.Token.line`/:attr:`~turbohtml.Token.col`, so a value migrated from either is identical. The position
-rides in two compact words appended to each element node only while tracking is on; nodes with no source -- a text or
-comment node, an implied ``html``/``head``/``body``, a fragment root, or a hand-built element -- read ``None``.
-
-Tracking is on by default. Pass ``positions=False`` to :func:`turbohtml.parse`, :func:`turbohtml.parse_fragment`, or
-``IncrementalParser`` to drop it when memory or parse speed matters more than source locations, after which the
-accessors read ``None``.
+Read where each element's start tag began in the source through :attr:`~turbohtml.Node.source_line`,
+:attr:`~turbohtml.Node.source_col`, and the :attr:`~turbohtml.Node.position` pair, so error locators, linters, and
+source-mapping tools can point back at the original markup the way ``lxml`` and ``BeautifulSoup`` expose ``sourceline``.
+Tracking is on by default; pass ``positions=False`` to :func:`turbohtml.parse` to drop it when memory or speed matters
+more.

--- a/docs/changelog/213.feature.rst
+++ b/docs/changelog/213.feature.rst
@@ -1,6 +1,4 @@
-Give :class:`turbohtml.Tokenizer` and :func:`turbohtml.tokenize` two opt-in surfaces. With ``resolve_references=False``
-each character reference in text becomes its own ``TokenType.CHARACTER_REFERENCE`` token (``token.data`` the resolved
-value, ``token.source`` the verbatim ``&...;``) instead of folding into the surrounding text run; attribute-value
-references stay decoded. With ``capture_source=True`` every markup token records the verbatim source slice it came from
-as ``token.source`` (the raw ``<a href=...>`` of a start tag, a comment, or a DOCTYPE). Both default off, so the
-existing token stream is byte-for-byte unchanged - by :user:`gaborbernat`.
+:class:`turbohtml.Tokenizer` and :func:`turbohtml.tokenize` gain two opt-in flags: ``resolve_references=False`` emits
+each character reference as its own ``TokenType.CHARACTER_REFERENCE`` token, and ``capture_source=True`` records each
+token's raw source on ``token.source``. Both default off, so the existing token stream is unchanged - by
+:user:`gaborbernat`.

--- a/docs/changelog/214.feature.rst
+++ b/docs/changelog/214.feature.rst
@@ -1,3 +1,3 @@
-Scrub the ``style`` attribute in the sanitizer: when ``style`` is an allowed attribute, each CSS declaration whose
-property name is not in ``Policy.css_properties`` (a safe default set) is dropped, so dangerous inline CSS cannot ride
-in on a kept ``style`` - by :user:`gaborbernat`.
+Scrub the inline ``style`` attribute in the sanitizer: when ``style`` is allowed, any CSS declaration whose property is
+not in ``Policy.css_properties`` is dropped, so dangerous inline CSS cannot ride in on a kept ``style`` - by
+:user:`gaborbernat`.

--- a/docs/changelog/218.feature.rst
+++ b/docs/changelog/218.feature.rst
@@ -1,5 +1,3 @@
 Add a ``converters`` keyword to :meth:`~turbohtml.Node.to_markdown`: a mapping from a lowercased tag name to a
-``callable(element, content) -> str`` that replaces how that tag renders. The callable receives the
-:class:`~turbohtml.Element` and the already-converted Markdown of its children and returns the element's Markdown, so a
-custom element or a one-off rule needs no subclass. It is the clean-break answer to ``markdownify``'s ``convert_<tag>``
-handlers, dispatched entirely in C and free unless a tag is registered.
+``callable(element, content) -> str`` that replaces how that tag renders, so a custom element or a one-off rule needs no
+subclass. It is the clean-break answer to ``markdownify``'s ``convert_<tag>`` handlers.

--- a/docs/changelog/219.feature.rst
+++ b/docs/changelog/219.feature.rst
@@ -1,4 +1,3 @@
-Add three output modes to :meth:`~turbohtml.Node.to_markdown`: ``wrap_width`` word-wraps prose at a column (with
-``wrap_list_items`` and ``wrap_links`` to tune it), ``image_mode="html"`` and ``table_mode="html"`` pass an ``<img>`` or
-``<table>`` element through verbatim, and ``transliterate`` folds common non-ASCII typography in prose to ASCII - by
-:user:`gaborbernat`.
+Add three output modes to :meth:`~turbohtml.Node.to_markdown`: ``wrap_width`` word-wraps prose at a column,
+``image_mode="html"`` and ``table_mode="html"`` pass an ``<img>`` or ``<table>`` through verbatim, and ``transliterate``
+folds common non-ASCII typography to ASCII - by :user:`gaborbernat`.

--- a/docs/changelog/221.feature.rst
+++ b/docs/changelog/221.feature.rst
@@ -1,4 +1,3 @@
 Add two output options to :meth:`~turbohtml.Node.serialize` and :meth:`~turbohtml.Node.encode`: ``sort_attributes``
 emits each start tag's attributes in ascending name order for deterministic diffs, and ``meta_charset`` ensures the
-document ``<head>`` declares the output encoding, normalizing an existing ``<meta charset>`` or injecting one. Both
-compose with every ``formatter`` and ``layout`` - by :user:`gaborbernat`.
+document ``<head>`` declares the output encoding - by :user:`gaborbernat`.

--- a/docs/changelog/222.feature.rst
+++ b/docs/changelog/222.feature.rst
@@ -1,5 +1,4 @@
 Add :class:`turbohtml.linkify.Detector`, a plain-text link detector that complements the HTML-aware
 :func:`~turbohtml.linkify.linkify`. ``Detector().find(text)`` returns a :class:`~turbohtml.linkify.LinkSpan` for every
-URL and email address, with its offsets, matched text, and normalized ``url``; ``has_link(text)`` answers the cheaper
-presence question. The detector accepts custom ``tlds`` for bare-domain matching and custom scheme-less ``schemes``
-(such as ``tel`` or ``bitcoin``), reusing the same C scanner that powers ``linkify``.
+URL and email address (with offsets, matched text, and a normalized ``url``), while ``has_link(text)`` answers the
+cheaper presence question; custom ``tlds`` and ``schemes`` extend matching.

--- a/docs/changelog/223.feature.rst
+++ b/docs/changelog/223.feature.rst
@@ -1,6 +1,4 @@
-Extend :func:`turbohtml.linkify.linkify` and :class:`turbohtml.linkify.Linker` with three keyword-only hooks.
-``process_existing`` runs the callbacks over ``<a>`` tags already in the input, not only freshly detected links; a
-callback reads the new ``Link.existing`` flag to tell an author's anchor from a detected one, and vetoing an existing
-anchor unwraps it to its contents. ``extra_tlds`` adds top-level domains that make a bare domain a link on top of the
-built-in IANA table, threaded into the C scanner as a lock-free frozenset probe. ``schemes`` restricts which
-explicit-scheme URLs autolink, leaving an unlisted scheme as plain text.
+Extend :func:`turbohtml.linkify.linkify` and :class:`turbohtml.linkify.Linker` with three keyword-only hooks:
+``process_existing`` runs the callbacks over ``<a>`` tags already in the input (vetoing one unwraps it to its contents),
+``extra_tlds`` adds top-level domains that make a bare domain a link, and ``schemes`` restricts which explicit-scheme
+URLs autolink.

--- a/docs/changelog/224.feature.rst
+++ b/docs/changelog/224.feature.rst
@@ -1,6 +1,5 @@
-Add the :meth:`~turbohtml.Node.links`, :meth:`~turbohtml.Node.rewrite_links`, and :meth:`~turbohtml.Node.resolve_links`
-node methods. :meth:`~turbohtml.Node.links` enumerates every link in a node's subtree as :class:`~turbohtml.Link`
-records -- including the URLs embedded in CSS ``url()``/``@import``, a ``<meta http-equiv=refresh>`` redirect, and the
-``srcset``/``ping``/``archive`` list attributes -- while :meth:`~turbohtml.Node.resolve_links` rewrites them absolute
-against a base URL and :meth:`~turbohtml.Node.rewrite_links` applies an arbitrary function, all in a single C tree walk
-- by :user:`gaborbernat`.
+Add the :meth:`~turbohtml.Node.links`, :meth:`~turbohtml.Node.resolve_links`, and :meth:`~turbohtml.Node.rewrite_links`
+methods: :meth:`~turbohtml.Node.links` enumerates every link in a subtree as :class:`~turbohtml.Link` records (including
+CSS ``url()``/``@import``, a ``<meta http-equiv=refresh>`` redirect, and ``srcset``/``ping``/``archive`` lists), while
+``resolve_links`` rewrites them absolute against a base URL and ``rewrite_links`` applies an arbitrary function - by
+:user:`gaborbernat`.

--- a/docs/changelog/225.feature.rst
+++ b/docs/changelog/225.feature.rst
@@ -1,4 +1,4 @@
 Add form-field helpers to ``Element``: ``field_value`` reads and writes a control's value with form semantics (input,
 textarea, option, and single/multiple ``select``), ``checked`` reads and sets a checkbox or radio with radio-group
-exclusivity, and ``form_data`` serializes a ``<form>``'s successful controls to a list of ``(name, value)`` pairs
-following the WHATWG submission rules - by :user:`gaborbernat`.
+exclusivity, and ``form_data`` serializes a ``<form>``'s successful controls to ``(name, value)`` pairs following the
+WHATWG submission rules - by :user:`gaborbernat`.

--- a/docs/changelog/226.feature.rst
+++ b/docs/changelog/226.feature.rst
@@ -1,3 +1,3 @@
-Add the :meth:`~turbohtml.Document.base_url` and :meth:`~turbohtml.Document.meta_refresh` methods on
-:class:`~turbohtml.Document`, the two ``w3lib.html`` helpers that read a document's own URL hints (its ``<base href>``
-and a ``<meta http-equiv=refresh>``) and resolve them against a fallback base URL - by :user:`gaborbernat`.
+Add :meth:`~turbohtml.Document.base_url` and :meth:`~turbohtml.Document.meta_refresh` on :class:`~turbohtml.Document`,
+the two ``w3lib.html`` helpers that read a document's own URL hints (its ``<base href>`` and a ``<meta
+http-equiv=refresh>``) and resolve them against a fallback base URL - by :user:`gaborbernat`.

--- a/docs/changelog/227.doc.rst
+++ b/docs/changelog/227.doc.rst
@@ -1,2 +1,2 @@
-Add a "Not yet ported / limitations" note to each migration section, dropping the stale gaps (lxml/html5-parser XPath,
+Refresh each migration section's "Not yet ported / limitations" note, dropping the stale gaps (lxml/html5-parser XPath,
 markdownify per-tag converters) that recent features now cover.

--- a/docs/changelog/246.feature.rst
+++ b/docs/changelog/246.feature.rst
@@ -1,6 +1,4 @@
 Add parsel-style string extraction: :meth:`~turbohtml.Element.attr` returns an attribute as a single raw string (so
-``class`` reads back as ``"a b c"`` rather than a token list) or a default when absent, and :meth:`~turbohtml.Node.re` /
-:meth:`~turbohtml.Node.re_first` run a regular expression over a node's text -- or over an attribute value with the
-``attr=`` keyword -- yielding the lone capturing group when the pattern has one and the whole match otherwise, the same
-group rule Scrapy's ``parsel`` uses. The pattern may be a ``str`` or a compiled :class:`re.Pattern`, and a whole
-selection extracts with a comprehension such as ``[a.attr("href") for a in doc.select("a")]`` - by :user:`gaborbernat`.
+``class`` reads back as ``"a b c"``) or a default when absent, and :meth:`~turbohtml.Node.re` /
+:meth:`~turbohtml.Node.re_first` run a regex over a node's text (or an attribute value via ``attr=``), yielding the lone
+capturing group or the whole match, like Scrapy's ``parsel`` - by :user:`gaborbernat`.

--- a/docs/changelog/247.feature.rst
+++ b/docs/changelog/247.feature.rst
@@ -1,6 +1,5 @@
-Add two bulk-wrap structural edits, the in-place counterpart of pyquery's ``.wrap_all``.
-:meth:`~turbohtml.Element.wrap_children` moves every child of an element into one new wrapper element and makes the
-wrapper the sole child; :meth:`~turbohtml.Node.wrap_siblings` wraps a node and the contiguous run of siblings that
-follow it -- through an ``until`` node or to the last sibling -- in one new element, placed where the run began. Both
-take a fresh wrapper element and return it, mirroring :meth:`~turbohtml.Node.wrap`, and run entirely in the C core under
-the per-tree critical section - by :user:`gaborbernat`.
+Add two bulk-wrap structural edits, the in-place counterpart of pyquery's ``.wrap_all``:
+:meth:`~turbohtml.Element.wrap_children` moves every child of an element into one new wrapper, and
+:meth:`~turbohtml.Node.wrap_siblings` wraps a node and the contiguous run of siblings that follow it, through an
+``until`` node or to the last sibling, in one element. Both return the wrapper, mirroring :meth:`~turbohtml.Node.wrap` -
+by :user:`gaborbernat`.

--- a/docs/changelog/248.feature.rst
+++ b/docs/changelog/248.feature.rst
@@ -1,4 +1,4 @@
 Add ``strip`` and ``convert`` keywords to :meth:`~turbohtml.Node.to_markdown`, the mutually exclusive tag filters
-``markdownify`` exposes under the same names: ``strip`` names tags whose markup is dropped while their text stays, and
-``convert`` names the only tags to keep markup for, dropping every other tag's. A name outside the tag table is ignored,
-and ``<script>``/``<style>``/``<head>`` still vanish whole - by :user:`gaborbernat`.
+``markdownify`` exposes: ``strip`` names tags whose markup is dropped while their text stays, and ``convert`` names the
+only tags to keep markup for. A name outside the tag table is ignored, and ``<script>``/``<style>``/``<head>`` still
+vanish whole - by :user:`gaborbernat`.

--- a/docs/changelog/249.feature.rst
+++ b/docs/changelog/249.feature.rst
@@ -1,5 +1,4 @@
-Add the :meth:`~turbohtml.Node.main_content` and :meth:`~turbohtml.Node.main_text` node methods, the ``resiliparse``
-main-content extractor role. :meth:`~turbohtml.Node.main_content` returns the dominant article element under a node --
-navigation, sidebars, advertising and comment boilerplate scored out by a content-density (readability) heuristic run
-entirely in C -- or ``None`` when nothing reads as content, and :meth:`~turbohtml.Node.main_text` renders that element
-with :meth:`~turbohtml.Node.to_text` - by :user:`gaborbernat`.
+Add :meth:`~turbohtml.Node.main_content` and :meth:`~turbohtml.Node.main_text`, the ``resiliparse`` main-content
+extractor role. :meth:`~turbohtml.Node.main_content` returns the dominant article element under a node, or ``None``; a
+content-density readability heuristic scores out navigation, sidebars, advertising, and comment boilerplate.
+:meth:`~turbohtml.Node.main_text` renders that element with :meth:`~turbohtml.Node.to_text` - by :user:`gaborbernat`.

--- a/docs/changelog/251.feature.rst
+++ b/docs/changelog/251.feature.rst
@@ -1,4 +1,4 @@
-Add the inscriptis annotation output processors as pure transforms over the ``(text, spans)`` pair
+Add the inscriptis annotation output processors over the ``(text, spans)`` pair
 :meth:`~turbohtml.Node.to_annotated_text` returns: :func:`turbohtml.annotation_surface` groups each label's matched
 substrings into a dict in document order, and :func:`turbohtml.annotation_tags` weaves the spans back into the text as
 inline ``<label>...</label>`` markup, closing the innermost span first so nested spans stay well-formed - by

--- a/docs/changelog/252.feature.rst
+++ b/docs/changelog/252.feature.rst
@@ -1,5 +1,4 @@
 Add :meth:`~turbohtml.Node.prune`, which trims a parsed tree to a CSS selector: it keeps every descendant matching the
-selector together with their ancestors and the whole subtree under each match, and removes everything else in place,
-returning the node. This is the post-parse equivalent of BeautifulSoup's ``SoupStrainer`` -- parse the whole document
-the WHATWG way, then collapse a large document to just the parts of interest in one locked, free-threading-safe C pass -
+selector together with their ancestors and subtrees, removes everything else in place, and returns the node. This is the
+post-parse equivalent of BeautifulSoup's ``SoupStrainer``: it collapses a large document to just the parts of interest -
 by :user:`gaborbernat`.

--- a/docs/changelog/32.bugfix.rst
+++ b/docs/changelog/32.bugfix.rst
@@ -1,4 +1,3 @@
-Place the implied ``<p>`` from an unmatched ``</p>`` end tag in foreign (SVG or MathML) content inside the foreign
-element rather than as a sibling under ``<body>``. The WHATWG tree construction algorithm's "any other end tag" rule for
-foreign content pops nothing and reprocesses the token in the current insertion mode with the foreign element still
-current, so ``<svg></p>`` now builds ``<svg><p></p></svg>``, matching lexbor and html5lib.
+An unmatched ``</p>`` end tag inside foreign (SVG or MathML) content now places its implied ``<p>`` inside the foreign
+element rather than as a sibling under ``<body>``, so ``<svg></p>`` builds ``<svg><p></p></svg>``, matching lexbor and
+html5lib.

--- a/docs/changelog/33.bugfix.rst
+++ b/docs/changelog/33.bugfix.rst
@@ -1,3 +1,2 @@
-Serialize ``frame`` as a void element, emitting only its start tag. The WHATWG fragment-serialization algorithm lists
-``frame`` among the void elements that take no end tag, so ``turbohtml.parse('<frameset><frame>').serialize()`` no
-longer appends a spurious ``</frame>``.
+Serializing ``frame`` no longer appends a spurious ``</frame>``; it is a void element, so
+``turbohtml.parse('<frameset><frame>').serialize()`` emits only its start tag.

--- a/docs/changelog/34.bugfix.rst
+++ b/docs/changelog/34.bugfix.rst
@@ -1,4 +1,2 @@
-Keep the underscore in a host label when linkifying. ``turbohtml.linkify`` stopped scanning a host at ``_``, so a URL
-like ``https://cdn_1.example.org/x`` lost its ``cdn_`` label and scheme and was rewritten to an anchor pointing at a
-different host (``http://1.example.org/x``) that never appeared in the input. Underscore is an RFC 3986 unreserved
-character, valid anywhere in a reg-name host (``_dmarc``, ``cdn_1``), so the whole URL is now linked as written.
+Linkifying a URL with an underscore in its host (e.g. ``https://cdn_1.example.org/x``) no longer truncates the host and
+rewrites it to a different one; underscore is valid in a host label, so the whole URL is now linked as written.

--- a/docs/changelog/35.bugfix.rst
+++ b/docs/changelog/35.bugfix.rst
@@ -1,4 +1,3 @@
-Ignore a stray end tag in the "before html" insertion mode instead of opening ``<html>`` on it.
-``parse("</x><!--c-->")`` now keeps the comment as a Document-level child before ``<html>``, matching the WHATWG
-tree-construction rule that "any other end tag" before ``<html>`` is a parse error that is ignored without creating the
-``html`` element. Previously the ignored end tag prematurely opened ``<html>``, nesting the following comment inside it.
+A stray end tag in the "before html" insertion mode is now ignored instead of opening ``<html>``, so
+``parse("</x><!--c-->")`` keeps the following comment as a Document-level child before ``<html>``, matching the WHATWG
+tree-construction rule.

--- a/docs/changelog/38.bugfix.rst
+++ b/docs/changelog/38.bugfix.rst
@@ -1,5 +1,3 @@
-Drop a URL attribute entirely when a duplicate of it carries a disallowed scheme. ``Sanitizer`` checked each ``href``
-value in isolation and removed a rejected one by name, which deleted the first (benign) occurrence and left the
-dangerous duplicate as the lone attribute, so ``<a href='http://ok' href='javascript:alert(1)'>`` survived sanitizing
-with a live ``javascript:`` link. Every occurrence of a URL attribute whose value fails the scheme policy is now
-removed, closing the duplicate-attribute desync and restoring ``sanitize(sanitize(x)) == sanitize(x)``.
+The sanitizer now drops every occurrence of a URL attribute whose value fails the scheme policy, not just the one
+matched by name, so ``<a href='http://ok' href='javascript:alert(1)'>`` no longer survives with a live ``javascript:``
+link, restoring ``sanitize(sanitize(x)) == sanitize(x)``.

--- a/docs/changelog/40.bugfix.rst
+++ b/docs/changelog/40.bugfix.rst
@@ -1,4 +1,2 @@
-Serialize arbitrarily deep trees without overflowing the C stack. The compact, pretty, and ``#document`` serializers
-each recursed once per tree level, so reading ``.html`` (or ``serialize()``) on a tree nested past roughly 130k levels
-aborted the process instead of raising. The walks now descend through child pointers and ascend through parent pointers
-iteratively, using constant stack regardless of depth.
+Serializing a deeply nested tree no longer aborts the process; ``.html`` and ``serialize()`` now handle trees nested
+past roughly 130k levels and raise instead of overflowing the stack.

--- a/docs/changelog/41.bugfix.rst
+++ b/docs/changelog/41.bugfix.rst
@@ -1,5 +1,2 @@
-Apply the WHATWG "adjust MathML attributes" step so a MathML ``definitionurl`` attribute is cased to ``definitionURL``
-in the parsed tree and every serialization, not only the ``#document`` debug format. ``parse_fragment("<math
-definitionURL=x></math>", "body")`` now reports ``definitionURL`` in ``Element.attrs`` and ``inner_html``, matching
-html5lib. Attribute lookups on foreign (MathML/SVG) elements stay case-insensitive, so ``math.attrs["definitionURL"]``
-and ``math.attrs["definitionurl"]`` both resolve.
+A MathML ``definitionurl`` attribute is now cased to ``definitionURL`` in ``Element.attrs``, ``inner_html``, and every
+serialization, matching html5lib; lookups on foreign elements stay case-insensitive.

--- a/docs/changelog/42.bugfix.rst
+++ b/docs/changelog/42.bugfix.rst
@@ -1,5 +1,2 @@
-Synthesize the implicit ``head`` and ``body`` for a ``parse_fragment(context="html")`` fragment at end of input. An
-html-context fragment starts in the "before head" insertion mode, so the WHATWG missing-element rules run on EOF and a
-``head`` and ``body`` are always present even when no token forces them: ``""`` now yields an empty ``head`` and
-``body``, ``"<title>t</title>"`` yields ``head`` plus an empty ``body``, and a leading comment is kept before the
-synthesized pair.
+A ``parse_fragment(context="html")`` fragment now always synthesizes the implicit ``head`` and ``body``, so even an
+empty or head-only fragment yields both elements, matching html5lib.

--- a/docs/changelog/43.bugfix.rst
+++ b/docs/changelog/43.bugfix.rst
@@ -1,6 +1,3 @@
-Apply the WHATWG "adjust SVG attributes" step so SVG attribute names such as ``viewbox``, ``attributename``,
-``basefrequency``, ``gradienttransform``, and ``textlength`` are cased back to ``viewBox``, ``attributeName``,
-``baseFrequency``, ``gradientTransform``, and ``textLength`` in the parsed tree and every serialization, not only the
-``#document`` debug format. ``Element.attrs`` and ``inner_html`` now report the cased names, matching html5lib, and
-attribute lookups on foreign (SVG/MathML) elements stay case-insensitive, so ``svg.attrs["viewBox"]`` and
-``svg.attrs["viewbox"]`` both resolve.
+SVG attribute names such as ``viewbox`` and ``attributename`` are now cased back to ``viewBox`` and ``attributeName`` in
+``Element.attrs``, ``inner_html``, and every serialization, matching html5lib; lookups on foreign elements stay
+case-insensitive.

--- a/docs/changelog/44.bugfix.rst
+++ b/docs/changelog/44.bugfix.rst
@@ -1,5 +1,3 @@
-Return to the "in table" insertion mode after a RCDATA/RAWTEXT element (``textarea``, ``title``, ``xmp``) is
-foster-parented out of a ``<table>``. The element was processed under the in-body rules, which saved "in body" as the
-original insertion mode, so closing it dropped the following ``<tr>``/``<td>`` and pushed trailing text straight into
-the table. The saved mode now follows the active table mode, so ``parse("<table><textarea></textarea><tr><td>x")``
-builds the expected ``table > tbody > tr > td`` structure, matching html5lib.
+A RCDATA/RAWTEXT element such as ``<textarea>`` foster-parented out of a ``<table>`` no longer drops the following
+``<tr>``/``<td>``, so ``parse("<table><textarea></textarea><tr><td>x")`` builds the expected table structure, matching
+html5lib.

--- a/docs/changelog/45.bugfix.rst
+++ b/docs/changelog/45.bugfix.rst
@@ -1,3 +1,2 @@
-Discard a duplicate attribute name during tokenization, keeping the first occurrence as the WHATWG specification
-requires, so ``<a href=x href=y>`` now carries a single ``href`` of ``x`` in the token, the parsed tree, and the
-serialized output.
+A duplicate attribute name now keeps its first occurrence per the WHATWG specification, so ``<a href=x href=y>`` carries
+a single ``href`` of ``x`` in the token, tree, and serialized output.

--- a/docs/changelog/46.bugfix.rst
+++ b/docs/changelog/46.bugfix.rst
@@ -1,5 +1,2 @@
-Keep head-only elements in ``<head>`` after a redundant ``<html>`` or duplicate ``<head>`` start tag. Such a tag in the
-"before head"/"in head" insertion modes prematurely left head mode, so a following ``style``, ``meta``, ``link``,
-``base``, or ``title`` was inserted into ``<body>``. Per the WHATWG tree-construction algorithm a redundant ``<html>``
-start tag merges its attributes onto the open ``<html>`` without changing the mode, and a duplicate ``<head>`` start tag
-is an ignored parse error; both now leave subsequent head content in ``<head>``.
+A redundant ``<html>`` or duplicate ``<head>`` start tag no longer leaves head mode early, so a following ``style``,
+``meta``, ``link``, ``base``, or ``title`` stays in ``<head>`` instead of landing in ``<body>``, matching html5lib.

--- a/docs/changelog/47.bugfix.rst
+++ b/docs/changelog/47.bugfix.rst
@@ -1,5 +1,2 @@
-Treat the MathML and SVG integration points (``mi``, ``mo``, ``mn``, ``ms``, ``mtext``, ``foreignObject``, ``desc``,
-``title``) as scope boundaries in the adoption agency's in-scope check. A formatting end tag separated from the current
-node by one of these foreign elements wrongly ran the adoption agency, splitting the foreign subtree out to ``<body>``;
-``parse("<b><math><mi></b>")`` now keeps ``mi`` nested as ``<b><math><mi></mi></math></b>`` and ignores the unmatched
-``</b>``, matching html5lib and lexbor.
+A formatting end tag no longer breaks out of a MathML or SVG integration point, so ``parse("<b><math><mi></b>")`` keeps
+``mi`` nested as ``<b><math><mi></mi></math></b>`` and ignores the unmatched ``</b>``, matching html5lib and lexbor.

--- a/docs/changelog/48.bugfix.rst
+++ b/docs/changelog/48.bugfix.rst
@@ -1,3 +1,2 @@
-Report a nameless ``<!DOCTYPE>``'s name as ``None`` from the public ``Token.name`` instead of an empty string. The
-WHATWG tokenizer treats a DOCTYPE name as "missing", a state distinct from the empty string, so a DOCTYPE that never
-enters the name state now surfaces ``None``, matching the internal tuple path and the html5lib-tests oracle.
+A nameless ``<!DOCTYPE>`` now reports its ``Token.name`` as ``None`` rather than an empty string, keeping a missing
+DOCTYPE name distinct from an empty one and matching the html5lib-tests oracle.

--- a/docs/changelog/49.bugfix.rst
+++ b/docs/changelog/49.bugfix.rst
@@ -1,5 +1,3 @@
-Ignore a stray ``<!DOCTYPE>`` encountered after the "initial" insertion mode without changing the insertion mode, per
-the WHATWG tree-construction rules. A second DOCTYPE previously drove the parser into the "in body" mode, fabricating a
-``<p>``, leaking leading whitespace into ``<body>``, and misplacing a leading comment inside ``<body>``;
-``parse("<!doctype html><!doctype><!--c-->")`` now keeps the comment before ``<html>`` with an empty body, matching
+A stray second ``<!DOCTYPE>`` is now ignored instead of fabricating a ``<p>`` and leaking content into ``<body>``, so
+``parse("<!doctype html><!doctype><!--c-->")`` keeps the comment before ``<html>`` with an empty body, matching
 html5lib.

--- a/docs/changelog/50.bugfix.rst
+++ b/docs/changelog/50.bugfix.rst
@@ -1,4 +1,2 @@
-Accept CSS escape sequences in :meth:`~turbohtml.Node.select`/:meth:`~turbohtml.Node.select_one` identifiers. A
-backslash escape (``.foo\:bar``, ``#ab``) and a hex code-point escape (``.\A9``, ``.\0000A9``) in a class, id, type, or
-attribute-name selector are decoded per CSS Syntax Module 4.3.7 instead of raising ``ValueError('invalid CSS
-selector')``, so spec-valid selectors that name characters like ``:`` or ``.`` inside an identifier now match.
+:meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.select_one` now decode CSS escape sequences in identifiers, so
+spec-valid selectors like ``.foo\:bar`` and ``.\A9`` match instead of raising ``ValueError('invalid CSS selector')``.

--- a/docs/changelog/53.bugfix.rst
+++ b/docs/changelog/53.bugfix.rst
@@ -1,6 +1,3 @@
-End an auto-linked URL at non-ASCII Unicode whitespace in :func:`turbohtml.linkify.linkify`. A no-break space
-(``U+00A0``/``&nbsp;``), an ideographic space (``U+3000``), and the other Unicode ``White_Space`` code points are
-forbidden in host labels by UTS46 and bound a URL the way an ASCII space does, matching bleach and linkify-it-py;
-previously they were swallowed as host/URL characters, which over-linked a trailing word, dropped a link flanked by
-``&nbsp;``, or emitted a bare-domain anchor next to an orphaned scheme. Internationalized domains and zero-width format
-characters (ZWSP, BOM, word joiner) are unaffected.
+:func:`turbohtml.linkify.linkify` now ends an auto-linked URL at non-ASCII Unicode whitespace such as ``&nbsp;``
+(``U+00A0``) and the ideographic space (``U+3000``), matching bleach and linkify-it-py and no longer over-linking
+trailing words or dropping flanked links.

--- a/docs/changelog/54.bugfix.rst
+++ b/docs/changelog/54.bugfix.rst
@@ -1,5 +1,3 @@
-Recognize the WHATWG encoding labels the sniffer was missing instead of mis-decoding the document as windows-1252. The
-``iso-8859-3/4/6/8/8-i/10/13/14/16``, ``iso-2022-jp``, ``ibm866``, ``x-mac-cyrillic``, and ``x-user-defined`` families
-(with their spec aliases) now resolve, so ``parse(b'<meta charset=iso-8859-8>...')`` decodes byte ``0xE0`` to Hebrew
-alef rather than ``à``. ``x-user-defined`` has no CPython codec, so its bytes ``0x80``\ –\ ``0xFF`` are mapped to the
-private-use block ``U+F780``\ –\ ``U+F7FF`` directly, per the standard.
+The encoding sniffer now recognizes more WHATWG labels (``iso-8859-3/4/6/8/8-i/10/13/14/16``, ``iso-2022-jp``,
+``ibm866``, ``x-mac-cyrillic``, ``x-user-defined`` and their aliases), so a declared charset like ``iso-8859-8`` decodes
+correctly instead of falling back to windows-1252.

--- a/docs/changelog/55.bugfix.rst
+++ b/docs/changelog/55.bugfix.rst
@@ -1,5 +1,2 @@
-Foster-parent out to the fragment root when parsing a fragment whose context is a table-section element (``tbody``,
-``table``, ``tr``, ``thead``, ``tfoot``) and no ``table`` element is on the stack of open elements. The WHATWG
-appropriate-place algorithm's "no last table" branch inserts at the first element on the stack, so
-``parse_fragment("<tr><li>x", context="tbody")`` now yields ``<tr></tr><li>x</li>`` (the ``<li>`` a sibling after the
-row) instead of nesting the ``<li>`` inside the open ``<tr>``, matching html5lib. Document-path fostering is unchanged.
+A fragment whose context is a table-section element now foster-parents out to the fragment root when no ``table`` is
+open, so ``parse_fragment("<tr><li>x", context="tbody")`` makes the ``<li>`` a sibling after the row, matching html5lib.

--- a/docs/changelog/56.bugfix.rst
+++ b/docs/changelog/56.bugfix.rst
@@ -1,4 +1,2 @@
-Process a stray ``<html>`` start tag in the "in column group" insertion mode with the in-body rules (merge attributes
-onto the open ``<html>``, leave the stack alone) instead of routing it through the anything-else branch. Previously the
-stray tag popped the open ``<colgroup>``, so ``parse("<table><colgroup><col><html><col>")`` produced two colgroups; it
-now keeps one colgroup with both ``<col>`` children, matching html5lib.
+A stray ``<html>`` start tag inside a ``<colgroup>`` no longer closes it, so
+``parse("<table><colgroup><col><html><col>")`` keeps one colgroup with both ``<col>`` children, matching html5lib.

--- a/docs/changelog/58.bugfix.rst
+++ b/docs/changelog/58.bugfix.rst
@@ -1,4 +1,2 @@
-Keep an otherwise-whitespace ``<table>`` text run inside the table when it contains a U+0000. In the "in table text"
-insertion mode a NUL is a parse error that is dropped, but turbohtml treated the run as containing a non-whitespace
-character and foster-parented the whitespace out as a sibling before the table. The whitespace check now ignores NUL, so
-``parse("<table>\x00 ")`` keeps the space as a child of ``<table>``, matching html5lib.
+An otherwise-whitespace ``<table>`` text run containing a U+0000 now stays inside the table, so ``parse("<table>\x00
+")`` keeps the space as a child of ``<table>`` instead of foster-parenting it out, matching html5lib.

--- a/docs/changelog/59.bugfix.rst
+++ b/docs/changelog/59.bugfix.rst
@@ -1,6 +1,3 @@
-Compare the HTML case-insensitive attribute set case-insensitively in :meth:`~turbohtml.Node.select`/
-:meth:`~turbohtml.Node.select_one` by default. Per the WHATWG "case-sensitivity of selectors" rules, a selector on one
-of a fixed set of attributes (``type``, ``rel``, ``lang``, ``method``, ``charset``, ...) compares its value ASCII
-case-insensitively on HTML elements without an explicit ``i`` flag, so ``input[type=text]`` now matches ``type="TEXT"``.
-An explicit ``s`` flag still forces a case-sensitive comparison, and the default does not apply to foreign (SVG/MathML)
-elements.
+:meth:`~turbohtml.Node.select` and :meth:`~turbohtml.Node.select_one` now compare the WHATWG case-insensitive attribute
+set (``type``, ``rel``, ``lang``, ...) case-insensitively by default, so ``input[type=text]`` matches ``type="TEXT"``;
+an explicit ``s`` flag still forces case-sensitive matching.

--- a/docs/changelog/60.bugfix.rst
+++ b/docs/changelog/60.bugfix.rst
@@ -1,3 +1,2 @@
-Limit the ``<meta charset>`` prescan to the first 1024 bytes, per the WHATWG "prescan a byte stream to determine its
-encoding" algorithm. A ``<meta>`` whose end reaches byte 1024 or later is no longer honored, so the document falls back
-to windows-1252 instead of adopting a late declaration (and an arbitrarily large input is no longer scanned in full).
+The ``<meta charset>`` prescan now stops after the first 1024 bytes per the WHATWG algorithm, so a late charset
+declaration is ignored and the document falls back to windows-1252.

--- a/docs/changelog/61.bugfix.rst
+++ b/docs/changelog/61.bugfix.rst
@@ -1,4 +1,2 @@
-Keep a trailing ``*`` in a linkified URL instead of trimming it. ``*`` is an RFC 3986 sub-delim that is valid in a path
-or query, and both bleach and linkify_it retain it, yet linkify dropped a ``*`` at the very end of a URL from the match
-span even though it kept one mid-path. The ``href`` no longer silently points at a different resource than the visible
-text.
+A trailing ``*`` in a linkified URL is now kept rather than trimmed, matching bleach and linkify_it, so the ``href`` no
+longer points at a different resource than the visible text.

--- a/docs/changelog/62.bugfix.rst
+++ b/docs/changelog/62.bugfix.rst
@@ -1,4 +1,2 @@
-Match a type selector against a custom or unknown element name case-insensitively, so ``select("MY-CARD")`` finds a
-``<my-card>`` just as ``select("DIV")`` finds a ``<div>``. Type selectors are ASCII case-insensitive in HTML documents,
-which already worked for the builtin tag names resolved through the atom table; an element outside that table fell back
-to a case-sensitive comparison against its lowercased stored name, so an uppercase selector never matched.
+A type selector now matches a custom or unknown element name case-insensitively, so ``select("MY-CARD")`` finds a
+``<my-card>`` just as ``select("DIV")`` finds a ``<div>``.

--- a/docs/changelog/63.bugfix.rst
+++ b/docs/changelog/63.bugfix.rst
@@ -1,4 +1,3 @@
-Place the synthesized ``<br>`` from a ``</br>`` end tag in foreign (SVG or MathML) content inside the foreign element
-rather than as a sibling under ``<body>``. Like ``</p>`` (issue #32), ``</br>`` is an "any other end tag" in the WHATWG
-foreign-content rules: nothing is popped and the token is reprocessed in the current insertion mode with the foreign
-element still current, so ``<svg></br>`` now builds ``<svg><br></svg>``, matching lexbor and html5lib.
+A ``</br>`` end tag inside foreign (SVG or MathML) content now places the synthesized ``<br>`` inside the foreign
+element, so ``<svg></br>`` builds ``<svg><br></svg>`` instead of a sibling under ``<body>``, matching lexbor and
+html5lib.

--- a/docs/changelog/63.misc.rst
+++ b/docs/changelog/63.misc.rst
@@ -1,5 +1,2 @@
-Add a dedicated regression test (``tests/dom/test_foreign_end_tag_breakout.py``) that asserts ``</p>`` and ``</br>`` end
-tags in SVG/MathML content stay *inside* the foreign root, independently of the conformance harness's overrides. This
-locks the spec-correct decision from issues #32 and #63 and stands as the standing rejection of the proposed "foreign
-breakout" divergence, which would have matched the stale ``html5lib-tests`` ``.dat`` fixtures over the literal WHATWG
-algorithm, lexbor, and html5lib's own library.
+Add a regression test asserting that ``</p>`` and ``</br>`` end tags in SVG/MathML content stay inside the foreign root,
+locking the spec-correct behavior from issues #32 and #63.

--- a/docs/changelog/64.bugfix.rst
+++ b/docs/changelog/64.bugfix.rst
@@ -1,4 +1,2 @@
-Place a plain ``xmlns`` attribute on a foreign (SVG/MathML) element in the ``http://www.w3.org/2000/xmlns/`` namespace,
-the last missing row of the WHATWG "adjust foreign attributes" table. turbohtml already moved ``xmlns:xlink`` and the
-``xlink:`` and ``xml:`` attributes into their namespaces but left a prefix-less ``xmlns`` in the null namespace, so the
-tree-construction ``#document`` output rendered ``xmlns="..."`` where html5lib renders ``xmlns xmlns="..."``.
+A prefix-less ``xmlns`` attribute on a foreign (SVG/MathML) element now lands in the ``http://www.w3.org/2000/xmlns/``
+namespace per the WHATWG "adjust foreign attributes" table, matching html5lib's serialization.

--- a/docs/changelog/65.bugfix.rst
+++ b/docs/changelog/65.bugfix.rst
@@ -1,5 +1,3 @@
-Accept namespace-qualified type selectors in ``select()``/``select_one()``. ``*|E``, ``*|*``, ``|E``, ``|*``, and
-``ns|E`` were rejected with ``ValueError('invalid CSS selector')``; the namespace prefix is part of the Selectors Level
-4 type-selector grammar and, in a namespaceless HTML document, the qualified form reduces to its unqualified selector
-(``*|a`` matches ``a``, ``*|*`` matches every element). The prefix is now parsed and ignored, matching lxml.cssselect,
-selectolax, and bs4.
+``select()`` and ``select_one()`` now accept namespace-qualified type selectors (``*|E``, ``*|*``, ``|E``, ``ns|E``)
+instead of raising ``ValueError('invalid CSS selector')``; in a namespaceless HTML document the prefix is parsed and
+ignored, matching lxml.cssselect, selectolax, and bs4.

--- a/docs/changelog/68.bugfix.rst
+++ b/docs/changelog/68.bugfix.rst
@@ -1,6 +1,3 @@
-Report a ``<!DOCTYPE>`` identifier that the source never supplied as ``None`` on the parsed :class:`~turbohtml.Doctype`
-node, instead of an empty string. A ``<!DOCTYPE html SYSTEM "s">`` now exposes ``public_id`` as ``None`` and ``<!DOCTYPE
-html PUBLIC "p">`` exposes ``system_id`` as ``None``, keeping a missing identifier distinct from a present-but-empty one
-such as ``<!DOCTYPE html PUBLIC "p" "">``. The distinction also survives pickling. The node previously collapsed an
-absent sibling identifier to ``''`` once either keyword was present, even though :func:`~turbohtml.tokenize` already
-reported it as ``None``.
+A missing ``<!DOCTYPE>`` identifier is now reported as ``None`` on the parsed :class:`~turbohtml.Doctype` node rather
+than an empty string, so ``<!DOCTYPE html SYSTEM "s">`` exposes ``public_id`` as ``None`` and the distinction from a
+present-but-empty identifier survives pickling.

--- a/docs/changelog/70.bugfix.rst
+++ b/docs/changelog/70.bugfix.rst
@@ -1,6 +1,3 @@
-Keep allowlisted SVG and MathML elements instead of escaping them to text. The sanitizer matched the ``tags`` allowlist
-only against HTML-namespace names, so every foreign element failed the lookup and was escaped even when its name was on
-the list. A foreign element now matches the allowlist by its serialized name (``svg``, ``foreignObject``, ...), matching
-bleach and nh3. Safety is preserved: the unsafe-element set still escapes scripting/raw-text elements in any namespace,
-and a foreign element is kept only inside kept context, so it never outlives its namespace (an ``svg`` ``<a>`` whose
-``<svg>`` is escaped never survives as a live HTML anchor).
+The sanitizer now keeps allowlisted SVG and MathML elements instead of escaping every foreign element to text, matching
+bleach and nh3; scripting and raw-text elements are still escaped in any namespace, and a kept foreign element never
+outlives its namespace.

--- a/docs/changelog/72.bugfix.rst
+++ b/docs/changelog/72.bugfix.rst
@@ -1,6 +1,3 @@
-Always neutralize ``<plaintext>`` in :func:`turbohtml.sanitizer.sanitize`, regardless of the policy allowlist, the way
-``<xmp>`` and ``<script>`` already are. ``<plaintext>`` switches the tokenizer to a raw-text state that runs to end of
-input, so a policy that allowlisted it kept content such as ``</select><img src=x onerror=alert(1)>`` as an unescapable
-raw text node; the serialized output reparsed into a live ``<img>`` whose ``onerror`` fired (a mutation-XSS bypass) and
-was not idempotent. The element is now escaped to inert text, matching nh3's safe handling. The default, ``strict``, and
-``relaxed`` policies were never affected because they already escape ``<plaintext>``.
+:func:`turbohtml.sanitizer.sanitize` now always escapes ``<plaintext>`` to inert text regardless of the policy
+allowlist, closing a mutation-XSS bypass where an allowlisted ``<plaintext>`` could reparse into a live ``<img>`` with a
+firing ``onerror``; the ``strict`` and ``relaxed`` policies were never affected.

--- a/docs/changelog/73.feature.rst
+++ b/docs/changelog/73.feature.rst
@@ -1,6 +1,1 @@
-Serialize a parsed document back to HTML up to 1.6 times faster: the writer scans each text run for the next character
-that needs escaping two code points at a time with the same SWAR lane probes :func:`~turbohtml.escape` uses, recovers
-each special's position straight from the lane mask, and reserves the whole-document buffer up front so the output grows
-in a single allocation instead of a dozen reallocations. The 1-byte data-state tokenizer scan now also runs straight
-through newlines in one vector sweep, folding line and column tracking in afterwards, so prose-heavy documents parse a
-few percent faster.
+Serialize a parsed document back to HTML up to 1.6 times faster, and parse prose-heavy documents a few percent faster.

--- a/docs/changelog/74.bugfix.rst
+++ b/docs/changelog/74.bugfix.rst
@@ -1,4 +1,2 @@
-Raise ``TypeError`` instead of ``AttributeError`` when :class:`~turbohtml.Element` is constructed with a non-mapping
-``attrs`` such as an ``int`` or ``list``. The constructor enumerates ``attrs`` through its ``keys()`` method, so a value
-without one previously surfaced the raw ``'int' object has no attribute 'keys'`` error; it now reports that ``attrs``
-must be a mapping. A ``keys()`` that exists but raises still propagates its own error rather than being relabeled.
+Constructing :class:`~turbohtml.Element` with a non-mapping ``attrs`` such as an ``int`` or ``list`` now raises a clear
+``TypeError`` reporting that ``attrs`` must be a mapping, instead of a cryptic ``AttributeError``.

--- a/docs/changelog/75.bugfix.rst
+++ b/docs/changelog/75.bugfix.rst
@@ -1,3 +1,2 @@
-Reject arguments passed to the :class:`~turbohtml.Tokenizer` constructor with a ``TypeError`` instead of silently
-ignoring them. A streaming tokenizer starts empty and takes no arguments, so ``Tokenizer("<p>")`` was a no-op that
-discarded its input; it now fails loudly.
+Passing arguments to the :class:`~turbohtml.Tokenizer` constructor now raises ``TypeError`` instead of silently
+discarding them, so ``Tokenizer("<p>")`` no longer drops its input. A streaming tokenizer starts empty.

--- a/docs/changelog/76.bugfix.rst
+++ b/docs/changelog/76.bugfix.rst
@@ -1,3 +1,2 @@
-Declare the private ``turbohtml._html._reconstruct`` pickle hook in the type stub so a type checker resolves it. The
-built-in is the first element of every node's ``__reduce__`` result, yet it was the one private helper missing from
-``_html.pyi``, which forced an ``unresolved-import`` suppression in the pickle tests that can now be dropped.
+Type checkers now resolve the private ``turbohtml._html._reconstruct`` pickle hook, which was the one helper missing
+from the type stub.

--- a/docs/changelog/78.bugfix.rst
+++ b/docs/changelog/78.bugfix.rst
@@ -1,5 +1,3 @@
-Resolve the WHATWG "replacement" encoding labels (``replacement``, ``iso-2022-kr``, ``csiso2022kr``, ``iso-2022-cn``,
-``iso-2022-cn-ext``, ``hz-gb-2312``) to the replacement decoder instead of windows-1252. These stateful ISO-2022/HZ
-escape sequences can smuggle markup past a sanitizer, so the standard mandates that a document declaring one of these
-labels decode its entire non-empty body to a single ``U+FFFD``. Previously the labels were unknown and the body was
-decoded literally as windows-1252.
+A document declaring a WHATWG "replacement" encoding label (``replacement``, ``iso-2022-kr``, ``iso-2022-cn``,
+``hz-gb-2312`` and friends) now decodes its body to a single ``U+FFFD`` as the standard mandates, instead of literally
+as windows-1252, closing a vector that could smuggle markup past a sanitizer.

--- a/docs/changelog/79.bugfix.rst
+++ b/docs/changelog/79.bugfix.rst
@@ -1,4 +1,3 @@
-Reject bytes passed where a ``str`` is documented — the ``context`` of :func:`~turbohtml.parse_fragment` and the
-``name`` of :meth:`turbohtml.Token.attr` — with a ``TypeError`` that names ``str``, instead of silently decoding the
-bytes as latin-1 into a garbage tag or attribute name. Wrong types other than bytes now also report that ``str`` is
-required rather than a bytes-like object.
+Passing ``bytes`` (or any non-``str``) where a ``str`` is documented now raises a ``TypeError`` naming ``str`` instead
+of silently decoding the bytes into a garbage tag or attribute name. The check covers the ``context`` of
+:func:`~turbohtml.parse_fragment` and the ``name`` of :meth:`turbohtml.Token.attr`.

--- a/docs/changelog/8.feature.rst
+++ b/docs/changelog/8.feature.rst
@@ -1,10 +1,5 @@
-Sanitize untrusted HTML against an allowlist with ``turbohtml.sanitizer``, a successor to ``bleach.clean``, which has no
-maintained replacement now that bleach is end of life (deprecated for sitting on the unmaintained html5lib). A frozen,
-thread-safe ``Policy`` describes what to keep -- ``tags``, per-tag ``attributes`` with a ``"*"`` wildcard,
-``url_schemes``, an ``OnDisallowed`` choice of escape, strip, or remove, and a rewriting ``attribute_filter`` -- with
-``strict``/``basic``/``relaxed`` presets, and ``Sanitizer``/``sanitize`` apply it. A non-overridable baseline removes
-``<script>``, event-handler attributes, and ``javascript:`` URLs even when a policy would admit them, so a no-argument
-``sanitize`` is safe by construction. It parses to a real tree, filters it, and serializes once -- no reparse round
-trip, the step that lets mutation XSS back in -- and the whole filtering walk runs in C, so it sanitizes several times
-faster than the Rust nh3 and far faster than bleach. A separate ``turbohtml.migration.bleach`` shim offers ``clean(text,
-tags=..., attributes=..., protocols=..., strip=...)`` for migrating bleach users with only an import change.
+Sanitize untrusted HTML against an allowlist with ``turbohtml.sanitizer``, a successor to the end-of-life
+``bleach.clean``. A frozen, thread-safe ``Policy`` with ``strict``/``basic``/``relaxed`` presets controls the allowed
+tags, attributes, and URL schemes, while a non-overridable baseline always removes ``<script>``, event-handler
+attributes, and ``javascript:`` URLs, so a no-argument ``sanitize`` is safe by default. A ``turbohtml.migration.bleach``
+shim migrates bleach users with an import-only change.

--- a/docs/changelog/80.bugfix.rst
+++ b/docs/changelog/80.bugfix.rst
@@ -1,3 +1,2 @@
-Reclaim the consumed prefix of a streaming :class:`~turbohtml.Tokenizer`'s input buffer on each ``feed()``, so feeding a
-long document in chunks stays memory-bounded instead of growing the buffer without limit for the lifetime of the
-tokenizer.
+Feeding a long document to a streaming :class:`~turbohtml.Tokenizer` in chunks now stays memory-bounded; each ``feed()``
+reclaims the consumed prefix of the input buffer instead of growing it for the tokenizer's lifetime.

--- a/docs/changelog/81.bugfix.rst
+++ b/docs/changelog/81.bugfix.rst
@@ -1,3 +1,2 @@
-Stop a crash when a node the :attr:`~turbohtml.Node.descendants` (or ``strings``) iterator has cached as its next
-position is detached with :meth:`~turbohtml.Node.extract` mid-iteration. The walk now ends safely once the cursor's
-ancestry no longer reaches the root instead of dereferencing a ``NULL`` parent pointer.
+Detaching a node with :meth:`~turbohtml.Node.extract` while iterating :attr:`~turbohtml.Node.descendants` (or
+``strings``) no longer crashes; the walk now ends safely once the cursor can no longer reach the root.

--- a/docs/changelog/82.bugfix.rst
+++ b/docs/changelog/82.bugfix.rst
@@ -1,5 +1,2 @@
-Guard the streaming ``Tokenizer`` with a per-object critical section so concurrent use from multiple threads on the
-free-threaded (no-GIL) interpreter is memory-safe. ``feed()``, ``close()``, ``reset()``, ``__exit__``, and the token
-iterator all mutate the tokenizer's shared state machine, its record buffers, and its free list; without a lock,
-concurrent ``feed()``/iteration on a single shared tokenizer corrupted the native heap and segfaulted. Each now runs
-under ``Py_BEGIN_CRITICAL_SECTION`` on the owning tokenizer (a no-op on the GIL builds).
+The streaming :class:`~turbohtml.Tokenizer` is now memory-safe when shared across threads on the free-threaded (no-GIL)
+interpreter; concurrent ``feed()`` or iteration on one tokenizer previously corrupted memory and segfaulted.

--- a/docs/changelog/83.bugfix.rst
+++ b/docs/changelog/83.bugfix.rst
@@ -1,4 +1,3 @@
-Round-trip a parsed element through :mod:`python:pickle` and :func:`python:copy.deepcopy` even when its tag name holds a
-character the public :class:`~turbohtml.Element` constructor rejects, such as the ``<`` the tokenizer keeps in ``a<b``
-from ``<a<b>``. Reconstruction rebuilds the element through a trusted builder rather than the validating constructor, so
-a parsed tree always survives pickling.
+A parsed element whose tag name holds a character the public :class:`~turbohtml.Element` constructor rejects, such as
+the ``<`` kept from ``<a<b>``, now survives :mod:`python:pickle` and :func:`python:copy.deepcopy` round-trips instead of
+failing to reconstruct.

--- a/docs/changelog/84.bugfix.rst
+++ b/docs/changelog/84.bugfix.rst
@@ -1,8 +1,3 @@
-Make the navigable node tree memory-safe under the free-threaded build. The ``_html`` extension declares
-``Py_MOD_GIL_NOT_USED``, so concurrent access to one shared tree was a data race: a reader walking child and sibling
-pointers (``find``/``find_all``/``select``/``serialize``/``.text``/``.html``) could dereference a pointer that another
-thread rewired through ``extract`` or another structural edit, segfaulting. Every read traversal and every mutation now
-takes a per-tree :c:macro:`Py_BEGIN_CRITICAL_SECTION` on the owning tree handle, a no-op on the GIL build (so
-single-threaded performance is unchanged) and a cheap per-tree lock on the free-threaded build (so independent trees
-still run fully in parallel), mirroring the tokenizer fix and CPython's own list and dict. The free-threaded test matrix
-covers Python 3.14t and 3.15t, where free-threading is officially supported.
+The navigable node tree is now memory-safe under the free-threaded build; concurrent reads
+(``find``/``select``/``serialize``/``.text``/``.html``) alongside a structural edit such as ``extract`` on a shared tree
+previously raced and segfaulted, while independent trees still run fully in parallel.

--- a/docs/changelog/84.misc.rst
+++ b/docs/changelog/84.misc.rst
@@ -1,4 +1,2 @@
-Validate free-threaded safety with three layers: the free-threaded tox envs re-run the thread-safety suite under
-``pytest-run-parallel`` (one thread per core), a ``conftest`` guard fails the run if a C extension silently re-enables
-the GIL, and a new ``tox -e tsan`` env plus CI job run the suite under ThreadSanitizer in the
-``ghcr.io/nascheme/cpython-tsan`` image to detect data races directly.
+Free-threaded safety is now validated in CI under ``pytest-run-parallel`` and a ThreadSanitizer job, with a guard that
+fails the run if a C extension silently re-enables the GIL.

--- a/docs/changelog/85.bugfix.rst
+++ b/docs/changelog/85.bugfix.rst
@@ -1,4 +1,2 @@
-Preserve a foreign-content element's namespace across a pickle round-trip. Pickling a detached SVG or MathML
-:class:`~turbohtml.Element` reset its ``namespace`` to ``Namespace.HTML``, because the ``__reduce__`` payload carried
-only the tag and attributes, unlike :func:`copy.deepcopy`. The payload now appends the namespace for a foreign element
-and the unpickle hook restores it, leaving HTML elements unchanged and rejecting an out-of-range namespace.
+A detached SVG or MathML :class:`~turbohtml.Element` now keeps its ``namespace`` across a :mod:`python:pickle`
+round-trip, instead of being reset to ``Namespace.HTML``.

--- a/docs/changelog/86.bugfix.rst
+++ b/docs/changelog/86.bugfix.rst
@@ -1,5 +1,2 @@
-Carry an element's tree-construction category flags when it is constructed or reconstructed, so a raw-text element
-(``style``, ``xmp``, ``iframe`` and friends) keeps serializing its text verbatim. ``th_tree_make_element`` set the tag
-atom but left the flags zero, so an unpickled raw-text element lost its raw-text bit and began HTML-escaping its
-content, unlike :func:`copy.deepcopy`. Building one directly with :class:`~turbohtml.Element` now also serializes its
-text literally.
+A raw-text element (``style``, ``xmp``, ``iframe`` and friends) now serializes its text verbatim after being unpickled
+or built directly with :class:`~turbohtml.Element`, instead of wrongly HTML-escaping its content.

--- a/docs/changelog/87.breaking.rst
+++ b/docs/changelog/87.breaking.rst
@@ -1,7 +1,4 @@
 A valueless attribute (``<x a>``) now reports the empty string instead of ``None`` in :attr:`turbohtml.Token.attrs`,
-:meth:`turbohtml.Token.attr`, and :attr:`turbohtml.Element.attrs` (the empty list for a token-list attribute such as
-``class``), matching the WHATWG tokenizer, which assigns the empty string to a missing value, and the DOM, where
-``getAttribute`` returns ``""``. A present-but-empty attribute (``<x a="">``) was already indistinguishable in the tree
-and reports the same. Setting an attribute to ``None`` still produces an empty attribute that serializes as ``a=""``.
-Code that tested ``element.attrs["a"] is None`` to detect a valueless attribute should test ``element.attrs.get("a") ==
-""`` or membership instead.
+:meth:`turbohtml.Token.attr`, and :attr:`turbohtml.Element.attrs`, matching the WHATWG tokenizer and the DOM. Code that
+tested ``element.attrs["a"] is None`` to detect a valueless attribute should now test ``element.attrs.get("a") == ""``
+or membership.

--- a/docs/changelog/88.bugfix.rst
+++ b/docs/changelog/88.bugfix.rst
@@ -1,4 +1,3 @@
-Insert whitespace seen in the "after head" insertion mode under the ``html`` element, between ``head`` and ``body``,
-rather than inside the ``body``. The leading whitespace of a mixed text run such as ``<head></head> text`` now becomes a
-text node child of ``html`` and only the first non-whitespace character creates the ``body`` and starts "in body",
-matching the WHATWG algorithm and html5lib.
+Leading whitespace in the "after head" insertion mode, such as the space in ``<head></head> text``, now becomes a text
+node under ``html`` between ``head`` and ``body`` rather than inside ``body``, matching the WHATWG algorithm and
+html5lib.

--- a/docs/changelog/89.bugfix.rst
+++ b/docs/changelog/89.bugfix.rst
@@ -1,4 +1,3 @@
-Pop an open ``option`` or ``optgroup`` before inserting a new ``optgroup`` (or ``option``) start tag in a
-``select``-context fragment, so the elements become siblings instead of nesting. The "in select" pop only fired when a
-``select`` element was in scope, which never holds in a fragment whose context is ``select`` and whose ``select`` is
-implied, so ``parse_fragment("<optgroup>1<optgroup>2", context="select")`` produced one optgroup nested in the other.
+Consecutive ``<optgroup>`` (or ``<option>``) start tags in a ``select``-context fragment now become siblings instead of
+nesting, so ``parse_fragment("<optgroup>1<optgroup>2", context="select")`` no longer nests one optgroup inside the
+other.

--- a/docs/changelog/9.feature.rst
+++ b/docs/changelog/9.feature.rst
@@ -1,8 +1,5 @@
-Auto-link URLs and email addresses in HTML with ``turbohtml.linkify``, a successor to ``bleach.linkify``, which has no
-replacement now that bleach is end of life. ``linkify(text, callbacks=..., skip_tags=..., parse_email=...)``, the
-reusable ``Linker``, and the ``nofollow``/``target_blank`` helpers keep bleach's names, so the common case is just an
-import change. Custom callbacks get a cleaner contract than bleach's tuple-keyed ``(attrs, new)``: each receives a
-``Link`` with plain ``url``, ``text``, and ``attrs`` and returns it to keep the link or ``None`` to drop it. It is
-HTML-aware: it parses with turbohtml's WHATWG tree builder, so it never links inside an existing ``<a>``, a
-``<script>``/``<style>``, or a caller's ``skip_tags``. A bare domain like ``example.com`` links only when its last label
-is a real TLD, matched against a regenerable IANA table, and the hot scan for link candidates runs in C.
+Auto-link URLs and email addresses in HTML with ``turbohtml.linkify``, a successor to the end-of-life
+``bleach.linkify``. ``linkify``, the reusable ``Linker``, and the ``nofollow``/``target_blank`` helpers keep bleach's
+names for an import-only migration, while custom callbacks now receive a plain ``Link`` with ``url``, ``text``, and
+``attrs``. It is HTML-aware: it never links inside an existing ``<a>``, a ``<script>``/``<style>``, or your
+``skip_tags``, and links a bare domain only when its last label is a real IANA TLD.

--- a/docs/changelog/90.bugfix.rst
+++ b/docs/changelog/90.bugfix.rst
@@ -1,5 +1,2 @@
-Pop an open ``<select>`` when a table-family start tag (``caption``, ``table``, ``tbody``, ``tfoot``, ``thead``, ``tr``,
-``td``, ``th``) appears in the "in select in table" context, instead of nesting the element inside the select. Per the
-WHATWG "in select in table" insertion mode the token pops the select, resets the insertion mode, and is reprocessed, so
-``parse("<table><tr><td><select><table>")`` now puts the inner table as a sibling of the (closed, empty) ``<select>`` in
-the cell, matching html5lib.
+A table-family start tag (``table``, ``tr``, ``td``, ``caption`` and friends) inside an open ``<select>`` in the "in
+select in table" context now closes the select and becomes its sibling instead of nesting inside it, matching html5lib.

--- a/docs/changelog/91.bugfix.rst
+++ b/docs/changelog/91.bugfix.rst
@@ -1,3 +1,2 @@
-Recognize ``0x2F`` (``/``) as a separator after ``<meta`` in the encoding prescan, so ``<meta/charset=utf-8>`` resolves
-its declared encoding. WHATWG's "prescan a byte stream" accepts whitespace or ``/`` after the tag name; only whitespace
-was honored, so a slash-separated ``<meta>`` fell through to the windows-1252 default.
+``<meta/charset=utf-8>`` now resolves its declared encoding; the prescan accepts ``/`` as a separator after ``<meta`` as
+WHATWG specifies, not just whitespace, so a slash-separated ``<meta>`` no longer falls through to windows-1252.

--- a/docs/changelog/92.bugfix.rst
+++ b/docs/changelog/92.bugfix.rst
@@ -1,4 +1,3 @@
-Require an exact ASCII case-insensitive match for a MathML ``annotation-xml`` element's ``encoding`` attribute before
-treating it as an HTML integration point. The check approximated ``text/html`` by three characters and accepted any
-21-character value as ``application/xhtml+xml``, so a near miss like ``encoding="text-html"`` wrongly became an
-integration point and kept HTML children nested instead of letting them break out of the foreign subtree.
+A MathML ``annotation-xml`` element is now an HTML integration point only on an exact case-insensitive ``text/html`` or
+``application/xhtml+xml`` ``encoding`` match; a near miss like ``encoding="text-html"`` no longer wrongly keeps HTML
+children nested in the foreign subtree.

--- a/docs/changelog/93.bugfix.rst
+++ b/docs/changelog/93.bugfix.rst
@@ -1,5 +1,2 @@
-Pop an open ``select`` when a ``keygen`` start tag is seen in the "in select" insertion mode, so the ``keygen`` becomes
-a sibling after the now-closed ``select`` rather than nesting inside it (and is ignored in a select-context fragment).
-The ``input``/``keygen``/``textarea`` rule was only half-implemented for ``input``; ``keygen`` fell through to a plain
-insert. html5lib's library and the WHATWG algorithm both pop the ``select``; the pinned tree-construction ``.dat`` still
-encodes the older nesting, so those two cases are overridden to the spec-correct trees.
+A ``<keygen>`` start tag in the "in select" insertion mode now pops the open ``select`` so the ``keygen`` becomes a
+sibling, matching WHATWG and html5lib, instead of nesting inside the select.

--- a/docs/changelog/94.bugfix.rst
+++ b/docs/changelog/94.bugfix.rst
@@ -1,4 +1,2 @@
-Pop an open ``option`` or ``optgroup`` before inserting an ``hr`` in a ``select``-context fragment, so the ``hr`` lands
-at ``select`` level as a sibling of the options instead of nesting inside one. WHATWG added this ``hr`` rule to the "in
-select" insertion mode in 2024; turbohtml only applied it when a ``select`` element was in scope, which never holds in a
-fragment whose ``select`` context is implied.
+An ``<hr>`` in a ``select``-context fragment now lands at ``select`` level as a sibling of the options instead of
+nesting inside one, applying the WHATWG "in select" ``hr`` rule even when the ``select`` context is implied.

--- a/docs/changelog/95.bugfix.rst
+++ b/docs/changelog/95.bugfix.rst
@@ -1,5 +1,2 @@
-Parse a ``template``-context fragment in the "in template" insertion mode. ``parse_fragment(..., context="template")``
-ran in the "in body" mode, so table-section start tags (``td``, ``th``, ``tr``, ``col``, ``caption``, ``tbody``,
-``tfoot``, ``thead``) were ignored and only their text survived. Per the WHATWG fragment-parsing algorithm a
-``template`` context pushes "in template" onto the template insertion mode stack, so those tags now build their
-elements.
+``parse_fragment(..., context="template")`` now parses in the "in template" insertion mode, so table-section start tags
+(``td``, ``tr``, ``caption``, ``tbody`` and friends) build their elements instead of being dropped to text.

--- a/docs/changelog/96.feature.rst
+++ b/docs/changelog/96.feature.rst
@@ -1,7 +1,4 @@
 Match the Selectors Level 4 functional pseudo-classes ``:is()``, ``:where()``, and ``:has()`` in
 :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`, :meth:`~turbohtml.Node.matches`, and
-:meth:`~turbohtml.Node.closest`, instead of rejecting them as invalid. ``:is()`` and ``:where()`` match an element
-against a nested selector list (a tree matcher treats them identically, since they differ only in specificity), and
-``:has()`` keeps an element when a relative selector -- with an optional leading ``>``, ``+``, or ``~`` combinator --
-finds a match anchored at it, so ``article:has(> img)`` and ``h2:has(+ p)`` work. The nested lists may themselves nest,
-and matching agrees with soupsieve and lexbor.
+:meth:`~turbohtml.Node.closest`, including relative selectors with a leading ``>``, ``+``, or ``~`` so ``article:has(>
+img)`` and ``h2:has(+ p)`` work, instead of rejecting them as invalid.

--- a/docs/changelog/97.bugfix.rst
+++ b/docs/changelog/97.bugfix.rst
@@ -1,5 +1,3 @@
-Return the exact-case WHATWG **Name** from :attr:`~turbohtml.Document.encoding` for the legacy single-byte and Japanese
-encodings whose name the Encoding Standard capitalizes — ``ISO-8859-2`` through ``ISO-8859-16`` (and ``ISO-8859-8-I``),
-``IBM866``, ``KOI8-R``, ``KOI8-U``, ``ISO-2022-JP``, and ``EUC-JP``. These resolved to their ASCII-lowercased label,
-which the spec defines as a label of the encoding rather than its name; the CJK and Unicode encodings already reported
-the correct ``Shift_JIS``/``Big5``/``EUC-KR`` casing.
+:attr:`~turbohtml.Document.encoding` now returns the exact-case WHATWG Name for the legacy single-byte and Japanese
+encodings the Encoding Standard capitalizes (``ISO-8859-2`` through ``ISO-8859-16``, ``IBM866``, ``KOI8-R``,
+``ISO-2022-JP``, ``EUC-JP`` and friends), instead of their ASCII-lowercased label.

--- a/docs/changelog/98.feature.rst
+++ b/docs/changelog/98.feature.rst
@@ -1,5 +1,4 @@
-Support the CSS tree-structural pseudo-classes in :meth:`~turbohtml.Node.select`/:meth:`~turbohtml.Node.select_one`:
-``:root``, ``:empty``, ``:first-child``, ``:last-child``, ``:only-child``, ``:first-of-type``, ``:last-of-type``,
-``:only-of-type``, and the functional ``:nth-child()``, ``:nth-last-child()``, ``:nth-of-type()``, and
-``:nth-last-of-type()`` (with the full ``An+B`` microsyntax, including the ``even`` and ``odd`` keywords). Previously
-every pseudo-class raised ``ValueError('invalid CSS selector')``.
+Match the CSS tree-structural pseudo-classes in :meth:`~turbohtml.Node.select`/:meth:`~turbohtml.Node.select_one`:
+``:root``, ``:empty``, ``:first-child``, ``:only-of-type``, and the functional ``:nth-child()``, ``:nth-of-type()`` and
+their last-of family with the full ``An+B`` microsyntax (including ``even`` and ``odd``). These previously raised
+``ValueError``.

--- a/docs/changelog/99.bugfix.rst
+++ b/docs/changelog/99.bugfix.rst
@@ -1,4 +1,3 @@
-Decode the ``gbk`` and ``gb2312`` labels with the ``gb18030`` codec, since the WHATWG Encoding Standard defines GBK's
-decoder as gb18030's decoder. Python's standalone ``gbk`` codec implements only the two-byte legacy subset, so a valid
-four-byte gb18030 sequence in a GBK-labeled stream decoded to ``U+FFFD``; it now decodes to its code point. The reported
-:attr:`~turbohtml.Document.encoding` name stays ``GBK``, which the standard lists as a distinct encoding.
+The ``gbk`` and ``gb2312`` labels now decode with the ``gb18030`` codec as the WHATWG Encoding Standard requires, so a
+valid four-byte sequence decodes to its code point instead of ``U+FFFD``; the reported
+:attr:`~turbohtml.Document.encoding` name stays ``GBK``.


### PR DESCRIPTION
## What

Rewrites every changelog entry as a concise end-user release note. The towncrier fragments and the released sections of `docs/changelog.rst` had grown into multi-paragraph technical write-ups (one was 426 words); this condenses each to one or two sentences in product-owner voice.

## How

- **Lead with the capability** a user gains, not the implementation. Dropped internals: C tree walks, translation units, free-threading/critical sections, arena/stack-frame notes, "byte-for-byte"/"single pass" framing, and exhaustive enumerations of every option (summarized as a category, with the `:doc:` guide link kept).
- **No-slop pass** over all prose: no em dashes, no adverbs doing vague work, no marketing words, active voice.
- **Preserved**: every public-API cross-reference (`:class:`/`:meth:`/`:func:`/`:mod:`), `:doc:` links, `:issue:`/`:user:` roles, and the ` - by :user:` attribution.

111 fragments + 5 released versions rewritten. `towncrier build --draft` renders cleanly; docstrfmt and the line-length limit pass.

Example (`172.feature.rst`): 426 words → 49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
