### PR TITLE
✨ feat(xpath): bind node-set variables

### DIFF
--- a/docs/changelog/264.feature.rst
+++ b/docs/changelog/264.feature.rst
@@ -1,0 +1,5 @@
+Bind a node-set to a ``$name`` XPath variable: a keyword argument to :meth:`~turbohtml.Node.xpath`,
+:meth:`~turbohtml.Node.xpath_one`, and :meth:`~turbohtml.Node.xpath_iter` now accepts an :class:`~turbohtml.Element` or
+an iterable of elements alongside the existing scalars, so a prior result can feed a later expression
+(``doc.xpath("$rows/td", rows=doc.xpath("//tr"))``) and the node-set joins path steps, ``count()``, unions, and
+predicates like any other, matching ``lxml``.

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -637,15 +637,17 @@ a reverse axis, a union, and a computed name test) runs over the 9.6 kB wpt page
 the sweep across every page size. turbohtml compiles each expression against the tree once, resolves name tests to
 interned atoms, and folds ``//`` to a single ``descendant`` walk, so it leads across the surface. The exception is a
 predicate that references ``position()`` (``[1]`` or ``position() <= 3``): it pins the result to proximity order and
-disables the ``//`` collapse, so on the largest pages lxml's streaming evaluation closes the gap. The last seven rows
+disables the ``//`` collapse, so on the largest pages lxml's streaming evaluation closes the gap. The last eight rows
 are the lxml/parsel options the parity work added: a ``$variable`` binding, an EXSLT ``re:test`` predicate (turbohtml's
 Python :mod:`re` against lxml's C libexslt), an EXSLT ``set:distinct`` node-set reduction (built-in C dispatch on both
 sides, so it races C against C), a ``smart_strings`` attribute read, a custom ``extensions=`` function, an
-``extensions=`` function whose return becomes a node-set feeding a later ``/@href`` step, and a ``namespaces=`` prefix
-binding that resolves ``//svg:rect`` against ``{"svg": ".../2000/svg"}`` over a page carrying an SVG block. turbohtml
-still leads, since lxml resolves the namespace map and option set on every call. The last row precompiles the expression
-once with :class:`~turbohtml.XPath` and re-evaluates it, lxml's ``etree.XPath`` doing the same: both skip the per-call
-parse :meth:`~turbohtml.Node.xpath` pays, and turbohtml's compiled program stays ahead per evaluation.
+``extensions=`` function whose return becomes a node-set feeding a later ``/@href`` step, a ``namespaces=`` prefix
+binding that resolves ``//svg:rect`` against ``{"svg": ".../2000/svg"}`` over a page carrying an SVG block, and a
+node-set ``$variable`` bound from a prior result (``$rows/div``, with ``rows`` reused from an earlier ``//div`` query)
+fed into a later path step. turbohtml still leads, since lxml resolves the namespace map and option set on every call.
+The last row precompiles the expression once with :class:`~turbohtml.XPath` and re-evaluates it, lxml's ``etree.XPath``
+doing the same: both skip the per-call parse :meth:`~turbohtml.Node.xpath` pays, and turbohtml's compiled program stays
+ahead per evaluation.
 
 .. list-table::
     :header-rows: 1
@@ -708,6 +710,9 @@ parse :meth:`~turbohtml.Node.xpath` pays, and turbohtml's compiled program stays
     - - ``//svg:rect`` (namespaces=)
       - 0.9 µs
       - 3.7 µs
+    - - ``$rows/div`` (node-set variable)
+      - 3.9 µs
+      - 6.1 µs
     - - ``//a[@href]`` (precompiled, reused)
       - 0.5 µs
       - 2.8 µs

--- a/docs/explanation/queries.rst
+++ b/docs/explanation/queries.rst
@@ -49,16 +49,20 @@ exactly otherwise, as the Selectors standard requires. :meth:`~turbohtml.Node.xp
 and :meth:`~turbohtml.Node.xpath_iter` evaluate XPath 1.0 over the same model: a native-C engine compiles each
 expression once into an immutable, per-tree-cached program, resolves name tests to interned atoms, and collapses the
 ``//`` abbreviation to a single ``descendant`` walk, so the structural axes, predicates, operators, unions, and the core
-function library run at lxml's speed. Because that program holds no tree pointers and no mutable state,
-:class:`turbohtml.XPath` exposes it directly: a hot expression compiles once and a single re-entrant, thread-shareable
-object evaluates against many context nodes, the same design lxml's ``etree.XPath`` uses. The EXSLT ``re:``, ``set:``,
-``str:``, ``math:``, and ``date:`` namespaces dispatch in the same C engine, so the regexp, node-set, string, numeric,
-and date helpers ``libexslt`` gives lxml work without registering a namespace. A prefix-to-URI mapping passed as
-``namespaces`` is resolved during evaluation rather than baked into the compiled program, so the one cached program
-serves every mapping; a prefixed name test then constrains the match to the foreign-content namespace the tree builder
-tagged (SVG or MathML), while unprefixed tests stay namespace-agnostic over the null-namespace HTML tree. The core API
-stays one-name-per-concept and returns plain lists, so the jQuery-style chaining pyquery users expect lives in an
-optional Python-side wrapper, :class:`turbohtml.query.Query`, whose traversal and mutation methods each return a
+function library run at lxml's speed. A ``$name`` variable bound through a keyword argument carries a scalar or a
+node-set across that boundary: an :class:`~turbohtml.Element` or an iterable of them is marshaled into the engine's
+node-set value, ordered and de-duplicated like any other, so a prior result can feed a later expression
+(``doc.xpath("$rows/td", rows=doc.xpath("//tr"))``) without re-walking the tree; elements wrapped against a different
+document are rejected rather than dereferenced into a foreign arena. Because that program holds no tree pointers and no
+mutable state, :class:`turbohtml.XPath` exposes it directly: a hot expression compiles once and a single re-entrant,
+thread-shareable object evaluates against many context nodes, the same design lxml's ``etree.XPath`` uses. The EXSLT
+``re:``, ``set:``, ``str:``, ``math:``, and ``date:`` namespaces dispatch in the same C engine, so the regexp, node-set,
+string, numeric, and date helpers ``libexslt`` gives lxml work without registering a namespace. A prefix-to-URI mapping
+passed as ``namespaces`` is resolved during evaluation rather than baked into the compiled program, so the one cached
+program serves every mapping; a prefixed name test then constrains the match to the foreign-content namespace the tree
+builder tagged (SVG or MathML), while unprefixed tests stay namespace-agnostic over the null-namespace HTML tree. The
+core API stays one-name-per-concept and returns plain lists, so the jQuery-style chaining pyquery users expect lives in
+an optional Python-side wrapper, :class:`turbohtml.query.Query`, whose traversal and mutation methods each return a
 wrapper. Output runs back through :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and
 :meth:`~turbohtml.Node.encode`, WHATWG-conformant by default with the escaping selectable through
 :class:`~turbohtml.Formatter`. A registered ``extensions=`` function crosses the same value boundary in both directions:

--- a/docs/how-to/querying.rst
+++ b/docs/how-to/querying.rst
@@ -376,6 +376,23 @@ quotes or special characters cannot break the query:
 
     ['out']
 
+A variable can also hold a node-set: bind an :class:`~turbohtml.Element` or any iterable of elements (a prior
+:meth:`~turbohtml.Node.xpath` result) and feed it back into a later expression instead of re-walking the tree. The
+node-set joins path steps, ``count()``, unions, and predicates like any other node-set:
+
+.. testcode::
+
+    import turbohtml
+    doc = turbohtml.parse("<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>")
+    rows = doc.xpath("//tr")
+    print([td.text for td in doc.xpath("$rows/td", rows=rows)])
+    print(doc.xpath("count($rows)", rows=rows))
+
+.. testoutput::
+
+    ['a', 'b', 'c']
+    2.0
+
 The EXSLT ``re:test`` and ``re:replace`` functions ``parsel`` and ``scrapy`` rely on work without registering a
 namespace; the ``re:`` prefix dispatches to Python's :mod:`re`:
 

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -84,6 +84,10 @@ lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtm
       - :meth:`~turbohtml.Node.find_all`, :meth:`~turbohtml.Node.xpath`
     - - ``etree.XPath("//a[@href=$u]")(el, u=v)``
       - :class:`~turbohtml.XPath` (``XPath("//a[@href=$u]")(el, u=v)``)
+    - - ``el.xpath("$rows/td", rows=el.xpath("//tr"))``
+      - :meth:`el.xpath("$rows/td", rows=el.xpath("//tr")) <turbohtml.Node.xpath>` (a ``$name`` variable binds a scalar,
+        an :class:`~turbohtml.Element`, or an iterable of elements; :meth:`~turbohtml.Node.xpath_one` and
+        :meth:`~turbohtml.Node.xpath_iter` take the same bindings)
     - - ``el.xpath("//svg:rect", namespaces={"svg": SVG})``
       - :meth:`~turbohtml.Node.xpath` with the same ``namespaces={"svg": SVG}`` (the prefix binds at evaluation time)
     - - ``el.cssselect("div a")``
@@ -178,6 +182,30 @@ wpt page with ``tox -e bench xpath``:
       - 1.1 µs
       - 3.2 µs
       - 2.9x
+
+Both engines accept a node-set ``$variable``, so a prior result feeds a later expression without re-querying:
+:meth:`el.xpath("$rows/td", rows=el.xpath("//tr")) <turbohtml.Node.xpath>` binds the node-set lxml's
+``tree.xpath("$rows/td", rows=tree.xpath("//tr"))`` would. turbohtml normalizes the bound node-set into the compiled
+program once and walks the following step over interned atoms, so binding a prior result and reusing it stays ahead of
+lxml across page sizes (``$rows/div`` reusing a prior ``//div`` result; see :doc:`/development/performance` for the full
+sweep):
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - node-set variable reuse
+      - turbohtml
+      - lxml
+      - speed-up
+    - - wpt page (4 kB)
+      - 4.3 µs
+      - 6.3 µs
+      - 1.5x
+    - - wpt page (9.6 kB)
+      - 3.9 µs
+      - 6.1 µs
+      - 1.5x
 
 A namespace-prefixed name test ports unchanged: pass the same ``namespaces=`` mapping to :meth:`~turbohtml.Node.xpath`
 that you give lxml. turbohtml binds the prefix at evaluation time against the per-tree cached program and resolves the

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1484,7 +1484,7 @@ static PyObject *xpath_scalar_to_py(const xp_result *result) {
 /* Evaluate an expression and marshal it to a Python object: a node-set becomes a
    list (elements as Element, attribute/text values as str); a scalar becomes the
    matching float / str / bool. */
-static int xpath_pyobject_to_scalar(PyObject *obj, xp_result *out, const char *what);
+static int xpath_pyobject_to_scalar(PyObject *obj, xp_result *out);
 
 /* The state an extension callback needs, threaded through xp_eval as a void *. */
 typedef struct {
@@ -1535,7 +1535,7 @@ static int xpath_append_result_node(xpath_ext_ctx *ec, PyObject *obj, xp_nodeset
    a node-set (issue #265). */
 static int xpath_extension_result(xpath_ext_ctx *ec, PyObject *obj, xp_result *out) {
     if (PyBool_Check(obj) || PyLong_Check(obj) || PyFloat_Check(obj) || PyUnicode_Check(obj)) {
-        return xpath_pyobject_to_scalar(obj, out, "an extension result");
+        return xpath_pyobject_to_scalar(obj, out);
     }
     memset(out, 0, sizeof(*out));
     out->kind = XP_NODESET;
@@ -1762,10 +1762,10 @@ static PyObject *xpath_run_program(module_state *state, PyObject *handle, th_nod
     return out;
 }
 
-/* Convert one keyword-argument value into an XPath variable binding value. */
-/* Convert a Python scalar (bool/int/float/str) to an xp_result; `what` names the
-   source for the type error a node-set or any other object triggers. */
-static int xpath_pyobject_to_scalar(PyObject *obj, xp_result *out, const char *what) {
+/* Convert a Python scalar to an xp_result. Both callers (variable and extension-result
+   marshaling) check the type is bool/int/float/str before calling, so the final branch
+   is str rather than a guarded case with an unreachable type error. */
+static int xpath_pyobject_to_scalar(PyObject *obj, xp_result *out) {
     memset(out, 0, sizeof(*out));
     if (PyBool_Check(obj)) {
         out->kind = XP_BOOLEAN;
@@ -1777,7 +1777,7 @@ static int xpath_pyobject_to_scalar(PyObject *obj, xp_result *out, const char *w
         }
         out->kind = XP_NUMBER;
         out->number = value;
-    } else if (PyUnicode_Check(obj)) {
+    } else {
         Py_ssize_t length = PyUnicode_GET_LENGTH(obj);
         Py_UCS4 *buf = PyUnicode_AsUCS4Copy(obj);
         if (buf == NULL) { /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
@@ -1786,16 +1786,68 @@ static int xpath_pyobject_to_scalar(PyObject *obj, xp_result *out, const char *w
         out->kind = XP_STRING;
         out->string = buf;
         out->string_len = length;
-    } else {
-        PyErr_Format(PyExc_TypeError, "xpath %s must be str, int, float, or bool, not %.80s", what,
-                     Py_TYPE(obj)->tp_name);
-        return -1;
     }
     return 0;
 }
 
-static int xpath_var_value(PyObject *obj, xp_result *out) {
-    return xpath_pyobject_to_scalar(obj, out, "variable");
+/* Append one Element's node to a node-set variable value. Its node pointer is only
+   valid inside the tree being queried, so a node wrapped against a different handle
+   (another document) is rejected rather than dereferenced into a foreign arena. */
+static int xpath_push_element(PyObject *obj, module_state *state, PyObject *reference_handle, xp_nodeset *ns) {
+    if (!is_node(obj, state)) {
+        PyErr_Format(PyExc_TypeError,
+                     "xpath variable must be str, int, float, bool, an element, or an iterable of elements, not %.80s",
+                     Py_TYPE(obj)->tp_name);
+        return -1;
+    }
+    NodeObject *element = (NodeObject *)obj;
+    if (element->handle != reference_handle) {
+        PyErr_SetString(PyExc_ValueError, "xpath variable refers to a node from a different tree");
+        return -1;
+    }
+    if (ns_push(ns, element->node, -1) < 0) { /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+        PyErr_NoMemory();                     /* GCOVR_EXCL_LINE */
+        return -1;                            /* GCOVR_EXCL_LINE */
+    }
+    return 0;
+}
+
+/* Convert one keyword-argument value into a variable binding. A scalar maps to its
+   XPath type; an Element or an iterable of Elements maps to a node-set the engine
+   then orders and de-duplicates on reference. */
+static int xpath_var_value(PyObject *obj, xp_result *out, module_state *state, PyObject *reference_handle) {
+    if (PyBool_Check(obj) || PyLong_Check(obj) || PyFloat_Check(obj) || PyUnicode_Check(obj)) {
+        return xpath_pyobject_to_scalar(obj, out);
+    }
+    memset(out, 0, sizeof(*out));
+    out->kind = XP_NODESET;
+    if (is_node(obj, state)) {
+        return xpath_push_element(obj, state, reference_handle, &out->nodes);
+    }
+    PyObject *iterator = PyObject_GetIter(obj);
+    if (iterator == NULL) {
+        PyErr_Clear();
+        PyErr_Format(PyExc_TypeError,
+                     "xpath variable must be str, int, float, bool, an element, or an iterable of elements, not %.80s",
+                     Py_TYPE(obj)->tp_name);
+        return -1;
+    }
+    PyObject *item;
+    while ((item = PyIter_Next(iterator)) != NULL) {
+        int rc = xpath_push_element(item, state, reference_handle, &out->nodes);
+        Py_DECREF(item);
+        if (rc < 0) {
+            Py_DECREF(iterator);
+            xp_nodeset_free(&out->nodes);
+            return -1;
+        }
+    }
+    Py_DECREF(iterator);
+    if (PyErr_Occurred()) { /* the iterable raised partway through */
+        xp_nodeset_free(&out->nodes);
+        return -1;
+    }
+    return 0;
 }
 
 static void free_xpath_vars(xp_binding *items, Py_ssize_t len) {
@@ -1871,10 +1923,15 @@ static int build_xpath_namespaces(PyObject *mapping, xp_namespace **out_items, P
    always str). With reserve_options set, the smart_strings and extensions keys are
    skipped because Node.xpath reads them as options off the same kwargs; the
    precompiled XPath object binds them at construction and clears the flag, so every
-   keyword is a $variable. On error an exception is set and partial bindings freed. */
-static int build_xpath_vars(PyObject *kwds, int reserve_options, xp_binding **out_items, Py_ssize_t *out_len) {
+   keyword is a $variable. self is the context Node: it supplies the module state and
+   the reference handle a bound Element is validated against. On error an exception is
+   set and partial bindings freed. */
+static int build_xpath_vars(PyObject *self, PyObject *kwds, int reserve_options, xp_binding **out_items,
+                            Py_ssize_t *out_len) {
     *out_items = NULL;
     *out_len = 0;
+    module_state *state = state_of(self);
+    PyObject *reference_handle = ((NodeObject *)self)->handle;
     Py_ssize_t total = kwds == NULL ? 0 : PyDict_Size(kwds);
     if (total == 0) {
         return 0;
@@ -1906,7 +1963,7 @@ static int build_xpath_vars(PyObject *kwds, int reserve_options, xp_binding **ou
             free_xpath_vars(items, count); /* GCOVR_EXCL_LINE */
             return -1;                     /* GCOVR_EXCL_LINE */
         }
-        if (xpath_var_value(value, &items[count].value) < 0) {
+        if (xpath_var_value(value, &items[count].value, state, reference_handle) < 0) {
             PyMem_Free(name);
             free_xpath_vars(items, count);
             return -1;
@@ -1956,7 +2013,7 @@ static PyObject *xpath_eval_with_vars(PyObject *self, PyObject *args, PyObject *
     }
     xp_binding *items;
     Py_ssize_t len;
-    if (build_xpath_vars(kwds, 1, &items, &len) < 0) {
+    if (build_xpath_vars(self, kwds, 1, &items, &len) < 0) {
         free_xpath_namespaces(ns_items, ns_len);
         return NULL;
     }
@@ -2094,7 +2151,7 @@ static PyObject *xpath_compiled_call(PyObject *self, PyObject *args, PyObject *k
     }
     xp_binding *items;
     Py_ssize_t len;
-    if (build_xpath_vars(kwds, 0, &items, &len) < 0) {
+    if (build_xpath_vars(node_obj, kwds, 0, &items, &len) < 0) {
         return NULL;
     }
     xp_bindings vars = {items, len};

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -1069,7 +1069,9 @@ PyDoc_STRVAR(xpath_doc, "xpath(expression, /, *, smart_strings=False, extensions
                         ":param extensions: maps an (namespace, name) pair to a callable, registering a\n"
                         "    custom XPath function; the callable may return a scalar, an Element, or an\n"
                         "    iterable of Elements (a node-set that feeds later steps).\n"
-                        ":param variables: values bound to the $name variables used in the expression.\n"
+                        ":param variables: values bound to the $name variables used in the expression; a\n"
+                        "    str, int, float, or bool binds a scalar, and an Element or an iterable of\n"
+                        "    Elements binds a node-set. A node from a different document raises ValueError.\n"
                         ":returns: the result list, of Elements and str values in document order.");
 
 PyDoc_STRVAR(xpath_iter_doc, "xpath_iter(expression, /, *, smart_strings=False, extensions=None, **variables)\n--\n\n"

--- a/src/turbohtml/_c/query/xpath/eval.c
+++ b/src/turbohtml/_c/query/xpath/eval.c
@@ -826,8 +826,10 @@ static int nodeset_union(xp_nodeset *target, xp_nodeset *source) {
     return 0;
 }
 
-/* Deep-copy a bound variable's value so the reference owns its result. The C API
-   only ever binds the scalar kinds, so there is no node-set arm. */
+/* Deep-copy a bound variable's value so the reference owns its result. A node-set
+   binding (an Element or an iterable of Elements from the caller) is copied and
+   normalized to document order without duplicates, the canonical node-set form the
+   rest of the evaluator assumes. */
 static int copy_result(const xp_result *src, xp_result *dst) {
     memset(dst, 0, sizeof(*dst));
     dst->kind = src->kind;
@@ -839,6 +841,17 @@ static int copy_result(const xp_result *src, xp_result *dst) {
         dst->string_len = src->string_len;
     } else if (src->kind == XP_NUMBER) {
         dst->number = src->number;
+    } else if (src->kind == XP_NODESET) {
+        if (src->nodes.len > 0) {
+            dst->nodes.items = PyMem_Malloc((size_t)src->nodes.len * sizeof(xp_item));
+            if (dst->nodes.items == NULL) { /* GCOVR_EXCL_BR_LINE: alloc */
+                return -1;                  /* GCOVR_EXCL_LINE */
+            }
+            memcpy(dst->nodes.items, src->nodes.items, (size_t)src->nodes.len * sizeof(xp_item));
+            dst->nodes.len = src->nodes.len;
+            dst->nodes.cap = src->nodes.len;
+            sort_unique(&dst->nodes);
+        }
     } else {
         dst->boolean = src->boolean;
     }

--- a/src/turbohtml/_c/query/xpath/internal.h
+++ b/src/turbohtml/_c/query/xpath/internal.h
@@ -173,8 +173,8 @@ typedef struct {
     void *extension_ctx;
 } xp_ctx;
 
-/* Node-set append and pre-order successor, shared by the evaluator and id(). */
-int ns_push(xp_nodeset *ns, struct th_node *node, Py_ssize_t attr);
+/* Pre-order successor, shared by the evaluator and id(). ns_push is declared in the
+   public xpath.h because the marshaling boundary also builds node-sets through it. */
 struct th_node *document_next(struct th_node *node);
 
 /* The XPath string-value of a node-set member, freshly allocated. */

--- a/src/turbohtml/_c/query/xpath/xpath.h
+++ b/src/turbohtml/_c/query/xpath/xpath.h
@@ -49,6 +49,11 @@ typedef struct {
 
 void xp_nodeset_free(xp_nodeset *ns);
 
+/* Append a member to a node-set, growing it as needed; -1 on allocation failure.
+   attr == -1 is the node itself, attr >= 0 one of its attributes. The marshaling
+   boundary uses this to build a node-set variable from caller-supplied elements. */
+int ns_push(xp_nodeset *ns, struct th_node *node, Py_ssize_t attr);
+
 /* The four XPath 1.0 value types an expression can evaluate to. */
 enum xp_result_kind { XP_NODESET, XP_NUMBER, XP_STRING, XP_BOOLEAN };
 

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -96,7 +96,7 @@ class Node:
         smart_strings: bool = ...,
         extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
         | None = ...,
-        **variables: str | float | bool,
+        **variables: str | float | bool | Element | Iterable[Element],
     ) -> list[Element | str]: ...
     def xpath_iter(
         self,
@@ -107,7 +107,7 @@ class Node:
         smart_strings: bool = ...,
         extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
         | None = ...,
-        **variables: str | float | bool,
+        **variables: str | float | bool | Element | Iterable[Element],
     ) -> Iterator[Element | str]: ...
     def xpath_one(
         self,
@@ -118,7 +118,7 @@ class Node:
         smart_strings: bool = ...,
         extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
         | None = ...,
-        **variables: str | float | bool,
+        **variables: str | float | bool | Element | Iterable[Element],
     ) -> Element | str | None: ...
     def matches(self, selector: str, /) -> bool: ...
     def closest(self, selector: str, /) -> Element | None: ...

--- a/tests/query/xpath/test_xpath_variables.py
+++ b/tests/query/xpath/test_xpath_variables.py
@@ -1,22 +1,41 @@
 """``$name`` variable references bound through keyword arguments, like lxml/parsel.
 
 A keyword argument binds a variable the expression can reference: ``str`` becomes a
-string, ``int``/``float`` a number, ``bool`` a boolean. Referencing an unbound name
-raises ``ValueError``; an unsupported value type raises ``TypeError``.
+string, ``int``/``float`` a number, ``bool`` a boolean, and an :class:`~turbohtml.Element`
+or an iterable of elements a node-set, so a prior result feeds a later expression
+(``doc.xpath("$rows/td", rows=doc.xpath("//tr"))``). A node-set variable joins path
+steps, ``count()``, unions, and predicates like any other node-set, ordered in document
+order with duplicates dropped on reference. Referencing an unbound name raises
+``ValueError``; a node from a different tree raises ``ValueError``; an unsupported value
+type raises ``TypeError``.
 """
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
 
 import turbohtml
 from turbohtml import Element
 
-HTML = "<html><body><p id='a'>one</p><p id='b'>two</p><p id='c'>three</p></body></html>"
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+
+HTML = (
+    "<html><body>"
+    "<table><tr id='r1'><td>a</td><td>b</td></tr><tr id='r2'><td>c</td></tr></table>"
+    "<p id='a'>one</p><p id='b'>two</p><p id='c'>three</p>"
+    "</body></html>"
+)
 
 
 def tags(result: list[Element | str]) -> list[str]:
     return [node.tag if isinstance(node, Element) else node for node in result]
+
+
+def ids(result: list[Element | str]) -> list[str | None]:
+    return [node.attr("id") for node in result if isinstance(node, Element)]
 
 
 @pytest.fixture
@@ -75,12 +94,12 @@ def test_unbound_variable_same_length_different_name(doc: turbohtml.Node) -> Non
 
 
 def test_unsupported_variable_type(doc: turbohtml.Node) -> None:
-    with pytest.raises(TypeError, match="str, int, float, or bool"):
-        doc.xpath("//p[@id=$x]", x=[1, 2])  # ty: ignore[invalid-argument-type]  # list is an unsupported var type
+    with pytest.raises(TypeError, match="an iterable of elements"):
+        doc.xpath("//p[@id=$x]", x=[1, 2])  # ty: ignore[invalid-argument-type]  # ints are not elements
 
 
 def test_unsupported_type_after_a_valid_binding_frees_the_partial(doc: turbohtml.Node) -> None:
-    with pytest.raises(TypeError, match="str, int, float, or bool"):
+    with pytest.raises(TypeError, match="an iterable of elements"):
         doc.xpath("$good", good="x", bad=[1])  # ty: ignore[invalid-argument-type]  # the second binding is unsupported
 
 
@@ -103,3 +122,132 @@ def test_variable_through_xpath_one(doc: turbohtml.Node) -> None:
     result = doc.xpath_one("//p[@id=$w]", w="c")
     assert isinstance(result, Element)
     assert result.text == "three"
+
+
+def query(node: turbohtml.Node, expression: str) -> list[Element]:
+    return [item for item in node.xpath(expression) if isinstance(item, Element)]
+
+
+def reversed_with_duplicate(node: turbohtml.Node) -> list[Element]:
+    paragraphs = query(node, "//p")
+    return [paragraphs[1], paragraphs[0], paragraphs[1]]
+
+
+@pytest.mark.parametrize(
+    ("expr", "make_kwargs", "expected_ids"),
+    [
+        pytest.param(
+            "$start//tr",
+            lambda document: {"start": query(document, "//table")[0]},
+            ["r1", "r2"],
+            id="single-element-feeds-a-descendant-step",
+        ),
+        pytest.param(
+            "$rows",
+            lambda document: {"rows": query(document, "//tr")},
+            ["r1", "r2"],
+            id="node-set-returned-directly-as-a-list",
+        ),
+        pytest.param(
+            "$rows | //p",
+            lambda document: {"rows": query(document, "//tr")},
+            ["r1", "r2", "a", "b", "c"],
+            id="union-with-a-node-set",
+        ),
+        pytest.param(
+            "//tr[. = $first]",
+            lambda document: {"first": query(document, "//tr[@id='r1']")},
+            ["r1"],
+            id="predicate-references-a-node-set",
+        ),
+        pytest.param(
+            "$items",
+            lambda document: {"items": reversed_with_duplicate(document)},
+            ["a", "b"],
+            id="normalized-to-document-order-without-duplicates",
+        ),
+        pytest.param(
+            "$items",
+            lambda document: {"items": query(document, "//section")},
+            [],
+            id="empty-node-set",
+        ),
+    ],
+)
+def test_node_set_variable_resolves_to_elements(
+    doc: turbohtml.Node,
+    expr: str,
+    make_kwargs: Callable[[turbohtml.Node], dict[str, Element | list[Element]]],
+    expected_ids: list[str],
+) -> None:
+    assert ids(doc.xpath(expr, **make_kwargs(doc))) == expected_ids  # ty: ignore[invalid-argument-type]  # variables unpacked as a dict
+
+
+def test_node_set_variable_feeds_a_path_step(doc: turbohtml.Node) -> None:
+    assert tags(doc.xpath("$rows/td", rows=query(doc, "//tr"))) == ["td", "td", "td"]
+
+
+@pytest.mark.parametrize(
+    ("query_expr", "expected"),
+    [
+        pytest.param("//p", 3.0, id="count-over-a-populated-node-set"),
+        pytest.param("//section", 0.0, id="count-over-an-empty-node-set"),
+    ],
+)
+def test_count_over_a_node_set_variable(doc: turbohtml.Node, query_expr: str, expected: float) -> None:
+    assert doc.xpath("count($items)", items=query(doc, query_expr)) == pytest.approx(expected)
+
+
+def test_node_set_variable_through_xpath_iter(doc: turbohtml.Node) -> None:
+    cells = [node for node in doc.xpath_iter("$rows/td", rows=query(doc, "//tr")) if isinstance(node, Element)]
+    assert [node.tag for node in cells] == ["td", "td", "td"]
+
+
+def test_node_set_variable_through_xpath_one(doc: turbohtml.Node) -> None:
+    first = doc.xpath_one("$rows", rows=query(doc, "//tr"))
+    assert isinstance(first, Element)
+    assert first.attr("id") == "r1"
+
+
+def foreign_nodes() -> list[Element]:
+    other = turbohtml.parse("<html><body><span id='x'>elsewhere</span></body></html>")
+    return query(other, "//span")
+
+
+def yield_then_raise(node: turbohtml.Node) -> Iterator[Element]:
+    yield query(node, "//p")[0]
+    msg = "boom"
+    raise RuntimeError(msg)
+
+
+@pytest.mark.parametrize(
+    ("make_items", "exc", "match"),
+    [
+        pytest.param(lambda _document: foreign_nodes(), ValueError, "different tree", id="node-from-a-different-tree"),
+        pytest.param(yield_then_raise, RuntimeError, "boom", id="iterable-raises-partway"),
+    ],
+)
+def test_node_set_variable_rejects_bad_node_sets(
+    doc: turbohtml.Node,
+    make_items: Callable[[turbohtml.Node], Iterable[Element]],
+    exc: type[Exception],
+    match: str,
+) -> None:
+    with pytest.raises(exc, match=match):
+        doc.xpath("$items", items=make_items(doc))
+
+
+@pytest.mark.parametrize(
+    "make_items",
+    [
+        pytest.param(
+            lambda document: [query(document, "//p")[0], "not-an-element"], id="non-element-inside-an-iterable"
+        ),
+        pytest.param(lambda _document: None, id="non-iterable-non-scalar-value"),
+    ],
+)
+def test_node_set_variable_rejects_unsupported_values(
+    doc: turbohtml.Node, make_items: Callable[[turbohtml.Node], object]
+) -> None:
+    with pytest.raises(TypeError, match="an iterable of elements"):
+        doc.xpath("$items", items=make_items(doc))  # ty: ignore[invalid-argument-type]  # deliberately wrong value type

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1882,6 +1882,16 @@ def lxml_namespaced(tree: HtmlElement) -> None:
     tree.xpath("//svg:rect", namespaces=_SVG_NS)
 
 
+def turbo_node_set(doc: Document, rows: Iterable[Element]) -> None:
+    """Reuse a prior result by binding it as a node-set ``$variable``, turbohtml."""
+    doc.xpath("$rows/div", rows=rows)
+
+
+def lxml_node_set(tree: HtmlElement, rows: object) -> None:
+    """Reuse a prior result by binding it as a node-set ``$variable``, lxml."""
+    tree.xpath("$rows/div", rows=rows)
+
+
 # Each parity feature paired with its turbohtml and lxml driver.
 XPATH_FEATURE_CASES: tuple[tuple[str, Callable[[Document], None], Callable[[HtmlElement], None]], ...] = (
     ("$variable binding", turbo_variable, lxml_variable),
@@ -1931,7 +1941,24 @@ def run_xpath_feature_suite(bench: Callable[[str, object, object], None]) -> lis
             lxml_reuse,
             (lxml_html.etree.XPath(REUSE_EXPR), lxml_tree(text)),
         )
-    return [label for label, _, _ in XPATH_FEATURE_CASES] + ["precompiled reuse"]
+    # The node-set case binds a prior result, so the rows are queried once outside the
+    # timed region and reused on every call -- both engines accept a node-set variable.
+    for size_name, path, enc in READPATH_CASES:
+        text = corpus_text(path, enc)
+        turbo_doc, lxml_doc = turbo_tree(text), lxml_tree(text)
+        turbo_rows = [node for node in turbo_doc.xpath("//div") if isinstance(node, turbohtml.Element)]
+        lxml_rows = lxml_doc.xpath("//div")
+        bench(
+            f"feature node-set variable | {size_name} [turbohtml]",
+            functools.partial(turbo_node_set, rows=turbo_rows),
+            turbo_doc,
+        )
+        bench(
+            f"feature node-set variable | {size_name} [lxml]",
+            functools.partial(lxml_node_set, rows=lxml_rows),
+            lxml_doc,
+        )
+    return [label for label, _, _ in XPATH_FEATURE_CASES] + ["precompiled reuse", "node-set variable"]
 
 
 def print_xpath_feature_table(means: dict[str, float], labels: list[str]) -> None:


### PR DESCRIPTION
XPath variables accepted only scalars, so a node-set produced by one query could not seed another. Reusing a prior result meant re-walking the tree or stitching strings together, while `lxml` has long let a variable carry a node-set.

This widens the `**variables` keyword on `xpath`, `xpath_one`, and `xpath_iter` to accept an `Element` or any iterable of elements. The binding marshals into a real node-set, deep-copied, sorted into document order, and deduplicated, so `$rows` behaves exactly like a node-set the engine produced itself: `doc.xpath("$rows/td", rows=doc.xpath("//tr"))` joins path steps and feeds `count()`, unions, and predicates. 🔗 Each node is checked against the tree being queried.

A node wrapped from a different document raises `ValueError`, and a value that is neither a scalar nor an iterable of elements raises `TypeError`.

closes #264
