### PR TITLE
✨ feat(xpath): return node-sets from extension functions

### DIFF
--- a/docs/changelog/265.feature.rst
+++ b/docs/changelog/265.feature.rst
@@ -1,0 +1,3 @@
+A custom XPath extension function registered through ``extensions=`` may now return an :class:`~turbohtml.Element` or an
+iterable of elements, not only a scalar. The result becomes a node-set that feeds later path steps and predicates,
+matching ``lxml`` -- ``doc.xpath("x:first_two(//div)/a", extensions={("x", "first_two"): first_two})``.

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -593,12 +593,13 @@ a reverse axis, a union, and a computed name test) runs over the 9.6 kB wpt page
 the sweep across every page size. turbohtml compiles each expression against the tree once, resolves name tests to
 interned atoms, and folds ``//`` to a single ``descendant`` walk, so it leads across the surface. The exception is a
 predicate that references ``position()`` (``[1]`` or ``position() <= 3``): it pins the result to proximity order and
-disables the ``//`` collapse, so on the largest pages lxml's streaming evaluation closes the gap. The last four rows are
+disables the ``//`` collapse, so on the largest pages lxml's streaming evaluation closes the gap. The last six rows are
 the lxml/parsel options the parity work added: a ``$variable`` binding, an EXSLT ``re:test`` predicate (turbohtml's
-Python :mod:`re` against lxml's C libexslt), a ``smart_strings`` attribute read, and a custom ``extensions=`` function.
-turbohtml still leads, since lxml resolves the namespace map and option set on every call. The last row precompiles the
-expression once with :class:`~turbohtml.XPath` and re-evaluates it, lxml's ``etree.XPath`` doing the same: both skip the
-per-call parse :meth:`~turbohtml.Node.xpath` pays, and turbohtml's compiled program stays ahead per evaluation.
+Python :mod:`re` against lxml's C libexslt), a ``smart_strings`` attribute read, a custom ``extensions=`` function, and
+an ``extensions=`` function whose return becomes a node-set feeding a later ``/@href`` step. turbohtml still leads,
+since lxml resolves the namespace map and option set on every call. The last row precompiles the expression once with
+:class:`~turbohtml.XPath` and re-evaluates it, lxml's ``etree.XPath`` doing the same: both skip the per-call parse
+:meth:`~turbohtml.Node.xpath` pays, and turbohtml's compiled program stays ahead per evaluation.
 
 .. list-table::
     :header-rows: 1
@@ -652,6 +653,9 @@ per-call parse :meth:`~turbohtml.Node.xpath` pays, and turbohtml's compiled prog
     - - ``ext(//a)`` (extensions)
       - 1.0 µs
       - 3.0 µs
+    - - ``ext(//a)/@href`` (node-set extension)
+      - 1.1 µs
+      - 3.2 µs
     - - ``//a[@href]`` (precompiled, reused)
       - 0.5 µs
       - 2.8 µs

--- a/docs/explanation/queries.rst
+++ b/docs/explanation/queries.rst
@@ -55,7 +55,11 @@ object evaluates against many context nodes, the same design lxml's ``etree.XPat
 one-name-per-concept and returns plain lists, so the jQuery-style chaining pyquery users expect lives in an optional
 Python-side wrapper, :class:`turbohtml.query.Query`, whose traversal and mutation methods each return a wrapper. Output
 runs back through :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and :meth:`~turbohtml.Node.encode`,
-WHATWG-conformant by default with the escaping selectable through :class:`~turbohtml.Formatter`.
+WHATWG-conformant by default with the escaping selectable through :class:`~turbohtml.Formatter`. A registered
+``extensions=`` function crosses the same value boundary in both directions: the four XPath value types marshal to and
+from Python, so a node-set argument arrives as a list of elements and a returned element or iterable of elements becomes
+a node-set the engine can feed into later steps. The extension only ever sees live wrappers bound to the queried tree,
+never the C node model, so a returned element from another document is rejected rather than silently mixing arenas.
 
 *****************************
  Extracting strings (parsel)

--- a/docs/how-to/querying.rst
+++ b/docs/how-to/querying.rst
@@ -374,6 +374,32 @@ namespace; the ``re:`` prefix dispatches to Python's :mod:`re`:
 
     ['/p/12']
 
+Register your own functions under ``extensions={(namespace, name): callable}`` (use ``None`` for the namespace to call
+the function unprefixed). The callable receives a context whose ``context_node`` is the current element, then the
+evaluated arguments: a node-set arrives as a ``list`` of :class:`~turbohtml.Element`, and a string, number, or boolean
+as the matching Python scalar. Returning a ``str``, number, or ``bool`` produces a scalar; returning an element or an
+iterable of elements produces a node-set that feeds later path steps and predicates, exactly as in ``lxml``:
+
+.. testcode::
+
+    import turbohtml
+    from types import SimpleNamespace
+    from turbohtml import Element
+
+    def first_two(context: SimpleNamespace, nodes: list[Element]) -> list[Element]:
+        return nodes[:2]
+
+    doc = turbohtml.parse("<ul><li>a</li><li>b</li><li>c</li></ul>")
+    result = doc.xpath("first_two(//li)/text()", extensions={(None, "first_two"): first_two})
+    print(result)
+
+.. testoutput::
+
+    ['a', 'b']
+
+Every element in a returned node-set must belong to the document being queried; returning one from another parse raises
+``ValueError``.
+
 When one expression runs over many nodes or documents -- a scraper looping rows, or one query across a corpus -- compile
 it once with :class:`turbohtml.XPath` instead of re-parsing it on every :meth:`~turbohtml.Node.xpath` call. Bind
 ``smart_strings`` and ``extensions`` at construction, then call the object with a context node and any ``$name``

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -86,6 +86,9 @@ lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtm
       - :class:`~turbohtml.XPath` (``XPath("//a[@href=$u]")(el, u=v)``)
     - - ``el.cssselect("div a")``
       - :meth:`~turbohtml.Node.select`
+    - - ``etree.FunctionNamespace(None)["f"] = fn``; ``el.xpath("f(//a)")``
+      - :meth:`el.xpath("f(//a)", extensions={(None, "f"): fn}) <turbohtml.Node.xpath>` (the function may return a
+        scalar, an :class:`~turbohtml.Element`, or an iterable of elements)
     - - ``lxml.html.Element("div")``, ``etree.SubElement(p, "div")``
       - :class:`~turbohtml.Element`, :meth:`p.append(Element("div")) <turbohtml.Element.append>`
     - - ``el.drop_tag()``, ``el.drop_tree()``
@@ -149,6 +152,30 @@ kB wpt page from the :doc:`/development/performance` benchmark (``tox -e bench x
 .. testoutput::
 
     ['/x']
+
+lxml registers custom XPath callables through ``etree.FunctionNamespace``; turbohtml passes them per call through the
+``extensions=`` mapping of :meth:`~turbohtml.Node.xpath`. Both dispatch a Python callable per match, but lxml
+re-resolves its namespace and function table on every evaluation while turbohtml binds the mapping once against the
+compiled expression, and a callable that returns an :class:`~turbohtml.Element` (or an iterable of them) is marshaled
+straight back into the evaluator's node-set so the next path step stays on the all-C fast path. Measured over the 9.6 kB
+wpt page with ``tox -e bench xpath``:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 46 18 18 18
+
+    - - extension call
+      - turbohtml
+      - lxml
+      - speed-up
+    - - scalar return (``ext_count(//a)``)
+      - 1.1 µs
+      - 4.1 µs
+      - 3.6x
+    - - node-set return (``ext_first_two(//a)/@href``)
+      - 1.1 µs
+      - 3.2 µs
+      - 2.9x
 
 **********
  Pitfalls

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1462,6 +1462,80 @@ typedef struct {
     th_tree *tree;
 } xpath_ext_ctx;
 
+/* Grow `set` by one node (attr -1, the node itself), doubling capacity as needed. */
+static int xpath_nodeset_push(xp_nodeset *set, th_node *node) {
+    if (set->len == set->cap) {
+        Py_ssize_t cap = set->cap ? set->cap * 2 : 8;
+        xp_item *grown = PyMem_Realloc(set->items, (size_t)cap * sizeof(xp_item));
+        if (grown == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+            PyErr_NoMemory(); /* GCOVR_EXCL_LINE */
+            return -1;        /* GCOVR_EXCL_LINE */
+        }
+        set->items = grown;
+        set->cap = cap;
+    }
+    set->items[set->len].node = node;
+    set->items[set->len].attr = -1;
+    set->len++;
+    return 0;
+}
+
+/* Append the tree node a returned element wraps to `set`, rejecting an object that
+   is not one of this module's nodes or an element bound to a different document. */
+static int xpath_append_result_node(xpath_ext_ctx *ec, PyObject *obj, xp_nodeset *set) {
+    if (!is_node(obj, ec->state)) {
+        PyErr_Format(PyExc_TypeError,
+                     "xpath extension result must be str, int, float, bool, an element, or an iterable of elements, "
+                     "not %.80s",
+                     Py_TYPE(obj)->tp_name);
+        return -1;
+    }
+    NodeObject *node_obj = (NodeObject *)obj;
+    if (node_obj->handle != ec->handle) {
+        PyErr_SetString(PyExc_ValueError, "xpath extension returned an element from a different document");
+        return -1;
+    }
+    return xpath_nodeset_push(set, node_obj->node);
+}
+
+/* Marshal an extension's return value into an xp_result: a Python scalar keeps the
+   str/int/float/bool conversion; a single element or an iterable of elements becomes
+   a node-set (issue #265). */
+static int xpath_extension_result(xpath_ext_ctx *ec, PyObject *obj, xp_result *out) {
+    if (PyBool_Check(obj) || PyLong_Check(obj) || PyFloat_Check(obj) || PyUnicode_Check(obj)) {
+        return xpath_pyobject_to_scalar(obj, out, "an extension result");
+    }
+    memset(out, 0, sizeof(*out));
+    out->kind = XP_NODESET;
+    if (is_node(obj, ec->state)) {
+        return xpath_append_result_node(ec, obj, &out->nodes);
+    }
+    PyObject *iterator = PyObject_GetIter(obj);
+    if (iterator == NULL) {
+        PyErr_Format(PyExc_TypeError,
+                     "xpath extension result must be str, int, float, bool, an element, or an iterable of elements, "
+                     "not %.80s",
+                     Py_TYPE(obj)->tp_name);
+        return -1;
+    }
+    PyObject *item;
+    while ((item = PyIter_Next(iterator)) != NULL) {
+        int rc = xpath_append_result_node(ec, item, &out->nodes);
+        Py_DECREF(item);
+        if (rc < 0) {
+            Py_DECREF(iterator);
+            xp_result_free(out);
+            return -1;
+        }
+    }
+    Py_DECREF(iterator);
+    if (PyErr_Occurred()) { /* the iterable raised partway through */
+        xp_result_free(out);
+        return -1;
+    }
+    return 0;
+}
+
 /* Marshal one evaluated argument to the Python object an extension receives. */
 static PyObject *xpath_arg_to_py(xpath_ext_ctx *ec, const xp_result *value) {
     if (value->kind == XP_NODESET) {
@@ -1559,7 +1633,7 @@ static int xpath_call_extension(void *vctx, th_node *context_node, const Py_UCS4
     if (result == NULL) {
         return -1; /* the extension raised */
     }
-    int rc = xpath_pyobject_to_scalar(result, out, "an extension result");
+    int rc = xpath_extension_result(ec, result, out);
     Py_DECREF(result);
     return rc;
 }

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -1057,7 +1057,8 @@ PyDoc_STRVAR(xpath_doc, "xpath(expression, /, *, smart_strings=False, extensions
                         ":param smart_strings: return each string result as a value that remembers the\n"
                         "    Element it came from.\n"
                         ":param extensions: maps an (namespace, name) pair to a callable, registering a\n"
-                        "    custom XPath function.\n"
+                        "    custom XPath function; the callable may return a scalar, an Element, or an\n"
+                        "    iterable of Elements (a node-set that feeds later steps).\n"
                         ":param variables: values bound to the $name variables used in the expression.\n"
                         ":returns: the result list, of Elements and str values in document order.");
 

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -93,7 +93,8 @@ class Node:
         /,
         *,
         smart_strings: bool = ...,
-        extensions: dict[tuple[str | None, str], Callable[..., str | float | bool]] | None = ...,
+        extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
+        | None = ...,
         **variables: str | float | bool,
     ) -> list[Element | str]: ...
     def xpath_iter(
@@ -102,7 +103,8 @@ class Node:
         /,
         *,
         smart_strings: bool = ...,
-        extensions: dict[tuple[str | None, str], Callable[..., str | float | bool]] | None = ...,
+        extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
+        | None = ...,
         **variables: str | float | bool,
     ) -> Iterator[Element | str]: ...
     def xpath_one(
@@ -111,7 +113,8 @@ class Node:
         /,
         *,
         smart_strings: bool = ...,
-        extensions: dict[tuple[str | None, str], Callable[..., str | float | bool]] | None = ...,
+        extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
+        | None = ...,
         **variables: str | float | bool,
     ) -> Element | str | None: ...
     def matches(self, selector: str, /) -> bool: ...

--- a/tests/query/xpath/test_xpath_extensions.py
+++ b/tests/query/xpath/test_xpath_extensions.py
@@ -4,12 +4,14 @@ A custom function is registered under a ``(namespace, name)`` key and called as
 ``name(...)`` (the un-namespaced ``(None, name)`` form, which needs no namespace
 mapping). It receives a context whose ``context_node`` is the current element,
 then the evaluated arguments: a node-set arrives as a list, a string/number/bool
-as the matching Python scalar. The return must be a str, number, or bool.
+as the matching Python scalar. The return may be a str, number, or bool, or (issue
+#265) an element or an iterable of elements that becomes a node-set feeding later
+path steps and predicates.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -17,7 +19,7 @@ import turbohtml
 from turbohtml import Element
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable, Iterator
     from types import SimpleNamespace
 
 HTML = "<html><body><a href='/x'>one</a><a href='/y'>two</a></body></html>"
@@ -39,7 +41,7 @@ def context_tag(context: SimpleNamespace) -> str:
     return context.context_node.tag
 
 
-EXTENSIONS: dict[tuple[str | None, str], Callable[..., str | float | bool]] = {
+EXTENSIONS: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]] = {
     (None, "count_nodes"): count_nodes,
     (None, "shout"): shout,
     (None, "echo"): echo,
@@ -126,3 +128,119 @@ def test_extension_receiving_an_element_from_a_nodeset(doc: turbohtml.Node) -> N
         return nodes[0].text
 
     assert doc.xpath("first_text(//a)", extensions={(None, "first_text"): first_text}) == "one"
+
+
+def first_node(_context: SimpleNamespace, nodes: list[Element]) -> Element:
+    return nodes[0]
+
+
+def first_two(_context: SimpleNamespace, nodes: list[Element]) -> list[Element]:
+    return nodes[:2]
+
+
+def each(_context: SimpleNamespace, nodes: list[Element]) -> Iterator[Element]:
+    yield from nodes
+
+
+def all_nodes(_context: SimpleNamespace, nodes: list[Element]) -> list[Element]:
+    return nodes
+
+
+def empty(_context: SimpleNamespace, _nodes: list[Element]) -> list[Element]:
+    return []
+
+
+NODESET_EXTENSIONS: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]] = {
+    (None, "first_node"): first_node,
+    (None, "first_two"): first_two,
+    (None, "each"): each,
+    (None, "all_nodes"): all_nodes,
+    (None, "empty"): empty,
+}
+
+
+@pytest.fixture
+def big_doc() -> turbohtml.Node:
+    return turbohtml.parse("<ul>" + "".join(f"<li>{index}</li>" for index in range(12)) + "</ul>")
+
+
+def _texts(result: object) -> list[str]:
+    assert isinstance(result, list)
+    return [node.text if isinstance(node, Element) else str(node) for node in result]
+
+
+@pytest.mark.parametrize(
+    ("fixture", "expression", "expected"),
+    [
+        pytest.param("doc", "first_node(//a)", ["one"], id="single-element-is-a-node-set"),
+        pytest.param("doc", "first_two(//a)", ["one", "two"], id="list-of-elements-is-a-node-set"),
+        pytest.param("doc", "each(//a)", ["one", "two"], id="generator-of-elements-is-a-node-set"),
+        pytest.param("doc", "empty(//a)", [], id="empty-iterable-is-an-empty-node-set"),
+        pytest.param("doc", "first_node(//a)/text()", ["one"], id="node-set-feeds-a-later-path-step"),
+        pytest.param("doc", "first_two(//a)[2]", ["two"], id="node-set-feeds-a-predicate"),
+        pytest.param(
+            "big_doc", "all_nodes(//li)", [str(index) for index in range(12)], id="many-elements-grow-the-node-set"
+        ),
+    ],
+)
+def test_extension_result_becomes_a_node_set(
+    request: pytest.FixtureRequest, *, fixture: str, expression: str, expected: list[str]
+) -> None:
+    page = cast("turbohtml.Node", request.getfixturevalue(fixture))
+    assert _texts(page.xpath(expression, extensions=NODESET_EXTENSIONS)) == expected
+
+
+def test_extension_returning_an_integer_stays_a_number(doc: turbohtml.Node) -> None:
+    assert doc.xpath("five()", extensions={(None, "five"): lambda _context: 5}) == pytest.approx(5.0)
+
+
+def return_none(_context: SimpleNamespace) -> Element:
+    return cast("Element", None)
+
+
+def mixed(_context: SimpleNamespace, nodes: list[Element]) -> list[Element]:
+    return [nodes[0], cast("Element", 123)]
+
+
+def raise_partway(_context: SimpleNamespace, nodes: list[Element]) -> Iterator[Element]:
+    yield nodes[0]
+    msg = "boom"
+    raise RuntimeError(msg)
+
+
+_OTHER_DOCUMENT = turbohtml.parse("<p>elsewhere</p>")
+_STRANGER = next(node for node in _OTHER_DOCUMENT.xpath("//p") if isinstance(node, Element))
+
+
+def steal(_context: SimpleNamespace) -> Element:
+    return _STRANGER
+
+
+@pytest.mark.parametrize(
+    ("function", "expression", "exception", "match"),
+    [
+        pytest.param(
+            return_none, "return_none()", TypeError, "extension result must be", id="none-result-is-a-type-error"
+        ),
+        pytest.param(
+            mixed, "mixed(//a)", TypeError, "extension result must be", id="non-element-in-iterable-is-a-type-error"
+        ),
+        pytest.param(
+            steal, "steal()", ValueError, "different document", id="foreign-document-element-is-a-value-error"
+        ),
+        pytest.param(
+            raise_partway, "raise_partway(//a)", RuntimeError, "boom", id="iterable-that-raises-partway-propagates"
+        ),
+    ],
+)
+def test_extension_result_marshaling_is_rejected(
+    doc: turbohtml.Node,
+    *,
+    function: Callable[..., str | float | bool | Element | Iterable[Element]],
+    expression: str,
+    exception: type[Exception],
+    match: str,
+) -> None:
+    name = expression[: expression.index("(")]
+    with pytest.raises(exception, match=match):
+        doc.xpath(expression, extensions={(None, name): function})

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -97,11 +97,11 @@ _LXML_CLEANER = lxml_html_clean.Cleaner()
 _HTML_SANITIZER = html_sanitizer.Sanitizer()
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from lxml.html import HtmlElement
 
-    from turbohtml import Document
+    from turbohtml import Document, Element
 
 CORPUS_DIR = Path(__file__).parent / "html5lib-python" / "benchmarks" / "data"
 CORPUS_FILES: list[tuple[str, str, str]] = [
@@ -1693,7 +1693,7 @@ def _bench_count_ext(_context: object, nodes: list[object]) -> float:
     return float(len(nodes))
 
 
-_XPATH_EXTENSIONS: dict[tuple[str | None, str], Callable[..., str | float | bool]] = {
+_XPATH_EXTENSIONS: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]] = {
     (None, "ext_count"): _bench_count_ext
 }
 
@@ -1738,12 +1738,33 @@ def lxml_extension(tree: HtmlElement) -> None:
     tree.xpath("ext_count(//a)", extensions=_XPATH_EXTENSIONS)
 
 
+def _bench_first_two(_context: object, nodes: list[Element]) -> list[Element]:
+    """Return the first two nodes as a node-set; the cheapest non-trivial node-set return."""
+    return nodes[:2]
+
+
+_XPATH_NODESET_EXTENSIONS: dict[
+    tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]
+] = {(None, "ext_first_two"): _bench_first_two}
+
+
+def turbo_nodeset_extension(doc: Document) -> None:
+    """Call an extension that returns a node-set feeding a later path step, turbohtml."""
+    doc.xpath("ext_first_two(//a)/@href", extensions=_XPATH_NODESET_EXTENSIONS)
+
+
+def lxml_nodeset_extension(tree: HtmlElement) -> None:
+    """Call an extension that returns a node-set feeding a later path step, lxml."""
+    tree.xpath("ext_first_two(//a)/@href", extensions=_XPATH_NODESET_EXTENSIONS)
+
+
 # Each parity feature paired with its turbohtml and lxml driver.
 XPATH_FEATURE_CASES: tuple[tuple[str, Callable[[Document], None], Callable[[HtmlElement], None]], ...] = (
     ("$variable binding", turbo_variable, lxml_variable),
     ("EXSLT re:test", turbo_retest, lxml_retest),
     ("smart_strings", turbo_smart, lxml_smart),
     ("extension function", turbo_extension, lxml_extension),
+    ("extension node-set", turbo_nodeset_extension, lxml_nodeset_extension),
 )
 
 # The reuse path turbohtml.XPath adds: parse the expression once into an immutable


### PR DESCRIPTION
A registered XPath extension function could return only a string, number, or boolean, so it could never hand a set of elements back to the expression that called it. That ruled out the most useful custom functions: the ones that select or filter nodes.

Extension callables registered through `extensions=` may now return an `Element` or any iterable of elements. The return value marshals into a node-set that flows into the surrounding expression, so `doc.xpath("first_two(//div)/a", extensions={(None, "first_two"): first_two})` steps from the function's result like any other path. ✨ Returned nodes are validated against the queried tree.

An element from another document raises `ValueError`, and a non-element return, or an iterable that yields one, raises `TypeError`.

closes #265
