### PR TITLE
✨ feat(xpath): bind namespace prefixes

### DIFF
--- a/docs/changelog/263.feature.rst
+++ b/docs/changelog/263.feature.rst
@@ -1,0 +1,4 @@
+Bind namespace prefixes for XPath name tests with a ``namespaces`` keyword on :meth:`~turbohtml.Node.xpath`,
+:meth:`~turbohtml.Node.xpath_one`, and :meth:`~turbohtml.Node.xpath_iter`, so a prefixed test like ``//svg:rect``
+resolves against a ``{"svg": "http://www.w3.org/2000/svg"}`` mapping and matches the SVG (or MathML) element by
+namespace and local name, mirroring ``lxml``'s ``namespaces=`` argument.

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -637,14 +637,15 @@ a reverse axis, a union, and a computed name test) runs over the 9.6 kB wpt page
 the sweep across every page size. turbohtml compiles each expression against the tree once, resolves name tests to
 interned atoms, and folds ``//`` to a single ``descendant`` walk, so it leads across the surface. The exception is a
 predicate that references ``position()`` (``[1]`` or ``position() <= 3``): it pins the result to proximity order and
-disables the ``//`` collapse, so on the largest pages lxml's streaming evaluation closes the gap. The last six rows are
-the lxml/parsel options the parity work added: a ``$variable`` binding, an EXSLT ``re:test`` predicate (turbohtml's
+disables the ``//`` collapse, so on the largest pages lxml's streaming evaluation closes the gap. The last seven rows
+are the lxml/parsel options the parity work added: a ``$variable`` binding, an EXSLT ``re:test`` predicate (turbohtml's
 Python :mod:`re` against lxml's C libexslt), an EXSLT ``set:distinct`` node-set reduction (built-in C dispatch on both
-sides, so it races C against C), a ``smart_strings`` attribute read, a custom ``extensions=`` function, and an
-``extensions=`` function whose return becomes a node-set feeding a later ``/@href`` step. turbohtml still leads, since
-lxml resolves the namespace map and option set on every call. The last row precompiles the expression once with
-:class:`~turbohtml.XPath` and re-evaluates it, lxml's ``etree.XPath`` doing the same: both skip the per-call parse
-:meth:`~turbohtml.Node.xpath` pays, and turbohtml's compiled program stays ahead per evaluation.
+sides, so it races C against C), a ``smart_strings`` attribute read, a custom ``extensions=`` function, an
+``extensions=`` function whose return becomes a node-set feeding a later ``/@href`` step, and a ``namespaces=`` prefix
+binding that resolves ``//svg:rect`` against ``{"svg": ".../2000/svg"}`` over a page carrying an SVG block. turbohtml
+still leads, since lxml resolves the namespace map and option set on every call. The last row precompiles the expression
+once with :class:`~turbohtml.XPath` and re-evaluates it, lxml's ``etree.XPath`` doing the same: both skip the per-call
+parse :meth:`~turbohtml.Node.xpath` pays, and turbohtml's compiled program stays ahead per evaluation.
 
 .. list-table::
     :header-rows: 1
@@ -704,6 +705,9 @@ lxml resolves the namespace map and option set on every call. The last row preco
     - - ``ext(//a)/@href`` (node-set extension)
       - 1.1 µs
       - 3.2 µs
+    - - ``//svg:rect`` (namespaces=)
+      - 0.9 µs
+      - 3.7 µs
     - - ``//a[@href]`` (precompiled, reused)
       - 0.5 µs
       - 2.8 µs

--- a/docs/explanation/queries.rst
+++ b/docs/explanation/queries.rst
@@ -53,15 +53,19 @@ function library run at lxml's speed. Because that program holds no tree pointer
 :class:`turbohtml.XPath` exposes it directly: a hot expression compiles once and a single re-entrant, thread-shareable
 object evaluates against many context nodes, the same design lxml's ``etree.XPath`` uses. The EXSLT ``re:``, ``set:``,
 ``str:``, ``math:``, and ``date:`` namespaces dispatch in the same C engine, so the regexp, node-set, string, numeric,
-and date helpers ``libexslt`` gives lxml work without registering a namespace. The core API stays one-name-per-concept
-and returns plain lists, so the jQuery-style chaining pyquery users expect lives in an optional Python-side wrapper,
-:class:`turbohtml.query.Query`, whose traversal and mutation methods each return a wrapper. Output runs back through
-:attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and :meth:`~turbohtml.Node.encode`, WHATWG-conformant
-by default with the escaping selectable through :class:`~turbohtml.Formatter`. A registered ``extensions=`` function
-crosses the same value boundary in both directions: the four XPath value types marshal to and from Python, so a node-set
-argument arrives as a list of elements and a returned element or iterable of elements becomes a node-set the engine can
-feed into later steps. The extension only ever sees live wrappers bound to the queried tree, never the C node model, so
-a returned element from another document is rejected rather than silently mixing arenas.
+and date helpers ``libexslt`` gives lxml work without registering a namespace. A prefix-to-URI mapping passed as
+``namespaces`` is resolved during evaluation rather than baked into the compiled program, so the one cached program
+serves every mapping; a prefixed name test then constrains the match to the foreign-content namespace the tree builder
+tagged (SVG or MathML), while unprefixed tests stay namespace-agnostic over the null-namespace HTML tree. The core API
+stays one-name-per-concept and returns plain lists, so the jQuery-style chaining pyquery users expect lives in an
+optional Python-side wrapper, :class:`turbohtml.query.Query`, whose traversal and mutation methods each return a
+wrapper. Output runs back through :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.serialize`, and
+:meth:`~turbohtml.Node.encode`, WHATWG-conformant by default with the escaping selectable through
+:class:`~turbohtml.Formatter`. A registered ``extensions=`` function crosses the same value boundary in both directions:
+the four XPath value types marshal to and from Python, so a node-set argument arrives as a list of elements and a
+returned element or iterable of elements becomes a node-set the engine can feed into later steps. The extension only
+ever sees live wrappers bound to the queried tree, never the C node model, so a returned element from another document
+is rejected rather than silently mixing arenas.
 
 *****************************
  Extracting strings (parsel)

--- a/docs/how-to/querying.rst
+++ b/docs/how-to/querying.rst
@@ -348,6 +348,21 @@ Two functions read the HTML document the way HTML means it, where ``lxml``'s leg
 real SVG and MathML namespace for foreign content (``lxml`` leaves it empty). HTML elements report no namespace in both,
 so an unprefixed name test keeps matching them.
 
+To select foreign content by namespace, bind each prefix to a URI through ``namespaces`` (the same argument ``lxml``
+takes). A prefixed name test then matches an element whose namespace equals the bound URI and whose local name equals
+the suffix, so ``//svg:rect`` finds the SVG rectangle while the unprefixed ``//rect`` keeps matching by name alone:
+
+.. testcode::
+
+    import turbohtml
+    doc = turbohtml.parse("<svg><rect/><circle/></svg>")
+    rects = doc.xpath("//svg:rect", namespaces={"svg": "http://www.w3.org/2000/svg"})
+    print(len(rects))
+
+.. testoutput::
+
+    1
+
 Pass ``$name`` variables as keyword arguments instead of formatting values into the expression string, so a value with
 quotes or special characters cannot break the query:
 

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -84,6 +84,8 @@ lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtm
       - :meth:`~turbohtml.Node.find_all`, :meth:`~turbohtml.Node.xpath`
     - - ``etree.XPath("//a[@href=$u]")(el, u=v)``
       - :class:`~turbohtml.XPath` (``XPath("//a[@href=$u]")(el, u=v)``)
+    - - ``el.xpath("//svg:rect", namespaces={"svg": SVG})``
+      - :meth:`~turbohtml.Node.xpath` with the same ``namespaces={"svg": SVG}`` (the prefix binds at evaluation time)
     - - ``el.cssselect("div a")``
       - :meth:`~turbohtml.Node.select`
     - - ``etree.FunctionNamespace(None)["f"] = fn``; ``el.xpath("f(//a)")``
@@ -176,6 +178,35 @@ wpt page with ``tox -e bench xpath``:
       - 1.1 µs
       - 3.2 µs
       - 2.9x
+
+A namespace-prefixed name test ports unchanged: pass the same ``namespaces=`` mapping to :meth:`~turbohtml.Node.xpath`
+that you give lxml. turbohtml binds the prefix at evaluation time against the per-tree cached program and resolves the
+suffix to an interned atom, while lxml re-reads the namespace map on every call, so ``//svg:rect`` with
+``namespaces={"svg": "http://www.w3.org/2000/svg"}`` runs several times faster across page sizes (``tox -e bench
+xpath``, over a page carrying an SVG block):
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - ``//svg:rect`` (namespaces=)
+      - turbohtml
+      - lxml
+      - speed-up
+    - - wpt page (4 kB)
+      - 0.8 µs
+      - 3.9 µs
+      - 4.8x
+    - - wpt page (9.6 kB)
+      - 0.9 µs
+      - 3.7 µs
+      - 3.9x
+    - - wpt page (92 kB)
+      - 15.5 µs
+      - 22.5 µs
+      - 1.5x
+
+The :doc:`/development/performance` page benchmarks the rest of the XPath surface against lxml.
 
 **********
  Pitfalls

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1699,8 +1699,8 @@ static PyObject *xpath_result_to_py(module_state *state, PyObject *handle, th_tr
     return out;
 }
 
-static PyObject *xpath_eval_object(PyObject *self, PyObject *arg, const xp_bindings *vars, int smart_strings,
-                                   PyObject *extensions) {
+static PyObject *xpath_eval_object(PyObject *self, PyObject *arg, const xp_bindings *vars,
+                                   const xp_namespaces *namespaces, int smart_strings, PyObject *extensions) {
     if (!PyUnicode_Check(arg)) {
         PyErr_SetString(PyExc_TypeError, "xpath expression must be a str");
         return NULL;
@@ -1720,7 +1720,7 @@ static PyObject *xpath_eval_object(PyObject *self, PyObject *arg, const xp_bindi
     if (prog != NULL) {
         compiled = 1;
         xp_result result;
-        status = xp_eval(prog, tree, origin, vars, extensions != NULL ? xpath_call_extension : NULL,
+        status = xp_eval(prog, tree, origin, vars, namespaces, extensions != NULL ? xpath_call_extension : NULL,
                          extensions != NULL ? &ext_ctx : NULL, &result, &feature);
         if (status == 0) {
             out = xpath_result_to_py(state, handle, tree, smart_strings, &result);
@@ -1750,7 +1750,7 @@ static PyObject *xpath_run_program(module_state *state, PyObject *handle, th_nod
     th_tree *tree = handle_obj->tree;
     xpath_ext_ctx ext_ctx = {extensions, handle, state, tree};
     xp_result result;
-    status = xp_eval(prog, tree, origin, vars, extensions != NULL ? xpath_call_extension : NULL,
+    status = xp_eval(prog, tree, origin, vars, NULL, extensions != NULL ? xpath_call_extension : NULL,
                      extensions != NULL ? &ext_ctx : NULL, &result, &feature);
     if (status == 0) {
         out = xpath_result_to_py(state, handle, tree, smart_strings, &result);
@@ -1806,6 +1806,67 @@ static void free_xpath_vars(xp_binding *items, Py_ssize_t len) {
     PyMem_Free(items);
 }
 
+static void free_xpath_namespaces(xp_namespace *items, Py_ssize_t len) {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        PyMem_Free((void *)items[index].prefix);
+        PyMem_Free((void *)items[index].uri);
+    }
+    PyMem_Free(items);
+}
+
+/* Build the prefix-to-URI bindings from the `namespaces` keyword: a dict mapping str
+   prefixes to str URIs. On error an exception is set and any partial bindings are freed. */
+static int build_xpath_namespaces(PyObject *mapping, xp_namespace **out_items, Py_ssize_t *out_len) {
+    *out_items = NULL;
+    *out_len = 0;
+    if (mapping == NULL || mapping == Py_None) {
+        return 0;
+    }
+    if (!PyDict_Check(mapping)) {
+        PyErr_SetString(PyExc_TypeError, "xpath namespaces must be a dict of prefix -> URI");
+        return -1;
+    }
+    Py_ssize_t total = PyDict_GET_SIZE(mapping);
+    if (total == 0) {
+        return 0;
+    }
+    xp_namespace *items = PyMem_Calloc((size_t)total, sizeof(xp_namespace));
+    if (items == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+        PyErr_NoMemory(); /* GCOVR_EXCL_LINE */
+        return -1;        /* GCOVR_EXCL_LINE */
+    }
+    Py_ssize_t count = 0;
+    Py_ssize_t pos = 0;
+    PyObject *key;
+    PyObject *value;
+    while (PyDict_Next(mapping, &pos, &key, &value)) {
+        if (!PyUnicode_Check(key) || !PyUnicode_Check(value)) {
+            free_xpath_namespaces(items, count);
+            PyErr_SetString(PyExc_TypeError, "xpath namespaces must map str prefixes to str URIs");
+            return -1;
+        }
+        Py_UCS4 *prefix = PyUnicode_AsUCS4Copy(key);
+        if (prefix == NULL) {                    /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+            free_xpath_namespaces(items, count); /* GCOVR_EXCL_LINE */
+            return -1;                           /* GCOVR_EXCL_LINE */
+        }
+        Py_UCS4 *uri = PyUnicode_AsUCS4Copy(value);
+        if (uri == NULL) {                       /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+            PyMem_Free(prefix);                  /* GCOVR_EXCL_LINE */
+            free_xpath_namespaces(items, count); /* GCOVR_EXCL_LINE */
+            return -1;                           /* GCOVR_EXCL_LINE */
+        }
+        items[count].prefix = prefix;
+        items[count].prefix_len = PyUnicode_GET_LENGTH(key);
+        items[count].uri = uri;
+        items[count].uri_len = PyUnicode_GET_LENGTH(value);
+        count++;
+    }
+    *out_items = items;
+    *out_len = count;
+    return 0;
+}
+
 /* Build the $name bindings from the call's keyword arguments (kwargs keys are
    always str). With reserve_options set, the smart_strings and extensions keys are
    skipped because Node.xpath reads them as options off the same kwargs; the
@@ -1834,6 +1895,9 @@ static int build_xpath_vars(PyObject *kwds, int reserve_options, xp_binding **ou
                 continue; /* a reserved option the caller reads, not a $variable */
             }
             if (PyUnicode_CompareWithASCIIString(key, "extensions") == 0) {
+                continue;
+            }
+            if (PyUnicode_CompareWithASCIIString(key, "namespaces") == 0) {
                 continue;
             }
         }
@@ -1884,14 +1948,24 @@ static PyObject *xpath_eval_with_vars(PyObject *self, PyObject *args, PyObject *
             extensions = PyDict_GET_SIZE(ext) > 0 ? ext : NULL;
         }
     }
+    xp_namespace *ns_items;
+    Py_ssize_t ns_len;
+    PyObject *ns_arg = kwds == NULL ? NULL : PyDict_GetItemString(kwds, "namespaces"); /* borrowed */
+    if (build_xpath_namespaces(ns_arg, &ns_items, &ns_len) < 0) {
+        return NULL;
+    }
     xp_binding *items;
     Py_ssize_t len;
     if (build_xpath_vars(kwds, 1, &items, &len) < 0) {
+        free_xpath_namespaces(ns_items, ns_len);
         return NULL;
     }
     xp_bindings vars = {items, len};
-    PyObject *result = xpath_eval_object(self, expr_obj, len == 0 ? NULL : &vars, smart_strings, extensions);
+    xp_namespaces namespaces = {ns_items, ns_len};
+    PyObject *result = xpath_eval_object(self, expr_obj, len == 0 ? NULL : &vars, ns_len == 0 ? NULL : &namespaces,
+                                         smart_strings, extensions);
     free_xpath_vars(items, len);
+    free_xpath_namespaces(ns_items, ns_len);
     return result;
 }
 

--- a/src/turbohtml/_c/query/xpath/eval.c
+++ b/src/turbohtml/_c/query/xpath/eval.c
@@ -64,21 +64,51 @@ static uint32_t resolve_attr_atom(struct th_tree *tree, const Py_UCS4 *name, Py_
     return th_attr_lookup(tree, buf, len);
 }
 
-static int element_name_matches(struct th_node *node, const xn *step, uint16_t atom) {
-    if (atom != TH_TAG_UNKNOWN) {
-        return node->atom == atom;
-    }
-    if (node->atom != TH_TAG_UNKNOWN || node->text_len != step->str_len) {
+/* A step's name test resolved once before the axis walk: the local part (the suffix
+   after any "prefix:"), its interned atoms, and the namespace constraint a bound prefix
+   adds. With no prefix the test matches by local name in any namespace, as before. */
+typedef struct {
+    uint16_t atom;      /* tag atom of the local name (element axes), else 0 */
+    uint32_t attr_atom; /* attr atom of the local name (attribute axis), else UINT32_MAX */
+    const Py_UCS4 *local;
+    Py_ssize_t local_len;
+    int has_ns;         /* the test carried a namespace prefix */
+    int ns_unmatchable; /* the bound URI names no namespace an HTML tree's elements carry */
+    uint8_t want_ns;    /* enum th_ns an element must carry when has_ns and not unmatchable */
+} step_match;
+
+static int ucs4_eq_ascii(const Py_UCS4 *text, Py_ssize_t text_len, const char *ascii, Py_ssize_t ascii_len) {
+    if (text_len != ascii_len) {
         return 0;
     }
-    return memcmp(node->text, step->str, (size_t)step->str_len * sizeof(Py_UCS4)) == 0;
+    for (Py_ssize_t index = 0; index < text_len; index++) {
+        if (text[index] != (Py_UCS4)(unsigned char)ascii[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int element_name_matches(struct th_node *node, const step_match *match) {
+    if (match->atom != TH_TAG_UNKNOWN) {
+        if (node->atom != match->atom) {
+            return 0;
+        }
+    } else if (node->atom != TH_TAG_UNKNOWN || node->text_len != match->local_len ||
+               memcmp(node->text, match->local, (size_t)match->local_len * sizeof(Py_UCS4)) != 0) {
+        return 0;
+    }
+    if (!match->has_ns) {
+        return 1;
+    }
+    return !match->ns_unmatchable && node->ns == match->want_ns;
 }
 
 /* Whether a node satisfies a step's node test on an element-principal axis. */
-static int node_test_matches(struct th_node *node, const xn *step, uint16_t atom) {
+static int node_test_matches(struct th_node *node, const xn *step, const step_match *match) {
     switch (step->test) {
     case NT_NAME:
-        return node->type == TH_NODE_ELEMENT && element_name_matches(node, step, atom);
+        return node->type == TH_NODE_ELEMENT && element_name_matches(node, match);
     case NT_STAR:
         return node->type == TH_NODE_ELEMENT;
     case NT_TEXT:
@@ -137,65 +167,66 @@ static void reverse_items(xp_nodeset *out, Py_ssize_t from) {
 
 /* Push node when it passes the step's node test. Returns 0, or -1 on allocation
    failure (which cannot be forced from a test). */
-static int emit_if_match(xp_nodeset *out, struct th_node *node, const xn *step, uint16_t atom) {
-    if (!node_test_matches(node, step, atom)) {
+static int emit_if_match(xp_nodeset *out, struct th_node *node, const xn *step, const step_match *match) {
+    if (!node_test_matches(node, step, match)) {
         return 0;
     }
     return ns_push(out, node, -1);
 }
 
-static int apply_step(xp_nodeset *out, struct th_node *ctx, const xn *step, uint16_t atom, uint32_t attr_atom) {
+static int apply_step(xp_nodeset *out, struct th_node *ctx, const xn *step, const step_match *match) {
     switch (step->axis) {
     case AX_ATTRIBUTE:
-        /* node() and * both match every attribute; a name test matches by atom;
+        /* node() and * both match every attribute; a name test matches by atom; a
+           prefixed name test matches none (HTML attributes carry no namespace);
            text()/comment()/processing-instruction() match no attribute. */
         for (Py_ssize_t index = 0; index < ctx->attr_count; index++) {
             int hit = step->test == NT_STAR || step->test == NT_NODE ||
-                      (step->test == NT_NAME && ctx->attrs[index].name_atom == attr_atom);
+                      (step->test == NT_NAME && !match->has_ns && ctx->attrs[index].name_atom == match->attr_atom);
             if (hit && ns_push(out, ctx, index) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced */
                 return -1;                             /* GCOVR_EXCL_LINE */
             }
         }
         return 0;
     case AX_SELF:
-        return emit_if_match(out, ctx, step, atom);
+        return emit_if_match(out, ctx, step, match);
     case AX_CHILD:
         for (struct th_node *child = ctx->first_child; child != NULL; child = child->next_sibling) {
-            if (emit_if_match(out, child, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                return -1;                                   /* GCOVR_EXCL_LINE */
+            if (emit_if_match(out, child, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                return -1;                                    /* GCOVR_EXCL_LINE */
             }
         }
         return 0;
     case AX_DESCENDANT_OR_SELF:
-        if (emit_if_match(out, ctx, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-            return -1;                                 /* GCOVR_EXCL_LINE */
+        if (emit_if_match(out, ctx, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+            return -1;                                  /* GCOVR_EXCL_LINE */
         }
         /* FALLTHROUGH: descendant-or-self is self plus the descendant walk */
     case AX_DESCENDANT:
         for (struct th_node *node = ctx->first_child; node != NULL; node = descendant_next(node, ctx)) {
-            if (emit_if_match(out, node, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                return -1;                                  /* GCOVR_EXCL_LINE */
+            if (emit_if_match(out, node, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                return -1;                                   /* GCOVR_EXCL_LINE */
             }
         }
         return 0;
     case AX_PARENT:
-        return ctx->parent != NULL ? emit_if_match(out, ctx->parent, step, atom) : 0;
+        return ctx->parent != NULL ? emit_if_match(out, ctx->parent, step, match) : 0;
     case AX_ANCESTOR_OR_SELF:
-        if (emit_if_match(out, ctx, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-            return -1;                                 /* GCOVR_EXCL_LINE */
+        if (emit_if_match(out, ctx, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+            return -1;                                  /* GCOVR_EXCL_LINE */
         }
         /* FALLTHROUGH: ancestor-or-self is self plus the ancestor walk */
     case AX_ANCESTOR:
         for (struct th_node *node = ctx->parent; node != NULL; node = node->parent) {
-            if (emit_if_match(out, node, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                return -1;                                  /* GCOVR_EXCL_LINE */
+            if (emit_if_match(out, node, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                return -1;                                   /* GCOVR_EXCL_LINE */
             }
         }
         return 0;
     case AX_FOLLOWING_SIBLING:
         for (struct th_node *node = ctx->next_sibling; node != NULL; node = node->next_sibling) {
-            if (emit_if_match(out, node, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                return -1;                                  /* GCOVR_EXCL_LINE */
+            if (emit_if_match(out, node, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                return -1;                                   /* GCOVR_EXCL_LINE */
             }
         }
         return 0;
@@ -206,8 +237,8 @@ static int apply_step(xp_nodeset *out, struct th_node *ctx, const xn *step, uint
             start = up->next_sibling;
         }
         for (struct th_node *node = start; node != NULL; node = document_next(node)) {
-            if (emit_if_match(out, node, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                return -1;                                  /* GCOVR_EXCL_LINE */
+            if (emit_if_match(out, node, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                return -1;                                   /* GCOVR_EXCL_LINE */
             }
         }
         return 0;
@@ -224,8 +255,8 @@ static int apply_step(xp_nodeset *out, struct th_node *ctx, const xn *step, uint
             if (is_ancestor_of(node, ctx)) {
                 continue;
             }
-            if (emit_if_match(out, node, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                return -1;                                  /* GCOVR_EXCL_LINE */
+            if (emit_if_match(out, node, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                return -1;                                   /* GCOVR_EXCL_LINE */
             }
         }
         reverse_items(out, from);
@@ -245,8 +276,8 @@ static int apply_step(xp_nodeset *out, struct th_node *ctx, const xn *step, uint
     }
     default: /* AX_PRECEDING_SIBLING */
         for (struct th_node *node = ctx->prev_sibling; node != NULL; node = node->prev_sibling) {
-            if (emit_if_match(out, node, step, atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                return -1;                                  /* GCOVR_EXCL_LINE */
+            if (emit_if_match(out, node, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                return -1;                                   /* GCOVR_EXCL_LINE */
             }
         }
         return 0;
@@ -537,8 +568,8 @@ static int apply_predicates(const xp_program *prog, int32_t pred_head, xp_ctx *c
         Py_ssize_t size = set->len;
         Py_ssize_t write_pos = 0;
         for (Py_ssize_t index = 0; index < set->len; index++) {
-            xp_ctx pctx = {ctx->tree, set->items[index].node, index + 1,         size, ctx->feature,
-                           ctx->vars, ctx->extension,         ctx->extension_ctx};
+            xp_ctx pctx = {ctx->tree,       set->items[index].node, index + 1,         size, ctx->feature, ctx->vars,
+                           ctx->namespaces, ctx->extension,         ctx->extension_ctx};
             xp_result value;
             int rc = eval_expr(prog, expr, &pctx, &value);
             if (rc < 0) {
@@ -551,6 +582,74 @@ static int apply_predicates(const xp_program *prog, int32_t pred_head, xp_ctx *c
             }
         }
         set->len = write_pos;
+    }
+    return 0;
+}
+
+/* Resolve a name-test prefix to the element namespace it constrains. On success fills
+   match->want_ns (the enum th_ns an element must carry) and match->ns_unmatchable (set
+   when the bound URI names no namespace an HTML tree's elements live in, e.g. a custom
+   or the XML URI). Returns 0, or -1 when the prefix has no binding. The XML prefix is
+   implicitly bound even without a mapping, matching lxml. */
+static int resolve_step_ns(xp_ctx *ctx, const Py_UCS4 *prefix, Py_ssize_t prefix_len, step_match *match) {
+    const Py_UCS4 *uri = NULL;
+    Py_ssize_t uri_len = 0;
+    int found = 0;
+    if (ctx->namespaces != NULL) {
+        for (Py_ssize_t index = 0; index < ctx->namespaces->len; index++) {
+            const xp_namespace *binding = &ctx->namespaces->items[index];
+            if (binding->prefix_len == prefix_len &&
+                memcmp(binding->prefix, prefix, (size_t)prefix_len * sizeof(Py_UCS4)) == 0) {
+                uri = binding->uri;
+                uri_len = binding->uri_len;
+                found = 1;
+                break;
+            }
+        }
+    }
+    if (!found) {
+        if (ucs4_eq_ascii(prefix, prefix_len, XP_XML_NS_PREFIX, sizeof(XP_XML_NS_PREFIX) - 1)) {
+            match->ns_unmatchable = 1; /* no element in an HTML tree is in the xml namespace */
+            return 0;
+        }
+        return -1;
+    }
+    if (ucs4_eq_ascii(uri, uri_len, XP_SVG_NS_URI, sizeof(XP_SVG_NS_URI) - 1)) {
+        match->want_ns = TH_NS_SVG;
+    } else if (ucs4_eq_ascii(uri, uri_len, XP_MATHML_NS_URI, sizeof(XP_MATHML_NS_URI) - 1)) {
+        match->want_ns = TH_NS_MATHML;
+    } else if (uri_len == 0) {
+        match->want_ns = TH_NS_HTML;
+    } else {
+        match->ns_unmatchable = 1;
+    }
+    return 0;
+}
+
+/* Resolve a step's name test once: the local part after any prefix, its interned atoms,
+   and the namespace the prefix binds. Returns 0, or -3 (with *feature set) for an
+   unbound prefix. */
+static int build_step_match(xp_ctx *ctx, const xn *step, step_match *match) {
+    memset(match, 0, sizeof(*match));
+    match->attr_atom = UINT32_MAX;
+    match->local = step->str;
+    match->local_len = step->str_len;
+    if (step->test != NT_NAME) {
+        return 0;
+    }
+    if (step->prefix_len > 0) {
+        match->has_ns = 1;
+        match->local = step->str + step->prefix_len + 1;
+        match->local_len = step->str_len - step->prefix_len - 1;
+        if (resolve_step_ns(ctx, step->str, step->prefix_len, match) < 0) {
+            *ctx->feature = "undefined namespace prefix";
+            return -3;
+        }
+    }
+    if (step->axis == AX_ATTRIBUTE) {
+        match->attr_atom = resolve_attr_atom(ctx->tree, match->local, match->local_len);
+    } else {
+        match->atom = resolve_tag_atom(match->local, match->local_len);
     }
     return 0;
 }
@@ -580,21 +679,23 @@ static int eval_path(const xp_program *prog, int32_t path_idx, xp_ctx *ctx, xp_n
     xp_nodeset next = {0};
     for (int32_t si = root->first; si >= 0; si = prog->nodes[si].next) {
         const xn *step = &prog->nodes[si];
-        int name_test = step->test == NT_NAME;
-        uint16_t atom = name_test && step->axis != AX_ATTRIBUTE ? resolve_tag_atom(step->str, step->str_len) : 0;
-        uint32_t attr_atom = name_test && step->axis == AX_ATTRIBUTE
-                                 ? resolve_attr_atom(ctx->tree, step->str, step->str_len)
-                                 : UINT32_MAX;
+        step_match match;
+        int resolved = build_step_match(ctx, step, &match);
+        if (resolved < 0) {
+            xp_nodeset_free(&cur);
+            xp_nodeset_free(&next);
+            return resolved;
+        }
         next.len = 0;
         for (Py_ssize_t index = 0; index < cur.len; index++) {
             if (cur.items[index].attr != -1) {
                 continue; /* an attribute or namespace node has no axes of its own */
             }
             Py_ssize_t before = next.len;
-            if (apply_step(&next, cur.items[index].node, step, atom, attr_atom) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                xp_nodeset_free(&cur);                                                 /* GCOVR_EXCL_LINE */
-                xp_nodeset_free(&next);                                                /* GCOVR_EXCL_LINE */
-                return -1;                                                             /* GCOVR_EXCL_LINE */
+            if (apply_step(&next, cur.items[index].node, step, &match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                xp_nodeset_free(&cur);                                        /* GCOVR_EXCL_LINE */
+                xp_nodeset_free(&next);                                       /* GCOVR_EXCL_LINE */
+                return -1;                                                    /* GCOVR_EXCL_LINE */
             }
             if (step->first >= 0) {
                 /* filter this context node's candidates in proximity order */
@@ -895,7 +996,8 @@ int eval_expr(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *out) 
 }
 
 int xp_eval(const xp_program *prog, struct th_tree *tree, struct th_node *context, const xp_bindings *vars,
-            xp_extension_fn extension, void *extension_ctx, xp_result *out, const char **feature) {
-    xp_ctx ctx = {tree, context, 1, 1, feature, vars, extension, extension_ctx};
+            const xp_namespaces *namespaces, xp_extension_fn extension, void *extension_ctx, xp_result *out,
+            const char **feature) {
+    xp_ctx ctx = {tree, context, 1, 1, feature, vars, namespaces, extension, extension_ctx};
     return eval_expr(prog, prog->root, &ctx, out);
 }

--- a/src/turbohtml/_c/query/xpath/internal.h
+++ b/src/turbohtml/_c/query/xpath/internal.h
@@ -76,6 +76,7 @@ typedef struct {
     double num;       /* XN_NUM */
     Py_UCS4 *str;     /* owned name/literal; NULL when none */
     Py_ssize_t str_len;
+    Py_ssize_t prefix_len; /* NT_NAME: length of the "prefix" before the ':' in str, else 0 */
 } xn;
 
 struct xp_program {
@@ -167,6 +168,7 @@ typedef struct {
     Py_ssize_t size;
     const char **feature;
     const xp_bindings *vars;
+    const xp_namespaces *namespaces;
     xp_extension_fn extension;
     void *extension_ctx;
 } xp_ctx;

--- a/src/turbohtml/_c/query/xpath/parser.c
+++ b/src/turbohtml/_c/query/xpath/parser.c
@@ -90,11 +90,8 @@ static void parse_node_test(parser *ps, int32_t step) {
         expect(ps, TK_RPAREN, "expected ')'");
         return;
     }
-    if (lx->tprefix > 0) {
-        fail(ps, "a namespace-prefixed name test needs a namespaces mapping");
-        return;
-    }
     ps->prog->nodes[step].test = NT_NAME;
+    ps->prog->nodes[step].prefix_len = lx->tprefix;            /* the resolved URI binds at eval time */
     if (copy_text(ps->prog, step, lx->tstart, lx->tlen) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
         fail(ps, "out of memory");                             /* GCOVR_EXCL_LINE */
     } /* GCOVR_EXCL_LINE: brace of the never-taken alloc-failure branch */
@@ -669,6 +666,7 @@ static void optimize_descendant_steps(xp_program *prog) {
             PyMem_Free(step->str); /* the node() test owns no name */
             step->str = follow->str;
             step->str_len = follow->str_len;
+            step->prefix_len = follow->prefix_len;
             follow->str = NULL; /* ownership moved to step */
             step->first = follow->first;
             step->next = follow->next;

--- a/src/turbohtml/_c/query/xpath/xpath.h
+++ b/src/turbohtml/_c/query/xpath/xpath.h
@@ -76,6 +76,20 @@ typedef struct {
     Py_ssize_t len;
 } xp_bindings;
 
+/* A prefix-to-URI binding for a name test. The strings are borrowed for the duration
+   of one eval (the caller owns the code-point buffers and frees them afterwards). */
+typedef struct {
+    const Py_UCS4 *prefix;
+    Py_ssize_t prefix_len;
+    const Py_UCS4 *uri;
+    Py_ssize_t uri_len;
+} xp_namespace;
+
+typedef struct {
+    const xp_namespace *items;
+    Py_ssize_t len;
+} xp_namespaces;
+
 /* A user extension-function call: resolve `name` against the registered
    extensions and run it over `args` with `context_node` as the XPath context.
    Returns 0 with *out filled, -2 when no extension has that name (the engine then
@@ -85,13 +99,16 @@ typedef int (*xp_extension_fn)(void *ctx, struct th_node *context_node, const Py
                                const xp_result *args, int argc, xp_result *out);
 
 /* Evaluate a compiled program against a context node. vars supplies $name bindings
-   (NULL when none); extension/extension_ctx supply user functions (extension NULL
-   when none). Returns 0 with *out filled (the caller frees it with xp_result_free).
-   Returns -2 for a construct not yet implemented, or -3 for an evaluation error (a
-   reference to an unbound variable), with *feature set to a short name for the
-   message. Returns -1 on allocation failure (or a Python error from an extension). */
+   (NULL when none); namespaces supplies prefix-to-URI bindings for prefixed name tests
+   (NULL when none); extension/extension_ctx supply user functions (extension NULL when
+   none). Returns 0 with *out filled (the caller frees it with xp_result_free). Returns
+   -2 for a construct not yet implemented, or -3 for an evaluation error (a reference to
+   an unbound variable, or a name test whose prefix is not bound), with *feature set to a
+   short name for the message. Returns -1 on allocation failure (or a Python error from
+   an extension). */
 struct th_tree;
 int xp_eval(const xp_program *prog, struct th_tree *tree, struct th_node *context, const xp_bindings *vars,
-            xp_extension_fn extension, void *extension_ctx, xp_result *out, const char **feature);
+            const xp_namespaces *namespaces, xp_extension_fn extension, void *extension_ctx, xp_result *out,
+            const char **feature);
 
 #endif /* TURBOHTML_XPATH_H */

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -92,6 +92,7 @@ class Node:
         expression: str,
         /,
         *,
+        namespaces: dict[str, str] | None = ...,
         smart_strings: bool = ...,
         extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
         | None = ...,
@@ -102,6 +103,7 @@ class Node:
         expression: str,
         /,
         *,
+        namespaces: dict[str, str] | None = ...,
         smart_strings: bool = ...,
         extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
         | None = ...,
@@ -112,6 +114,7 @@ class Node:
         expression: str,
         /,
         *,
+        namespaces: dict[str, str] | None = ...,
         smart_strings: bool = ...,
         extensions: dict[tuple[str | None, str], Callable[..., str | float | bool | Element | Iterable[Element]]]
         | None = ...,

--- a/tests/query/xpath/test_xpath_eval.py
+++ b/tests/query/xpath/test_xpath_eval.py
@@ -52,6 +52,19 @@ def doc() -> turbohtml.Node:
     return turbohtml.parse(HTML)
 
 
+SVG = "http://www.w3.org/2000/svg"
+MATHML = "http://www.w3.org/1998/Math/MathML"
+
+NS_HTML = (
+    "<html><body><p id='para'>html</p><svg width='10'><circle r='5'/><rect/></svg><math><mi>x</mi></math></body></html>"
+)
+
+
+@pytest.fixture
+def ns_doc() -> turbohtml.Node:
+    return turbohtml.parse(NS_HTML)
+
+
 def test_descendant_name(doc: turbohtml.Node) -> None:
     assert tags(doc.xpath("//p")) == ["p", "p"]
 
@@ -448,3 +461,117 @@ def test_predicate_survives_in_compound_expression(
         assert len(result) == 2
     else:
         assert result == pytest.approx(expected)
+
+
+# Namespace-prefixed name tests bound through the ``namespaces=`` keyword (issue #263).
+# A prefixed test like ``//svg:rect`` resolves its prefix against the supplied mapping, then
+# matches an element whose foreign-content namespace equals the bound URI and whose local name
+# equals the suffix. HTML elements stay in the null namespace, so unprefixed tests are unaffected.
+# The binding happens at evaluation time, so the cached compiled program runs under any mapping.
+
+
+@pytest.mark.parametrize(
+    ("expr", "mapping", "expected"),
+    [
+        pytest.param("//svg:circle", {"svg": SVG}, ["circle"], id="svg-text-matched-local"),
+        pytest.param("//svg:rect", {"svg": SVG}, ["rect"], id="svg-second-child"),
+        pytest.param("//s:circle", {"s": SVG}, ["circle"], id="prefix-name-is-arbitrary"),
+        pytest.param("//m:math", {"m": MATHML}, ["math"], id="mathml-atom-matched-local"),
+        pytest.param("//m:mi", {"m": MATHML}, ["mi"], id="mathml-leaf"),
+        pytest.param("//svg:circle | //m:mi", {"svg": SVG, "m": MATHML}, ["circle", "mi"], id="two-prefixes"),
+        pytest.param("/html/body/svg:svg", {"svg": SVG}, ["svg"], id="prefixed-step-in-path"),
+        # a prefix bound to the empty URI selects the null (HTML) namespace
+        pytest.param("//h:p", {"h": ""}, ["p"], id="null-namespace-prefix-matches-html"),
+        # a same-length-but-different bound prefix is skipped; a later exact entry still resolves
+        pytest.param("//svg:circle", {"abc": MATHML, "svg": SVG}, ["circle"], id="same-length-prefix-distinguished"),
+    ],
+)
+def test_prefixed_match(ns_doc: turbohtml.Node, expr: str, mapping: dict[str, str], expected: list[str]) -> None:
+    assert tags(ns_doc.xpath(expr, namespaces=mapping)) == expected
+
+
+@pytest.mark.parametrize(
+    ("expr", "mapping"),
+    [
+        pytest.param("//svg:circle", {"svg": MATHML}, id="wrong-uri-for-prefix"),
+        pytest.param("//svg:p", {"svg": SVG}, id="html-local-name-not-in-svg-ns"),
+        pytest.param("//html:circle", {"html": ""}, id="svg-element-not-in-null-ns"),
+        pytest.param("//svg:nope", {"svg": SVG}, id="no-such-local-name"),
+        pytest.param("//c:circle", {"c": "urn:custom"}, id="custom-uri-matches-no-element"),
+        # a URI the same length as the SVG one but differing in content is not the SVG namespace
+        pytest.param("//c:circle", {"c": "http://www.w3.org/2000/SVG"}, id="same-length-near-miss-uri"),
+        pytest.param("//xml:circle", {}, id="implicit-xml-prefix-matches-no-element"),
+    ],
+)
+def test_prefixed_no_match(ns_doc: turbohtml.Node, expr: str, mapping: dict[str, str]) -> None:
+    assert ns_doc.xpath(expr, namespaces=mapping) == []
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        pytest.param({}, id="empty-mapping"),
+        pytest.param({"other": SVG}, id="mapping-lacks-prefix"),
+        pytest.param({"abc": SVG}, id="same-length-prefix-only"),
+    ],
+)
+def test_undefined_prefix_raises(ns_doc: turbohtml.Node, mapping: dict[str, str]) -> None:
+    with pytest.raises(ValueError, match="undefined namespace prefix"):
+        ns_doc.xpath("//svg:circle", namespaces=mapping)
+
+
+def test_undefined_prefix_raises_without_mapping(ns_doc: turbohtml.Node) -> None:
+    with pytest.raises(ValueError, match="undefined namespace prefix"):
+        ns_doc.xpath("//svg:circle")
+
+
+@pytest.mark.parametrize(
+    ("namespaces", "message"),
+    [
+        pytest.param([("svg", SVG)], "namespaces must be a dict", id="not-a-dict"),
+        pytest.param({"svg": 1}, "map str prefixes to str URIs", id="non-str-value"),
+        pytest.param({1: SVG}, "map str prefixes to str URIs", id="non-str-key"),
+    ],
+)
+def test_namespaces_type_errors(ns_doc: turbohtml.Node, namespaces: object, message: str) -> None:
+    with pytest.raises(TypeError, match=message):
+        # a wrong-typed mapping exercises the TypeError path the C binding guards
+        ns_doc.xpath("//svg:circle", namespaces=namespaces)  # ty: ignore[invalid-argument-type]
+
+
+def test_unprefixed_name_test_is_namespace_agnostic(ns_doc: turbohtml.Node) -> None:
+    # Without a prefix the test matches by local name in any namespace, as before.
+    assert tags(ns_doc.xpath("//circle")) == ["circle"]
+    assert tags(ns_doc.xpath("//circle", namespaces={"svg": SVG})) == ["circle"]
+
+
+def test_prefixed_attribute_never_matches(ns_doc: turbohtml.Node) -> None:
+    # HTML attributes carry no namespace, so a prefixed attribute test selects nothing,
+    # while the unprefixed name still reads the attribute value.
+    assert ns_doc.xpath("//svg:svg/@svg:width", namespaces={"svg": SVG}) == []
+    assert ns_doc.xpath("//svg:svg/@width", namespaces={"svg": SVG}) == ["10"]
+
+
+def test_xpath_one_accepts_namespaces(ns_doc: turbohtml.Node) -> None:
+    node = ns_doc.xpath_one("//svg:circle", namespaces={"svg": SVG})
+    assert isinstance(node, Element)
+    assert node.tag == "circle"
+
+
+def test_xpath_iter_accepts_namespaces(ns_doc: turbohtml.Node) -> None:
+    assert tags(list(ns_doc.xpath_iter("//m:mi", namespaces={"m": MATHML}))) == ["mi"]
+
+
+def test_namespaces_none_is_no_mapping(ns_doc: turbohtml.Node) -> None:
+    assert tags(ns_doc.xpath("//p", namespaces=None)) == ["p"]
+
+
+def test_namespaces_combines_with_variables(ns_doc: turbohtml.Node) -> None:
+    result = ns_doc.xpath("//svg:circle[@r=$radius]", namespaces={"svg": SVG}, radius="5")
+    assert tags(result) == ["circle"]
+
+
+def test_same_expression_rebinds_per_call(ns_doc: turbohtml.Node) -> None:
+    # The compiled program is cached by string; the prefix resolves per call.
+    assert tags(ns_doc.xpath("//p:circle", namespaces={"p": SVG})) == ["circle"]
+    assert ns_doc.xpath("//p:circle", namespaces={"p": MATHML}) == []

--- a/tests/query/xpath/test_xpath_parse.py
+++ b/tests/query/xpath/test_xpath_parse.py
@@ -117,6 +117,9 @@ parse = _html._xpath_parse
         pytest.param("following::p", "(path rel (step following name 'p'))", id="axis-following"),
         pytest.param("preceding::p", "(path rel (step preceding name 'p'))", id="axis-preceding"),
         pytest.param("namespace::x", "(path rel (step namespace name 'x'))", id="axis-namespace"),
+        # a namespace-prefixed name test keeps the whole QName; the prefix binds at eval time
+        pytest.param("a:b", "(path rel (step child name 'a:b'))", id="prefixed-name"),
+        pytest.param("//svg:circle", "(path abs (step descendant name 'svg:circle'))", id="prefixed-descendant"),
         # node tests
         pytest.param("node()", "(path rel (step child node()))", id="test-node"),
         pytest.param("text()", "(path rel (step child text()))", id="test-text"),
@@ -277,14 +280,12 @@ def test_large_expression_grows_the_arena() -> None:
         pytest.param(".a", "trailing tokens", id="dot-then-name"),
         pytest.param("4a", "trailing tokens", id="digit-then-name"),
         pytest.param("1.5a", "trailing tokens", id="fraction-then-name"),
-        pytest.param("a:b", "namespace-prefixed", id="single-colon-name"),
         pytest.param("a:5", "invalid character", id="colon-then-non-name"),
         pytest.param("div::", "trailing tokens", id="bad-axis"),
         pytest.param("count(", "node test", id="unclosed-call"),
         pytest.param("1 2", "trailing tokens", id="two-numbers"),
         pytest.param("$5", "expected a name", id="dollar-then-number"),
         pytest.param("$", "expected a name", id="dollar-at-end"),
-        pytest.param("//svg:circle", "namespace-prefixed", id="prefixed-name-test"),
     ],
 )
 def test_rejects(expr: str, message: str) -> None:

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1787,6 +1787,9 @@ def print_xpath_table(means: dict[str, float], suite: tuple[list[str], list[str]
 # Python-backed surface. set:distinct stays in C on both sides (turbohtml's
 # built-in dispatch, lxml's registered libexslt), so it races C against C.
 _EXSLT_NS = {"re": "http://exslt.org/regular-expressions", "set": "http://exslt.org/sets"}
+_SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
+# a small SVG block appended to each feature page so the namespaced name test resolves over foreign content
+_SVG_FRAGMENT = "<svg><rect/><rect/></svg>"
 
 
 def _bench_count_ext(_context: object, nodes: list[object]) -> float:
@@ -1869,6 +1872,16 @@ def lxml_nodeset_extension(tree: HtmlElement) -> None:
     tree.xpath("ext_first_two(//a)/@href", extensions=_XPATH_NODESET_EXTENSIONS)
 
 
+def turbo_namespaced(doc: Document) -> None:
+    """Resolve a namespace-prefixed name test against a ``namespaces=`` mapping, turbohtml."""
+    doc.xpath("//svg:rect", namespaces=_SVG_NS)
+
+
+def lxml_namespaced(tree: HtmlElement) -> None:
+    """Resolve the same namespace-prefixed name test against the same mapping, lxml."""
+    tree.xpath("//svg:rect", namespaces=_SVG_NS)
+
+
 # Each parity feature paired with its turbohtml and lxml driver.
 XPATH_FEATURE_CASES: tuple[tuple[str, Callable[[Document], None], Callable[[HtmlElement], None]], ...] = (
     ("$variable binding", turbo_variable, lxml_variable),
@@ -1877,6 +1890,7 @@ XPATH_FEATURE_CASES: tuple[tuple[str, Callable[[Document], None], Callable[[Html
     ("smart_strings", turbo_smart, lxml_smart),
     ("extension function", turbo_extension, lxml_extension),
     ("extension node-set", turbo_nodeset_extension, lxml_nodeset_extension),
+    ("namespaces= name test", turbo_namespaced, lxml_namespaced),
 )
 
 # The reuse path turbohtml.XPath adds: parse the expression once into an immutable
@@ -1902,7 +1916,7 @@ def run_xpath_feature_suite(bench: Callable[[str, object, object], None]) -> lis
     """Benchmark each parity feature across the page sizes; return the case labels."""
     for label, turbo_run, lxml_run in XPATH_FEATURE_CASES:
         for size_name, path, enc in READPATH_CASES:
-            text = corpus_text(path, enc)
+            text = corpus_text(path, enc) + _SVG_FRAGMENT
             bench(f"feature {label} | {size_name} [turbohtml]", turbo_run, turbo_tree(text))
             bench(f"feature {label} | {size_name} [lxml]", lxml_run, lxml_tree(text))
     for size_name, path, enc in READPATH_CASES:


### PR DESCRIPTION
The XPath engine rejected prefixed name tests outright, so there was no way to match SVG or MathML elements in foreign content. Anyone porting expressions from `lxml`, where a `namespaces` mapping is routine, hit a wall.

This adds a `namespaces` keyword to `xpath`, `xpath_one`, and `xpath_iter` that binds prefixes to namespace URIs. A prefixed test such as `//svg:rect` matches an element whose foreign-content namespace equals the bound URI and whose local name matches the suffix. Resolution happens at evaluation time, so the per-tree compiled program still serves every mapping. The `xml` prefix is bound implicitly, matching `lxml`.

HTML elements stay in the null namespace, so unprefixed expressions behave exactly as before.

closes #263
