### PR TITLE
✨ feat(build): add E element builder for HTML generation

### DIFF
--- a/docs/changelog/275.feature.rst
+++ b/docs/changelog/275.feature.rst
@@ -1,0 +1,3 @@
+Add :data:`turbohtml.build.E`, a terse builder for constructing HTML trees in the spirit of ``lxml.builder.E``:
+``E.div({"class": "card"}, E.h1("Title"), E.p("body"))`` builds real :class:`~turbohtml.Element` nodes that serialize
+through the existing API, and a new migration section maps dominate, yattag, htpy, airium, and ``lxml.builder`` onto it.

--- a/docs/explanation/stdlib-parity.rst
+++ b/docs/explanation/stdlib-parity.rst
@@ -45,3 +45,11 @@ place; the URL resolution itself is :func:`urllib.parse.urljoin` from the standa
 reimplemented in C, because RFC 3986 reference resolution is a solved, standard problem and not where turbohtml's value
 lies. The line between the two is the project's rule in miniature: the HTML-specific, performance-sensitive work is C,
 and a thin typed facade wires it to the stdlib.
+
+Generating HTML is the one place a builder helper earns a little Python of its own. :data:`turbohtml.build.E` adds no
+tree mechanics: every ``E.<tag>(...)`` call constructs a real :class:`~turbohtml.Element` and appends its children
+through the same C edit surface, so the helper is pure construction sugar -- the way ``lxml.builder.E`` is pure Python
+over libxml2's tree. The tree, the attribute storage, and the serialize step all stay in C; the Python layer only spells
+the call ``E.div({...}, child, "text")`` instead of three statements. Keeping it thin is deliberate: a generator that
+reimplemented escaping or attribute handling in Python would drift from the parser's behavior, and the value of building
+on the same tree is that what you generate serializes by exactly the rules that parse it back.

--- a/docs/how-to/building.rst
+++ b/docs/how-to/building.rst
@@ -1,0 +1,46 @@
+###################
+ Build HTML with E
+###################
+
+*******************************
+ Build an HTML fragment with E
+*******************************
+
+When you generate HTML rather than parse it, :data:`turbohtml.build.E` builds the tree without the ``Element`` and
+``append`` boilerplate. A leading mapping is the attributes, and each remaining argument is a child node or a string
+that becomes text:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    article = E.article(
+        {"class": "post"},
+        E.h1("Release notes"),
+        E.ul(E.li("faster serialize"), E.li("new builder")),
+    )
+    print(article.serialize())
+
+.. testoutput::
+
+    <article class="post"><h1>Release notes</h1><ul><li>faster serialize</li><li>new builder</li></ul></article>
+
+The result is an ordinary :class:`~turbohtml.Element`, so you can keep editing or querying it before serializing -- the
+builder only saves the construction step.
+
+*********************************************
+ Build a tag that is not a Python identifier
+*********************************************
+
+``E.<tag>`` covers any tag spelled as an attribute, but a custom element or namespaced name needs the call form
+``E("tag", ...)``. A list-valued attribute joins on a space, so a class list reads naturally:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    print(E("my-card", {"class": ["card", "lg"]}, "hi").serialize())
+
+.. testoutput::
+
+    <my-card class="card lg">hi</my-card>

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -16,6 +16,7 @@ page is a short, self-contained walkthrough you can lift straight into your own 
     querying
     forms
     editing
+    building
     serializing
     links
     sanitizing

--- a/docs/migration/dominate.rst
+++ b/docs/migration/dominate.rst
@@ -1,0 +1,81 @@
+########################
+ From the HTML builders
+########################
+
+.. image:: https://static.pepy.tech/badge/dominate
+    :alt: dominate downloads
+    :target: https://pepy.tech/project/dominate
+
+The HTML *generators* -- `dominate <https://github.com/Knio/dominate>`_, `yattag <https://www.yattag.org>`_, `htpy
+<https://htpy.dev>`_, `airium <https://gitlab.com/kamichal/airium>`_, and `lxml.builder
+<https://lxml.de/api/lxml.builder.html>`_'s ``E`` -- all do the same job from the other direction than a parser: they
+assemble a tree in code and stringify it. They differ mainly in how they spell nesting, from dominate's ``with`` blocks
+to htpy's ``[...]`` subscripts to ``lxml.builder``'s nested calls.
+
+***************
+ Why turbohtml
+***************
+
+turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
+:data:`turbohtml.build.E` is a terse front end for it that reads like ``lxml.builder``: ``E.<tag>(attrs, *children)``,
+where a leading mapping is the attributes and each child is a node or a string that becomes text. The result is a real
+turbohtml tree, so the whole edit, query, and serialize surface stays available and the markup you generate serializes
+by exactly the rules that parse it back:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
+
+*************
+ The mapping
+*************
+
+The builders differ mainly in how they spell nesting; the translation is mechanical:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - generator
+      - turbohtml
+    - - ``lxml.builder``'s ``E.div(E.p("x"))``
+      - :data:`E.div(E.p("x")) <turbohtml.build.E>`, the same factory shape
+    - - dominate's ``div(p("x"), cls="card")`` / ``with`` blocks
+      - ``E.div({"class": "card"}, E.p("x"))``; nest by passing children, not a context manager
+    - - yattag's ``doc, tag, text`` and ``with tag("div"):``
+      - ``E.div(...)`` returns the element; build children inline instead of opening a tag scope
+    - - htpy's ``div(".card")[h1("Title")]``
+      - ``E.div({"class": "card"}, E.h1("Title"))``; attributes are a mapping, children are arguments
+    - - airium's ``a("div", klass="card")`` with indentation tracking
+      - ``E.div({"class": "card"}, ...)``; turbohtml tracks structure in the tree, not by call depth
+
+``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
+attribute joins on a space so a class list reads naturally:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    print(E("my-card", {"class": ["card", "lg"]}, "hi").serialize())
+
+.. testoutput::
+
+    <my-card class="card lg">hi</my-card>
+
+**********
+ Pitfalls
+**********
+
+- ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
+  Serialize the element you built, or append it under a parsed document when you need the full page shell.
+- A leading mapping is always read as attributes; to start an element with literal text, pass the string first
+  (``E.p("text", E.b("bold"))``).
+- The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
+  ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -13,6 +13,7 @@ treebuilder choices. This page maps each library to turbohtml; `BeautifulSoup
     markupsafe
     beautifulsoup
     lxml
+    dominate
     linkify-it-py
     bleach
     markdownify

--- a/docs/reference/serialize.rst
+++ b/docs/reference/serialize.rst
@@ -27,6 +27,23 @@ annotated-text result.
 
 .. autofunction:: annotation_tags
 
+*****************
+ turbohtml.build
+*****************
+
+.. module:: turbohtml.build
+
+A terse builder for constructing HTML trees, in the spirit of ``lxml.builder.E``. It is a thin layer over
+:class:`~turbohtml.Element` and :meth:`~turbohtml.Node.serialize`: ``E.<tag>(attrs, *children)`` builds a real element,
+folds a leading mapping into its attributes, and appends each remaining argument as a child (a string becomes a
+:class:`~turbohtml.Text` node, a node is appended as-is).
+
+.. autodata:: E
+    :no-value:
+
+.. autoclass:: ElementMaker
+    :members:
+
 ********************************
  turbohtml.migration.markupsafe
 ********************************

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,7 @@ py.install_sources(
         'src/turbohtml/_html.pyi',
         'src/turbohtml/_links.py',
         'src/turbohtml/_xpath.py',
+        'src/turbohtml/build.py',
         'src/turbohtml/linkify.py',
         'src/turbohtml/query.py',
         'src/turbohtml/sanitizer.py',

--- a/src/turbohtml/__init__.py
+++ b/src/turbohtml/__init__.py
@@ -34,6 +34,7 @@ from ._html import (
 )
 from ._links import Link  # registers the Link record type with the C core on import
 from ._xpath import XPathString  # registers the smart-string type with the C core on import
+from .build import E, ElementMaker
 
 __version__ = version("turbohtml")
 """The installed package version."""
@@ -44,7 +45,9 @@ __all__ = [
     "Comment",
     "Doctype",
     "Document",
+    "E",
     "Element",
+    "ElementMaker",
     "Formatter",
     "HTMLParseError",
     "IncrementalParser",

--- a/src/turbohtml/build.py
+++ b/src/turbohtml/build.py
@@ -1,0 +1,106 @@
+"""
+A terse builder for constructing HTML trees, the way ``lxml.builder.E`` did.
+
+This is a thin ergonomic layer over the existing element API: every ``E.<tag>(...)`` call builds a real
+:class:`turbohtml.Element` and appends its children through :meth:`turbohtml.Element.append`, so the result is an
+ordinary turbohtml tree that serializes with :meth:`turbohtml.Element.serialize`. The module is the one place a small
+amount of Python logic is justified, mirroring how ``lxml.builder.E`` is pure Python over its C tree; it adds no tree
+mechanics of its own.
+
+A call takes its arguments in order: a leading mapping is the element's attributes, a string becomes a
+:class:`turbohtml.Text` node, and any other node is appended as-is::
+
+    from turbohtml.build import E
+
+    doc = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(doc.serialize())  # <div class="card"><h1>Title</h1><p>body</p></div>
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, TypeAlias, TypeGuard
+
+from ._html import Element, Text
+
+if TYPE_CHECKING:
+    from ._html import Node
+
+#: Attributes accepted by :class:`turbohtml.Element`: a name maps to a string, a token list, or ``None`` for a bare
+#: boolean attribute such as ``disabled``.
+Attributes: TypeAlias = "Mapping[str, str | list[str] | None]"
+
+#: A single builder argument: a leading attribute mapping, an existing node, or a string that becomes a
+#: :class:`turbohtml.Text` node.
+Content: TypeAlias = "Attributes | Node | str"
+
+
+def _is_attributes(arg: Content) -> TypeGuard[Attributes]:
+    """Treat a mapping argument as the element's attributes and any other argument as a child."""
+    return isinstance(arg, Mapping)
+
+
+def _to_node(arg: Content) -> Node:
+    """Turn one child argument into a node: a string becomes text, a node passes through, a mapping is rejected."""
+    if isinstance(arg, str):
+        return Text(arg)
+    if isinstance(arg, Mapping):
+        msg = "a mapping argument sets attributes and must come first, before any child"
+        raise TypeError(msg)
+    return arg
+
+
+def _build(tag: str, args: tuple[Content, ...]) -> Element:
+    """Build one element: a leading mapping sets its attributes, and the rest become children in order."""
+    attrs: Attributes | None = None
+    children = args
+    if args and _is_attributes(args[0]):
+        attrs = args[0]
+        children = args[1:]
+    element = Element(tag, attrs)
+    element.extend(_to_node(arg) for arg in children)
+    return element
+
+
+class _TagFactory:
+    """The callable returned by ``E.<tag>``; it remembers the tag name and builds that element when called."""
+
+    __slots__ = ("_tag",)
+
+    def __init__(self, tag: str) -> None:
+        """Remember the tag name this factory builds."""
+        self._tag = tag
+
+    def __call__(self, *args: Content) -> Element:
+        """Build the element from a leading attribute mapping and the child nodes and strings that follow."""
+        return _build(self._tag, args)
+
+
+class ElementMaker:
+    """
+    A factory whose attribute access names the tag to build: ``E.div`` returns a callable that builds a ``<div>``.
+
+    Use the singleton ``E``, or instantiate a private maker. ``E.section(...)`` and ``E("section", ...)`` are
+    equivalent; the call form takes a tag that is not a Python identifier.
+    """
+
+    def __getattr__(self, tag: str) -> _TagFactory:
+        """Return the factory for ``tag``; dunder lookups fall through so copy and pickle protocols are not hijacked."""
+        if tag.startswith("__") and tag.endswith("__"):
+            raise AttributeError(tag)
+        return _TagFactory(tag)
+
+    def __call__(self, tag: str, /, *args: Content) -> Element:
+        """Build ``tag`` from a leading attribute mapping and the child nodes and strings that follow."""
+        return _build(tag, args)
+
+
+#: The shared builder: ``E.div(...)`` or ``E("div", ...)`` builds a ``<div>`` element.
+E = ElementMaker()
+
+__all__ = [
+    "Attributes",
+    "Content",
+    "E",
+    "ElementMaker",
+]

--- a/tests/features/test_build.py
+++ b/tests/features/test_build.py
@@ -1,0 +1,92 @@
+"""The turbohtml.build.E builder: construction sugar over Element() plus serialize()."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from turbohtml import Comment, Element, Text, parse_fragment
+from turbohtml.build import E
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def test_empty_element_serializes_with_end_tag() -> None:
+    assert E.div().serialize() == "<div></div>"
+
+
+def test_void_element_has_no_end_tag() -> None:
+    assert E.br().serialize() == "<br>"
+
+
+def test_text_child_becomes_a_text_node() -> None:
+    paragraph = E.p("body")
+    (child,) = paragraph.children
+    assert isinstance(child, Text)
+    assert child.data == "body"
+
+
+def test_text_child_serializes() -> None:
+    assert E.p("body").serialize() == "<p>body</p>"
+
+
+def test_leading_mapping_is_attributes() -> None:
+    assert E.div({"class": "card"}).serialize() == '<div class="card"></div>'
+
+
+def test_list_valued_attribute_joins_on_space() -> None:
+    assert E.div({"class": ["a", "b"]}).serialize() == '<div class="a b"></div>'
+
+
+def test_none_attribute_is_valueless() -> None:
+    assert E.input({"disabled": None}).serialize() == '<input disabled="">'
+
+
+def test_nesting_builds_real_child_elements() -> None:
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    assert card.serialize() == '<div class="card"><h1>Title</h1><p>body</p></div>'
+
+
+def test_children_keep_their_order() -> None:
+    assert E.p("a", E.b("b"), "c").serialize() == "<p>a<b>b</b>c</p>"
+
+
+def test_prebuilt_text_node_child_is_appended_not_rewrapped() -> None:
+    paragraph = E.p(Text("body"))
+    (child,) = paragraph.children
+    assert isinstance(child, Text)
+    assert child.data == "body"
+
+
+def test_non_string_node_child_passes_through_append() -> None:
+    assert E.div(Comment("note")).serialize() == "<div><!--note--></div>"
+
+
+def test_returns_a_real_element() -> None:
+    assert isinstance(E.div(), Element)
+
+
+def test_mixed_text_and_element_children() -> None:
+    assert E.div("before", E.span("mid"), "after").serialize() == "<div>before<span>mid</span>after</div>"
+
+
+@pytest.mark.parametrize(
+    ("markup_builder", "expected"),
+    [
+        pytest.param(
+            lambda: E.section(E.h2("Heading"), E.p("text")),
+            "<section><h2>Heading</h2><p>text</p></section>",
+            id="section",
+        ),
+        pytest.param(
+            lambda: E.ul(E.li("one"), E.li("two")),
+            "<ul><li>one</li><li>two</li></ul>",
+            id="list",
+        ),
+    ],
+)
+def test_round_trip_through_parse(markup_builder: Callable[[], Element], expected: str) -> None:
+    assert markup_builder().serialize() == expected
+    assert parse_fragment(expected).inner_html == expected

--- a/tests/features/test_build_factory.py
+++ b/tests/features/test_build_factory.py
@@ -1,0 +1,57 @@
+"""The ElementMaker factory mechanics: the call form, custom makers, attribute merging, and dunder fall-through."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from turbohtml import Element
+from turbohtml.build import E, ElementMaker
+
+
+def test_call_form_names_the_tag() -> None:
+    assert E("div", "body").serialize() == "<div>body</div>"
+
+
+def test_call_form_takes_a_leading_mapping() -> None:
+    assert E("a", {"href": "/x"}, "link").serialize() == '<a href="/x">link</a>'
+
+
+def test_call_form_builds_a_non_identifier_tag() -> None:
+    assert E("my-widget").serialize() == "<my-widget></my-widget>"
+
+
+def test_attribute_access_returns_a_fresh_callable() -> None:
+    assert E.div is not E.div  # each access builds its own factory; no shared mutable state
+
+
+def test_a_separate_maker_builds_the_same_way() -> None:
+    maker = ElementMaker()
+    assert maker.span("x").serialize() == "<span>x</span>"
+
+
+def test_non_leading_mapping_is_rejected() -> None:
+    with pytest.raises(TypeError, match="must come first"):
+        E.div("text", {"id": "b"})
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("__deepcopy__", id="deepcopy"),
+        pytest.param("__setstate__", id="setstate"),
+        pytest.param("__wrapped__", id="wrapped"),
+    ],
+)
+def test_dunder_lookup_falls_through(name: str) -> None:
+    with pytest.raises(AttributeError):
+        getattr(E, name)
+
+
+def test_deepcopy_is_not_hijacked_by_getattr() -> None:
+    assert isinstance(copy.deepcopy(E), ElementMaker)
+
+
+def test_builds_a_real_element_via_call_form() -> None:
+    assert isinstance(E("p"), Element)


### PR DESCRIPTION
turbohtml could already build trees with `Element()` and `serialize()`, but nothing made generation terse, and users coming from a builder library had no migration path.

This adds `turbohtml.build.E`, a thin factory over the existing element API: `E.div({"class": "card"}, E.h1("Title"), E.p("body")).serialize()`. 🏗️ A leading mapping sets attributes, a `str` child becomes a text node, and any other node is appended as is; the call form `E("tag", ...)` covers custom elements and other non-identifier tags. No tree mechanics live in Python, so the builder stays a pure ergonomic layer over the C tree, the same shape `lxml.builder.E` has.

The migration guide gains a "Building HTML" section mapping dominate, yattag, htpy, airium, and `lxml.builder.E` onto `E` and `Element()` plus `serialize`.

closes #275
