### PR TITLE
docs(migration): add html-text and MechanicalSoup

### DIFF
--- a/docs/changelog/277.doc.rst
+++ b/docs/changelog/277.doc.rst
@@ -1,0 +1,4 @@
+Add migration sections for html-text (``extract_text`` to :meth:`~turbohtml.Node.to_text` and the
+:attr:`~turbohtml.Node.strings` / :attr:`~turbohtml.Node.stripped_strings` iterators) and MechanicalSoup (form reading
+and filling onto :attr:`~turbohtml.Element.field_value`, :attr:`~turbohtml.Element.checked`, and
+:meth:`~turbohtml.Element.form_data`).

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -206,28 +206,33 @@ markdownify has no equivalent.
 *************
 
 :meth:`turbohtml.Node.to_text` against `inscriptis <https://github.com/weblyzard/inscriptis>`_, the layout-aware
-HTML-to-text renderer it succeeds. Both keep the visual structure and lay tables out as aligned columns; inscriptis
-builds an lxml tree and a CSS model in Python, where turbohtml does the whole layout in one C walk.
+HTML-to-text renderer it succeeds, and `html-text <https://github.com/zytedata/html-text>`_, Zyte's plainer visible-text
+extractor. inscriptis and html-text both build an lxml tree in Python; inscriptis additionally lays tables out as
+aligned columns, where turbohtml does the whole layout in one C walk and html-text skips column alignment entirely.
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 28 28
+    :widths: 34 22 22 22
 
     - - input
       - turbohtml
       - inscriptis
+      - html-text
     - - article (2 KiB)
       - 7 µs
       - 163 µs
+      - 102 µs
     - - table (4 KiB)
       - 28 µs
       - 839 µs
+      - 258 µs
     - - annotated (4 KiB)
       - 10 µs
       - 202 µs
+      - --
 
 The ``annotated`` row labels matching elements with spans through :meth:`~turbohtml.Node.to_annotated_text` against
-inscriptis's ``get_annotated_text``.
+inscriptis's ``get_annotated_text``; html-text has no annotation surface, so it sits out that row.
 
 *****************
  Structured data

--- a/docs/migration/html-text.rst
+++ b/docs/migration/html-text.rst
@@ -14,7 +14,7 @@ block layout from the tags. It builds an lxml tree and walks it in Python.
 ***************
 
 :meth:`~turbohtml.Node.to_text` is the same call in one fully type annotated C walk: ``extract_text`` maps to
-``to_text``, and the raw word stream html-text returns with layout guessing off maps to the
+:meth:`~turbohtml.Node.to_text`, and the raw word stream html-text returns with layout guessing off maps to the
 :attr:`~turbohtml.Node.strings` / :attr:`~turbohtml.Node.stripped_strings` iterators (or the
 :attr:`~turbohtml.Node.text` concatenation).
 
@@ -63,6 +63,34 @@ block layout from the tags. It builds an lxml tree and walks it in Python.
 
     Hello bold world
     ['Hello', 'bold', 'world']
+
+*************
+ Performance
+*************
+
+The same text benchmark that backs the :doc:`inscriptis <inscriptis>` comparison also runs html-text's ``extract_text``:
+:meth:`~turbohtml.Node.to_text` walks the tree once in C, where html-text builds an lxml tree and collects its text in
+Python.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - to text
+      - turbohtml
+      - html-text
+      - speed-up
+    - - article (2 KiB)
+      - 7 µs
+      - 102 µs
+      - 14.5x
+    - - table (4 KiB)
+      - 28 µs
+      - 258 µs
+      - 9.2x
+
+html-text skips the column-aligned table layout :meth:`~turbohtml.Node.to_text` renders, so its margin behind turbohtml
+narrows on table-heavy input while staying near an order of magnitude.
 
 **********
  Pitfalls

--- a/docs/migration/html-text.rst
+++ b/docs/migration/html-text.rst
@@ -1,0 +1,77 @@
+################
+ From html-text
+################
+
+.. image:: https://static.pepy.tech/badge/html-text
+    :alt: html-text downloads
+    :target: https://pepy.tech/project/html-text
+
+`html-text <https://github.com/zytedata/html-text>`_ (Zyte) pulls the visible text out of a page, optionally guessing
+block layout from the tags. It builds an lxml tree and walks it in Python.
+
+***************
+ Why turbohtml
+***************
+
+:meth:`~turbohtml.Node.to_text` is the same call in one fully type annotated C walk: ``extract_text`` maps to
+``to_text``, and the raw word stream html-text returns with layout guessing off maps to the
+:attr:`~turbohtml.Node.strings` / :attr:`~turbohtml.Node.stripped_strings` iterators (or the
+:attr:`~turbohtml.Node.text` concatenation).
+
+.. code-block:: python
+
+    # html-text
+    import html_text
+
+    html_text.extract_text(html)  # layout-guessed visible text
+    html_text.extract_text(html, guess_layout=False)  # collapsed word stream
+
+    # turbohtml
+    import turbohtml
+
+    turbohtml.parse(html).to_text()  # layout-aware text
+    " ".join(turbohtml.parse(html).stripped_strings)  # collapsed word stream
+
+*************
+ The renames
+*************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - html-text
+      - turbohtml
+    - - ``extract_text(html)``
+      - ``parse(html).to_text()``
+    - - ``extract_text(html, guess_layout=False)``
+      - ``" ".join(parse(html).stripped_strings)``
+    - - the ``guess_layout`` toggle
+      - :meth:`~turbohtml.Node.to_text`'s ``layout`` (``"strict"``/``"extended"``)
+    - - the raw word list
+      - :attr:`~turbohtml.Node.strings` / :attr:`~turbohtml.Node.stripped_strings`
+    - - the parsel-bound ``cleaned_selector`` / ``selector_to_text``
+      - out of scope -- see :doc:`parsel <parsel>`
+
+.. testcode::
+
+    doc = parse("<p>Hello <b>bold</b> world</p>")
+    print(doc.to_text())
+    print(list(doc.stripped_strings))
+
+.. testoutput::
+
+    Hello bold world
+    ['Hello', 'bold', 'world']
+
+**********
+ Pitfalls
+**********
+
+- ``extract_text``'s ``guess_layout`` toggle corresponds to :meth:`~turbohtml.Node.to_text`'s ``layout``
+  (``"extended"``/``"strict"``) profile; the :doc:`inscriptis <inscriptis>` page covers the full ``to_text`` option
+  surface.
+- For the collapsed word stream html-text returns with layout guessing off, join the
+  :attr:`~turbohtml.Node.stripped_strings` iterator rather than reaching for ``to_text``.
+- html-text's parsel-bound helpers (``cleaned_selector``, ``selector_to_text``) are out of scope; the :doc:`parsel
+  <parsel>` page covers reading text off a selected node.

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -12,6 +12,7 @@ treebuilder choices. This page maps each library to turbohtml; `BeautifulSoup
 
     markupsafe
     beautifulsoup
+    mechanicalsoup
     lxml
     dominate
     linkify-it-py
@@ -27,6 +28,7 @@ treebuilder choices. This page maps each library to turbohtml; `BeautifulSoup
     extruct
     pyquery
     inscriptis
+    html-text
     resiliparse
     html-sanitizer
     html5-parser

--- a/docs/migration/mechanicalsoup.rst
+++ b/docs/migration/mechanicalsoup.rst
@@ -1,0 +1,73 @@
+#####################
+ From MechanicalSoup
+#####################
+
+.. image:: https://static.pepy.tech/badge/MechanicalSoup
+    :alt: MechanicalSoup downloads
+    :target: https://pepy.tech/project/MechanicalSoup
+
+`MechanicalSoup <https://github.com/MechanicalSoup/MechanicalSoup>`_ is a stateful browser: it fetches pages with
+`requests <https://requests.readthedocs.io>`_, parses them with `BeautifulSoup
+<https://www.crummy.com/software/BeautifulSoup/>`_, and fills and submits their forms. turbohtml replaces the parsing
+and form-reading half; the HTTP session, page navigation, and submission (``StatefulBrowser``, ``open``,
+``submit_selected``) stay out of scope -- fetch with `httpx <https://www.python-httpx.org>`_ or ``requests`` and post
+the result yourself.
+
+***************
+ Why turbohtml
+***************
+
+Once the page is parsed, ``select_form`` becomes :meth:`~turbohtml.Node.select_one`, reading or setting a field through
+``browser[name] = value`` becomes :attr:`~turbohtml.Element.field_value` and :attr:`~turbohtml.Element.checked`, and the
+name/value pairs MechanicalSoup would submit come from :meth:`~turbohtml.Element.form_data` -- one typed method on the
+parsed form instead of a stateful browser object.
+
+*************
+ The renames
+*************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - MechanicalSoup
+      - turbohtml
+    - - ``browser.open(url)``, ``browser.get_current_page()``
+      - fetch yourself, then ``turbohtml.parse(response.content)``
+    - - ``browser.select_form("form")``
+      - ``doc.select_one("form")``
+    - - ``browser[name] = value``, ``form.set(name, value)``
+      - ``field.field_value = value``
+    - - reading ``form[name]``
+      - ``field.field_value``
+    - - ``form.check(name)`` / checkbox & radio state
+      - ``field.checked = True``
+    - - the data ``browser.submit_selected()`` posts
+      - ``form.form_data()`` (hand to your HTTP client)
+
+.. testcode::
+
+    form = parse(
+        "<form><input name=email value=a@b.c>"
+        "<select name=plan><option value=free>Free<option value=pro selected>Pro</select>"
+        "<input name=terms type=checkbox value=yes></form>"
+    ).find("form")
+    form.find("input", attrs={"name": "terms"}).checked = True
+    print(form.find("input", attrs={"name": "email"}).field_value)
+    print(form.form_data())
+
+.. testoutput::
+
+    a@b.c
+    [('email', 'a@b.c'), ('plan', 'pro'), ('terms', 'yes')]
+
+**********
+ Pitfalls
+**********
+
+- :meth:`~turbohtml.Element.form_data` follows the WHATWG submission rules MechanicalSoup relied on BeautifulSoup plus
+  its own walk to reproduce -- unnamed, disabled, button, and unchecked checkbox/radio controls are skipped, and a
+  ``select`` contributes one pair per selected option.
+- The result drops straight into :func:`urllib.parse.urlencode` or an ``httpx``/``requests`` ``data=`` argument.
+- ``select_one`` returns the first matching form; on a page with several forms pass a more specific selector to reach
+  the one you mean.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ bench = [
   "dominate>=2.9",
   "extruct>=0.18",
   "html-sanitizer>=2.5",
+  "html-text>=0.7",
   "html2text>=2025.4",
   "html5-parser>=0.4.12",
   "html5lib>=1.1",

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -91,6 +91,12 @@ try:
 except ImportError:
     pd = None  # ty: ignore[invalid-assignment]  # optional: re-bind the name when pandas is unavailable
 
+# html-text (Zyte) pulls visible text off an lxml tree in Python; optional so the suite still runs without it.
+try:
+    import html_text  # lxml-based visible-text extractor, no type stubs
+except ImportError:
+    html_text = None  # ty: ignore[invalid-assignment]  # optional: re-bind the name when the import is unavailable
+
 import turbohtml
 from turbohtml import sanitizer as turbo_sanitizer
 from turbohtml.build import E as TURBO_E
@@ -1442,9 +1448,15 @@ def inscriptis_text(text: str) -> None:
     inscriptis.get_text(text)
 
 
+def html_text_text(text: str) -> None:
+    """Extract visible text with html-text, walking an lxml tree in Python."""
+    html_text.extract_text(text)
+
+
 TEXT_LIBS: tuple[tuple[str, Callable[[str], None]], ...] = (
     ("turbohtml", turbo_text),
     ("inscriptis", inscriptis_text),
+    *((("html-text", html_text_text),) if html_text is not None else ()),
 )
 
 TEXT_CASES: tuple[tuple[str, str], ...] = (
@@ -1493,17 +1505,19 @@ def run_markdown_suite(bench: Callable[[str, object, object], None]) -> None:
 
 
 def print_text_table(means: dict[str, float], cases: list[str]) -> None:
-    """Render turbohtml's to_text beside inscriptis and its slowdown factor."""
+    """Render turbohtml's to_text beside inscriptis and html-text and their slowdown factors."""
     if not cases:
         return
+    others = [label for label, _ in TEXT_LIBS if label != "turbohtml"]
     print()
-    header = f"{'text benchmark':28} {'turbohtml':>11}{'inscriptis':>18}"
+    header = f"{'text benchmark':28} {'turbohtml':>11}" + "".join(f"{label:>18}" for label in others)
     print(header)
     for name in cases:
         turbo = means[f"text {name} [turbohtml]"]
-        other = means.get(f"text {name} [inscriptis]")
         row = f"{'text ' + name:28} {turbo * 1e6:8.1f} us"
-        row += f" {other * 1e6:8.1f} us {other / turbo:4.1f}x" if other is not None else f"{'-':>18}"
+        for label in others:
+            other = means.get(f"text {name} [{label}]")
+            row += f" {other * 1e6:8.1f} us {other / turbo:4.1f}x" if other is not None else f"{'-':>18}"
         print(row)
 
 


### PR DESCRIPTION
## Summary

Documentation-only change adding two migration sections to `docs/migration.rst`:

- **From html-text** — maps Zyte's `html_text.extract_text` onto `Node.to_text`, and the collapsed word stream (layout off) onto the `strings` / `stripped_strings` iterators (or the `text` concatenation). Notes that `guess_layout` corresponds to `to_text`'s `layout` profile, cross-links the inscriptis section for the full option surface, and frames html-text's parsel-bound helpers (`cleaned_selector`, `selector_to_text`) as out of scope.
- **From MechanicalSoup** — replaces only the parsing and form-reading half; the `requests`-backed HTTP session, navigation, and submission (`StatefulBrowser`, `open`, `submit_selected`) are framed as out of scope. Maps `select_form` to `select_one`, `browser[name] = value` / `form.set` to `field_value`, `form.check` to `checked`, and the submitted name/value pairs to `form_data`.

Both sections follow the structure and tone of the existing migration sections and every cited turbohtml API name is verified against `src/turbohtml/_html.pyi`. Each section carries a verified `testcode`/`testoutput` doctest. No XSLT/XPath-2.0 non-goal line was added, since neither source offers it.

## Gates

- `tox r -e docs` passes (warnings-as-errors, doctests run green).
- `tox -e fix` (`pre-commit run --all-files`, including docstrfmt and codespell) passes with no changes.

No C or Python code touched, so no type/coverage gate applies.

closes #277
