### PR TITLE
📚 docs(migration): order guides by monthly downloads

### DIFF
--- a/docs/changelog/295.doc.rst
+++ b/docs/changelog/295.doc.rst
@@ -1,0 +1,2 @@
+Order the :doc:`migration guide <migration/index>` index by adoption, listing each library from most to least monthly
+PyPI downloads so the libraries readers are most likely to port from appear first.

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -10,11 +10,10 @@ treebuilder choices. This page maps each library to turbohtml; `BeautifulSoup
 .. toctree::
     :maxdepth: 1
 
+    pandas
     markupsafe
     beautifulsoup
-    mechanicalsoup
     lxml
-    dominate
     linkify-it-py
     bleach
     markdownify
@@ -23,17 +22,18 @@ treebuilder choices. This page maps each library to turbohtml; `BeautifulSoup
     html2text
     lxml-html-clean
     w3lib
+    trafilatura
     selectolax
     parsel
-    extruct
     pyquery
+    dominate
     inscriptis
+    readability-lxml
     html-text
     resiliparse
-    trafilatura
     newspaper3k
-    readability-lxml
     html-sanitizer
+    extruct
+    mechanicalsoup
     html5-parser
-    pandas
     stdlib


### PR DESCRIPTION
Reorder the migration guide index (`docs/migration/index.rst`) so the per-library guides appear in descending order of live monthly PyPI downloads (most-used first), making the libraries readers are most likely to be porting from surface at the top. `stdlib` stays last.

No content changes beyond the toctree ordering; every entry still resolves to its existing `docs/migration/<name>.rst` page.

Adds a towncrier doc fragment noting the reorder.