### PR TITLE
📖 docs: add design principles to the landing page

### DIFF
--- a/docs/changelog/297.doc.rst
+++ b/docs/changelog/297.doc.rst
@@ -1,0 +1,2 @@
+The documentation landing page now enumerates the seven design principles that shape turbohtml, from the C hot path to
+the typed API edge - by :user:`gaborbernat`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,34 @@ counterpart and supports the free-threaded build.
     uses ``.string``. So ``node[i]`` indexes a node's children, and attributes are reached through ``node.attrs``, never
     ``node["attr"]``.
 
+*******************
+ Design principles
+*******************
+
+These rules shape every part of turbohtml, from the C core to the typed surface you import.
+
+1. **Speed over ease of maintenance.** The hot path is C: the tokenizer, the WHATWG tree builder, the CSS and XPath
+   engines, escaping, and serialization run over a single bump-allocated arena that holds no Python objects. Python
+   appears only at the typed API edge, where a thin facade wraps the nodes you actually touch.
+2. **A modern, fully-typed API.** Every concept carries one name and the whole surface is type-annotated. turbohtml is
+   not a drop-in for the libraries it replaces; the ``turbohtml.migration`` modules and guides translate code from
+   BeautifulSoup, lxml, html5lib, markupsafe, and the standard library rather than aliasing their APIs.
+3. **Still maintainable.** The C sources are split by subsystem and the code is written to read as its own
+   documentation. Both Python and C coverage gates require 100% line and branch coverage, on the gcc and llvm-cov
+   toolchains alike, before a change lands.
+4. **WHATWG conformance first.** The tokenizer and tree builder follow the WHATWG HTML standard state by state,
+   validated against the shared html5lib-tests suite browsers use. turbohtml matches a competitor's behavior only where
+   the spec leaves it open.
+5. **Free-threading ready.** The extension holds no shared mutable state and declares free-threading support, and every
+   tree edit and string read runs under a per-tree critical section. A read snapshots the arena before any Python
+   callback runs, so a concurrent mutation can never tear a walk.
+6. **Native and dependency-free.** The core is pure C with no libxml2 or lxml underneath, accelerated with SIMD, SWAR,
+   and an incremental codec. It reuses the standard library for solved problems such as URL resolution and regex
+   matching instead of reimplementing them.
+7. **Benchmark-driven and competitor-informed.** Designs are measured with pyperf against the fastest implementations
+   across C, Rust, and Go, and adopt their proven techniques: the lexbor and html5ever arena layout, html5ever's bulk
+   text scan, the Rust ``linkify`` scanner. A change that regresses the benchmarks does not ship.
+
 The documentation follows the `Diátaxis <https://diataxis.fr>`_ framework.
 
 .. toctree::


### PR DESCRIPTION
Adds a clearly-enumerated **Design principles** section to the docs landing page (`docs/index.rst`), grounding each principle in how the codebase actually works.

The seven principles:

1. Speed over ease of maintenance — the hot path is C; Python lives only at the typed API edge.
2. A modern, fully-typed API — one name per concept, not a drop-in for the libraries it replaces (migration is translation, not aliases).
3. Still maintainable — self-documenting code, subsystem-first layout, 100% line+branch coverage on C and Python.
4. WHATWG conformance first — spec state-by-state, validated against html5lib-tests; match competitors only where the spec is open.
5. Free-threading ready — no shared mutable state, per-tree critical section, snapshot-before-callback reads.
6. Native and dependency-free — pure C, no libxml2/lxml; SIMD/SWAR/codec; reuse the stdlib for solved problems.
7. Benchmark-driven and competitor-informed — measured with pyperf against the fastest C/Rust/Go implementations.

Gates: `prek run --all-files` clean (docstrfmt reflow applied), `tox r -e docs` builds with no warnings.