### PR TITLE
📖 docs: tighten and reorganize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,9 @@
 [![Documentation status](https://readthedocs.org/projects/turbohtml/badge/?version=latest)](https://turbohtml.readthedocs.io/en/latest/?badge=latest)
 [![check](https://github.com/tox-dev/turbohtml/actions/workflows/check.yaml/badge.svg)](https://github.com/tox-dev/turbohtml/actions/workflows/check.yaml)
 
-A fast, fully typed HTML toolkit for Python with a C-accelerated core. turbohtml escapes and unescapes HTML to match the
-standard library byte for byte, tokenizes markup with a WHATWG-conformant streaming tokenizer, and parses whole
-documents into a navigable element tree you query with CSS selectors, edit in place, build from scratch, serialize back
-to conformant HTML, and export to GitHub-Flavored Markdown or layout-aware plain text. A
-[markupsafe](https://markupsafe.palletsprojects.com)-compatible `turbohtml.migration.markupsafe` covers template
-autoescaping, `turbohtml.linkify` auto-links URLs and emails the way [bleach](https://github.com/mozilla/bleach) did,
-and `turbohtml.sanitizer` scrubs untrusted HTML against an allowlist as `bleach.clean` did. Each operation runs several
-times faster than its pure-Python counterpart and supports the free-threaded build.
+A fast, fully typed HTML toolkit for Python with a C-accelerated core: tokenize, parse, query, edit, serialize, and
+extract HTML several times faster than the pure-Python alternatives, with free-threading support. The hot path is C; a
+thin typed facade is the only Python you touch. It is not a drop-in for the libraries it replaces.
 
 ## Install
 
@@ -23,219 +18,66 @@ $ pip install turbohtml
 
 Wheels ship per interpreter for CPython 3.10–3.15 (including free-threading), so there is nothing to compile.
 
-## Usage
+## Quickstart
 
-Escape text before interpolating it into HTML so it cannot break out of its context:
+Parse a document, query it with a CSS selector, and serialize a node back to HTML with the escaping you choose:
 
 ```python
 import turbohtml
-
-print(turbohtml.escape('<a href="?x=1&y=2">Tom & Jerry</a>'))
-# &lt;a href=&quot;?x=1&amp;y=2&quot;&gt;Tom &amp; Jerry&lt;/a&gt;
-```
-
-Inside a text node the quotes are safe, so pass `quote=False` to keep the output smaller:
-
-```python
-print(turbohtml.escape('He said "hi" & left', quote=False))
-# He said "hi" &amp; left
-```
-
-Turn HTML character references back into text, following the full HTML5 rules (named, numeric, and longest-match
-references that omit the trailing semicolon):
-
-```python
-print(turbohtml.unescape("caf&eacute; &amp; r&eacute;sum&eacute; &#127881;"))
-# café & résumé 🎉
-```
-
-`escape` and `unescape` reproduce `html.escape` and `html.unescape` exactly, so turbohtml is a drop-in replacement on
-hot paths.
-
-For template output, `turbohtml.migration.markupsafe` is a markupsafe drop-in: `Markup` marks trusted HTML, and
-combining it with untrusted values escapes them. Swap `from markupsafe import ...` for
-`from turbohtml.migration.markupsafe import ...`:
-
-```python
-from turbohtml.migration.markupsafe import Markup, escape
-
-print(Markup("<li>{}</li>").format("<script>alert(1)</script>"))
-# <li>&lt;script&gt;alert(1)&lt;/script&gt;</li>
-print(escape("Tom & Jerry"))
-# Tom &amp; Jerry
-```
-
-`turbohtml.linkify` replaces `bleach.linkify`, which has no other successor now that bleach is end of life. It parses
-the HTML first, so it never links inside an existing `<a>`, a `<script>`, or a tag you skip:
-
-```python
-from turbohtml.linkify import linkify
-
-print(linkify("email bob@example.com or visit https://example.com", parse_email=True))
-# email <a href="mailto:bob@example.com">bob@example.com</a> or visit <a href="https://example.com" rel="nofollow">https://example.com</a>
-```
-
-Tokenize markup into a stream of tokens that follows the WHATWG tokenization algorithm:
-
-```python
-for token in turbohtml.tokenize('<p class="x">Tom &amp; Jerry</p>'):
-    print(token.type.name, token.tag or token.data, token.attrs)
-# START_TAG p [('class', 'x')]
-# TEXT Tom & Jerry None
-# END_TAG p []
-```
-
-For incremental input, `Tokenizer.feed()` returns the tokens completed by each chunk and `close()` flushes the rest:
-
-```python
-tokenizer = turbohtml.Tokenizer()
-print([token.tag for token in tokenizer.feed("<div><sp")])  # ['div']
-print([token.tag for token in tokenizer.feed("an>")])  # ['span']
-print(list(tokenizer.close()))  # []
-```
-
-Parse a whole document into a tree and walk it with `find`, `find_all`, and the navigation accessors:
-
-```python
-doc = turbohtml.parse("<ul><li>one<li>two</ul>")
-print([li.text for li in doc.find_all("li")])  # ['one', 'two']
-print(doc.find("ul").children[0].tag)  # li
-```
-
-Every parsed element knows where it came from in the source (`source_line`/`source_col`/`position`, the 1-based-line,
-0-based-column convention of `html.parser` and lxml's `sourceline`); pass `positions=False` to skip the tracking:
-
-```python
-doc = turbohtml.parse("<ul>\n  <li>one</li>\n</ul>")
-print(doc.find("li").position)  # (2, 2)
-```
-
-Query with a CSS selector, and serialize a node back to HTML with the escaping you choose:
-
-```python
 from turbohtml import Formatter
 
 doc = turbohtml.parse("<article><h1>Tea</h1><p class=note>café &amp; cake</p></article>")
-print(doc.select_one("p.note").text)
-# café & cake
+print([h.text for h in doc.find_all("h1")])  # ['Tea']
+print(doc.select_one("p.note").text)  # café & cake
 print(doc.select_one("p").serialize(formatter=Formatter.NAMED_ENTITIES))
 # <p class="note">caf&eacute; &amp; cake</p>
 ```
 
-Export a node to GitHub-Flavored Markdown, the `scrape` → `Markdown` step that needed html2text or markdownify:
+turbohtml models text as real child nodes following the WHATWG DOM shape, so `node[i]` indexes children and attributes
+are reached through `node.attrs`.
 
-```python
-doc = turbohtml.parse("<h1>Tea</h1><p>Steep <b>green</b> tea.</p><ul><li>cup</li><li>water</li></ul>")
-print(doc.to_markdown())
-# # Tea
-#
-# Steep **green** tea.
-#
-# - cup
-# - water
-```
+## Capabilities
 
-The keyword options cover the markdownify and html2text surface; `google_doc=True` adds html2text's Google-Docs mode,
-reading the inline-CSS styling such an export carries.
-
-Or to layout-aware plain text (the `inscriptis` role), with tables laid out as aligned columns:
-
-```python
-doc = turbohtml.parse("<table><tr><th>Item</th><th>Qty</th></tr><tr><td>Apples</td><td>3</td></tr></table>")
-print(doc.to_text())
-# Item    Qty
-# Apples  3
-```
-
-`to_annotated_text` returns that text with `(start, end, label)` spans for elements matching an `annotation_rules`
-mapping, the inscriptis annotation role:
-
-```python
-doc = turbohtml.parse("<h1>Q3</h1><p>Up <b>12%</b></p>")
-text, labels = doc.to_annotated_text({"h1": ["heading"], "b": ["metric"]})
-# ("Q3\n\nUp 12%", [(0, 2, "heading"), (7, 10, "metric")])
-```
-
-Pass `bytes` to sniff the encoding the WHATWG way (byte-order mark, then a `<meta>` declaration):
-
-```python
-doc = turbohtml.parse(b'<meta charset="iso-8859-2"><p>\xe1</p>')
-print((doc.encoding, doc.find("p").text))  # ('ISO-8859-2', 'á')
-```
-
-Parse a fragment as the contents of a context element, the way `innerHTML` does:
-
-```python
-cell = turbohtml.parse_fragment("<td>data", context="tr")
-print((cell.tag, cell.text))  # ('tr', 'data')
-```
-
-Build a tree from scratch with the node constructors, then assemble it (a list value for a token-list attribute like
-`class` joins on a space, and the `text` setter fills an element with a single text child):
-
-```python
-from turbohtml import Element
-
-card = Element("article", {"class": ["card", "lg"]})
-heading = Element("h2")
-heading.text = "Tea"
-card.append(heading)
-print(card.html)
-# <article class="card lg"><h2>Tea</h2></article>
-```
-
-Edit a parsed tree in place. `unwrap`, `decompose`, `wrap`, `insert_before`, `replace_with`, and the rest move nodes
-within a tree or adopt them from another, and `element.attrs` is a live mapping you assign to:
-
-```python
-doc = turbohtml.parse("<p>keep <b>bold</b> <span>drop</span></p>")
-doc.find("b").unwrap()
-doc.find("span").decompose()
-doc.find("p").attrs["class"] = "lead"
-print(doc.find("p").html)
-# <p class="lead">keep bold </p>
-```
-
-The sealed node hierarchy (`Element`, `Text`, `Comment`, `Doctype`, `ProcessingInstruction`, `CData`, and `Document`)
-sets `__match_args__` for structural pattern matching, and any node deep-copies with `copy.copy`, `copy.deepcopy`, or
-`pickle`.
+| Task              | API                                                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| Escape / unescape | `escape`, `unescape` — byte-for-byte with `html.escape`/`html.unescape`                                |
+| Tokenize          | `tokenize`, `Tokenizer` — WHATWG streaming tokenizer with incremental `feed`/`close`                   |
+| Parse             | `parse`, `parse_fragment`, `IncrementalParser` — encoding sniffing and source positions                |
+| Query             | `find`/`find_all`, CSS `select`/`select_one`, XPath `xpath`/`xpath_one`                                |
+| Serialize         | `serialize` with `Formatter` for escaping and `Minify` for whitespace                                  |
+| Sanitize          | `sanitize` — allowlist scrub of untrusted HTML (the `bleach.clean` successor)                          |
+| Linkify           | `linkify` — auto-link URLs and emails without touching existing links (the `bleach.linkify` successor) |
+| Markdown          | `to_markdown` — GitHub-Flavored Markdown export                                                        |
+| Plain text        | `to_text`, `to_annotated_text` — layout-aware text, optionally with `(start, end, label)` spans        |
+| Extract           | `tables`, `structured_data` (JSON-LD / Microdata / OpenGraph), `article` (main content)                |
+| Build / edit      | `Element`, `E`/`ElementMaker`, `unwrap`/`wrap`/`decompose`/`replace_with` and live `attrs`             |
+| Migration         | `turbohtml.migration.*` — drop-in shims for `markupsafe` and template autoescaping                     |
 
 ## Performance
 
-turbohtml's C core makes every operation several times faster than its pure-Python counterpart, and it runs faster than
-the other C libraries on the read-path benchmarks. Measured with [pyperf](https://pyperf.readthedocs.io) on an Apple M4:
+On an Apple M4 measured with [pyperf](https://pyperf.readthedocs.io), `parse` builds a full WHATWG tree 2–5× faster than
+the C parsers [lxml](https://lxml.de) and [selectolax](https://github.com/rushter/selectolax) and 30–80× faster than
+[BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/), and `tokenize` runs 9–15× faster than `html.parser`.
+See the [performance page](https://turbohtml.readthedocs.io/en/latest/development/performance.html) for the full tables
+and methodology.
 
-- `escape` and `unescape` match the standard library byte for byte while running several times faster, up to 22× on
-  no-op text and 13× on entity-dense input.
-- `turbohtml.migration.markupsafe.escape` matches markupsafe and runs 2–4× faster on the small strings template
-  autoescaping escapes.
-- `turbohtml.linkify` auto-links HTML 5–20× faster than bleach and 5–10× faster than the plain-text
-  [linkify-it-py](https://github.com/tsutsu3/linkify-it-py) scanner, which only finds links without rewriting them.
-- `tokenize` is 9–15× faster than `html.parser` wherever markup appears.
-- `parse` builds a full WHATWG tree 2–5× faster than the C parsers [lxml](https://lxml.de) and
-  [selectolax](https://github.com/rushter/selectolax), and 30–80× faster than the pure-Python
-  [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/) and
-  [html5lib](https://github.com/html5lib/html5lib-python).
-- `find_all` runs 9–13× faster than lxml's C `findall`, and a reused CSS `select` runs several times to hundreds of
-  times faster than lxml's [cssselect](https://github.com/scrapy/cssselect) (≈17× on the largest page, up to ≈390× on
-  small ones, since the selector compiles against the tree once); both run hundreds to over a thousand times faster than
-  BeautifulSoup.
-- serializing a tree back to HTML runs 3–5× faster than lxml and selectolax and about 50× faster than BeautifulSoup.
-- `to_markdown` exports GitHub-Flavored Markdown 30–110× faster than markdownify and html2text, which build and convert
-  in Python.
-- `to_text` renders layout-aware plain text 20–30× faster than [inscriptis](https://github.com/weblyzard/inscriptis).
-- building a tree from scratch runs about twice as fast as lxml, and editing a parsed one runs 5–11× faster; both run an
-  order of magnitude or more faster than BeautifulSoup.
+## Design principles
 
-See the [performance page](https://turbohtml.readthedocs.io/en/latest/development/performance.html) for the full
-sectioned tables and the methodology.
+turbohtml puts the hot path in C over a single bump-allocated arena, exposes one fully-typed Python name per concept,
+conforms to the WHATWG HTML standard, is free-threading ready, and carries no native dependencies. The full list lives
+in the [design principles](https://turbohtml.readthedocs.io/en/latest/#design-principles).
+
+## Migration
+
+turbohtml is a clean break, not an API-compatible replacement. The
+[migration guides](https://turbohtml.readthedocs.io/en/latest/migration/) translate code from pandas, markupsafe,
+BeautifulSoup, lxml, html5lib, the standard library, and 20+ other libraries, ordered by adoption.
 
 ## Documentation
 
-Full documentation, including tutorials, how-to guides, migration guides from BeautifulSoup, lxml, selectolax, html5lib,
-and the standard library, the API reference, and the design rationale, lives at
+Full documentation — tutorials, how-to guides, migration guides, the API reference, and the design rationale — lives at
 [turbohtml.readthedocs.io](https://turbohtml.readthedocs.io).
 
 ## License
 
-`turbohtml` is released under the [MIT license](LICENSE).
+`turbohtml` is released under the [MIT license](LICENSE). </content> </invoke>

--- a/docs/changelog/298.doc.rst
+++ b/docs/changelog/298.doc.rst
@@ -1,0 +1,3 @@
+Reorganize the README into a compact front door: a one-line value proposition, a single runnable quickstart, a
+capability table, one headline performance line, and pointers to the design principles and migration guides - by
+:user:`gaborbernat`.


### PR DESCRIPTION
Reorganize the README into a compact, high-signal front door so a reader grasps what turbohtml is, why it exists, and what it can do in about 30 seconds.

## Changes

- Collapse the long intro into a one-sentence value proposition (fast, native, fully-typed; C core, Python edge; not a drop-in).
- Replace the ~17 walkthrough code examples with a single runnable quickstart (parse to query to serialize).
- Move the capability tour into one compact table: tokenize, parse, CSS+XPath query, serialize/minify, sanitize, linkify, markdown, text/annotated-text, table/structured-data/article extraction, build/edit, migration.
- Trim the 12-bullet performance dump to one headline line with two numbers and a link to the performance page.
- Add a one-line design-principles summary linking the docs principles section instead of duplicating the full list.
- Add a migration pointer linking the migration guides, ordered by adoption.
- Keep and curate the badges, documentation link, and license.

README drops from 242 to 83 lines. Badges, the WHATWG-DOM note, and the quickstart snippets are reused from the prior (validated) examples, so the embedded code still runs.
</content>
