### PR TITLE
📚 docs(migration): unify all guides — monthly badges, perf inside Why turbohtml, speed-up multipliers

### DIFF
--- a/docs/changelog/300.doc.rst
+++ b/docs/changelog/300.doc.rst
@@ -1,0 +1,2 @@
+Every migration guide now follows one pattern: a monthly-downloads badge, the performance comparison inside the "Why
+turbohtml" section, and a consistent speed-up multiplier on each table - by :user:`gaborbernat`.

--- a/docs/migration/beautifulsoup.rst
+++ b/docs/migration/beautifulsoup.rst
@@ -2,8 +2,8 @@
  From BeautifulSoup
 ####################
 
-.. image:: https://static.pepy.tech/badge/beautifulsoup4
-    :alt: beautifulsoup4 downloads
+.. image:: https://static.pepy.tech/badge/beautifulsoup4/month
+    :alt: beautifulsoup4 monthly downloads
     :target: https://pepy.tech/project/beautifulsoup4
 
 `BeautifulSoup <https://www.crummy.com/software/BeautifulSoup/bs4/doc/>`_ is the long-standing convenience layer over a
@@ -45,6 +45,78 @@ to two orders of magnitude faster than BeautifulSoup over ``html.parser``:
       - 56.8x
 
 The :doc:`/development/performance` page benchmarks the build and edit paths against BeautifulSoup too.
+
+Filtering elements by text through :meth:`~turbohtml.Node.find` / :meth:`~turbohtml.Node.find_all` (``text=``) gathers
+each candidate's subtree text in C and matches once, where ``bs4``'s ``find_all(string=...)`` runs the predicate in
+Python mid-walk. The :doc:`/development/performance` query suite races the two over the wpt pages:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - find ``text=`` regex
+      - turbohtml
+      - BeautifulSoup
+      - speed-up
+    - - wpt page (4 kB)
+      - 9.3 µs
+      - 19.7 µs
+      - 2.1x
+    - - wpt page (9.6 kB)
+      - 13.9 µs
+      - 38.2 µs
+      - 2.7x
+    - - wpt page (92 kB)
+      - 741 µs
+      - 989 µs
+      - 1.3x
+
+Walking the whole tree (:attr:`~turbohtml.Node.descendants` against ``soup.descendants``) and reading its text
+(:attr:`~turbohtml.Node.text` against ``soup.get_text()``) stay ahead too; both libraries parse once outside the timed
+region. The descendant walk yields comparable node counts on both sides, so the gap is narrower, while ``get_text``
+concatenates in C where ``bs4`` joins Python strings node by node:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - navigate (walk descendants)
+      - turbohtml
+      - BeautifulSoup
+      - speed-up
+    - - wpt page (4 kB)
+      - 2.0 µs
+      - 2.9 µs
+      - 1.5x
+    - - wpt page (9.6 kB)
+      - 3.7 µs
+      - 5.0 µs
+      - 1.4x
+    - - wpt page (92 kB)
+      - 100.4 µs
+      - 125.0 µs
+      - 1.2x
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - text (whole-document ``get_text``)
+      - turbohtml
+      - BeautifulSoup
+      - speed-up
+    - - wpt page (4 kB)
+      - 0.8 µs
+      - 6.7 µs
+      - 8.3x
+    - - wpt page (9.6 kB)
+      - 1.1 µs
+      - 13.7 µs
+      - 12.9x
+    - - wpt page (92 kB)
+      - 38.0 µs
+      - 372.4 µs
+      - 9.8x
 
 *********
  Parsing
@@ -198,82 +270,6 @@ text rather than a substring (use a regex to search within):
 
     Buy now
     ['Buy now']
-
-*************
- Performance
-*************
-
-Filtering elements by text through :meth:`~turbohtml.Node.find` / :meth:`~turbohtml.Node.find_all` (``text=``) gathers
-each candidate's subtree text in C and matches once, where ``bs4``'s ``find_all(string=...)`` runs the predicate in
-Python mid-walk. The :doc:`/development/performance` query suite races the two over the wpt pages:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - find ``text=`` regex
-      - turbohtml
-      - BeautifulSoup
-      - speed-up
-    - - wpt page (4 kB)
-      - 9.3 µs
-      - 19.7 µs
-      - 2.1x
-    - - wpt page (9.6 kB)
-      - 13.9 µs
-      - 38.2 µs
-      - 2.7x
-    - - wpt page (92 kB)
-      - 741 µs
-      - 989 µs
-      - 1.3x
-
-Walking the whole tree (:attr:`~turbohtml.Node.descendants` against ``soup.descendants``) and reading its text
-(:attr:`~turbohtml.Node.text` against ``soup.get_text()``) stay ahead too; both libraries parse once outside the timed
-region. The descendant walk yields comparable node counts on both sides, so the gap is narrower, while ``get_text``
-concatenates in C where ``bs4`` joins Python strings node by node:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - navigate (walk descendants)
-      - turbohtml
-      - BeautifulSoup
-      - speed-up
-    - - wpt page (4 kB)
-      - 2.0 µs
-      - 2.9 µs
-      - 1.5x
-    - - wpt page (9.6 kB)
-      - 3.7 µs
-      - 5.0 µs
-      - 1.4x
-    - - wpt page (92 kB)
-      - 100.4 µs
-      - 125.0 µs
-      - 1.2x
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - text (whole-document ``get_text``)
-      - turbohtml
-      - BeautifulSoup
-      - speed-up
-    - - wpt page (4 kB)
-      - 0.8 µs
-      - 6.7 µs
-      - 8.3x
-    - - wpt page (9.6 kB)
-      - 1.1 µs
-      - 13.7 µs
-      - 12.9x
-    - - wpt page (92 kB)
-      - 38.0 µs
-      - 372.4 µs
-      - 9.8x
 
 *********************
  Attributes and text

--- a/docs/migration/bleach.rst
+++ b/docs/migration/bleach.rst
@@ -2,8 +2,8 @@
  From bleach
 #############
 
-.. image:: https://static.pepy.tech/badge/bleach
-    :alt: bleach downloads
+.. image:: https://static.pepy.tech/badge/bleach/month
+    :alt: bleach monthly downloads
     :target: https://pepy.tech/project/bleach
 
 `bleach <https://github.com/mozilla/bleach>`_ was the standard HTML allowlist sanitizer and linkifier, built on

--- a/docs/migration/dominate.rst
+++ b/docs/migration/dominate.rst
@@ -2,8 +2,8 @@
  From the HTML builders
 ########################
 
-.. image:: https://static.pepy.tech/badge/dominate
-    :alt: dominate downloads
+.. image:: https://static.pepy.tech/badge/dominate/month
+    :alt: dominate monthly downloads
     :target: https://pepy.tech/project/dominate
 
 The HTML *generators* -- `dominate <https://github.com/Knio/dominate>`_, `yattag <https://www.yattag.org>`_, `htpy
@@ -33,6 +33,31 @@ by exactly the rules that parse it back:
 .. testoutput::
 
     <div class="card"><h1>Title</h1><p>body</p></div>
+
+``E`` assembles the fragment in turbohtml's arena and serializes it in C; dominate and yattag stay in Python. The same
+``<ul>`` of rows -- a class, a ``data`` attribute, and a text child apiece -- built three ways, from ``tox -e bench
+build`` on the reference machine in :doc:`/development/performance`:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 28 24 24 24
+
+    - - build a list
+      - :data:`E <turbohtml.build.E>`
+      - dominate
+      - yattag
+    - - 100 rows
+      - 104 µs
+      - 320 µs (3.1x)
+      - 94 µs (0.9x)
+    - - 1000 rows
+      - 1.08 ms
+      - 3.34 ms (3.1x)
+      - 1.06 ms (1.0x)
+
+``E`` is about three times faster than dominate and on par with yattag, and the decisive difference is the result type:
+``E`` hands back a real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree
+you can query, edit, and re-:meth:`~turbohtml.Node.serialize`.
 
 *************
  The mapping
@@ -69,35 +94,6 @@ attribute joins on a space so a class list reads naturally:
 .. testoutput::
 
     <my-card class="card lg">hi</my-card>
-
-*************
- Performance
-*************
-
-``E`` assembles the fragment in turbohtml's arena and serializes it in C; dominate and yattag stay in Python. The same
-``<ul>`` of rows -- a class, a ``data`` attribute, and a text child apiece -- built three ways, from ``tox -e bench
-build`` on the reference machine in :doc:`/development/performance`:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 28 24 24 24
-
-    - - build a list
-      - :data:`E <turbohtml.build.E>`
-      - dominate
-      - yattag
-    - - 100 rows
-      - 104 µs
-      - 320 µs
-      - 94 µs
-    - - 1000 rows
-      - 1.08 ms
-      - 3.34 ms
-      - 1.06 ms
-
-``E`` is about three times faster than dominate and on par with yattag, and the decisive difference is the result type:
-``E`` hands back a real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree
-you can query, edit, and re-:meth:`~turbohtml.Node.serialize`.
 
 **********
  Pitfalls

--- a/docs/migration/extruct.rst
+++ b/docs/migration/extruct.rst
@@ -2,8 +2,8 @@
  From extruct / metadata_parser
 ################################
 
-.. image:: https://static.pepy.tech/badge/extruct
-    :alt: extruct downloads
+.. image:: https://static.pepy.tech/badge/extruct/month
+    :alt: extruct monthly downloads
     :target: https://pepy.tech/project/extruct
 
 `extruct <https://github.com/scrapinghub/extruct>`_ and `metadata_parser <https://github.com/jvanasco/metadata_parser>`_
@@ -45,10 +45,6 @@ extractors you happened to enable:
     {'og:title': 'Widget'}
     https://schema.org/Offer {'price': ['9.99']}
 
-*************
- Performance
-*************
-
 Both libraries start from the raw HTML string, so each parses before it extracts: ``extruct`` builds an lxml tree and
 runs a separate extractor per syntax, where :meth:`~turbohtml.Document.structured_data` parses to the WHATWG tree and
 gathers every format in one C walk. On a product page carrying JSON-LD, Microdata, and OpenGraph at once, the single
@@ -57,17 +53,20 @@ bench structured``):
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 28 28
+    :widths: 40 20 20 20
 
     - - input
       - turbohtml
       - extruct
+      - speed-up
     - - product page
       - 5.4 µs
       - 59.0 µs
+      - 10.9x
     - - catalog (8 KiB)
       - 54.5 µs
       - 494.9 µs
+      - 9.1x
 
 *************
  The renames

--- a/docs/migration/html-text.rst
+++ b/docs/migration/html-text.rst
@@ -2,8 +2,8 @@
  From html-text
 ################
 
-.. image:: https://static.pepy.tech/badge/html-text
-    :alt: html-text downloads
+.. image:: https://static.pepy.tech/badge/html-text/month
+    :alt: html-text monthly downloads
     :target: https://pepy.tech/project/html-text
 
 `html-text <https://github.com/zytedata/html-text>`_ (Zyte) pulls the visible text out of a page, optionally guessing
@@ -31,6 +31,36 @@ block layout from the tags. It builds an lxml tree and walks it in Python.
 
     turbohtml.parse(html).to_text()  # layout-aware text
     " ".join(turbohtml.parse(html).stripped_strings)  # collapsed word stream
+
+The same text benchmark that backs the :doc:`inscriptis <inscriptis>` comparison also runs html-text's ``extract_text``:
+:meth:`~turbohtml.Node.to_text` walks the tree once in C, where html-text builds an lxml tree and collects its text in
+Python.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - to text
+      - turbohtml
+      - html-text
+      - speed-up
+    - - article (2 KiB)
+      - 7 µs
+      - 102 µs
+      - 14.5x
+    - - table (4 KiB)
+      - 28 µs
+      - 258 µs
+      - 9.2x
+    - - word stream (2 KiB)
+      - 7 µs
+      - 101 µs
+      - 14.0x
+
+html-text skips the column-aligned table layout :meth:`~turbohtml.Node.to_text` renders, so its margin behind turbohtml
+narrows on table-heavy input while staying near an order of magnitude. The ``word stream`` row turns layout guessing off
+(``extract_text(guess_layout=False)``) against joining the :attr:`~turbohtml.Node.stripped_strings` iterator, the
+collapsed visible text both return without layout.
 
 *************
  The renames
@@ -63,40 +93,6 @@ block layout from the tags. It builds an lxml tree and walks it in Python.
 
     Hello bold world
     ['Hello', 'bold', 'world']
-
-*************
- Performance
-*************
-
-The same text benchmark that backs the :doc:`inscriptis <inscriptis>` comparison also runs html-text's ``extract_text``:
-:meth:`~turbohtml.Node.to_text` walks the tree once in C, where html-text builds an lxml tree and collects its text in
-Python.
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - to text
-      - turbohtml
-      - html-text
-      - speed-up
-    - - article (2 KiB)
-      - 7 µs
-      - 102 µs
-      - 14.5x
-    - - table (4 KiB)
-      - 28 µs
-      - 258 µs
-      - 9.2x
-    - - word stream (2 KiB)
-      - 7 µs
-      - 101 µs
-      - 14.0x
-
-html-text skips the column-aligned table layout :meth:`~turbohtml.Node.to_text` renders, so its margin behind turbohtml
-narrows on table-heavy input while staying near an order of magnitude. The ``word stream`` row turns layout guessing off
-(``extract_text(guess_layout=False)``) against joining the :attr:`~turbohtml.Node.stripped_strings` iterator, the
-collapsed visible text both return without layout.
 
 **********
  Pitfalls

--- a/docs/migration/html2text.rst
+++ b/docs/migration/html2text.rst
@@ -2,8 +2,8 @@
  From html2text
 ################
 
-.. image:: https://static.pepy.tech/badge/html2text
-    :alt: html2text downloads
+.. image:: https://static.pepy.tech/badge/html2text/month
+    :alt: html2text monthly downloads
     :target: https://pepy.tech/project/html2text
 
 `html2text <https://github.com/Alir3z4/html2text>`_ converts HTML to Markdown with a streaming ``HTMLParser`` subclass

--- a/docs/migration/html5-parser.rst
+++ b/docs/migration/html5-parser.rst
@@ -2,8 +2,8 @@
  From html5-parser
 ###################
 
-.. image:: https://static.pepy.tech/badge/html5-parser
-    :alt: html5-parser downloads
+.. image:: https://static.pepy.tech/badge/html5-parser/month
+    :alt: html5-parser monthly downloads
     :target: https://pepy.tech/project/html5-parser
 
 `html5-parser <https://html5-parser.readthedocs.io>`_ wraps gumbo, the C WHATWG parser, and hands the result back as an

--- a/docs/migration/html5lib.rst
+++ b/docs/migration/html5lib.rst
@@ -2,8 +2,8 @@
  From html5lib
 ###############
 
-.. image:: https://static.pepy.tech/badge/html5lib
-    :alt: html5lib downloads
+.. image:: https://static.pepy.tech/badge/html5lib/month
+    :alt: html5lib monthly downloads
     :target: https://pepy.tech/project/html5lib
 
 `html5lib <https://html5lib.readthedocs.io>`_ is the reference pure-Python implementation of the WHATWG parsing
@@ -43,6 +43,24 @@ parsing and tokenizing are 30 to 80 times faster than the pure-Python implementa
       - 19.2 ms
       - 27.9x
 
+:func:`html5lib.parseFragment() <html5lib.html5parser.parseFragment>` maps to :func:`turbohtml.parse_fragment`, which
+parses an ``innerHTML``-style snippet in its container context. Both run the WHATWG fragment algorithm, but turbohtml
+runs it in C, so a table-row fragment parsed in its ``<tbody>`` context is roughly seventy times faster (``tox -e bench
+fragment``):
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - input
+      - turbohtml
+      - html5lib
+      - speed-up
+    - - table-row fragment (2 kB)
+      - 12.6 µs
+      - 867 µs
+      - 69.0x
+
 *************
  The renames
 *************
@@ -75,28 +93,6 @@ parsing and tokenizing are 30 to 80 times faster than the pure-Python implementa
 .. testoutput::
 
     x
-
-*************
- Performance
-*************
-
-:func:`html5lib.parseFragment() <html5lib.html5parser.parseFragment>` maps to :func:`turbohtml.parse_fragment`, which
-parses an ``innerHTML``-style snippet in its container context. Both run the WHATWG fragment algorithm, but turbohtml
-runs it in C, so a table-row fragment parsed in its ``<tbody>`` context is roughly seventy times faster (``tox -e bench
-fragment``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - input
-      - turbohtml
-      - html5lib
-      - speed-up
-    - - table-row fragment (2 kB)
-      - 12.6 µs
-      - 867 µs
-      - 69.0x
 
 **********
  Pitfalls

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -25,8 +25,8 @@ treebuilder choices. This page maps each library to turbohtml; `BeautifulSoup
     trafilatura
     selectolax
     parsel
-    pyquery
     dominate
+    pyquery
     inscriptis
     readability-lxml
     html-text

--- a/docs/migration/inscriptis.rst
+++ b/docs/migration/inscriptis.rst
@@ -2,8 +2,8 @@
  From inscriptis
 #################
 
-.. image:: https://static.pepy.tech/badge/inscriptis
-    :alt: inscriptis downloads
+.. image:: https://static.pepy.tech/badge/inscriptis/month
+    :alt: inscriptis monthly downloads
     :target: https://pepy.tech/project/inscriptis
 
 `inscriptis <https://github.com/weblyzard/inscriptis>`_ renders HTML to *layout-aware* plain text: it keeps the visual

--- a/docs/migration/linkify-it-py.rst
+++ b/docs/migration/linkify-it-py.rst
@@ -2,8 +2,8 @@
  From linkify-it-py
 ####################
 
-.. image:: https://static.pepy.tech/badge/linkify-it-py
-    :alt: linkify-it-py downloads
+.. image:: https://static.pepy.tech/badge/linkify-it-py/month
+    :alt: linkify-it-py monthly downloads
     :target: https://pepy.tech/project/linkify-it-py
 
 `linkify-it-py <https://github.com/tsutsu3/linkify-it-py>`_ is the pure-Python link scanner `markdown-it-py

--- a/docs/migration/lxml-html-clean.rst
+++ b/docs/migration/lxml-html-clean.rst
@@ -2,8 +2,8 @@
  From lxml-html-clean
 ######################
 
-.. image:: https://static.pepy.tech/badge/lxml_html_clean
-    :alt: lxml-html-clean downloads
+.. image:: https://static.pepy.tech/badge/lxml_html_clean/month
+    :alt: lxml-html-clean monthly downloads
     :target: https://pepy.tech/project/lxml_html_clean
 
 `lxml-html-clean <https://github.com/fedora-python/lxml_html_clean>`_ is the ``Cleaner`` split out of

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -4,8 +4,8 @@
  From lxml
 ###########
 
-.. image:: https://static.pepy.tech/badge/lxml
-    :alt: lxml downloads
+.. image:: https://static.pepy.tech/badge/lxml/month
+    :alt: lxml monthly downloads
     :target: https://pepy.tech/project/lxml
 
 `lxml <https://lxml.de>`_ is the libxml2/libxslt binding that most Python HTML and XML processing has been built on:
@@ -122,9 +122,9 @@ lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtm
     [Element('a')]
     /x
 
-********************************
- Performance: tree and link ops
-********************************
+**************************
+ Tree and link operations
+**************************
 
 Beyond XPath and CSS, the operational renames above each beat lxml on the wpt pages from the
 :doc:`/development/performance` benchmark. :func:`turbohtml.parse_fragment` (lxml's ``lxml.html.fromstring``) parses an
@@ -167,9 +167,9 @@ turbohtml runs each in C over its native tree (``tox -e bench fragment text navi
       - 2.38 ms
       - 106.7x
 
-*************
- Performance
-*************
+*******
+ XPath
+*******
 
 When one expression runs against many nodes, precompile it once with :class:`~turbohtml.XPath` instead of calling
 :meth:`~turbohtml.Node.xpath`, which reparses the expression on every call. This is the same move as reaching for
@@ -326,9 +326,9 @@ generators across every page size.
   2.0/XQuery either), so an lxml ``el.xpath(...)`` call ports straight to :meth:`~turbohtml.Node.xpath` — only the
   node-synthesizing ``str:tokenize``/``str:split`` and the implicit current-date ``date:`` forms stay out of scope.
 
-*************
- Performance
-*************
+*******
+ EXSLT
+*******
 
 turbohtml's EXSLT namespaces dispatch in the same compiled-C XPath engine as the core functions, so an EXSLT predicate
 through :meth:`~turbohtml.Node.xpath` costs no registration: the prefix is built in. lxml resolves the namespace map and
@@ -338,17 +338,20 @@ wpt page:
 
 .. list-table::
     :header-rows: 1
-    :widths: 44 14 14
+    :widths: 40 20 20 20
 
     - - EXSLT (9.6 kB page)
       - turbohtml
       - lxml
+      - speed-up
     - - ``//a[re:test(@href, ...)]``
       - 0.5 µs
       - 4.6 µs
+      - 9.2x
     - - ``set:distinct(//a)``
       - 0.6 µs
       - 4.0 µs
+      - 6.7x
 
 ``re:`` dispatches to Python's :mod:`re` where lxml uses C libexslt, yet still leads because it skips the per-call
 namespace resolution; ``set:distinct`` stays in C on both sides. The :doc:`/development/performance` page sweeps these

--- a/docs/migration/markdownify.rst
+++ b/docs/migration/markdownify.rst
@@ -2,8 +2,8 @@
  From markdownify
 ##################
 
-.. image:: https://static.pepy.tech/badge/markdownify
-    :alt: markdownify downloads
+.. image:: https://static.pepy.tech/badge/markdownify/month
+    :alt: markdownify monthly downloads
     :target: https://pepy.tech/project/markdownify
 
 `markdownify <https://github.com/matthewwithanm/python-markdownify>`_ converts HTML to Markdown by walking a

--- a/docs/migration/markupsafe.rst
+++ b/docs/migration/markupsafe.rst
@@ -2,8 +2,8 @@
  From markupsafe
 #################
 
-.. image:: https://static.pepy.tech/badge/markupsafe
-    :alt: markupsafe downloads
+.. image:: https://static.pepy.tech/badge/markupsafe/month
+    :alt: markupsafe monthly downloads
     :target: https://pepy.tech/project/markupsafe
 
 `markupsafe <https://markupsafe.palletsprojects.com>`_ is the safe-string library behind `Jinja2

--- a/docs/migration/mechanicalsoup.rst
+++ b/docs/migration/mechanicalsoup.rst
@@ -2,8 +2,8 @@
  From MechanicalSoup
 #####################
 
-.. image:: https://static.pepy.tech/badge/MechanicalSoup
-    :alt: MechanicalSoup downloads
+.. image:: https://static.pepy.tech/badge/MechanicalSoup/month
+    :alt: MechanicalSoup monthly downloads
     :target: https://pepy.tech/project/MechanicalSoup
 
 `MechanicalSoup <https://github.com/MechanicalSoup/MechanicalSoup>`_ is a stateful browser: it fetches pages with

--- a/docs/migration/newspaper3k.rst
+++ b/docs/migration/newspaper3k.rst
@@ -2,8 +2,8 @@
  From newspaper3k
 ##################
 
-.. image:: https://static.pepy.tech/badge/newspaper3k
-    :alt: newspaper3k downloads
+.. image:: https://static.pepy.tech/badge/newspaper3k/month
+    :alt: newspaper3k monthly downloads
     :target: https://pepy.tech/project/newspaper3k
 
 `newspaper3k <https://newspaper.readthedocs.io>`_ is a news-article scraper: an ``Article`` downloads a URL, then
@@ -57,22 +57,6 @@ bundles has no equivalent and is out of scope.
 
     Comets | Ada Lovelace | A short guide to comets. | en
 
-**********
- Pitfalls
-**********
-
-- newspaper3k downloads and caches URLs; :meth:`~turbohtml.Node.article` takes parsed HTML. Fetch the page yourself
-  (``urllib`` or ``httpx``) and pass the markup to :func:`turbohtml.parse`.
-- ``article().byline`` is a single whitespace-folded string from the first author source, where newspaper's
-  ``article.authors`` is a list; split it yourself if you need the individual names.
-- newspaper's keyword extraction, summarization, and other NLP have no turbohtml equivalent and are out of scope.
-- A page with no scoring article leaves ``element`` ``None`` and ``text`` empty while still filling the metadata, so
-  branch on ``art.element`` rather than assuming a body.
-
-*************
- Performance
-*************
-
 Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer -- measured with
 ``tox -e bench article`` on CPython 3.14 (release build, Apple M4, macOS 26). :meth:`~turbohtml.Node.article` scores and
 harvests in one C pass over the parsed tree; newspaper3k builds an lxml tree and runs its own regex-driven metadata
@@ -85,7 +69,7 @@ scan. Numbers vary with input and hardware.
     - - input
       - turbohtml
       - newspaper3k
-      - speedup
+      - speed-up
     - - post (4 KiB)
       - 23 µs
       - 3.52 ms
@@ -94,3 +78,15 @@ scan. Numbers vary with input and hardware.
       - 70 µs
       - 8.97 ms
       - 128x
+
+**********
+ Pitfalls
+**********
+
+- newspaper3k downloads and caches URLs; :meth:`~turbohtml.Node.article` takes parsed HTML. Fetch the page yourself
+  (``urllib`` or ``httpx``) and pass the markup to :func:`turbohtml.parse`.
+- ``article().byline`` is a single whitespace-folded string from the first author source, where newspaper's
+  ``article.authors`` is a list; split it yourself if you need the individual names.
+- newspaper's keyword extraction, summarization, and other NLP have no turbohtml equivalent and are out of scope.
+- A page with no scoring article leaves ``element`` ``None`` and ``text`` empty while still filling the metadata, so
+  branch on ``art.element`` rather than assuming a body.

--- a/docs/migration/nh3.rst
+++ b/docs/migration/nh3.rst
@@ -2,8 +2,8 @@
  From nh3
 ##########
 
-.. image:: https://static.pepy.tech/badge/nh3
-    :alt: nh3 downloads
+.. image:: https://static.pepy.tech/badge/nh3/month
+    :alt: nh3 monthly downloads
     :target: https://pepy.tech/project/nh3
 
 `nh3 <https://nh3.readthedocs.io>`_ is the Python binding for the Rust `ammonia

--- a/docs/migration/pandas.rst
+++ b/docs/migration/pandas.rst
@@ -2,8 +2,8 @@
  From pandas
 #############
 
-.. image:: https://static.pepy.tech/badge/pandas
-    :alt: pandas downloads
+.. image:: https://static.pepy.tech/badge/pandas/month
+    :alt: pandas monthly downloads
     :target: https://pepy.tech/project/pandas
 
 `pandas <https://pandas.pydata.org>`_ is how scrapers turn ``<table>`` markup into rows: ``pandas.read_html`` parses
@@ -33,6 +33,45 @@ exact shape ``pandas.DataFrame`` takes, so hand them over yourself and keep pand
 .. testoutput::
 
     [{'name': 'pen', 'qty': '3'}]
+
+Reading a four-column table with :meth:`~turbohtml.Element.rows` and :meth:`~turbohtml.Element.records` against
+``pandas.read_html``, both parsing the markup and resolving spans into a rectangular grid. turbohtml's C cell-grid walk
+returns plain lists and dicts where ``read_html`` builds a ``DataFrame`` (importing NumPy), so it runs roughly twelve to
+ninety times faster: the gap is widest on small tables, where pandas pays a fixed per-frame cost, and narrows as the row
+count grows. Reproduce with ``tox -e bench tables``; see :doc:`/development/performance` for the methodology.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - input
+      - turbohtml
+      - pandas.read_html
+      - speed-up
+    - - rows (10 rows)
+      - 10.8 µs
+      - 943 µs
+      - 87.3x
+    - - records (10 rows)
+      - 15.8 µs
+      - 970 µs
+      - 61.4x
+    - - rows (100 rows)
+      - 99.7 µs
+      - 2178 µs
+      - 21.8x
+    - - records (100 rows)
+      - 98.5 µs
+      - 2165 µs
+      - 22.0x
+    - - rows (1000 rows)
+      - 853 µs
+      - 10.6 ms
+      - 12.4x
+    - - records (1000 rows)
+      - 893 µs
+      - 13.0 ms
+      - 14.6x
 
 *************
  The renames
@@ -64,42 +103,6 @@ so a whole document reads back without locating each ``<table>`` first:
 .. testoutput::
 
     [[['a']], [['b', 'c']]]
-
-*************
- Performance
-*************
-
-Reading a four-column table with :meth:`~turbohtml.Element.rows` and :meth:`~turbohtml.Element.records` against
-``pandas.read_html``, both parsing the markup and resolving spans into a rectangular grid. turbohtml's C cell-grid walk
-returns plain lists and dicts where ``read_html`` builds a ``DataFrame`` (importing NumPy), so it runs roughly twelve to
-ninety times faster: the gap is widest on small tables, where pandas pays a fixed per-frame cost, and narrows as the row
-count grows. Reproduce with ``tox -e bench tables``; see :doc:`/development/performance` for the methodology.
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 30 30
-
-    - - input
-      - turbohtml
-      - pandas.read_html
-    - - rows (10 rows)
-      - 10.8 µs
-      - 943 µs
-    - - records (10 rows)
-      - 15.8 µs
-      - 970 µs
-    - - rows (100 rows)
-      - 99.7 µs
-      - 2178 µs
-    - - records (100 rows)
-      - 98.5 µs
-      - 2165 µs
-    - - rows (1000 rows)
-      - 853 µs
-      - 10.6 ms
-    - - records (1000 rows)
-      - 893 µs
-      - 13.0 ms
 
 **********
  Pitfalls

--- a/docs/migration/parsel.rst
+++ b/docs/migration/parsel.rst
@@ -2,8 +2,8 @@
  From parsel
 #############
 
-.. image:: https://static.pepy.tech/badge/parsel
-    :alt: parsel downloads
+.. image:: https://static.pepy.tech/badge/parsel/month
+    :alt: parsel monthly downloads
     :target: https://pepy.tech/project/parsel
 
 `parsel <https://parsel.readthedocs.io>`_ is `Scrapy <https://scrapy.org>`_'s extraction-oriented selector library: a
@@ -41,6 +41,33 @@ re-evaluates it on libxml2 per call, so a reused query is roughly thirteen to tw
       - 2.0 µs
       - 25.4 µs
       - 12.9x
+
+Pulling the values out of a matched set is parsel's whole point: ``sel.css("a::attr(href)").getall()`` and
+``sel.css("a::text").getall()`` against turbohtml selecting once and reading :meth:`~turbohtml.Element.attr` and
+:attr:`~turbohtml.Node.text` off each node. Both libraries parse the page once outside the timed call. turbohtml
+compiles the selector once and reads interned atoms, where parsel re-translates the CSS to XPath on libxml2 every call,
+so reading every anchor runs tens of times faster (``tox -e bench extract``):
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - extract per match
+      - turbohtml
+      - parsel
+      - speed-up
+    - - ``@href`` -- wpt page (9.6 kB)
+      - 0.1 µs
+      - 4.3 µs
+      - 86.2x
+    - - ``@href`` -- wpt page (92 kB)
+      - 8.2 µs
+      - 222 µs
+      - 27.0x
+    - - text -- wpt page (92 kB)
+      - 8.0 µs
+      - 214 µs
+      - 26.6x
 
 *************
  The renames
@@ -92,37 +119,6 @@ including their ``attr`` keyword for running a pattern over an attribute value i
     ['/x', '/y']
     ['home', 'about']
     x
-
-*************
- Performance
-*************
-
-Pulling the values out of a matched set is parsel's whole point: ``sel.css("a::attr(href)").getall()`` and
-``sel.css("a::text").getall()`` against turbohtml selecting once and reading :meth:`~turbohtml.Element.attr` and
-:attr:`~turbohtml.Node.text` off each node. Both libraries parse the page once outside the timed call. turbohtml
-compiles the selector once and reads interned atoms, where parsel re-translates the CSS to XPath on libxml2 every call,
-so reading every anchor runs tens of times faster (``tox -e bench extract``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - extract per match
-      - turbohtml
-      - parsel
-      - speed-up
-    - - ``@href`` -- wpt page (9.6 kB)
-      - 0.1 µs
-      - 4.3 µs
-      - 86.2x
-    - - ``@href`` -- wpt page (92 kB)
-      - 8.2 µs
-      - 222 µs
-      - 27.0x
-    - - text -- wpt page (92 kB)
-      - 8.0 µs
-      - 214 µs
-      - 26.6x
 
 **********
  Pitfalls

--- a/docs/migration/pyquery.rst
+++ b/docs/migration/pyquery.rst
@@ -2,8 +2,8 @@
  From pyquery
 ##############
 
-.. image:: https://static.pepy.tech/badge/pyquery
-    :alt: pyquery downloads
+.. image:: https://static.pepy.tech/badge/pyquery/month
+    :alt: pyquery monthly downloads
     :target: https://pepy.tech/project/pyquery
 
 `pyquery <https://github.com/gawel/pyquery>`_ puts a jQuery-style fluent, chainable wrapper over `lxml
@@ -38,6 +38,77 @@ so the same chain runs roughly ten times faster than pyquery's lxml-backed wrapp
       - 21.8 µs
       - 278 µs
       - 12.8x
+
+pyquery's content setters carry the same C advantage as the rest of its wrapper. Both libraries parse the page once
+outside the timed call, then replace a ``<body>``'s content on every run: turbohtml reparses the fragment and splices it
+in one C call, where pyquery's ``.html()`` routes through lxml's ``fromstring`` and reassembly. The numbers come from
+the 9.6 kB ``wpt`` page in the ``edit`` suite (``tox -e bench edit``):
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - content setter (9.6 kB page)
+      - turbohtml
+      - pyquery
+      - speed-up
+    - - :meth:`~turbohtml.Element.set_inner_html` vs ``.html()``
+      - 1.3 µs
+      - 7.7 µs
+      - 5.9x
+    - - :meth:`~turbohtml.Element.set_text` vs ``.text()``
+      - 0.13 µs
+      - 4.6 µs
+      - 35.4x
+
+Bulk tag editing over a 92 kB page holding 839 ``<code>``/``<a>``/``<q>`` elements: dropping the matches with their
+subtrees (jQuery's ``.remove()`` against :meth:`~turbohtml.Node.remove`) and unwrapping them to keep their content
+(jQuery's ``.unwrap()`` against :meth:`~turbohtml.Node.strip_tags`). pyquery drives lxml under its wrapper, where
+turbohtml edits its native tree in C, so the same pass runs three to four times faster:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 46 18 18 18
+
+    - - bulk edit (92 kB)
+      - turbohtml
+      - pyquery
+      - speed-up
+    - - drop subtree (``remove`` / ``.remove()``)
+      - 554 µs
+      - 2.06 ms
+      - 3.7x
+    - - keep content (``strip_tags`` / ``.unwrap()``)
+      - 607 µs
+      - 2.35 ms
+      - 3.9x
+
+Reading a value off every match -- iterating ``for item in pq("a").items()`` and calling ``.attr("href")`` or
+``.text()`` -- against turbohtml selecting once and reading :meth:`~turbohtml.Element.attr` and
+:attr:`~turbohtml.Node.text` off each node. Both parse the page once outside the timed call. pyquery boxes every match
+in a fresh wrapper object, where turbohtml reads interned atoms straight off the selected nodes, so the per-match read
+runs tens of times faster (``tox -e bench extract``):
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - extract per match
+      - turbohtml
+      - pyquery
+      - speed-up
+    - - ``@href`` -- wpt page (9.6 kB)
+      - 0.1 µs
+      - 4.8 µs
+      - 96.6x
+    - - ``@href`` -- wpt page (92 kB)
+      - 8.2 µs
+      - 542 µs
+      - 65.8x
+    - - text -- wpt page (92 kB)
+      - 8.0 µs
+      - 297 µs
+      - 37.0x
 
 *************
  The renames
@@ -124,78 +195,6 @@ one verbatim text node; and :meth:`~turbohtml.Element.insert_adjacent_html` spli
       - :meth:`el.set_text(s) <turbohtml.Element.set_text>`
     - - ``pq(el).append(markup)``
       - :meth:`el.insert_adjacent_html("beforeend", markup) <turbohtml.Element.insert_adjacent_html>`
-
-*************
- Performance
-*************
-
-The content setters carry the same C advantage as the rest of the wrapper. Both libraries parse the page once outside
-the timed call, then replace a ``<body>``'s content on every run: turbohtml reparses the fragment and splices it in one
-C call, where pyquery's ``.html()`` routes through lxml's ``fromstring`` and reassembly. The numbers come from the 9.6
-kB ``wpt`` page in the ``edit`` suite (``tox -e bench edit``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 30 30
-
-    - - content setter (9.6 kB page)
-      - turbohtml
-      - pyquery
-    - - :meth:`~turbohtml.Element.set_inner_html` vs ``.html()``
-      - 1.3 µs
-      - 7.7 µs
-    - - :meth:`~turbohtml.Element.set_text` vs ``.text()``
-      - 0.13 µs
-      - 4.6 µs
-
-Bulk tag editing over a 92 kB page holding 839 ``<code>``/``<a>``/``<q>`` elements: dropping the matches with their
-subtrees (jQuery's ``.remove()`` against :meth:`~turbohtml.Node.remove`) and unwrapping them to keep their content
-(jQuery's ``.unwrap()`` against :meth:`~turbohtml.Node.strip_tags`). pyquery drives lxml under its wrapper, where
-turbohtml edits its native tree in C, so the same pass runs three to four times faster:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 46 18 18 18
-
-    - - bulk edit (92 kB)
-      - turbohtml
-      - pyquery
-      - speed-up
-    - - drop subtree (``remove`` / ``.remove()``)
-      - 554 µs
-      - 2.06 ms
-      - 3.7x
-    - - keep content (``strip_tags`` / ``.unwrap()``)
-      - 607 µs
-      - 2.35 ms
-      - 3.9x
-
-Reading a value off every match -- iterating ``for item in pq("a").items()`` and calling ``.attr("href")`` or
-``.text()`` -- against turbohtml selecting once and reading :meth:`~turbohtml.Element.attr` and
-:attr:`~turbohtml.Node.text` off each node. Both parse the page once outside the timed call. pyquery boxes every match
-in a fresh wrapper object, where turbohtml reads interned atoms straight off the selected nodes, so the per-match read
-runs tens of times faster (``tox -e bench extract``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - extract per match
-      - turbohtml
-      - pyquery
-      - speed-up
-    - - ``@href`` -- wpt page (9.6 kB)
-      - 0.1 µs
-      - 4.8 µs
-      - 96.6x
-    - - ``@href`` -- wpt page (92 kB)
-      - 8.2 µs
-      - 542 µs
-      - 65.8x
-    - - text -- wpt page (92 kB)
-      - 8.0 µs
-      - 297 µs
-      - 37.0x
 
 **********
  Pitfalls

--- a/docs/migration/readability-lxml.rst
+++ b/docs/migration/readability-lxml.rst
@@ -2,8 +2,8 @@
  From readability-lxml
 #######################
 
-.. image:: https://static.pepy.tech/badge/readability-lxml
-    :alt: readability-lxml downloads
+.. image:: https://static.pepy.tech/badge/readability-lxml/month
+    :alt: readability-lxml monthly downloads
     :target: https://pepy.tech/project/readability-lxml
 
 `readability-lxml <https://github.com/buriy/python-readability>`_ is a Python port of Arc90's Readability: a
@@ -51,21 +51,6 @@ when you need a scrubbed body.
 
     Comets | article
 
-**********
- Pitfalls
-**********
-
-- ``Document.summary()`` returns cleaned HTML; ``doc.article().element`` is the scored element from the live tree,
-  unchanged. Read :attr:`~turbohtml.Node.html` for its markup, or sanitize it first for a scrubbed fragment.
-- readability-lxml extracts only the body and title; the byline, date, description and language come for free in the
-  same :class:`~turbohtml.Article` record.
-- A page with no scoring article leaves ``element`` ``None`` and ``text`` empty while still filling the metadata, so
-  branch on ``art.element`` rather than assuming a body.
-
-*************
- Performance
-*************
-
 Scoring the content body of a full page -- navigation, a scored article, and a footer -- measured with ``tox -e bench
 article`` on CPython 3.14 (release build, Apple M4, macOS 26). :meth:`~turbohtml.Node.article` runs the same
 content-density heuristic in C and selects the live element; readability-lxml builds an lxml tree and rewrites it into a
@@ -78,7 +63,7 @@ cleaned summary fragment. Numbers vary with input and hardware.
     - - input
       - turbohtml
       - readability-lxml
-      - speedup
+      - speed-up
     - - post (4 KiB)
       - 23 µs
       - 1.26 ms
@@ -87,3 +72,14 @@ cleaned summary fragment. Numbers vary with input and hardware.
       - 70 µs
       - 2.54 ms
       - 36x
+
+**********
+ Pitfalls
+**********
+
+- ``Document.summary()`` returns cleaned HTML; ``doc.article().element`` is the scored element from the live tree,
+  unchanged. Read :attr:`~turbohtml.Node.html` for its markup, or sanitize it first for a scrubbed fragment.
+- readability-lxml extracts only the body and title; the byline, date, description and language come for free in the
+  same :class:`~turbohtml.Article` record.
+- A page with no scoring article leaves ``element`` ``None`` and ``text`` empty while still filling the metadata, so
+  branch on ``art.element`` rather than assuming a body.

--- a/docs/migration/resiliparse.rst
+++ b/docs/migration/resiliparse.rst
@@ -2,8 +2,8 @@
  From resiliparse
 ##################
 
-.. image:: https://static.pepy.tech/badge/resiliparse
-    :alt: resiliparse downloads
+.. image:: https://static.pepy.tech/badge/resiliparse/month
+    :alt: resiliparse monthly downloads
     :target: https://pepy.tech/project/resiliparse
 
 `resiliparse <https://github.com/chatnoir-eu/chatnoir-resiliparse>`_ is the web-crawl processing toolkit from ChatNoir.
@@ -38,6 +38,35 @@ while returning a fully type annotated, mutable :class:`~turbohtml.Document` and
       - 4.54 ms
       - 5.35 ms
       - 1.2x
+
+The parse table above is throughput only. resiliparse's ``extract_plain_text`` maps to :meth:`~turbohtml.Node.to_text`,
+and its ``main_content=True`` mode to :meth:`~turbohtml.Node.main_text`; both render text off the lexbor tree in a
+second pass, where turbohtml walks the WHATWG tree once in C:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 20 20 20
+
+    - - to text
+      - turbohtml
+      - resiliparse
+      - speed-up
+    - - article (2 KiB)
+      - 7 µs
+      - 23 µs
+      - 3.1x
+    - - table (4 KiB)
+      - 28 µs
+      - 52 µs
+      - 1.8x
+    - - main content (4 KiB)
+      - 7 µs
+      - 21 µs
+      - 2.9x
+
+The ``main content`` row strips page boilerplate first (:meth:`~turbohtml.Node.main_text` against
+``extract_plain_text(main_content=True)``); resiliparse matches turbohtml on the raw parse but trails it on the text
+walk, where the layout runs natively rather than over the lexbor tree.
 
 *************
  The renames
@@ -85,39 +114,6 @@ while returning a fully type annotated, mutable :class:`~turbohtml.Document` and
 
     /u
     Hi link
-
-*************
- Performance
-*************
-
-The parse table above is throughput only. resiliparse's ``extract_plain_text`` maps to :meth:`~turbohtml.Node.to_text`,
-and its ``main_content=True`` mode to :meth:`~turbohtml.Node.main_text`; both render text off the lexbor tree in a
-second pass, where turbohtml walks the WHATWG tree once in C:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - to text
-      - turbohtml
-      - resiliparse
-      - speed-up
-    - - article (2 KiB)
-      - 7 µs
-      - 23 µs
-      - 3.1x
-    - - table (4 KiB)
-      - 28 µs
-      - 52 µs
-      - 1.8x
-    - - main content (4 KiB)
-      - 7 µs
-      - 21 µs
-      - 2.9x
-
-The ``main content`` row strips page boilerplate first (:meth:`~turbohtml.Node.main_text` against
-``extract_plain_text(main_content=True)``); resiliparse matches turbohtml on the raw parse but trails it on the text
-walk, where the layout runs natively rather than over the lexbor tree.
 
 **********
  Pitfalls

--- a/docs/migration/selectolax.rst
+++ b/docs/migration/selectolax.rst
@@ -2,8 +2,8 @@
  From selectolax
 #################
 
-.. image:: https://static.pepy.tech/badge/selectolax
-    :alt: selectolax downloads
+.. image:: https://static.pepy.tech/badge/selectolax/month
+    :alt: selectolax monthly downloads
     :target: https://pepy.tech/project/selectolax
 
 `selectolax <https://github.com/rushter/selectolax>`_ is a fast CSS-only HTML parser that wraps the `lexbor
@@ -38,47 +38,6 @@ heavier object layer, turbohtml's lighter native tree parses and serializes fast
       - 105 µs
       - 339 µs
       - 3.2x
-
-*************
- The renames
-*************
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    - - selectolax
-      - turbohtml
-    - - ``LexborHTMLParser(html)``
-      - :func:`turbohtml.parse`
-    - - ``parser.root``, ``parser.body``
-      - :attr:`doc.root <turbohtml.Document.root>`, :meth:`doc.find("body") <turbohtml.Node.find>`
-    - - ``node.css("a")``, ``node.css_first("a")``
-      - :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`
-    - - ``node.tag``
-      - :attr:`~turbohtml.Element.tag` (same)
-    - - ``node.attributes``
-      - :attr:`~turbohtml.Element.attrs`
-    - - ``node.text()`` (a method)
-      - :attr:`~turbohtml.Node.text` (a property), :attr:`~turbohtml.Node.strings`,
-        :attr:`~turbohtml.Node.stripped_strings`
-    - - ``node.html``, ``node.decompose()``, ``node.unwrap()``
-      - :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.decompose`, :meth:`~turbohtml.Node.unwrap`
-    - - ``parser.strip_tags(["script"])``, ``node.unwrap_tags(["b"])``
-      - :meth:`node.remove("script") <turbohtml.Node.remove>`, :meth:`node.strip_tags("b") <turbohtml.Node.strip_tags>`
-
-.. testcode::
-
-    doc = parse("<ul><li>a</li><li>b</li></ul>")
-    print([li.text for li in doc.select("li")])
-
-.. testoutput::
-
-    ['a', 'b']
-
-*************
- Performance
-*************
 
 Dropping a set of tags together with their subtrees: selectolax's ``strip_tags`` against turbohtml's
 :meth:`~turbohtml.Node.remove`, over a 92 kB page holding 839 ``<code>``/``<a>``/``<q>`` elements. Both rewrites are
@@ -123,6 +82,43 @@ buffer reserved up front, where selectolax crosses the lexbor boundary per node,
       - 36.9 µs
       - 488 µs
       - 13.2x
+
+*************
+ The renames
+*************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - selectolax
+      - turbohtml
+    - - ``LexborHTMLParser(html)``
+      - :func:`turbohtml.parse`
+    - - ``parser.root``, ``parser.body``
+      - :attr:`doc.root <turbohtml.Document.root>`, :meth:`doc.find("body") <turbohtml.Node.find>`
+    - - ``node.css("a")``, ``node.css_first("a")``
+      - :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`
+    - - ``node.tag``
+      - :attr:`~turbohtml.Element.tag` (same)
+    - - ``node.attributes``
+      - :attr:`~turbohtml.Element.attrs`
+    - - ``node.text()`` (a method)
+      - :attr:`~turbohtml.Node.text` (a property), :attr:`~turbohtml.Node.strings`,
+        :attr:`~turbohtml.Node.stripped_strings`
+    - - ``node.html``, ``node.decompose()``, ``node.unwrap()``
+      - :attr:`~turbohtml.Node.html`, :meth:`~turbohtml.Node.decompose`, :meth:`~turbohtml.Node.unwrap`
+    - - ``parser.strip_tags(["script"])``, ``node.unwrap_tags(["b"])``
+      - :meth:`node.remove("script") <turbohtml.Node.remove>`, :meth:`node.strip_tags("b") <turbohtml.Node.strip_tags>`
+
+.. testcode::
+
+    doc = parse("<ul><li>a</li><li>b</li></ul>")
+    print([li.text for li in doc.select("li")])
+
+.. testoutput::
+
+    ['a', 'b']
 
 **********
  Pitfalls

--- a/docs/migration/trafilatura.rst
+++ b/docs/migration/trafilatura.rst
@@ -2,8 +2,8 @@
  From trafilatura
 ##################
 
-.. image:: https://static.pepy.tech/badge/trafilatura
-    :alt: trafilatura downloads
+.. image:: https://static.pepy.tech/badge/trafilatura/month
+    :alt: trafilatura monthly downloads
     :target: https://pepy.tech/project/trafilatura
 
 `trafilatura <https://trafilatura.readthedocs.io>`_ extracts the main text and metadata from a web page: it downloads
@@ -57,21 +57,6 @@ you need them, trafilatura's heavier language and date heuristics.
 
     Comets | Ada Lovelace | 2024-05-06 | en
 
-******************************
- Publication dates (htmldate)
-******************************
-
-trafilatura's date support comes from `htmldate <https://htmldate.readthedocs.io>`_, whose ``find_date(html)`` scans
-many patterns and validates the result against a range. ``doc.article().date`` is the lightweight counterpart: it
-returns the first of a ``<time>``, an ``article:published_time`` meta, and a common date meta (``date``, ``pubdate``,
-``dc.date``) exactly as the page declares it, without parsing or normalizing the value. Wrap it in
-``datetime.date.fromisoformat`` or ``dateutil`` when you need a real date object, and keep htmldate for pages whose date
-is only inferable.
-
-*************
- Performance
-*************
-
 Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer -- measured with
 ``tox -e bench article`` on CPython 3.14 (release build, Apple M4, macOS 26). :meth:`~turbohtml.Node.article` scores and
 harvests in one C pass over the parsed tree; trafilatura builds an lxml tree in Python first. Numbers vary with input
@@ -84,7 +69,7 @@ and hardware.
     - - input
       - turbohtml
       - trafilatura
-      - speedup
+      - speed-up
     - - post (4 KiB)
       - 23 µs
       - 1.34 ms
@@ -93,6 +78,17 @@ and hardware.
       - 70 µs
       - 3.13 ms
       - 45x
+
+******************************
+ Publication dates (htmldate)
+******************************
+
+trafilatura's date support comes from `htmldate <https://htmldate.readthedocs.io>`_, whose ``find_date(html)`` scans
+many patterns and validates the result against a range. ``doc.article().date`` is the lightweight counterpart: it
+returns the first of a ``<time>``, an ``article:published_time`` meta, and a common date meta (``date``, ``pubdate``,
+``dc.date``) exactly as the page declares it, without parsing or normalizing the value. Wrap it in
+``datetime.date.fromisoformat`` or ``dateutil`` when you need a real date object, and keep htmldate for pages whose date
+is only inferable.
 
 **********
  Pitfalls

--- a/docs/migration/w3lib.rst
+++ b/docs/migration/w3lib.rst
@@ -2,8 +2,8 @@
  From w3lib (Scrapy)
 #####################
 
-.. image:: https://static.pepy.tech/badge/w3lib
-    :alt: w3lib downloads
+.. image:: https://static.pepy.tech/badge/w3lib/month
+    :alt: w3lib monthly downloads
     :target: https://pepy.tech/project/w3lib
 
 `w3lib <https://w3lib.readthedocs.io>`_ collects the web utilities `Scrapy <https://scrapy.org>`_ reuses: entity
@@ -37,6 +37,46 @@ type annotated and running the scan in C, so it is a drop-in that runs several t
       - 2.51 ms
       - 13.5 ms
       - 5.4x
+
+Stripping a set of tags while keeping their text: w3lib's regex ``remove_tags`` against turbohtml's
+:meth:`~turbohtml.Node.strip_tags`, over a 92 kB page holding 839 ``<code>``/``<a>``/``<q>`` elements. w3lib runs a
+regular-expression substitution over the string; turbohtml builds the WHATWG tree, unwraps each match in place, and
+serializes. turbohtml does the structure-aware pass a regex misreads on nested markup, and still runs it faster:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 46 18 18 18
+
+    - - strip tags, keep text (92 kB)
+      - turbohtml
+      - w3lib
+      - speed-up
+    - - ``strip_tags`` vs ``remove_tags``
+      - 607 µs
+      - 1.11 ms
+      - 1.8x
+
+Reading a document's own URL hints: w3lib's ``get_base_url`` and ``get_meta_refresh`` against
+:meth:`~turbohtml.Document.base_url` and :meth:`~turbohtml.Document.meta_refresh`. Both parse the string each call, over
+a small page carrying a ``<base>`` and a meta refresh. w3lib runs a regular-expression pass; turbohtml runs the WHATWG
+tree builder and reads the hint off the parsed ``<head>``, and still comes out ahead (``tox -e bench extract``):
+
+.. list-table::
+    :header-rows: 1
+    :widths: 46 18 18 18
+
+    - - url hint
+      - turbohtml
+      - w3lib
+      - speed-up
+    - - ``base_url`` vs ``get_base_url``
+      - 2.9 µs
+      - 7.4 µs
+      - 2.6x
+    - - ``meta_refresh`` vs ``get_meta_refresh``
+      - 3.0 µs
+      - 6.5 µs
+      - 2.1x
 
 *************
  The renames
@@ -109,50 +149,6 @@ The two helpers that read a document's own URL hints map to the :meth:`~turbohtm
 
     http://site.com/sub/
     (5.0, 'http://site.com/next.html')
-
-*************
- Performance
-*************
-
-Stripping a set of tags while keeping their text: w3lib's regex ``remove_tags`` against turbohtml's
-:meth:`~turbohtml.Node.strip_tags`, over a 92 kB page holding 839 ``<code>``/``<a>``/``<q>`` elements. w3lib runs a
-regular-expression substitution over the string; turbohtml builds the WHATWG tree, unwraps each match in place, and
-serializes. turbohtml does the structure-aware pass a regex misreads on nested markup, and still runs it faster:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 46 18 18 18
-
-    - - strip tags, keep text (92 kB)
-      - turbohtml
-      - w3lib
-      - speed-up
-    - - ``strip_tags`` vs ``remove_tags``
-      - 607 µs
-      - 1.11 ms
-      - 1.8x
-
-Reading a document's own URL hints: w3lib's ``get_base_url`` and ``get_meta_refresh`` against
-:meth:`~turbohtml.Document.base_url` and :meth:`~turbohtml.Document.meta_refresh`. Both parse the string each call, over
-a small page carrying a ``<base>`` and a meta refresh. w3lib runs a regular-expression pass; turbohtml runs the WHATWG
-tree builder and reads the hint off the parsed ``<head>``, and still comes out ahead (``tox -e bench extract``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 46 18 18 18
-
-    - - url hint
-      - turbohtml
-      - w3lib
-      - speed-up
-    - - ``base_url`` vs ``get_base_url``
-      - 2.9 µs
-      - 7.4 µs
-      - 2.6x
-    - - ``meta_refresh`` vs ``get_meta_refresh``
-      - 3.0 µs
-      - 6.5 µs
-      - 2.1x
 
 **********
  Pitfalls


### PR DESCRIPTION
Unifies every migration guide under `docs/migration/` onto one consistent pattern.

## What changed

**Monthly download badges** — every pepy shield now points at the `/month`
endpoint with an alt of `<pkg> monthly downloads` (target link unchanged).
All 25 `/month` URLs were confirmed to return 200, so no page fell back to
the total-downloads badge.

**Performance folded into "Why turbohtml"** — the established convention keeps
the comparison table inside the "Why turbohtml" section. Pages that had grown
a separate `Performance` heading have had their table(s) moved up, so no page
keeps a standalone `Performance` section: beautifulsoup, dominate, extruct,
html-text, html5lib, newspaper3k, pandas, parsel, pyquery, readability-lxml,
resiliparse, selectolax, trafilatura, w3lib.

`lxml` is the one exception: its parse comparison already lives in "Why
turbohtml", and its three deep benchmark sections are interleaved with XPath
testcode and ~8 tables, so folding them up would be destructive. They are
instead retitled to describe their content (`Tree and link operations`,
`XPath`, `EXSLT`); no `Performance` heading remains.

**Speed-up multipliers, consistent wording** — every one-competitor table now
ends with a `speed-up` column, and multi-competitor tables append ` (Nx)`
after each competitor's number. Added the missing column to the extruct,
pandas, pyquery content-setter, and lxml EXSLT tables; appended `(Nx)` to the
two-competitor dominate build table; and replaced every `speedup` header with
`speed-up` (newspaper3k, readability-lxml, trafilatura).

**Index order** — re-fetched current monthly downloads and corrected the one
drift: `dominate` (1,911,129) edges out `pyquery` (1,904,542), so the two are
swapped; the toctree is otherwise already strictly monthly-descending with
stdlib last.

## Gates

- `prek run --all-files` — clean (docstrfmt reflowed `lxml.rst`, re-run clean)
- `tox r -e docs` — `sphinx-build -W`, every page builds, toctree resolves,
  0 warnings, no malformed tables