### PR TITLE
📝 docs(migration): report monthly downloads not totals

### DIFF
--- a/docs/changelog/301.doc.rst
+++ b/docs/changelog/301.doc.rst
@@ -1,0 +1,3 @@
+Report monthly PyPI downloads instead of all-time totals across the :doc:`migration
+guides <migration/index>`: the index now lists each library with its monthly-downloads
+badge, and every per-library page shows the monthly figure - by :user:`gaborbernat`.

--- a/docs/changelog/301.doc.rst
+++ b/docs/changelog/301.doc.rst
@@ -1,3 +1,3 @@
-Report monthly PyPI downloads instead of all-time totals across the :doc:`migration
-guides <migration/index>`: the index now lists each library with its monthly-downloads
-badge, and every per-library page shows the monthly figure - by :user:`gaborbernat`.
+Report monthly PyPI downloads instead of all-time totals across the :doc:`migration guides <migration/index>`: the index
+now lists each library with its monthly-downloads badge, and every per-library page shows the monthly figure - by
+:user:`gaborbernat`.

--- a/docs/migration/beautifulsoup.rst
+++ b/docs/migration/beautifulsoup.rst
@@ -2,8 +2,8 @@
  From BeautifulSoup
 ####################
 
-.. image:: https://static.pepy.tech/badge/beautifulsoup4
-    :alt: beautifulsoup4 downloads
+.. image:: https://static.pepy.tech/badge/beautifulsoup4/month
+    :alt: beautifulsoup4 monthly downloads
     :target: https://pepy.tech/project/beautifulsoup4
 
 `BeautifulSoup <https://www.crummy.com/software/BeautifulSoup/bs4/doc/>`_ is the long-standing convenience layer over a

--- a/docs/migration/bleach.rst
+++ b/docs/migration/bleach.rst
@@ -2,8 +2,8 @@
  From bleach
 #############
 
-.. image:: https://static.pepy.tech/badge/bleach
-    :alt: bleach downloads
+.. image:: https://static.pepy.tech/badge/bleach/month
+    :alt: bleach monthly downloads
     :target: https://pepy.tech/project/bleach
 
 `bleach <https://github.com/mozilla/bleach>`_ was the standard HTML allowlist sanitizer and linkifier, built on

--- a/docs/migration/dominate.rst
+++ b/docs/migration/dominate.rst
@@ -2,8 +2,8 @@
  From the HTML builders
 ########################
 
-.. image:: https://static.pepy.tech/badge/dominate
-    :alt: dominate downloads
+.. image:: https://static.pepy.tech/badge/dominate/month
+    :alt: dominate monthly downloads
     :target: https://pepy.tech/project/dominate
 
 The HTML *generators* -- `dominate <https://github.com/Knio/dominate>`_, `yattag <https://www.yattag.org>`_, `htpy

--- a/docs/migration/extruct.rst
+++ b/docs/migration/extruct.rst
@@ -2,8 +2,8 @@
  From extruct / metadata_parser
 ################################
 
-.. image:: https://static.pepy.tech/badge/extruct
-    :alt: extruct downloads
+.. image:: https://static.pepy.tech/badge/extruct/month
+    :alt: extruct monthly downloads
     :target: https://pepy.tech/project/extruct
 
 `extruct <https://github.com/scrapinghub/extruct>`_ and `metadata_parser <https://github.com/jvanasco/metadata_parser>`_

--- a/docs/migration/html-sanitizer.rst
+++ b/docs/migration/html-sanitizer.rst
@@ -2,8 +2,8 @@
  From html-sanitizer
 #####################
 
-.. image:: https://static.pepy.tech/badge/html-sanitizer
-    :alt: html-sanitizer downloads
+.. image:: https://static.pepy.tech/badge/html-sanitizer/month
+    :alt: html-sanitizer monthly downloads
     :target: https://pepy.tech/project/html-sanitizer
 
 `html-sanitizer <https://github.com/matthiask/html-sanitizer>`_ is an allowlist sanitizer over lxml, configured with a

--- a/docs/migration/html-text.rst
+++ b/docs/migration/html-text.rst
@@ -2,8 +2,8 @@
  From html-text
 ################
 
-.. image:: https://static.pepy.tech/badge/html-text
-    :alt: html-text downloads
+.. image:: https://static.pepy.tech/badge/html-text/month
+    :alt: html-text monthly downloads
     :target: https://pepy.tech/project/html-text
 
 `html-text <https://github.com/zytedata/html-text>`_ (Zyte) pulls the visible text out of a page, optionally guessing

--- a/docs/migration/html2text.rst
+++ b/docs/migration/html2text.rst
@@ -2,8 +2,8 @@
  From html2text
 ################
 
-.. image:: https://static.pepy.tech/badge/html2text
-    :alt: html2text downloads
+.. image:: https://static.pepy.tech/badge/html2text/month
+    :alt: html2text monthly downloads
     :target: https://pepy.tech/project/html2text
 
 `html2text <https://github.com/Alir3z4/html2text>`_ converts HTML to Markdown with a streaming ``HTMLParser`` subclass

--- a/docs/migration/html5-parser.rst
+++ b/docs/migration/html5-parser.rst
@@ -2,8 +2,8 @@
  From html5-parser
 ###################
 
-.. image:: https://static.pepy.tech/badge/html5-parser
-    :alt: html5-parser downloads
+.. image:: https://static.pepy.tech/badge/html5-parser/month
+    :alt: html5-parser monthly downloads
     :target: https://pepy.tech/project/html5-parser
 
 `html5-parser <https://html5-parser.readthedocs.io>`_ wraps gumbo, the C WHATWG parser, and hands the result back as an

--- a/docs/migration/html5lib.rst
+++ b/docs/migration/html5lib.rst
@@ -2,8 +2,8 @@
  From html5lib
 ###############
 
-.. image:: https://static.pepy.tech/badge/html5lib
-    :alt: html5lib downloads
+.. image:: https://static.pepy.tech/badge/html5lib/month
+    :alt: html5lib monthly downloads
     :target: https://pepy.tech/project/html5lib
 
 `html5lib <https://html5lib.readthedocs.io>`_ is the reference pure-Python implementation of the WHATWG parsing

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -2,15 +2,13 @@
  Migrating to turbohtml
 ########################
 
-turbohtml replaces the HTML libraries it benchmarks against. None is API-compatible, so
-porting is a translation: turbohtml uses one name per concept and a typed shape where
-those libraries spread the work across aliases, methods, and treebuilder choices. This
-page maps each library to turbohtml; `BeautifulSoup
-<https://www.crummy.com/software/BeautifulSoup/>`_ gets the deepest treatment because it
-shares the most surface.
+turbohtml replaces the HTML libraries it benchmarks against. None is API-compatible, so porting is a translation:
+turbohtml uses one name per concept and a typed shape where those libraries spread the work across aliases, methods, and
+treebuilder choices. This page maps each library to turbohtml; `BeautifulSoup
+<https://www.crummy.com/software/BeautifulSoup/>`_ gets the deepest treatment because it shares the most surface.
 
-The guides are ordered by adoption, most to least monthly PyPI downloads, so the
-libraries you are most likely to port from come first.
+The guides are ordered by adoption, most to least monthly PyPI downloads, so the libraries you are most likely to port
+from come first.
 
 .. list-table::
     :header-rows: 1

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -2,12 +2,131 @@
  Migrating to turbohtml
 ########################
 
-turbohtml replaces the HTML libraries it benchmarks against. None is API-compatible, so porting is a translation:
-turbohtml uses one name per concept and a typed shape where those libraries spread the work across aliases, methods, and
-treebuilder choices. This page maps each library to turbohtml; `BeautifulSoup
-<https://www.crummy.com/software/BeautifulSoup/>`_ gets the deepest treatment because it shares the most surface.
+turbohtml replaces the HTML libraries it benchmarks against. None is API-compatible, so
+porting is a translation: turbohtml uses one name per concept and a typed shape where
+those libraries spread the work across aliases, methods, and treebuilder choices. This
+page maps each library to turbohtml; `BeautifulSoup
+<https://www.crummy.com/software/BeautifulSoup/>`_ gets the deepest treatment because it
+shares the most surface.
+
+The guides are ordered by adoption, most to least monthly PyPI downloads, so the
+libraries you are most likely to port from come first.
+
+.. list-table::
+    :header-rows: 1
+    :widths: auto
+
+    - - Library
+      - Monthly downloads
+    - - :doc:`pandas <pandas>`
+      - .. image:: https://static.pepy.tech/badge/pandas/month
+            :alt: pandas monthly downloads
+            :target: https://pepy.tech/project/pandas
+    - - :doc:`markupsafe <markupsafe>`
+      - .. image:: https://static.pepy.tech/badge/markupsafe/month
+            :alt: markupsafe monthly downloads
+            :target: https://pepy.tech/project/markupsafe
+    - - :doc:`beautifulsoup <beautifulsoup>`
+      - .. image:: https://static.pepy.tech/badge/beautifulsoup4/month
+            :alt: beautifulsoup4 monthly downloads
+            :target: https://pepy.tech/project/beautifulsoup4
+    - - :doc:`lxml <lxml>`
+      - .. image:: https://static.pepy.tech/badge/lxml/month
+            :alt: lxml monthly downloads
+            :target: https://pepy.tech/project/lxml
+    - - :doc:`linkify-it-py <linkify-it-py>`
+      - .. image:: https://static.pepy.tech/badge/linkify-it-py/month
+            :alt: linkify-it-py monthly downloads
+            :target: https://pepy.tech/project/linkify-it-py
+    - - :doc:`bleach <bleach>`
+      - .. image:: https://static.pepy.tech/badge/bleach/month
+            :alt: bleach monthly downloads
+            :target: https://pepy.tech/project/bleach
+    - - :doc:`markdownify <markdownify>`
+      - .. image:: https://static.pepy.tech/badge/markdownify/month
+            :alt: markdownify monthly downloads
+            :target: https://pepy.tech/project/markdownify
+    - - :doc:`nh3 <nh3>`
+      - .. image:: https://static.pepy.tech/badge/nh3/month
+            :alt: nh3 monthly downloads
+            :target: https://pepy.tech/project/nh3
+    - - :doc:`html5lib <html5lib>`
+      - .. image:: https://static.pepy.tech/badge/html5lib/month
+            :alt: html5lib monthly downloads
+            :target: https://pepy.tech/project/html5lib
+    - - :doc:`html2text <html2text>`
+      - .. image:: https://static.pepy.tech/badge/html2text/month
+            :alt: html2text monthly downloads
+            :target: https://pepy.tech/project/html2text
+    - - :doc:`lxml-html-clean <lxml-html-clean>`
+      - .. image:: https://static.pepy.tech/badge/lxml_html_clean/month
+            :alt: lxml-html-clean monthly downloads
+            :target: https://pepy.tech/project/lxml_html_clean
+    - - :doc:`w3lib <w3lib>`
+      - .. image:: https://static.pepy.tech/badge/w3lib/month
+            :alt: w3lib monthly downloads
+            :target: https://pepy.tech/project/w3lib
+    - - :doc:`trafilatura <trafilatura>`
+      - .. image:: https://static.pepy.tech/badge/trafilatura/month
+            :alt: trafilatura monthly downloads
+            :target: https://pepy.tech/project/trafilatura
+    - - :doc:`selectolax <selectolax>`
+      - .. image:: https://static.pepy.tech/badge/selectolax/month
+            :alt: selectolax monthly downloads
+            :target: https://pepy.tech/project/selectolax
+    - - :doc:`parsel <parsel>`
+      - .. image:: https://static.pepy.tech/badge/parsel/month
+            :alt: parsel monthly downloads
+            :target: https://pepy.tech/project/parsel
+    - - :doc:`pyquery <pyquery>`
+      - .. image:: https://static.pepy.tech/badge/pyquery/month
+            :alt: pyquery monthly downloads
+            :target: https://pepy.tech/project/pyquery
+    - - :doc:`dominate <dominate>`
+      - .. image:: https://static.pepy.tech/badge/dominate/month
+            :alt: dominate monthly downloads
+            :target: https://pepy.tech/project/dominate
+    - - :doc:`inscriptis <inscriptis>`
+      - .. image:: https://static.pepy.tech/badge/inscriptis/month
+            :alt: inscriptis monthly downloads
+            :target: https://pepy.tech/project/inscriptis
+    - - :doc:`readability-lxml <readability-lxml>`
+      - .. image:: https://static.pepy.tech/badge/readability-lxml/month
+            :alt: readability-lxml monthly downloads
+            :target: https://pepy.tech/project/readability-lxml
+    - - :doc:`html-text <html-text>`
+      - .. image:: https://static.pepy.tech/badge/html-text/month
+            :alt: html-text monthly downloads
+            :target: https://pepy.tech/project/html-text
+    - - :doc:`resiliparse <resiliparse>`
+      - .. image:: https://static.pepy.tech/badge/resiliparse/month
+            :alt: resiliparse monthly downloads
+            :target: https://pepy.tech/project/resiliparse
+    - - :doc:`newspaper3k <newspaper3k>`
+      - .. image:: https://static.pepy.tech/badge/newspaper3k/month
+            :alt: newspaper3k monthly downloads
+            :target: https://pepy.tech/project/newspaper3k
+    - - :doc:`html-sanitizer <html-sanitizer>`
+      - .. image:: https://static.pepy.tech/badge/html-sanitizer/month
+            :alt: html-sanitizer monthly downloads
+            :target: https://pepy.tech/project/html-sanitizer
+    - - :doc:`extruct <extruct>`
+      - .. image:: https://static.pepy.tech/badge/extruct/month
+            :alt: extruct monthly downloads
+            :target: https://pepy.tech/project/extruct
+    - - :doc:`mechanicalsoup <mechanicalsoup>`
+      - .. image:: https://static.pepy.tech/badge/MechanicalSoup/month
+            :alt: MechanicalSoup monthly downloads
+            :target: https://pepy.tech/project/MechanicalSoup
+    - - :doc:`html5-parser <html5-parser>`
+      - .. image:: https://static.pepy.tech/badge/html5-parser/month
+            :alt: html5-parser monthly downloads
+            :target: https://pepy.tech/project/html5-parser
+    - - :doc:`stdlib <stdlib>`
+      - Bundled with Python
 
 .. toctree::
+    :hidden:
     :maxdepth: 1
 
     pandas

--- a/docs/migration/inscriptis.rst
+++ b/docs/migration/inscriptis.rst
@@ -2,8 +2,8 @@
  From inscriptis
 #################
 
-.. image:: https://static.pepy.tech/badge/inscriptis
-    :alt: inscriptis downloads
+.. image:: https://static.pepy.tech/badge/inscriptis/month
+    :alt: inscriptis monthly downloads
     :target: https://pepy.tech/project/inscriptis
 
 `inscriptis <https://github.com/weblyzard/inscriptis>`_ renders HTML to *layout-aware* plain text: it keeps the visual

--- a/docs/migration/linkify-it-py.rst
+++ b/docs/migration/linkify-it-py.rst
@@ -2,8 +2,8 @@
  From linkify-it-py
 ####################
 
-.. image:: https://static.pepy.tech/badge/linkify-it-py
-    :alt: linkify-it-py downloads
+.. image:: https://static.pepy.tech/badge/linkify-it-py/month
+    :alt: linkify-it-py monthly downloads
     :target: https://pepy.tech/project/linkify-it-py
 
 `linkify-it-py <https://github.com/tsutsu3/linkify-it-py>`_ is the pure-Python link scanner `markdown-it-py

--- a/docs/migration/lxml-html-clean.rst
+++ b/docs/migration/lxml-html-clean.rst
@@ -2,8 +2,8 @@
  From lxml-html-clean
 ######################
 
-.. image:: https://static.pepy.tech/badge/lxml_html_clean
-    :alt: lxml-html-clean downloads
+.. image:: https://static.pepy.tech/badge/lxml_html_clean/month
+    :alt: lxml-html-clean monthly downloads
     :target: https://pepy.tech/project/lxml_html_clean
 
 `lxml-html-clean <https://github.com/fedora-python/lxml_html_clean>`_ is the ``Cleaner`` split out of

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -4,8 +4,8 @@
  From lxml
 ###########
 
-.. image:: https://static.pepy.tech/badge/lxml
-    :alt: lxml downloads
+.. image:: https://static.pepy.tech/badge/lxml/month
+    :alt: lxml monthly downloads
     :target: https://pepy.tech/project/lxml
 
 `lxml <https://lxml.de>`_ is the libxml2/libxslt binding that most Python HTML and XML processing has been built on:

--- a/docs/migration/markdownify.rst
+++ b/docs/migration/markdownify.rst
@@ -2,8 +2,8 @@
  From markdownify
 ##################
 
-.. image:: https://static.pepy.tech/badge/markdownify
-    :alt: markdownify downloads
+.. image:: https://static.pepy.tech/badge/markdownify/month
+    :alt: markdownify monthly downloads
     :target: https://pepy.tech/project/markdownify
 
 `markdownify <https://github.com/matthewwithanm/python-markdownify>`_ converts HTML to Markdown by walking a

--- a/docs/migration/markupsafe.rst
+++ b/docs/migration/markupsafe.rst
@@ -2,8 +2,8 @@
  From markupsafe
 #################
 
-.. image:: https://static.pepy.tech/badge/markupsafe
-    :alt: markupsafe downloads
+.. image:: https://static.pepy.tech/badge/markupsafe/month
+    :alt: markupsafe monthly downloads
     :target: https://pepy.tech/project/markupsafe
 
 `markupsafe <https://markupsafe.palletsprojects.com>`_ is the safe-string library behind `Jinja2

--- a/docs/migration/mechanicalsoup.rst
+++ b/docs/migration/mechanicalsoup.rst
@@ -2,8 +2,8 @@
  From MechanicalSoup
 #####################
 
-.. image:: https://static.pepy.tech/badge/MechanicalSoup
-    :alt: MechanicalSoup downloads
+.. image:: https://static.pepy.tech/badge/MechanicalSoup/month
+    :alt: MechanicalSoup monthly downloads
     :target: https://pepy.tech/project/MechanicalSoup
 
 `MechanicalSoup <https://github.com/MechanicalSoup/MechanicalSoup>`_ is a stateful browser: it fetches pages with

--- a/docs/migration/newspaper3k.rst
+++ b/docs/migration/newspaper3k.rst
@@ -2,8 +2,8 @@
  From newspaper3k
 ##################
 
-.. image:: https://static.pepy.tech/badge/newspaper3k
-    :alt: newspaper3k downloads
+.. image:: https://static.pepy.tech/badge/newspaper3k/month
+    :alt: newspaper3k monthly downloads
     :target: https://pepy.tech/project/newspaper3k
 
 `newspaper3k <https://newspaper.readthedocs.io>`_ is a news-article scraper: an ``Article`` downloads a URL, then

--- a/docs/migration/nh3.rst
+++ b/docs/migration/nh3.rst
@@ -2,8 +2,8 @@
  From nh3
 ##########
 
-.. image:: https://static.pepy.tech/badge/nh3
-    :alt: nh3 downloads
+.. image:: https://static.pepy.tech/badge/nh3/month
+    :alt: nh3 monthly downloads
     :target: https://pepy.tech/project/nh3
 
 `nh3 <https://nh3.readthedocs.io>`_ is the Python binding for the Rust `ammonia

--- a/docs/migration/pandas.rst
+++ b/docs/migration/pandas.rst
@@ -2,8 +2,8 @@
  From pandas
 #############
 
-.. image:: https://static.pepy.tech/badge/pandas
-    :alt: pandas downloads
+.. image:: https://static.pepy.tech/badge/pandas/month
+    :alt: pandas monthly downloads
     :target: https://pepy.tech/project/pandas
 
 `pandas <https://pandas.pydata.org>`_ is how scrapers turn ``<table>`` markup into rows: ``pandas.read_html`` parses

--- a/docs/migration/parsel.rst
+++ b/docs/migration/parsel.rst
@@ -2,8 +2,8 @@
  From parsel
 #############
 
-.. image:: https://static.pepy.tech/badge/parsel
-    :alt: parsel downloads
+.. image:: https://static.pepy.tech/badge/parsel/month
+    :alt: parsel monthly downloads
     :target: https://pepy.tech/project/parsel
 
 `parsel <https://parsel.readthedocs.io>`_ is `Scrapy <https://scrapy.org>`_'s extraction-oriented selector library: a

--- a/docs/migration/pyquery.rst
+++ b/docs/migration/pyquery.rst
@@ -2,8 +2,8 @@
  From pyquery
 ##############
 
-.. image:: https://static.pepy.tech/badge/pyquery
-    :alt: pyquery downloads
+.. image:: https://static.pepy.tech/badge/pyquery/month
+    :alt: pyquery monthly downloads
     :target: https://pepy.tech/project/pyquery
 
 `pyquery <https://github.com/gawel/pyquery>`_ puts a jQuery-style fluent, chainable wrapper over `lxml

--- a/docs/migration/readability-lxml.rst
+++ b/docs/migration/readability-lxml.rst
@@ -2,8 +2,8 @@
  From readability-lxml
 #######################
 
-.. image:: https://static.pepy.tech/badge/readability-lxml
-    :alt: readability-lxml downloads
+.. image:: https://static.pepy.tech/badge/readability-lxml/month
+    :alt: readability-lxml monthly downloads
     :target: https://pepy.tech/project/readability-lxml
 
 `readability-lxml <https://github.com/buriy/python-readability>`_ is a Python port of Arc90's Readability: a

--- a/docs/migration/resiliparse.rst
+++ b/docs/migration/resiliparse.rst
@@ -2,8 +2,8 @@
  From resiliparse
 ##################
 
-.. image:: https://static.pepy.tech/badge/resiliparse
-    :alt: resiliparse downloads
+.. image:: https://static.pepy.tech/badge/resiliparse/month
+    :alt: resiliparse monthly downloads
     :target: https://pepy.tech/project/resiliparse
 
 `resiliparse <https://github.com/chatnoir-eu/chatnoir-resiliparse>`_ is the web-crawl processing toolkit from ChatNoir.

--- a/docs/migration/selectolax.rst
+++ b/docs/migration/selectolax.rst
@@ -2,8 +2,8 @@
  From selectolax
 #################
 
-.. image:: https://static.pepy.tech/badge/selectolax
-    :alt: selectolax downloads
+.. image:: https://static.pepy.tech/badge/selectolax/month
+    :alt: selectolax monthly downloads
     :target: https://pepy.tech/project/selectolax
 
 `selectolax <https://github.com/rushter/selectolax>`_ is a fast CSS-only HTML parser that wraps the `lexbor

--- a/docs/migration/trafilatura.rst
+++ b/docs/migration/trafilatura.rst
@@ -2,8 +2,8 @@
  From trafilatura
 ##################
 
-.. image:: https://static.pepy.tech/badge/trafilatura
-    :alt: trafilatura downloads
+.. image:: https://static.pepy.tech/badge/trafilatura/month
+    :alt: trafilatura monthly downloads
     :target: https://pepy.tech/project/trafilatura
 
 `trafilatura <https://trafilatura.readthedocs.io>`_ extracts the main text and metadata from a web page: it downloads

--- a/docs/migration/w3lib.rst
+++ b/docs/migration/w3lib.rst
@@ -2,8 +2,8 @@
  From w3lib (Scrapy)
 #####################
 
-.. image:: https://static.pepy.tech/badge/w3lib
-    :alt: w3lib downloads
+.. image:: https://static.pepy.tech/badge/w3lib/month
+    :alt: w3lib monthly downloads
     :target: https://pepy.tech/project/w3lib
 
 `w3lib <https://w3lib.readthedocs.io>`_ collects the web utilities `Scrapy <https://scrapy.org>`_ reuses: entity


### PR DESCRIPTION
The migration badges reported all-time PyPI download counts, which blend a decade of legacy installs with present-day usage and overstate libraries that peaked years ago. 📊 Monthly figures reflect who readers are actually porting from now, and they line up with the index ordering that already ranks the guides by monthly volume.

Every per-library page now points its pepy badge at the `/month` endpoint instead of the lifetime total. The index gains a per-library table that surfaces the same monthly badge next to each guide, so the adoption signal is visible before a reader opens any single page. The `toctree` moves to `:hidden:` since the table now carries the on-page navigation while the sidebar stays intact.

`stdlib` has no PyPI project, so its row reads `Bundled with Python` rather than a badge.