### PR TITLE
🔧 build(pre-commit): ruff-format and lint RST doc snippets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,10 @@ repos:
       - id: ruff-format
       - id: ruff-check
         args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix"]
+  - repo: https://github.com/pre-commit/sync-pre-commit-deps
+    rev: "v0.0.4" # v0.0.4
+    hooks:
+      - id: sync-pre-commit-deps
   - repo: https://github.com/google/yamlfmt
     rev: "v0.21.0" # v0.21.0
     hooks:
@@ -49,9 +53,9 @@ repos:
         files: ^src/turbohtml/.*\.c$
         require_serial: true
         additional_dependencies:
-          - clang-tidy==22.1.0.1
+          - clang-tidy==22.1.7
           - meson>=1.11.1
-          - ninja>=1.11.1
+          - ninja>=1.13
       - id: mdformat
         name: mdformat
         entry: mdformat --wrap 120
@@ -61,6 +65,13 @@ repos:
           - mdformat-gfm>=1
           - mdformat-ruff>=0.1.3
           - mdformat-frontmatter>=2.1.2 # keep the YAML front matter in issue templates intact
+      - id: ruff-docs
+        name: ruff (doc snippets)
+        entry: python tools/ruff_docs.py
+        language: python
+        files: ^docs/.*\.rst$
+        additional_dependencies:
+          - ruff==0.15.18 # kept on the ruff-pre-commit rev by sync-pre-commit-deps
       - id: changelogs-rst
         name: changelog filenames
         language: fail
@@ -71,7 +82,7 @@ repos:
     rev: "v2.2.0" # v2.1.0
     hooks:
       - id: docstrfmt
-        args: ["--line-length=120"]
+        args: ["--line-length=120", "--no-format-python-code-blocks"] # ruff-docs owns the Python snippets
         types_or: [rst]
         files: ^docs/.*\.rst$
   - repo: https://github.com/zizmorcore/zizmor-pre-commit

--- a/docs/how-to/editing.rst
+++ b/docs/how-to/editing.rst
@@ -13,6 +13,7 @@ setter fills an element with a single text child:
 .. testcode::
 
     from turbohtml import Element
+
     card = Element("article", {"class": ["card", "lg"]})
     heading = Element("h2")
     heading.text = "Title"
@@ -82,6 +83,7 @@ return it:
 .. testcode::
 
     from turbohtml import Element
+
     doc = turbohtml.parse("<section><h2>Title</h2><p>one</p><p>two</p></section>")
     section = doc.find("section")
     paragraphs = section.find_all("p")
@@ -187,6 +189,7 @@ empty text nodes, throughout the subtree (the DOM operation `BeautifulSoup
 .. testcode::
 
     from turbohtml import Text
+
     p = turbohtml.Element("p")
     p.extend([Text("Hello "), Text(""), Text("world")])
     p.normalize()
@@ -207,6 +210,7 @@ preserve processing instructions and CDATA sections exactly:
 .. testcode::
 
     import copy
+
     menu = turbohtml.parse("<ul><li>tea</li></ul>").find("ul")
     clone = copy.deepcopy(menu)
     clone.append(turbohtml.Element("li"))

--- a/docs/how-to/encoding.rst
+++ b/docs/how-to/encoding.rst
@@ -13,6 +13,7 @@
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse(b'<meta charset="iso-8859-2"><p>\xe1</p>')
     print(doc.encoding)
     print(doc.find("p").text)

--- a/docs/how-to/escaping.rst
+++ b/docs/how-to/escaping.rst
@@ -11,6 +11,7 @@ When you interpolate user-supplied text into HTML, escape it first so it cannot 
 .. testcode::
 
     import turbohtml
+
     comment = '<script>alert("xss")</script>'
     print(f"<p>{turbohtml.escape(comment)}</p>")
 

--- a/docs/how-to/parsing.rst
+++ b/docs/how-to/parsing.rst
@@ -30,8 +30,8 @@ parser releases its work-in-progress when the block exits, so you can stop early
 .. testcode::
 
     with turbohtml.IncrementalParser(encoding="utf-8") as parser:
-        parser.feed("<p>caf".encode("utf-8"))
-        parser.feed("é</p>".encode("utf-8"))
+        parser.feed(b"<p>caf")
+        parser.feed("é</p>".encode())
         document = parser.close()
     print(document.find("p").text)
 
@@ -50,6 +50,7 @@ the source position (1-based ``line``, 0-based ``col``); a well-formed document 
 .. testcode::
 
     import turbohtml
+
     document = turbohtml.parse("<a b b>")
     for error in document.errors:
         print(f"{error.code} at {error.line}:{error.col}")

--- a/docs/how-to/querying.rst
+++ b/docs/how-to/querying.rst
@@ -48,6 +48,7 @@ or from any element, searching its descendants:
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<form><input name=email><input name=token type=hidden></form>")
     print(doc.find("input", type="hidden").attrs["name"])
     print([field.attrs["name"] for field in doc.find_all("input")])
@@ -115,6 +116,8 @@ node kind and unpacks the defining field (``tag`` for an :class:`~turbohtml.Elem
                 return f"<!--{data}-->"
             case _:
                 return "?"
+
+
     print([summarize(child) for child in turbohtml.parse("<p>hi<!--x--><b>bold</b></p>").find("p")])
 
 .. testoutput::
@@ -136,6 +139,7 @@ comma groups:
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse('<ul><li class=on>a<li><a href="/x">b</a></ul>')
     print([li.text for li in doc.select("li.on")])
     print(doc.select_one('a[href^="/"]').text)
@@ -153,10 +157,7 @@ them:
 
 .. testcode::
 
-    table = turbohtml.parse(
-        "<ul><li class=row>a</li><li class=sep>-</li>"
-        "<li class=row>b</li><li class=row>c</li></ul>"
-    )
+    table = turbohtml.parse("<ul><li class=row>a</li><li class=sep>-</li><li class=row>b</li><li class=row>c</li></ul>")
     print([li.text for li in table.select("li:nth-child(2 of .row)")])
 
 .. testoutput::
@@ -171,10 +172,7 @@ and nests with the others (``article:not(:has(img))`` selects the image-less art
 
 .. testcode::
 
-    page = turbohtml.parse(
-        '<article><h1>Post</h1><figure><img></figure></article>'
-        "<article><h1>Note</h1></article>"
-    )
+    page = turbohtml.parse("<article><h1>Post</h1><figure><img></figure></article><article><h1>Note</h1></article>")
     print([a.select_one("h1").text for a in page.select("article:has(img)")])
     print([e.tag for e in page.select(":is(h1, figure)")])
     print([a.select_one("h1").text for a in page.select("article:not(:has(img))")])
@@ -193,8 +191,7 @@ resolved text direction. ``:scope`` is the element the query is rooted at, which
 .. testcode::
 
     form = turbohtml.parse(
-        "<form><input name=agree type=checkbox checked>"
-        "<input name=email required><input name=token disabled></form>"
+        "<form><input name=agree type=checkbox checked><input name=email required><input name=token disabled></form>"
     )
     print([e.attrs["name"] for e in form.select(":checked")])
     print([e.attrs["name"] for e in form.select(":required")])
@@ -327,6 +324,7 @@ predicates, the boolean, relational, and arithmetic operators, unions, and the c
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>")
     print([td.text for td in doc.xpath("//td")])
     print(doc.xpath("//tr[2]/td[1]/text()"))
@@ -355,6 +353,7 @@ the suffix, so ``//svg:rect`` finds the SVG rectangle while the unprefixed ``//r
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<svg><rect/><circle/></svg>")
     rects = doc.xpath("//svg:rect", namespaces={"svg": "http://www.w3.org/2000/svg"})
     print(len(rects))
@@ -369,6 +368,7 @@ quotes or special characters cannot break the query:
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<a href='/in'>in</a><a href='/out'>out</a>")
     print([a.text for a in doc.xpath("//a[@href=$href]", href="/out")])
 
@@ -383,6 +383,7 @@ node-set joins path steps, ``count()``, unions, and predicates like any other no
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>")
     rows = doc.xpath("//tr")
     print([td.text for td in doc.xpath("$rows/td", rows=rows)])
@@ -399,6 +400,7 @@ namespace; the ``re:`` prefix dispatches to Python's :mod:`re`:
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<a href='/p/12'>a</a><a href='/q'>b</a>")
     print([a.attrs["href"] for a in doc.xpath(r"//a[re:test(@href, '\d')]")])
 
@@ -418,8 +420,10 @@ iterable of elements produces a node-set that feeds later path steps and predica
     from types import SimpleNamespace
     from turbohtml import Element
 
+
     def first_two(context: SimpleNamespace, nodes: list[Element]) -> list[Element]:
         return nodes[:2]
+
 
     doc = turbohtml.parse("<ul><li>a</li><li>b</li><li>c</li></ul>")
     result = doc.xpath("first_two(//li)/text()", extensions={(None, "first_two"): first_two})
@@ -441,6 +445,7 @@ immutable and re-entrant, so one instance can be shared across threads.
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<table><tr><td class='num'>1</td><td>x</td></tr><tr><td class='num'>2</td></tr></table>")
     cells = turbohtml.XPath(".//td[@class=$cls]")
     for row in doc.xpath("//tr"):
@@ -461,6 +466,7 @@ numbers (``min``, ``max``, ``highest``, ``lowest``, ``abs``, ``power``), and ``d
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<ul><li>3</li><li>1</li><li>1</li></ul>")
     print([li.text for li in doc.xpath("set:distinct(//li)")])
     print(doc.xpath("math:max(//li)"))
@@ -492,6 +498,7 @@ to log a match, store a stable reference, or debug a scrape:
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<body><div><p>one</p><p>two</p></div></body>")
     second = doc.select("p")[1]
     print(second.css_path())
@@ -531,6 +538,7 @@ a token in the class list, and ``axis`` aims the search at something other than 
 .. testcode::
 
     import re, turbohtml
+
     doc = turbohtml.parse('<a class="btn lg" href="/a">A</a><a href="mailto:x">B</a>')
     print([a.attrs["href"] for a in doc.find_all("a", href=re.compile(r"^/"))])
     print(doc.find("a", class_="lg").text)
@@ -552,12 +560,9 @@ anything else. It composes with the tag, ``class_``, and attribute filters:
 .. testcode::
 
     import re, turbohtml
+
     doc = turbohtml.parse(
-        "<section>"
-        '<button class="buy">Add to cart</button>'
-        "<p>Price: $19</p>"
-        "<span>SKU-7788</span>"
-        "</section>"
+        '<section><button class="buy">Add to cart</button><p>Price: $19</p><span>SKU-7788</span></section>'
     ).find("section")
     print(doc.find(text="Add to cart").tag)
     print([node.tag for node in doc.find_all(text=re.compile(r"\$\d+"))])

--- a/docs/how-to/serializing.rst
+++ b/docs/how-to/serializing.rst
@@ -16,6 +16,7 @@ whitespace and so does not preserve meaning. :meth:`~turbohtml.Node.encode` is t
 
     import turbohtml
     from turbohtml import Formatter, Indent
+
     card = turbohtml.parse("<div><p>café &amp; co</p></div>").select_one("div")
     print(card.inner_html)
     print(card.serialize(formatter=Formatter.NAMED_ENTITIES))
@@ -47,9 +48,9 @@ strip comments; all default on. Because ``layout`` holds one mode, a :class:`~tu
 
     import turbohtml
     from turbohtml import Minify
+
     doc = turbohtml.parse(
-        "<html><head><title>Hi</title></head>"
-        "<body><p class='lead'>one</p>  <p>two</p><!--note--></body></html>"
+        "<html><head><title>Hi</title></head><body><p class='lead'>one</p>  <p>two</p><!--note--></body></html>"
     )
     print(doc.serialize(layout=Minify()))
     print(doc.serialize(layout=Minify(omit_optional_tags=False, collapse_whitespace=False)))
@@ -74,6 +75,7 @@ two serializations of equal trees diff cleanly:
 .. testcode::
 
     import turbohtml
+
     node = turbohtml.parse("<p id=main class=lead data-x=1>hi</p>").select_one("p")
     print(node.serialize(sort_attributes=True))
 
@@ -89,6 +91,7 @@ as its first child, never a duplicate. ``serialize`` declares ``utf-8`` (the enc
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<title>Hi</title>")
     print(doc.serialize(meta_charset=True))
     print(doc.encode("iso-8859-1", meta_charset=True))
@@ -110,6 +113,7 @@ second dependency and the whole walk in C:
 .. testcode::
 
     import turbohtml
+
     page = turbohtml.parse(
         "<h1>Recipe</h1><p>A <b>quick</b> loaf.</p>"
         "<ul><li>flour</li><li>water</li></ul>"
@@ -227,6 +231,7 @@ not know is ignored, and ``<script>``, ``<style>``, and ``<head>`` still vanish 
 .. testcode::
 
     import turbohtml
+
     page = turbohtml.parse(
         "<h2>Stock</h2>"
         "<table><tr><th>Item</th><th>Qty</th></tr>"
@@ -257,9 +262,11 @@ would, plus a list of ``(start, end, label)`` triples whose offsets index into t
 .. testcode::
 
     import turbohtml
-    text, labels = turbohtml.parse("<h1>Q3</h1><p>Up <b>12%</b> on the year.</p>").to_annotated_text(
-        {"h1": ["heading"], "b": ["metric"]}
-    )
+
+    text, labels = turbohtml.parse("<h1>Q3</h1><p>Up <b>12%</b> on the year.</p>").to_annotated_text({
+        "h1": ["heading"],
+        "b": ["metric"],
+    })
     print(text)
     for start, end, label in labels:
         print(label, "->", repr(text[start:end]))
@@ -288,6 +295,7 @@ sidebars, advertising and comment boilerplate scored out), so you can work on ju
 .. testcode::
 
     import turbohtml
+
     page = turbohtml.parse(
         "<body>"
         "<nav><a href='/'>Home</a> <a href='/about'>About</a></nav>"
@@ -336,6 +344,7 @@ case):
 .. testcode::
 
     import turbohtml
+
     page = turbohtml.parse(
         "<html lang='en'>"
         "<head><title>Comets — Astronomy Today</title>"
@@ -389,9 +398,11 @@ the surface forms an NLP or information-extraction pipeline consumes:
 .. testcode::
 
     import turbohtml
-    text, labels = turbohtml.parse("<h1>Q3</h1><p>Up <b>12%</b> on the year.</p>").to_annotated_text(
-        {"h1": ["heading"], "b": ["metric"]}
-    )
+
+    text, labels = turbohtml.parse("<h1>Q3</h1><p>Up <b>12%</b> on the year.</p>").to_annotated_text({
+        "h1": ["heading"],
+        "b": ["metric"],
+    })
     print(turbohtml.annotation_surface(text, labels))
 
 .. testoutput::
@@ -403,9 +414,7 @@ innermost span always closes first, so properly nested spans stay well-formed:
 
 .. testcode::
 
-    text, labels = turbohtml.parse("<p>a <b><i>both</i></b> c</p>").to_annotated_text(
-        {"b": ["bold"], "i": ["italic"]}
-    )
+    text, labels = turbohtml.parse("<p>a <b><i>both</i></b> c</p>").to_annotated_text({"b": ["bold"], "i": ["italic"]})
     print(turbohtml.annotation_tags(text, labels))
 
 .. testoutput::

--- a/docs/how-to/tokenizing.rst
+++ b/docs/how-to/tokenizing.rst
@@ -14,6 +14,7 @@ the base class and the handlers fire as before:
 
     from turbohtml.migration.stdlib import HTMLParser
 
+
     class LinkCollector(HTMLParser):
         def __init__(self):
             super().__init__()
@@ -22,6 +23,7 @@ the base class and the handlers fire as before:
         def handle_starttag(self, tag, attrs):
             if tag == "a":
                 self.links += [v for n, v in attrs if n == "href" and v]
+
 
     collector = LinkCollector()
     collector.feed('<a href="/x">x</a> <a href="/y">y</a>')
@@ -53,9 +55,7 @@ per-callback Python call overhead. A typical parser:
 
         def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
             if tag == "a":
-                self.links.extend(
-                    value for name, value in attrs if name == "href" and value
-                )
+                self.links.extend(value for name, value in attrs if name == "href" and value)
 
 
     collector = LinkCollector()
@@ -71,9 +71,7 @@ becomes a loop:
     links = [
         href
         for token in turbohtml.tokenize(page)
-        if token.type is turbohtml.TokenType.START_TAG
-        and token.tag == "a"
-        and (href := token.attr("href"))
+        if token.type is turbohtml.TokenType.START_TAG and token.tag == "a" and (href := token.attr("href"))
     ]
 
 The events map one to one:
@@ -108,8 +106,11 @@ string for a valueless attribute and your fallback when the attribute is missing
 .. testcode::
 
     page = '<p><a href="/a">one</a> and <a href="/b" download>two</a></p>'
-    print([token.attr("href") for token in turbohtml.tokenize(page)
-     if token.type is turbohtml.TokenType.START_TAG and token.tag == "a"])
+    print([
+        token.attr("href")
+        for token in turbohtml.tokenize(page)
+        if token.type is turbohtml.TokenType.START_TAG and token.tag == "a"
+    ])
 
 .. testoutput::
 
@@ -126,6 +127,8 @@ track the enclosing tag yourself:
 .. testcode::
 
     from collections.abc import Iterator
+
+
     def visible_text(page: str) -> Iterator[str]:
         hidden = 0
         for token in turbohtml.tokenize(page):
@@ -135,6 +138,8 @@ track the enclosing tag yourself:
                 hidden -= 1
             elif token.type is turbohtml.TokenType.TEXT and not hidden:
                 yield token.data
+
+
     print("".join(visible_text("<style>p{}</style><p>Tom &amp; Jerry</p>")))
 
 .. testoutput::
@@ -188,8 +193,11 @@ the offending markup:
 .. testcode::
 
     page = "<h1>title</h1>\n<img src='a.png'>"
-    print([f"{token.tag} at {token.line}:{token.col}" for token in turbohtml.tokenize(page)
-     if token.type is turbohtml.TokenType.START_TAG and token.tag == "img"])
+    print([
+        f"{token.tag} at {token.line}:{token.col}"
+        for token in turbohtml.tokenize(page)
+        if token.type is turbohtml.TokenType.START_TAG and token.tag == "img"
+    ])
 
 .. testoutput::
 

--- a/docs/migration/beautifulsoup.rst
+++ b/docs/migration/beautifulsoup.rst
@@ -63,6 +63,7 @@ since turbohtml always runs the WHATWG algorithm:
 .. testcode::
 
     from turbohtml import parse
+
     doc = parse("<p id=intro>Hello</p>")
     print(doc.find("p").attrs["id"])
 
@@ -158,6 +159,7 @@ attribute; ``class_`` and ``attrs`` match the rest; ``axis`` replaces the direct
 .. testcode::
 
     from turbohtml import Axis
+
     doc = parse('<ul><li class="x">a</li><li class="y">b</li></ul>')
     print([li.text for li in doc.find_all("li")])
     print(doc.find("li", class_="y").text)
@@ -190,9 +192,10 @@ text rather than a substring (use a regex to search within):
 .. testcode::
 
     import re
-    doc = parse('<ul><li>Buy now</li><li>Later</li></ul>')
+
+    doc = parse("<ul><li>Buy now</li><li>Later</li></ul>")
     print(doc.find("li", text="Buy now").text)
-    print([li.text for li in doc.find_all("li", text=re.compile("now"))])
+    print([li.text for li in doc.find_all("li", text=re.compile(r"now"))])
 
 .. testoutput::
 
@@ -307,6 +310,7 @@ attribute order, and ``<br>`` versus ``<br/>``. Choose ``Formatter.NAMED_ENTITIE
 .. testcode::
 
     from turbohtml import Formatter
+
     node = parse("<p>café &amp; co</p>").find("p")
     print(node.html)
     print(node.serialize(formatter=Formatter.NAMED_ENTITIES))

--- a/docs/migration/bleach.rst
+++ b/docs/migration/bleach.rst
@@ -151,9 +151,11 @@ tuple keys:
 
     from turbohtml.linkify import linkify, Link
 
+
     def shorten(link: Link) -> Link | None:
         link.text = link.url.removeprefix("https://").removeprefix("http://")
         return link
+
 
     print(linkify("read https://example.com/page", callbacks=[shorten]))
 

--- a/docs/migration/html-sanitizer.rst
+++ b/docs/migration/html-sanitizer.rst
@@ -44,9 +44,7 @@ builder in C instead of an lxml parse, leading html-sanitizer by one to two orde
     # html-sanitizer
     from html_sanitizer import Sanitizer
 
-    Sanitizer(
-        {"tags": {"a", "p"}, "attributes": {"a": {"href"}}, "add_nofollow": True}
-    ).sanitize(text)
+    Sanitizer({"tags": {"a", "p"}, "attributes": {"a": {"href"}}, "add_nofollow": True}).sanitize(text)
 
 .. list-table::
     :header-rows: 1
@@ -69,14 +67,16 @@ builder in C instead of an lxml parse, leading html-sanitizer by one to two orde
 
     from turbohtml.sanitizer import sanitize, Policy
 
-    print(sanitize(
-        '<p>Hi <a href="http://x">l</a></p>',
-        Policy(
-            tags=frozenset({"p", "a"}),
-            attributes={"a": frozenset({"href"})},
-            add_link_rel=frozenset({"nofollow"}),
-        ),
-    ))
+    print(
+        sanitize(
+            '<p>Hi <a href="http://x">l</a></p>',
+            Policy(
+                tags=frozenset({"p", "a"}),
+                attributes={"a": frozenset({"href"})},
+                add_link_rel=frozenset({"nofollow"}),
+            ),
+        )
+    )
 
 .. testoutput::
 

--- a/docs/migration/html5-parser.rst
+++ b/docs/migration/html5-parser.rst
@@ -55,6 +55,7 @@ document is more than an order of magnitude faster:
 .. testcode::
 
     from turbohtml import parse
+
     doc = parse("<table><tr><td>cell</td></table>")
     print(doc.find("td").text)  # the tbody the WHATWG algorithm inserts is walked the same way
 

--- a/docs/migration/inscriptis.rst
+++ b/docs/migration/inscriptis.rst
@@ -109,9 +109,10 @@ of ``(start, end, label)`` triples over its code-point offsets, taking every ``t
 
 .. testcode::
 
-    text, labels = parse("<h1>Title</h1><p>Some <b>bold</b> words.</p>").to_annotated_text(
-        {"h1": ["heading"], "b": ["emphasis"]}
-    )
+    text, labels = parse("<h1>Title</h1><p>Some <b>bold</b> words.</p>").to_annotated_text({
+        "h1": ["heading"],
+        "b": ["emphasis"],
+    })
     print(text)
     print([(label, text[start:end]) for start, end, label in labels])
 
@@ -146,9 +147,10 @@ as ``<label>...</label>`` markup, innermost span closing first).
 
     from turbohtml import annotation_surface, annotation_tags, parse
 
-    text, spans = parse("<h1>Q3</h1><p>Up <b>12%</b> on the year.</p>").to_annotated_text(
-        {"h1": ["heading"], "b": ["metric"]}
-    )
+    text, spans = parse("<h1>Q3</h1><p>Up <b>12%</b> on the year.</p>").to_annotated_text({
+        "h1": ["heading"],
+        "b": ["metric"],
+    })
     print(annotation_surface(text, spans))
     print(annotation_tags(text, spans))
 

--- a/docs/migration/lxml-html-clean.rst
+++ b/docs/migration/lxml-html-clean.rst
@@ -48,9 +48,7 @@ Porting inverts the model. Instead of switching dangerous things off, declare th
     # lxml-html-clean: enumerate what to strip, keep the rest
     from lxml_html_clean import Cleaner
 
-    Cleaner(
-        scripts=True, javascript=True, comments=True, style=True, forms=True
-    ).clean_html(text)
+    Cleaner(scripts=True, javascript=True, comments=True, style=True, forms=True).clean_html(text)
 
 .. list-table::
     :header-rows: 1
@@ -71,10 +69,12 @@ Porting inverts the model. Instead of switching dangerous things off, declare th
 
     from turbohtml.sanitizer import sanitize, Policy
 
-    print(sanitize(
-        "<p>Hi<script>x()</script> <a href='javascript:1'>l</a></p>",
-        Policy(tags=frozenset({"p", "a"}), attributes={"a": frozenset({"href"})}),
-    ))
+    print(
+        sanitize(
+            "<p>Hi<script>x()</script> <a href='javascript:1'>l</a></p>",
+            Policy(tags=frozenset({"p", "a"}), attributes={"a": frozenset({"href"})}),
+        )
+    )
 
 .. testoutput::
 

--- a/docs/migration/pandas.rst
+++ b/docs/migration/pandas.rst
@@ -23,9 +23,9 @@ exact shape ``pandas.DataFrame`` takes, so hand them over yourself and keep pand
 
     import turbohtml
 
-    table = turbohtml.parse(
-        "<table><tr><th>name</th><th>qty</th></tr><tr><td>pen</td><td>3</td></tr></table>"
-    ).find("table")
+    table = turbohtml.parse("<table><tr><th>name</th><th>qty</th></tr><tr><td>pen</td><td>3</td></tr></table>").find(
+        "table"
+    )
     records = table.records()
     print(records)
     # pandas.DataFrame(records) builds the frame, keeping pandas optional

--- a/docs/migration/stdlib.rst
+++ b/docs/migration/stdlib.rst
@@ -47,6 +47,7 @@ WHATWG-conformant where ``html.parser`` is not, and the whole surface is fully t
 
     import html
     from turbohtml import escape, unescape
+
     print(escape('<a href="x">') == html.escape('<a href="x">'))
     print(unescape("caf&eacute; &#127881;") == html.unescape("caf&eacute; &#127881;"))
 

--- a/docs/migration/w3lib.rst
+++ b/docs/migration/w3lib.rst
@@ -67,6 +67,7 @@ type annotated and running the scan in C, so it is a drop-in that runs several t
 .. testcode::
 
     from turbohtml import unescape
+
     print(unescape("caf&eacute; &amp; co"))
 
 .. testoutput::
@@ -80,6 +81,7 @@ comments never appear in ``text``:
 .. testcode::
 
     from turbohtml import parse
+
     print(parse("<p>Tom &amp; Jerry <b>says</b> hi</p><!--note-->").text)
 
 .. testoutput::

--- a/docs/tutorials/editing.rst
+++ b/docs/tutorials/editing.rst
@@ -9,6 +9,7 @@ assemble them with :meth:`~turbohtml.Element.append`; the ``text`` setter fills 
 
     import turbohtml
     from turbohtml import Element, Comment
+
     article = turbohtml.Element("article", {"class": "post"})
     title = turbohtml.Element("h1")
     title.text = "Tea"
@@ -54,6 +55,7 @@ edit without touching the original:
 .. testcode::
 
     import copy
+
     clone = copy.deepcopy(article)
     clone.append(turbohtml.Element("footer"))
     print(clone.html == article.html)
@@ -69,6 +71,7 @@ the same tree. Here the ``</li>`` tags stay because real whitespace separates th
 .. testcode::
 
     from turbohtml import Minify
+
     page = turbohtml.parse("<ul>\n  <li>one</li>\n  <li>two</li>\n</ul>")
     print(page.find("ul").serialize(layout=Minify()))
 

--- a/docs/tutorials/exporting.rst
+++ b/docs/tutorials/exporting.rst
@@ -8,6 +8,7 @@ so a scraping script ends with Markdown instead of a tag soup:
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<article><h2>Tea</h2><p>Steep <em>green</em> tea for <b>3</b> minutes.</p></article>")
     print(doc.find("article").to_markdown())
 
@@ -54,6 +55,7 @@ escapes the elements it removes rather than discarding their text:
 .. testcode::
 
     from turbohtml.sanitizer import sanitize
+
     print(sanitize('<a href="javascript:alert(1)">x</a> <b onclick="y()">bold</b><script>bad()</script>'))
 
 .. testoutput::

--- a/docs/tutorials/getting-started.rst
+++ b/docs/tutorials/getting-started.rst
@@ -15,6 +15,7 @@ Open a Python prompt and escape some text for safe inclusion in an HTML page:
 .. testcode::
 
     import turbohtml
+
     print(turbohtml.escape("5 > 3 & 2 < 4"))
 
 .. testoutput::
@@ -25,7 +26,7 @@ By default ``escape`` escapes quotation marks too, which you want inside an attr
 
 .. testcode::
 
-    print(turbohtml.escape("name=\"O'Brien\""))
+    print(turbohtml.escape('name="O\'Brien"'))
 
 .. testoutput::
 
@@ -54,6 +55,7 @@ quickest way to turn a plain message into clickable HTML:
 .. testcode::
 
     from turbohtml.linkify import linkify
+
     print(linkify("Visit https://example.com today"))
 
 .. testoutput::

--- a/docs/tutorials/navigating.rst
+++ b/docs/tutorials/navigating.rst
@@ -19,6 +19,7 @@ browsers run, including the error recovery that inserts the missing ``html``, ``
 .. testcode::
 
     import turbohtml
+
     doc = turbohtml.parse("<h1>Hello</h1><p>Tom &amp; <a href='/x'>Jerry</a></p>")
     print(doc.root)
 
@@ -196,6 +197,7 @@ variable:
 .. testcode::
 
     from turbohtml.query import Query
+
     anchors = Query(doc).find("a")
     print(anchors.text())
     print(anchors.attr("href"))

--- a/docs/tutorials/tokenizing.rst
+++ b/docs/tutorials/tokenizing.rst
@@ -10,6 +10,7 @@ Start with a small document and hand it to :func:`turbohtml.tokenize`, which ret
 .. testcode::
 
     import turbohtml
+
     for token in turbohtml.tokenize('<p class="intro">Tom &amp; Jerry</p>'):
         print(token)
 
@@ -40,8 +41,11 @@ HTML specification treats as raw, such as a script body, arrives as one text tok
 
 .. testcode::
 
-    print([token.data for token in turbohtml.tokenize("<script>if (a < b) run()</script>")
-           if token.type is turbohtml.TokenType.TEXT])
+    print([
+        token.data
+        for token in turbohtml.tokenize("<script>if (a < b) run()</script>")
+        if token.type is turbohtml.TokenType.TEXT
+    ])
 
 .. testoutput::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "mesonpy"
 requires = [
   "meson>=1.11.1",
-  "meson-python>=0.19",
+  "meson-python>=0.20",
   "ninja>=1.13",
 ]
 
@@ -60,18 +60,18 @@ dev = [
 ]
 test = [
   "covdefaults>=2.3",
-  "jinja2>=3.1",              # the markup migration test renders templates with markupsafe swapped for turbohtml.markup
-  "markdown-it-py>=4",        # a pure-Python GFM reference to round-trip to_markdown() output back to HTML and check it
+  "jinja2>=3.1.6",              # the markup migration test renders templates with markupsafe swapped for turbohtml.markup
+  "markdown-it-py>=4.2",        # a pure-Python GFM reference to round-trip to_markdown() output back to HTML and check it
   "meson>=1.11.1",
-  "meson-python>=0.19",
+  "meson-python>=0.20",
   "ninja>=1.13",
-  "pytest>=9.0.3",
+  "pytest>=9.1.1",
   "pytest-cov>=7.1",
   "pytest-mock>=3.15.1",
-  "pytest-run-parallel>=0.8", # runs each test in many threads to surface free-threaded data races
+  "pytest-run-parallel>=0.9.1", # runs each test in many threads to surface free-threaded data races
 ]
 type = [
-  "ty>=0.0.44",
+  "ty>=0.0.52",
   { include-group = "bench" },  # tools/benchmark.py imports pyperf and html5lib
 ]
 docs = [
@@ -79,60 +79,60 @@ docs = [
   "sphinx>=9.1",
   "sphinx-autodoc-typehints>=3.11",   # 3.11 types C getset descriptors from the stub
   "sphinx-copybutton>=0.5.2",
-  "sphinx-issues>=5.0.1",
-  "sphinxcontrib-mermaid>=1",
+  "sphinx-issues>=6",
+  "sphinxcontrib-mermaid>=2.0.2",
   "sphinxcontrib-towncrier>=0.5.0a0",
   "towncrier>=25.8",
 ]
 bench = [
-  "beautifulsoup4>=4.13",
-  "bleach>=6.2",
-  "cssselect>=1.3",
-  "dominate>=2.9",
+  "beautifulsoup4>=4.15",
+  "bleach>=6.4",
+  "cssselect>=1.4",
+  "dominate>=2.9.1",
   "extruct>=0.18",
-  "html-sanitizer>=2.5",
-  "html-text>=0.7",
-  "html2text>=2025.4",
+  "html-sanitizer>=2.6",
+  "html-text>=0.7.1",
+  "html2text>=2025.4.15",
   "html5-parser>=0.4.12",
   "html5lib>=1.1",
-  "inscriptis>=2.6",
-  "linkify-it-py>=2",
-  "lxml>=6.1",
-  "lxml-html-clean>=0.4",
-  "markdownify>=1.2",
-  "markupsafe>=3",
-  "minify-html>=0.15",
+  "inscriptis>=2.7.2",
+  "linkify-it-py>=2.1",
+  "lxml>=6.1.1",
+  "lxml-html-clean>=0.4.5",
+  "markdownify>=1.2.2",
+  "markupsafe>=3.0.3",
+  "minify-html>=0.18.1",
   "newspaper3k>=0.2.8",
-  "nh3>=0.2",
-  "pandas>=2.2",
-  "parsel>=1.9",
-  "pyperf>=2.9",
-  "pyquery>=2",
+  "nh3>=0.3.6",
+  "pandas>=3.0.3",
+  "parsel>=1.11",
+  "pyperf>=2.10",
+  "pyquery>=2.0.1",
   "readability-lxml>=0.8.4.1",
   "resiliparse>=1.0.8",
-  "selectolax>=0.3.30",
-  "soupsieve>=2.8",
-  "trafilatura>=2",
-  "w3lib>=2.3",
-  "yattag>=1.15",
+  "selectolax>=0.4.10",
+  "soupsieve>=2.8.4",
+  "trafilatura>=2.1",
+  "w3lib>=2.4.1",
+  "yattag>=1.16.1",
   { include-group = "test" },
 ]
 coverage = [
   "covdefaults>=2.3",
-  "coverage[toml]>=7.14.1",
+  "coverage[toml]>=7.14.3",
 ]
 fix = [
-  "pre-commit-uv>=4.2.1",
+  "pre-commit-uv>=4.2.2",
 ]
 pkg-meta = [
   "check-wheel-contents>=0.6.3",
   "twine>=6.2",
-  "uv>=0.11.19",
+  "uv>=0.11.23",
 ]
 release = [
-  "gitpython>=3.1.46",
-  "packaging>=26",
-  "pre-commit>=4.5.1",
+  "gitpython>=3.1.50",
+  "packaging>=26.2",
+  "pre-commit>=4.6",
   "towncrier>=25.8",
 ]
 

--- a/tools/ruff_docs.py
+++ b/tools/ruff_docs.py
@@ -1,0 +1,164 @@
+"""
+Format and lint the Python snippets embedded in the reStructuredText docs with Ruff.
+
+Ruff has no native reStructuredText support, so this hook extracts every ``testcode`` and
+``code-block:: python`` body, dedents it, runs ``ruff check --fix`` and ``ruff format`` over
+it under the project configuration, then splices the result back at the original indentation.
+Files are rewritten only when their snippets change, and the hook exits non-zero on any
+rewrite or residual lint finding so the commit fails until the docs match the code style.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / "pyproject.toml"
+DIRECTIVE = re.compile(r"^(?P<indent>[ \t]*)\.\. (?:testcode::|code-block:: (?:python|py|python3))\s*$")
+
+# Rules that fire on every well-formed doctest example, so enforcing them would only push noqa
+# noise into the rendered docs (and let --fix corrupt the migration before/after blocks).
+SNIPPET_IGNORE = (
+    "T201",  # examples print to produce the testoutput block
+    "INP001",  # a doc snippet is not an importable package
+    "D",  # examples carry no docstrings
+    "ANN",  # examples skip annotations for brevity
+    "I001",  # before/after blocks keep two import groups isort would merge
+    "I002",  # snippets do not carry the from __future__ import boilerplate
+    "F821",  # turbohtml and parse come from conf.py's doctest_global_setup
+    "F401",  # migration blocks show the old import without using it
+    "F811",  # ... and redefine the same name on the turbohtml side
+    "E401",  # comparison imports are grouped on one line
+    "E402",  # imports follow prose-driven setup statements
+    "ARG001",  # illustrative callbacks accept arguments they ignore
+)
+
+
+@dataclass(slots=True)
+class Snippet:
+    """One extracted Python block: where it lives and how it was indented."""
+
+    source: Path
+    line_no: int
+    body_start: int
+    body_end: int
+    content_indent: int
+    code: str
+
+
+def indent_of(line: str) -> int:
+    """Return the count of leading whitespace characters in ``line``."""
+    return len(line) - len(line.lstrip())
+
+
+def snippets_of(source: Path, lines: list[str]) -> list[Snippet]:
+    """Return every ``testcode``/``code-block:: python`` block found in ``lines``."""
+    blocks: list[Snippet] = []
+    cursor = 0
+    while cursor < len(lines):
+        if not (directive := DIRECTIVE.match(lines[cursor])):
+            cursor += 1
+            continue
+        base = len(directive.group("indent"))
+        line_no = cursor + 1
+        cursor += 1
+        while cursor < len(lines) and (
+            not lines[cursor].strip() or (lines[cursor].lstrip().startswith(":") and indent_of(lines[cursor]) > base)
+        ):
+            cursor += 1
+        body_start = cursor
+        while cursor < len(lines) and (not lines[cursor].strip() or indent_of(lines[cursor]) > base):
+            cursor += 1
+        body_end = cursor
+        while body_end > body_start and not lines[body_end - 1].strip():
+            body_end -= 1
+        if body := [line for line in lines[body_start:body_end] if line.strip()]:
+            content_indent = min(indent_of(line) for line in body)
+            code = "\n".join(line[content_indent:] if line.strip() else "" for line in lines[body_start:body_end])
+            blocks.append(Snippet(source, line_no, body_start, body_end, content_indent, code + "\n"))
+    return blocks
+
+
+def run_ruff(staging: Path) -> dict[Path, str]:
+    """Fix and format every staged snippet file in ``staging`` and return their new contents."""
+    ignore = ["--extend-ignore", ",".join(SNIPPET_IGNORE)]
+    common = ["--config", str(CONFIG), str(staging)]
+    subprocess.run(["ruff", "check", "--fix", "--quiet", *ignore, *common], check=False)
+    subprocess.run(["ruff", "format", "--quiet", *common], check=False)
+    return {path: path.read_text() for path in staging.glob("*.py")}
+
+
+def reindent(code: str, content_indent: int) -> list[str]:
+    """Re-apply ``content_indent`` to a dedented snippet, leaving blank lines empty."""
+    pad = " " * content_indent
+    return [pad + line if line.strip() else "" for line in code.rstrip("\n").split("\n")]
+
+
+def report_residuals(staging: Path, owners: dict[Path, Snippet]) -> bool:
+    """Print any lint finding Ruff could not auto-fix, mapped to its docs location."""
+    result = subprocess.run(
+        [
+            "ruff",
+            "check",
+            "--no-fix",
+            "--quiet",
+            "--output-format=concise",
+            "--extend-ignore",
+            ",".join(SNIPPET_IGNORE),
+            "--config",
+            str(CONFIG),
+            str(staging),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    findings = result.stdout.strip()
+    if not findings:
+        return False
+    for line in findings.splitlines():
+        if match := re.match(r"^(?P<file>.*\.py):(?P<row>\d+):(?P<col>\d+): (?P<rest>.*)$", line):
+            owner = owners[Path(match.group("file"))]
+            print(f"{owner.source}: snippet at line {owner.line_no}: {match.group('rest')}")
+        else:
+            print(line)
+    return True
+
+
+def main(argv: list[str]) -> int:
+    """Format and lint the snippets in the ``.rst`` paths in ``argv``; return the hook exit code."""
+    paths = [Path(arg) for arg in argv if arg.endswith(".rst")] or sorted(ROOT.joinpath("docs").rglob("*.rst"))
+    documents = {path: path.read_text().splitlines() for path in paths}
+    blocks = [block for path, lines in documents.items() for block in snippets_of(path, lines)]
+    if not blocks:
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        staging = Path(tmp)
+        owners = {staging / f"s{index}.py": block for index, block in enumerate(blocks)}
+        for path, block in owners.items():
+            path.write_text(block.code)
+        formatted = run_ruff(staging)
+        has_residuals = report_residuals(staging, owners)
+
+    changed: set[Path] = set()
+    for path, block in sorted(owners.items(), key=lambda item: item[1].body_start, reverse=True):
+        new_body = reindent(formatted[path], block.content_indent)
+        if documents[block.source][block.body_start : block.body_end] != new_body:
+            documents[block.source][block.body_start : block.body_end] = new_body
+            changed.add(block.source)
+
+    for source in changed:
+        source.write_text("\n".join(documents[source]) + "\n")
+        print(f"reformatted snippets in {source}")
+
+    return 1 if changed or has_residuals else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tox.toml
+++ b/tox.toml
@@ -9,7 +9,7 @@ package = "skip"  # we install an instrumented editable build ourselves below
 # no gcov on Windows, so pull it in only where the coverage gate actually runs
 deps = [
   { replace = "if", condition = "factor.win32 or factor['3.15'] or factor['3.14t'] or factor['3.15t']", then = [], else = [
-    "gcovr>=8.4"
+    "gcovr>=8.6"
   ], extend = true },
 ]
 dependency_groups = [ "test" ]


### PR DESCRIPTION
Ruff has no reStructuredText support, so the Python inside ``testcode::`` and ``code-block:: python`` blocks under `docs/` escaped the formatter and linter that cover the rest of the codebase. `docstrfmt` reformatted `code-block:: python` with `black` and left every `testcode::` example untouched, so snippets drifted from the house style and nothing caught a malformed example before it shipped. 📝

A new `tools/ruff_docs.py` pre-commit hook extracts each snippet body, runs `ruff check --fix` and `ruff format` under the project configuration, and writes the result back at its original indentation, failing the commit on any change or residual finding. Linting keeps the full `ALL` ruleset minus a documented `SNIPPET_IGNORE` set for the rules every well-formed doctest example trips: `print` output, missing module docstrings, names injected by `doctest_global_setup`, and the before/after import pairs in the migration guides. `docstrfmt` now runs with `--no-format-python-code-blocks` so `ruff` is the single source of truth for snippet code, and `sync-pre-commit-deps` keeps the hook pinned to the same `ruff` version as `ruff-pre-commit` when `autoupdate` runs. ✨

The first pass reformatted the snippets across 21 documentation pages. ⚠️ This commit also carries dependency lower-bound bumps in `pyproject.toml` and `tox.toml` that were already in the working tree; they are unrelated to the hook and ride along here rather than in a separate change.