### PR TITLE
🔧 build(c): clear -Wall/-Wextra warnings and gate them in CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,9 @@
 # clang-tidy for the C extension. We enable the deterministic, low-false-positive
-# diagnostic families — bug patterns, performance, portability — and turn every
-# remaining warning into an error so the gate is binary.
+# diagnostic families — compiler diagnostics, bug patterns, performance, portability —
+# and turn every remaining warning into an error so the gate is binary. clang-diagnostic-*
+# surfaces the same -Wall/-Wextra warnings the compile_commands.json flags (warning_level=2)
+# carry, so unused/comment/fallthrough/unsequenced slips fail the local hook too; -Wpedantic
+# is not in those flags, so the API-mandated void*/function-pointer slot casts stay quiet.
 #
 # Disabled sub-checks are either opinionated style (easily-swappable-parameters,
 # assignment-in-if-condition), inherent to the Python C API (reserved-identifier
@@ -10,7 +13,7 @@
 # generated tag table and the width-tagged th_buf union, and is better run as a
 # separate scan-build pass.
 Checks: >
-  -*, bugprone-*, performance-*, portability-*, -bugprone-easily-swappable-parameters, -bugprone-reserved-identifier, -bugprone-multi-level-implicit-pointer-conversion, -bugprone-narrowing-conversions, -bugprone-assignment-in-if-condition
+  -*, clang-diagnostic-*, bugprone-*, performance-*, portability-*, -bugprone-easily-swappable-parameters, -bugprone-reserved-identifier, -bugprone-multi-level-implicit-pointer-conversion, -bugprone-narrowing-conversions, -bugprone-assignment-in-if-condition
 
 WarningsAsErrors: "*"
 HeaderFilterRegex: "src/turbohtml/_c/.*\\.h$"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -62,6 +62,101 @@ jobs:
         run: uvx --with tox-uv tox run -e ${{ matrix.tox_env }}
         env:
           UV_PYTHON_PREFERENCE: only-managed
+  warnings:
+    name: 🚨 -Werror (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    # compile the C extension with -Werror so any compiler warning fails the build. The
+    # warning set differs per compiler (gcc flags fall-through clang does not) and the SIMD
+    # helpers are #if-gated per architecture (SSE2 on x86, NEON on arm64), so the gate is a
+    # compiler x SIMD-path grid: gcc and clang each over x86 and arm64. MSVC is a separate
+    # job below because it is detected without CC. macOS gcc is omitted as redundant with
+    # Linux gcc arm64 — same compiler, same NEON path, and the OS does not change the warnings.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: "ubuntu-24.04", cc: "gcc", label: "gcc · Linux x64"}
+          - {os: "ubuntu-24.04", cc: "clang", label: "clang · Linux x64"}
+          - {os: "ubuntu-24.04-arm", cc: "gcc", label: "gcc · Linux arm64"}
+          - {os: "macos-15", cc: "clang", label: "clang · macOS arm64"}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # meson project() derives the version from git history
+          persist-credentials: false
+      - name: 🔄 Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: ✅ Build with -Werror
+        run: uvx --with tox-uv tox run -e warnings
+        env:
+          UV_PYTHON_PREFERENCE: only-managed
+          CC: ${{ matrix.cc }}
+  warnings-msvc:
+    name: 🚨 -Werror (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    # MSVC is detected by meson without a CC override and maps -Werror to /WX; split from the matrix
+    # above so an empty CC env never shadows the auto-detection. x64 builds the SSE2 branch; on
+    # windows-11-arm meson does not self-detect MSVC, so that cell installs an arm64 dev Python and
+    # activates the native arm64 toolchain with msvc-dev-cmd (its INCLUDE/LIB ride through tox via
+    # pass_env), giving MSVC coverage of the _M_ARM64 NEON branch too.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: "windows-2025", label: "MSVC · Windows x64", arm: false}
+          - {os: "windows-11-arm", label: "MSVC · Windows arm64", arm: true}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # meson project() derives the version from git history
+          persist-credentials: false
+      - name: 🐍 Install arm64 dev Python (carries the .lib meson needs)
+        if: matrix.arm
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+          architecture: arm64
+      - name: 🧰 Activate native arm64 MSVC (so meson picks cl over MinGW gcc)
+        if: matrix.arm
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        with:
+          arch: arm64
+      - name: 🔄 Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: ✅ Build with -Werror
+        run: uvx --with tox-uv tox run -e warnings
+        env:
+          UV_PYTHON_PREFERENCE: ${{ matrix.arm && 'only-system' || 'only-managed' }}
+  clang-tidy:
+    name: 🧹 clang-tidy (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    # the clang-tidy pre-commit hook needs a local Meson build of the C extension, so it
+    # is skipped on pre-commit.ci; run it here where the toolchain and headers are available.
+    # both architectures run because the SIMD escape/scan helpers are #if-gated — x86 compiles
+    # the SSE2 variant, arm64 the NEON one — and clang-tidy only analyzes the branch it builds.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: "ubuntu-24.04", arch: "x64"}
+          - {os: "ubuntu-24.04-arm", arch: "arm64"}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # meson project() derives the version from git history
+          persist-credentials: false
+      - name: 🔄 Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: ✅ Run clang-tidy
+        run: uvx pre-commit run clang-tidy --all-files --show-diff-on-failure --color always
+        env:
+          UV_PYTHON_PREFERENCE: only-managed
   tsan:
     name: 🧵 ThreadSanitizer
     runs-on: ubuntu-24.04

--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -12,6 +12,16 @@
 
 #include <stdint.h>
 
+/* Mark an intentional switch fall-through. gcc turns on -Wimplicit-fallthrough with
+   -Wextra and only honors the fallthrough attribute across versions; the C23
+   [[fallthrough]] spelling is unavailable under c_std=c11, and MSVC has no C
+   equivalent and does not raise the warning. */
+#if defined(__GNUC__) || defined(__clang__)
+#define TH_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define TH_FALLTHROUGH ((void)0)
+#endif
+
 /* Implemented in escape.c. Signature matches METH_VARARGS | METH_KEYWORDS. */
 PyObject *turbohtml_escape(PyObject *module, PyObject *args, PyObject *kwds);
 

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1183,6 +1183,7 @@ static PyObject *regex_source(PyObject *handle, th_tree *tree, th_node *node, co
                               Py_ssize_t attr_len, int *absent) {
     *absent = 0;
     PyObject *source = NULL;
+    (void)handle; /* only the per-tree lock on free-threaded builds; a no-op argument otherwise */
     Py_BEGIN_CRITICAL_SECTION(handle);
     if (attr_name == NULL) {
         source = str_from_accessor(th_node_text, tree, node);
@@ -2869,8 +2870,7 @@ static int path_id_safe(const Py_UCS4 *value, Py_ssize_t len) {
 /* Whether candidate is the only element in the document carrying this id value,
    so #value selects it alone. Matched case-insensitively in quirks mode, where
    the id selector itself folds case. */
-static int path_id_unique(th_tree *tree, th_node *document, th_node *candidate, const Py_UCS4 *value, Py_ssize_t len,
-                          int ci) {
+static int path_id_unique(th_node *document, th_node *candidate, const Py_UCS4 *value, Py_ssize_t len, int ci) {
     for (th_node *node = document->first_child; node != NULL; node = preorder_next(node, document)) {
         if (node == candidate || node->type != TH_NODE_ELEMENT) {
             continue;
@@ -2936,7 +2936,7 @@ static PyObject *element_css_path(PyObject *self, PyObject *Py_UNUSED(ignored)) 
         for (Py_ssize_t index = 0; index < count; index++) {
             const th_node_attr *id = find_node_attr(chain[index], TH_ATTR_ID);
             if (id != NULL && id->value != NULL && path_id_safe(id->value, id->value_len) &&
-                path_id_unique(tree, document, chain[index], id->value, id->value_len, quirks)) {
+                path_id_unique(document, chain[index], id->value, id->value_len, quirks)) {
                 top = index;
                 anchored = 1;
                 break;
@@ -2980,12 +2980,11 @@ PyDoc_STRVAR(xpath_path_doc, "xpath_path()\n--\n\n"
                              "document returns exactly this element.");
 
 static PyObject *element_xpath_path(PyObject *self, PyObject *Py_UNUSED(ignored)) {
-    PyObject *handle = ((NodeObject *)self)->handle;
     th_node *node = ((NodeObject *)self)->node;
     path_buf buf = {0};
     th_node **chain = NULL;
     int error = 0;
-    Py_BEGIN_CRITICAL_SECTION(handle);
+    Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
     Py_ssize_t count = path_collect_chain(node, &chain);
     if (count < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         error = 1;   /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -439,7 +439,7 @@ int th_node_doctype_ids(th_node *node, const Py_UCS4 **public_id, Py_ssize_t *pu
 
 /* The source position where a parsed element's start tag began: 1-based line and
    0-based column, the same convention th_token and html.parser's getpos use.
-   Returns 1 with *line/*col set for an element that carries a position, or 0 when
+   Returns 1 with *line and *col set for an element that carries a position, or 0 when
    the tree was parsed without positions, the node is not an element, or it is a
    synthetic element (implied html/head/body, a fragment root, or one constructed
    by hand) with no source. */

--- a/src/turbohtml/_c/encoding/detect.h
+++ b/src/turbohtml/_c/encoding/detect.h
@@ -1048,7 +1048,7 @@ static void th_cjk_feed(th_cjk_candidate *cand, const unsigned char *buf, Py_ssi
 }
 
 /* Run one CJK candidate end to end against the strict CPython codec named by entry,
-   updating *winner/*max when it both survives and beats the running best. */
+   updating *winner and *max when it both survives and beats the running best. */
 static void th_cjk_run(th_cjk_kind kind, const char *label, const unsigned char *buf, Py_ssize_t len,
                        const char **winner, long *max) {
     const th_encoding_entry *entry = th_encoding_lookup(label, (Py_ssize_t)strlen(label));

--- a/src/turbohtml/_c/features/tables.c
+++ b/src/turbohtml/_c/features/tables.c
@@ -360,8 +360,9 @@ static th_node *next_in_subtree(th_node *current, th_node *root) {
 /* Element.rows() -> list[list[str]]. Snapshot the table under the per-tree lock, then materialize the grid. */
 PyObject *turbohtml_element_table_rows(PyObject *owner, th_tree *tree, th_node *table) {
     table_grid grid = {NULL, 0};
-    PyObject *handle = turbohtml_node_handle(owner);
     int failed;
+    PyObject *handle = turbohtml_node_handle(owner);
+    (void)handle;                      /* only the per-tree lock on free-threaded builds; a no-op argument otherwise */
     Py_BEGIN_CRITICAL_SECTION(handle); /* per-tree lock: no concurrent mutation mid-walk */
     failed = build_grid_locked(tree, table, &grid) < 0;
     Py_END_CRITICAL_SECTION();
@@ -373,8 +374,9 @@ PyObject *turbohtml_element_table_rows(PyObject *owner, th_tree *tree, th_node *
 /* Element.records() -> list[dict[str, str]]. Same snapshot, keyed by the first row. */
 PyObject *turbohtml_element_table_records(PyObject *owner, th_tree *tree, th_node *table) {
     table_grid grid = {NULL, 0};
-    PyObject *handle = turbohtml_node_handle(owner);
     int failed;
+    PyObject *handle = turbohtml_node_handle(owner);
+    (void)handle;                      /* only the per-tree lock on free-threaded builds; a no-op argument otherwise */
     Py_BEGIN_CRITICAL_SECTION(handle); /* per-tree lock: no concurrent mutation mid-walk */
     failed = build_grid_locked(tree, table, &grid) < 0;
     Py_END_CRITICAL_SECTION();
@@ -391,6 +393,7 @@ PyObject *turbohtml_node_tables(PyObject *owner, th_tree *tree, th_node *root) {
     Py_ssize_t grid_cap = 0;
     int failed = 0;
     PyObject *handle = turbohtml_node_handle(owner);
+    (void)handle;                      /* only the per-tree lock on free-threaded builds; a no-op argument otherwise */
     Py_BEGIN_CRITICAL_SECTION(handle); /* per-tree lock: no concurrent mutation mid-walk */
     for (th_node *current = root->first_child; current != NULL; current = next_in_subtree(current, root)) {
         if (current->type != TH_NODE_ELEMENT || current->atom != TH_TAG_TABLE) {

--- a/src/turbohtml/_c/query/find/find.c
+++ b/src/turbohtml/_c/query/find/find.c
@@ -486,14 +486,13 @@ static int text_candidate(const query_t *query, th_node *node) {
 static int snapshot_text_candidates(PyObject *self, const query_t *query, th_node ***out_nodes, PyObject ***out_texts,
                                     Py_ssize_t *out_count) {
     module_state *state = state_of(self);
-    PyObject *handle = ((NodeObject *)self)->handle;
     th_node *origin = ((NodeObject *)self)->node;
     th_tree *tree = tree_of(self);
     th_node **nodes = NULL;
     PyObject **texts = NULL;
     Py_ssize_t filled = 0;
     int error = 0;
-    Py_BEGIN_CRITICAL_SECTION(handle);
+    Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
     Py_ssize_t capacity = 0;
     for (th_node *node = axis_first(origin, query->axis); node != NULL; node = axis_next(node, origin, query->axis)) {
         if (text_candidate(query, node)) {

--- a/src/turbohtml/_c/query/xpath/eval.c
+++ b/src/turbohtml/_c/query/xpath/eval.c
@@ -201,7 +201,7 @@ static int apply_step(xp_nodeset *out, struct th_node *ctx, const xn *step, cons
         if (emit_if_match(out, ctx, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
             return -1;                                  /* GCOVR_EXCL_LINE */
         }
-        /* FALLTHROUGH: descendant-or-self is self plus the descendant walk */
+        TH_FALLTHROUGH; /* descendant-or-self is self plus the descendant walk */
     case AX_DESCENDANT:
         for (struct th_node *node = ctx->first_child; node != NULL; node = descendant_next(node, ctx)) {
             if (emit_if_match(out, node, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
@@ -215,7 +215,7 @@ static int apply_step(xp_nodeset *out, struct th_node *ctx, const xn *step, cons
         if (emit_if_match(out, ctx, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
             return -1;                                  /* GCOVR_EXCL_LINE */
         }
-        /* FALLTHROUGH: ancestor-or-self is self plus the ancestor walk */
+        TH_FALLTHROUGH; /* ancestor-or-self is self plus the ancestor walk */
     case AX_ANCESTOR:
         for (struct th_node *node = ctx->parent; node != NULL; node = node->parent) {
             if (emit_if_match(out, node, step, match) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */

--- a/src/turbohtml/_c/serialize/escape.c
+++ b/src/turbohtml/_c/serialize/escape.c
@@ -121,7 +121,7 @@ static inline Py_ssize_t block_extra(const uint8_t *block, int quote) {
         extras = _mm_add_epi8(extras, _mm_and_si128(_mm_cmpeq_epi8(bytes, _mm_set1_epi8('\'')), _mm_set1_epi8(5)));
     }
     __m128i sums = _mm_sad_epu8(extras, _mm_setzero_si128());
-    return (Py_ssize_t)(_mm_cvtsi128_si32(sums) + _mm_extract_epi16(sums, 4));
+    return (Py_ssize_t)_mm_cvtsi128_si32(sums) + (Py_ssize_t)_mm_extract_epi16(sums, 4);
 }
 
 /* One mask bit per byte; SPECIAL_INDEX / SPECIAL_CLEAR hide the layout. */

--- a/src/turbohtml/_c/tokenizer/statemachine.c
+++ b/src/turbohtml/_c/tokenizer/statemachine.c
@@ -66,9 +66,9 @@ static int buf_ensure(th_buf *buf, Py_ssize_t need) {
         cap *= 2;
     }
     char *grown = buf->data;
-    grown = PyMem_Resize(grown, char, (size_t)cap); /* GCOVR_EXCL_BR_LINE: size-overflow guard */
-    if (grown == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return -1;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    PyMem_Resize(grown, char, (size_t)cap); /* GCOVR_EXCL_BR_LINE: size-overflow guard */
+    if (grown == NULL) {                    /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;                          /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     buf->data = grown;
     buf->cap = cap;

--- a/src/turbohtml/_c/tokenizer/tokenizer.c
+++ b/src/turbohtml/_c/tokenizer/tokenizer.c
@@ -458,7 +458,7 @@ PyObject *turbohtml_tokenize_states(PyObject *Py_UNUSED(module), PyObject *args)
     if (sm == NULL) {            /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    if (storage_kind > PyUnicode_KIND(text)) {
+    if (storage_kind > (int)PyUnicode_KIND(text)) {
         th_tok_widen_input(sm, storage_kind);
     }
     if (last_tag != Py_None) {

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,19 @@
 requires = [ "tox>=4.56", "tox-uv>=1.35.2" ]
-env_list = [ "3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "3.14t", "3.15t", "docs", "fix", "pkg_meta", "type" ]
+env_list = [
+  "3.15",
+  "3.14",
+  "3.13",
+  "3.12",
+  "3.11",
+  "3.10",
+  "3.14t",
+  "3.15t",
+  "docs",
+  "fix",
+  "pkg_meta",
+  "type",
+  "warnings"
+]
 skip_missing_interpreters = true
 
 [env_run_base]
@@ -154,6 +168,33 @@ commands = [
 description = "run the type checker on the code base"
 dependency_groups = [ "type" ]
 commands = [ [ "ty", "check", "--output-format", "concise", "--error-on-warning", "src", "tests", "tools" ] ]
+
+[env.warnings]
+description = "compile the C extension with -Werror so any -Wall/-Wextra warning fails the build"
+package = "skip"  # the throwaway wheel below is the gate; nothing installs it
+deps = []  # uv build pulls meson-python/meson/ninja in its own isolated build env
+dependency_groups = []  # no test deps; this env only compiles
+# CC lets CI pick gcc vs clang; INCLUDE/LIB/LIBPATH forward the MSVC toolchain env that
+# msvc-dev-cmd activates for the Windows arm64 cell, which tox would otherwise strip so cl
+# compiles with no headers or libs (on x64 meson self-detects MSVC via vswhere and needs none)
+pass_env = [ "CC", "INCLUDE", "LIB", "LIBPATH" ]
+commands_pre = []  # this env builds with -Werror itself; skip the inherited coverage install
+# uv build (the same path users hit) streams every ninja compile line and the warning that
+# trips -Werror, and its meson-python backend writes the native file that locates Python on
+# every platform — plain `meson setup` cannot find the headers for a uv-managed Windows arm64
+# interpreter. buildtype=release is uv build's default, so optimization-only gcc diagnostics
+# (-Wmaybe-uninitialized) are in scope. The wheel itself is discarded.
+commands = [
+  [
+    "uv",
+    "build",
+    "--wheel",
+    "--out-dir",
+    "{env_tmp_dir}{/}dist",
+    "--config-settings=setup-args=-Dwerror=true",
+    "{tox_root}",
+  ],
+]
 
 [env.bench]
 description = "benchmark escape/unescape/tokenize against the standard library and html5lib (not run in CI)"


### PR DESCRIPTION
A plain `uv build` emitted a stream of compiler warnings. The loudest was a `*line/*col` fragment inside a `tree.h` comment whose `/*` reads as a nested block-comment opener, so it re-fired once per translation unit that includes the header. 🔇 The rest were unused `handle`/`tree` bindings that the per-tree critical section only consumes on free-threaded builds, plus one genuine defect: `buf_ensure` assigned the result of `PyMem_Resize` back into `grown`, but the macro already assigns to its first argument, leaving `grown` with two unsequenced writes.

The comments are reworded so the `/*` no longer appears, the lock-only bindings are inlined or `(void)`-cast, the dead `tree` parameter is gone, and the macro now owns its assignment. An intentional switch fall-through in the XPath axis walk moves to a `TH_FALLTHROUGH` attribute macro, since gcc's `-Wimplicit-fallthrough` (on under `-Wextra`) does not honor the prose comment form. The extension now compiles clean under `-Wall -Wextra` on both clang and gcc.

Nothing enforced this, so the warnings had accrued silently: clang-tidy ran with `-*` as its base, which also disabled the `clang-diagnostic-*` family, and the hook is skipped on pre-commit.ci. A new `warnings` tox env compiles with `-Dwerror=true` at warning level 2, so the API-mandated `void*`/function-pointer slot casts that only `-Wpedantic` flags stay out of scope. 🚦 That env and a `clang-tidy` job join the GHA check matrix, and `clang-diagnostic-*` is enabled in the tidy config so the same warnings fail the local hook too.