### PR TITLE
⚡ perf(dom): pool node wrappers on a freelist

### DIFF
--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -632,22 +632,22 @@ times ahead of selectolax, parsel (Scrapy's cssselect-over-libxml2 selector libr
       - BeautifulSoup
     - - wpt page (4 kB)
       - 0.1 µs
-      - 0.5 µs (5.0x)
-      - 2.1 µs (21.0x)
-      - 3.8 µs (38.0x)
-      - 5.7 µs (57.0x)
+      - 0.6 µs (7.2x)
+      - 2.2 µs (28.4x)
+      - 4.1 µs (53.0x)
+      - 5.8 µs (75.3x)
     - - wpt page (9.6 kB)
       - 0.1 µs
-      - 0.5 µs (5.0x)
-      - 2.6 µs (26.0x)
-      - 4.2 µs (42.0x)
-      - 9.3 µs (93.0x)
+      - 0.6 µs (7.2x)
+      - 2.6 µs (34.0x)
+      - 4.4 µs (57.7x)
+      - 9.6 µs (124.6x)
     - - wpt page (92 kB)
-      - 1.9 µs
-      - 23.3 µs (12.3x)
-      - 45.3 µs (23.8x)
-      - 79.5 µs (41.8x)
-      - 207 µs (108.9x)
+      - 1.4 µs
+      - 25.4 µs (18.6x)
+      - 45.9 µs (33.7x)
+      - 81.6 µs (59.8x)
+      - 210 µs (154.1x)
 
 ``select`` runs the CSS selector ``div a[href]`` (turbohtml's :meth:`~turbohtml.Node.select`, lxml's `cssselect
 <https://github.com/scrapy/cssselect>`_, selectolax's ``css``, parsel's ``css``, BeautifulSoup's `soupsieve
@@ -994,17 +994,17 @@ so it has no entry.
       - lxml
       - BeautifulSoup
     - - wpt page (4 kB)
-      - 2.0 µs
-      - 8.3 µs (4.2x)
-      - 2.9 µs (1.5x)
+      - 1.3 µs
+      - 8.0 µs (6.1x)
+      - 2.7 µs (2.1x)
     - - wpt page (9.6 kB)
-      - 3.6 µs
-      - 12.1 µs (3.4x)
-      - 5.0 µs (1.4x)
+      - 2.3 µs
+      - 11.6 µs (5.1x)
+      - 4.8 µs (2.1x)
     - - wpt page (92 kB)
-      - 101 µs
-      - 295 µs (2.9x)
-      - 125 µs (1.2x)
+      - 65.2 µs
+      - 278 µs (4.3x)
+      - 123 µs (1.9x)
 
 *************
  Serializing

--- a/docs/migration/beautifulsoup.rst
+++ b/docs/migration/beautifulsoup.rst
@@ -85,17 +85,17 @@ concatenates in C where ``bs4`` joins Python strings node by node:
       - BeautifulSoup
       - speed-up
     - - wpt page (4 kB)
-      - 2.0 µs
-      - 2.9 µs
-      - 1.5x
+      - 1.3 µs
+      - 2.7 µs
+      - 2.1x
     - - wpt page (9.6 kB)
-      - 3.7 µs
-      - 5.0 µs
-      - 1.4x
+      - 2.3 µs
+      - 4.8 µs
+      - 2.1x
     - - wpt page (92 kB)
-      - 100.4 µs
-      - 125.0 µs
-      - 1.2x
+      - 65.2 µs
+      - 123.3 µs
+      - 1.9x
 
 .. list-table::
     :header-rows: 1

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -151,9 +151,9 @@ turbohtml runs each in C over its native tree (``tox -e bench fragment text navi
       - 47.2 µs
       - 1.3x
     - - descendant walk (92 kB)
-      - 101 µs
-      - 295 µs
-      - 2.9x
+      - 65.2 µs
+      - 278 µs
+      - 4.3x
     - - extract links (92 kB)
       - 60.6 µs
       - 2.28 ms

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -186,6 +186,7 @@ static int html_traverse(PyObject *module, visitproc visit, void *arg) {
 
 static int html_clear(PyObject *module) {
     module_state *state = PyModule_GetState(module);
+    th_node_freelist_clear(state); /* free pooled wrappers while their node types are still live */
     Py_CLEAR(state->token_type);
     Py_CLEAR(state->tokenizer_type);
     Py_CLEAR(state->iter_type);

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -28,9 +28,43 @@ PyObject *turbohtml_node_wrap_in(PyObject *owner, th_node *node) {
     return node_wrap(state_of(owner), ((NodeObject *)owner)->handle, node);
 }
 
+#ifndef Py_GIL_DISABLED
+/* The pool caps the wrappers a burst of find_all()/select()/iteration may recycle
+   without pinning unbounded memory afterwards. At sizeof(NodeObject) (32 bytes) the
+   cap costs at most ~32 KiB resident per interpreter, and it covers a query result
+   or transient walk of up to this many nodes; a larger result falls back to malloc
+   for the surplus. */
+#define NODE_FREELIST_MAX 1024
+
+void th_node_freelist_clear(module_state *state) {
+    while (state->node_freelist != NULL) {
+        NodeObject *self = (NodeObject *)state->node_freelist;
+        state->node_freelist = (PyObject *)self->node;
+        Py_TYPE(self)->tp_free(self); /* the type ref was dropped on push; the types are still live here */
+    }
+    state->node_freelist_len = 0;
+}
+#else
+void th_node_freelist_clear(module_state *Py_UNUSED(state)) {
+} /* the free-threaded build keeps no pool */
+#endif
+
 static void node_dealloc(PyObject *self) {
     PyTypeObject *type = Py_TYPE(self);
     Py_DECREF(((NodeObject *)self)->handle);
+#ifndef Py_GIL_DISABLED
+    /* Park the wrapper for reuse instead of freeing it, unless the pool is full.
+       Every node type has basicsize sizeof(NodeObject) and none accept a subclass,
+       so any node object fits a base-type reuse. */
+    module_state *state = state_of(self);
+    if (state->node_freelist_len < NODE_FREELIST_MAX) {
+        ((NodeObject *)self)->node = (th_node *)state->node_freelist; /* stash the next link in the node field */
+        state->node_freelist = self;
+        state->node_freelist_len++;
+        Py_DECREF(type); /* release this object's type ref; PyObject_Init re-takes it on revive */
+        return;
+    }
+#endif
     type->tp_free(self);
     Py_DECREF(type);
 }

--- a/src/turbohtml/_c/dom/nodes.h
+++ b/src/turbohtml/_c/dom/nodes.h
@@ -184,9 +184,20 @@ static inline PyObject *node_wrap(module_state *state, PyObject *handle, th_node
         Py_RETURN_NONE;
     }
     PyTypeObject *type = (PyTypeObject *)type_for_node(state, node);
-    NodeObject *self = (NodeObject *)type->tp_alloc(type, 0);
-    if (self == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+    NodeObject *self;
+#ifndef Py_GIL_DISABLED
+    if (state->node_freelist != NULL) {
+        self = (NodeObject *)state->node_freelist;
+        state->node_freelist = (PyObject *)self->node; /* the next link rode in the node field */
+        state->node_freelist_len--;
+        PyObject_Init((PyObject *)self, type); /* revive: refcount 1, restamp ob_type (+incref heaptype) */
+    } else
+#endif
+    {
+        self = (NodeObject *)type->tp_alloc(type, 0);
+        if (self == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
     }
     self->handle = Py_NewRef(handle);
     self->node = node;

--- a/src/turbohtml/_c/tokenizer/binding.h
+++ b/src/turbohtml/_c/tokenizer/binding.h
@@ -62,12 +62,25 @@ typedef struct {
     PyObject *microdata_item_type;  /* turbohtml._structured_data.MicrodataItem, one Microdata item record */
     PyObject *structured_data_type; /* turbohtml._structured_data.StructuredData, the combined-format record */
     PyObject *article_type;         /* turbohtml._article.Article, the record Node.article() yields */
+    /* A freelist of node wrappers: find_all()/select()/iteration mint and drop one
+       NodeObject per visited node, and every node subtype shares sizeof(NodeObject)
+       (the payload lives in the C th_node), so one pool re-stamps ob_type on reuse.
+       The head is a NodeObject* (held as PyObject* since NodeObject is declared
+       later); the link rides in each pooled object's unused node field. Built only
+       on the GIL build, where the GIL serializes access; the free-threaded build
+       skips it (a shared pool would race) and keeps the tp_alloc/tp_free path. */
+    PyObject *node_freelist;
+    int node_freelist_len;
 } module_state;
 
 /* Register the types and enum into module/state. Each returns 0 or -1. */
 int token_register(PyObject *module, module_state *state);
 int tokenizer_register(PyObject *module, module_state *state);
 int tree_register(PyObject *module, module_state *state);
+
+/* Free every node wrapper parked on the freelist; called from module teardown
+   before the node types are cleared. A no-op on the free-threaded build. */
+void th_node_freelist_clear(module_state *state);
 
 /* Public navigable-tree entry points (dom/node.c), wired as parse() and
    parse_fragment(). parse() matches METH_O; parse_fragment() matches

--- a/tests/dom/test_tree_api.py
+++ b/tests/dom/test_tree_api.py
@@ -139,3 +139,43 @@ def test_types_are_not_constructible(node_type: type) -> None:
 
 def test_namespace_values() -> None:
     assert {member.value for member in Namespace} == {"html", "svg", "math"}
+
+
+# find_all()/select()/iteration recycle their node wrappers on a freelist; the count
+# exceeds the pool cap so dropping a result also frees past the pool's limit.
+_WIDE = "<ul>" + "".join(f'<li class="row">item {index}</li>' for index in range(1200)) + "</ul>"
+
+
+def test_recycled_wrapper_does_not_alias_a_held_node() -> None:
+    document = parse(_WIDE)
+    rows = document.find_all("li")
+    held = rows[0]
+    del rows  # frees every wrapper but `held`, parking them on the freelist
+    gc.collect()
+    rewrapped = document.find_all("li")  # pops the pooled wrappers and re-stamps them
+    assert held.tag == "li"  # the held wrapper is untouched by the reuse
+    assert held.attrs["class"] == ["row"]
+    assert rewrapped[0] == held  # a fresh wrapper for the same node compares equal
+
+
+def test_recycled_result_over_cap_stays_correct() -> None:
+    document = parse(_WIDE)
+    for _ in range(3):  # cycle wrappers through the pool, freeing past its cap each round
+        rows = document.find_all("li")
+        assert len(rows) == 1200
+        assert [row.text for row in rows[:2]] == ["item 0", "item 1"]
+        assert rows[-1].text == "item 1199"
+        del rows
+        gc.collect()
+
+
+def test_transient_iteration_reads_every_node() -> None:
+    # each wrapper is dropped before the next is built, the churn the pool targets
+    document = parse(_WIDE)
+    li_count = sum(1 for node in document.descendants if isinstance(node, Element) and node.tag == "li")
+    assert li_count == 1200
+
+
+def test_repeated_queries_return_equal_nodes() -> None:
+    document = parse(_WIDE)
+    assert document.find_all("li") == document.find_all("li")  # equal nodes despite recycled wrappers


### PR DESCRIPTION
`find_all()`, `select()`, and descendant iteration create one `NodeObject` wrapper per visited node and drop it again, so every read-path query pays a `PyObject_Malloc` and a zero-init per node even though the wrappers are interchangeable and short-lived. ⚡

A bounded freelist now recycles those wrappers. Because every node subtype is the same size (the payload lives in the C `th_node`, not the Python object), one pool serves all of them: a dropped wrapper is parked, and the next allocation revives it with `PyObject_Init`, re-stamping `ob_type` and skipping both the malloc and the zero-init. The pool caps at 1024 entries (about 32 KiB resident) and exists only on the GIL build, where the GIL already serializes access. The free-threaded build keeps the ordinary allocate/free path, so there is no shared-pool race to guard.

On the 92 kB page `find_all()` drops from 1.9 to 1.4 µs and a descendant walk from 101 to 65 µs, widening its lead over lxml from 2.9x to 4.3x; `select` and `chain` stay flat. The one cost is `list(doc.descendants)`, which holds the whole tree's wrappers alive at once, so nothing recycles mid-walk and the pool bookkeeping runs about 8% slower on a 9k-node tree. Ordinary `for node in doc.descendants` recycles each wrapper and is the faster path above. The querying and tree-navigation tables on the performance page carry the new numbers.
