### PR TITLE
🐛 fix(bench): measure mutating ops on fresh trees

### DIFF
--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -3,17 +3,24 @@
 #############
 
 Every number here comes from `pyperf <https://pyperf.readthedocs.io>`_ on CPython 3.14.6 (a release build) on an Apple
-M4 running macOS 26. pyperf runs each case in isolated worker processes and reports the mean. The corpora are real
-documents: `Project Gutenberg's War and Peace <https://www.gutenberg.org/ebooks/2600>`_, the `WHATWG HTML specification
-source <https://github.com/whatwg/html/blob/main/source>`_, the `ECMAScript specification
-<https://github.com/tc39/ecma262>`_, and a size-weighted sample of `web-platform-tests
-<https://github.com/web-platform-tests/wpt>`_ pages. The harness benchmarks each competitor in its own isolated ``uv``
-venv -- turbohtml in a venv of its own as the shared baseline -- so one library's dependency pins never perturb
-another's. Every table below is one harness operation, so each is reproducible with ``tox -e bench <command>``, where
-the command is ``core`` (turbohtml's own baseline for every operation), an operation name (the cross-competitor table),
-a package name (that competitor's own report), or ``all``. Most operations are a single call; a few aggregate workloads
-(``build``, ``build-e``) sweep a size, and the ``construct`` and ``emit`` breakdowns decompose that write path into the
-constructor and the serializer in isolation. Numbers vary with input and hardware.
+M4 running macOS 26. pyperf runs each case in isolated worker processes and reports the mean; the harness prints the
+run-to-run standard deviation beside it as ``±N%`` so a real gap reads apart from noise, and these tables quote the
+mean. For the lowest-noise figures, tune the machine with ``pyperf system tune`` first (and ``sudo pyperf system reset``
+after); pyperf options like ``--rigorous`` or ``--affinity`` pass straight through after the ``tox -e bench`` command.
+Operations that mutate the tree they are handed -- the edits, the content setters, link absolutization -- are timed on a
+fresh parse rebuilt before each iteration (the rebuild itself untimed), so the figure is the repeatable cost of the
+mutation alone rather than a tree a prior iteration already changed; read-path operations reuse one cached parse and
+time only the query. The corpora are real documents: `Project Gutenberg's War and Peace
+<https://www.gutenberg.org/ebooks/2600>`_, the `WHATWG HTML specification source
+<https://github.com/whatwg/html/blob/main/source>`_, the `ECMAScript specification <https://github.com/tc39/ecma262>`_,
+and a size-weighted sample of `web-platform-tests <https://github.com/web-platform-tests/wpt>`_ pages. The harness
+benchmarks each competitor in its own isolated ``uv`` venv -- turbohtml in a venv of its own as the shared baseline --
+so one library's dependency pins never perturb another's. Every table below is one harness operation, so each is
+reproducible with ``tox -e bench <command>``, where the command is ``core`` (turbohtml's own baseline for every
+operation), an operation name (the cross-competitor table), a package name (that competitor's own report), or ``all``.
+Most operations are a single call; a few aggregate workloads (``build``, ``build-e``) sweep a size, and the
+``construct`` and ``emit`` breakdowns decompose that write path into the constructor and the serializer in isolation.
+Numbers vary with input and hardware.
 
 **********
  Escaping
@@ -1147,13 +1154,13 @@ price of the leading-mapping and per-child dispatch the sugar runs in Python.
  Editing
 *********
 
-Editing a parsed tree: tag every ``<a>`` with ``rel="nofollow"``, a link-rewriting pass. Each library parses once
-outside the timed region, then the timed call walks its links and sets the attribute (turbohtml through the live
-:attr:`~turbohtml.Element.attrs` mapping, lxml through ``Element.set``, BeautifulSoup through item assignment).
-selectolax mutation is limited, so it has no entry. The last row is a content-setter pass:
-:meth:`~turbohtml.Element.set_inner_html` reparses a fixed fragment in the ``<body>``'s context and replaces its
-children, against lxml clearing the body and appending ``fragments_fromstring`` and BeautifulSoup clearing it and
-appending a reparsed soup. turbohtml does the parse and splice in one C call.
+Editing a parsed tree: tag every ``<a>`` with ``rel="nofollow"``, a link-rewriting pass. Because the pass mutates the
+tree, each library rebuilds a fresh parse before every iteration outside the timed region, then the timed call walks its
+links and sets the attribute (turbohtml through the live :attr:`~turbohtml.Element.attrs` mapping, lxml through
+``Element.set``, BeautifulSoup through item assignment). selectolax mutation is limited, so it has no entry. The last
+row is a content-setter pass: :meth:`~turbohtml.Element.set_inner_html` reparses a fixed fragment in the ``<body>``'s
+context and replaces its children, against lxml clearing the body and appending ``fragments_fromstring`` and
+BeautifulSoup clearing it and appending a reparsed soup. turbohtml does the parse and splice in one C call.
 
 The last row is a second pass: a classList churn that adds then drops a token on every link (turbohtml's
 :meth:`~turbohtml.Element.add_class`/:meth:`~turbohtml.Element.remove_class` against lxml's ``classes`` set). The
@@ -1222,9 +1229,10 @@ The link surface: extract every in-document link, resolve them against a base UR
 turbohtml's :meth:`~turbohtml.Node.links`, :meth:`~turbohtml.Node.resolve_links`, and
 :meth:`~turbohtml.Node.rewrite_links` against lxml.html's ``iterlinks()``, ``make_links_absolute()``, and
 ``rewrite_links()`` -- the only other library that walks the link-bearing attributes (``href``, ``src``, ``srcset``,
-...) as a set. Each timed call runs one operation over the 92 kB wpt page; extraction is read-only, while absolutize and
-rewrite are idempotent once applied. turbohtml walks the attribute set in C where lxml re-resolves each URL in Python,
-so it leads by ten to over a hundred times.
+...) as a set. Each timed call runs one operation over the 92 kB wpt page; extraction is read-only and rewrite applies
+an identity callback, so both reuse one cached parse, while absolutize rebuilds a fresh tree before each iteration since
+``make_links_absolute`` rewrites the hrefs in place. turbohtml walks the attribute set in C where lxml re-resolves each
+URL in Python, so it leads by ten to over a hundred times.
 
 .. list-table::
     :header-rows: 1

--- a/tools/bench/__main__.py
+++ b/tools/bench/__main__.py
@@ -2,7 +2,8 @@
 CLI entry point: ``python -m bench <command>``.
 
 Commands: ``core`` (turbohtml baseline for every operation), ``all`` (every operation table), an operation name
-(cross-package table), or a package name (that package's own report). The orchestrator provisions one isolated venv per
+(cross-package table), or a package name (that package's own report). Anything after the command is forwarded verbatim
+to pyperf in every worker (e.g. ``--rigorous``, ``--affinity=2``). The orchestrator provisions one isolated venv per
 target, so this entry point itself needs only uv on PATH -- no turbohtml, no competitor.
 """
 
@@ -14,11 +15,11 @@ from bench import orchestrator
 
 
 def main() -> None:
-    """Parse the single command argument and run the matching report."""
-    if len(sys.argv) != 2:
-        msg = "usage: python -m bench <core|all|operation|package>"
+    """Parse the command argument plus any pyperf passthrough options and run the matching report."""
+    if len(sys.argv) < 2:
+        msg = "usage: python -m bench <core|all|operation|package> [pyperf options...]"
         raise SystemExit(msg)
-    orchestrator.run(sys.argv[1])
+    orchestrator.run(sys.argv[1], tuple(sys.argv[2:]))
 
 
 if __name__ == "__main__":

--- a/tools/bench/competitors/beautifulsoup4.py
+++ b/tools/bench/competitors/beautifulsoup4.py
@@ -7,6 +7,8 @@ import re
 
 from bs4 import BeautifulSoup
 
+from bench.timing import Mutating
+
 REQUIREMENTS = ("beautifulsoup4>=4.15",)
 
 _FIND_TEXT_PATTERN = re.compile(r"test")
@@ -54,6 +56,11 @@ def emit(count: int) -> None:
     _ = _tree(count).decode()  # ty: ignore[unresolved-attribute]  # bs4 Tag has no stubs
 
 
+def _fresh(text: str) -> BeautifulSoup:
+    """Parse a fresh document for the mutating operations, which each iteration must run on an unmodified tree."""
+    return BeautifulSoup(text, "html.parser")
+
+
 @functools.cache
 def _parsed(text: str) -> BeautifulSoup:
     """Return a document parsed once, cached so the read-path operations time only the query."""
@@ -90,15 +97,15 @@ def serialize(text: str) -> None:
     _parsed(text).decode()
 
 
-def edit(text: str) -> None:
-    """Tag every link with rel=nofollow through BeautifulSoup's item assignment."""
-    for anchor in _parsed(text).find_all("a"):
+def edit(soup: BeautifulSoup) -> None:
+    """Tag every link with rel=nofollow on a freshly parsed tree through BeautifulSoup's item assignment."""
+    for anchor in soup.find_all("a"):
         anchor["rel"] = "nofollow"
 
 
-def set_html(text: str) -> None:
-    """Clear the body and append a reparsed fragment, BeautifulSoup's inner-HTML shape."""
-    body = _parsed(text).find_all("body")[0]
+def set_html(soup: BeautifulSoup) -> None:
+    """Clear a freshly parsed body and append a reparsed fragment, BeautifulSoup's inner-HTML shape."""
+    body = soup.find_all("body")[0]
     body.clear()
     for node in list(BeautifulSoup(_SET_HTML, "html.parser").children):
         body.append(node)
@@ -121,7 +128,7 @@ OPERATIONS = {
     "find-text": (find_text, "BeautifulSoup"),
     "text-content": (text_content, "BeautifulSoup"),
     "serialize": (serialize, "BeautifulSoup"),
-    "edit": (edit, "BeautifulSoup"),
-    "set-html": (set_html, "BeautifulSoup"),
+    "edit": (Mutating(_fresh, edit), "BeautifulSoup"),
+    "set-html": (Mutating(_fresh, set_html), "BeautifulSoup"),
     "navigate": (navigate, "BeautifulSoup"),
 }

--- a/tools/bench/competitors/lxml.py
+++ b/tools/bench/competitors/lxml.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 from lxml import html as lxml_html
 from lxml.builder import E
 
+from bench.timing import Mutating
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -98,9 +100,9 @@ def serialize(text: str) -> None:
     lxml_html.tostring(_parsed(text))
 
 
-def edit(text: str) -> None:
-    """Tag every link with rel=nofollow through lxml's Element.set."""
-    for anchor in _parsed(text).findall(".//a"):
+def edit(tree: HtmlElement) -> None:
+    """Tag every link with rel=nofollow on a freshly parsed tree through lxml's Element.set."""
+    for anchor in tree.findall(".//a"):
         anchor.set("rel", "nofollow")
 
 
@@ -111,9 +113,9 @@ def class_edit(text: str) -> None:
         anchor.classes.discard("seen")
 
 
-def set_html(text: str) -> None:
-    """Clear the body and append a reparsed fragment, lxml's nearest inner-HTML shape."""
-    body = _parsed(text).findall(".//body")[0]
+def set_html(tree: HtmlElement) -> None:
+    """Clear a freshly parsed body and append a reparsed fragment, lxml's nearest inner-HTML shape."""
+    body = tree.findall(".//body")[0]
     body.clear()
     for piece in lxml_html.fragments_fromstring(_SET_HTML):
         body.append(piece)
@@ -131,9 +133,9 @@ def links_extract(text: str) -> None:
         pass
 
 
-def links_absolutize(text: str) -> None:
-    """Resolve every relative link against a base with lxml's make_links_absolute()."""
-    _parsed(text).make_links_absolute(_LINKS_BASE)
+def links_absolutize(tree: HtmlElement) -> None:
+    """Resolve every relative link on a freshly parsed tree against a base with lxml's make_links_absolute()."""
+    tree.make_links_absolute(_LINKS_BASE)
 
 
 def links_rewrite(text: str) -> None:
@@ -217,12 +219,12 @@ OPERATIONS = {
     "select-has": (select_has, "lxml"),
     "text-content": (text_content, "lxml"),
     "serialize": (serialize, "lxml"),
-    "edit": (edit, "lxml"),
+    "edit": (Mutating(lxml_html.document_fromstring, edit), "lxml"),
     "class-edit": (class_edit, "lxml"),
-    "set-html": (set_html, "lxml"),
+    "set-html": (Mutating(lxml_html.document_fromstring, set_html), "lxml"),
     "navigate": (navigate, "lxml"),
     "links-extract": (links_extract, "lxml"),
-    "links-absolutize": (links_absolutize, "lxml"),
+    "links-absolutize": (Mutating(lxml_html.document_fromstring, links_absolutize), "lxml"),
     "links-rewrite": (links_rewrite, "lxml"),
     "path": (getpath, "lxml getpath"),
     "path-xpath": (getpath, "lxml getpath"),

--- a/tools/bench/competitors/pyquery.py
+++ b/tools/bench/competitors/pyquery.py
@@ -6,6 +6,8 @@ import functools
 
 from pyquery import PyQuery
 
+from bench.timing import Mutating
+
 REQUIREMENTS = ("pyquery>=2.0.1",)
 _SET_HTML = "<p>Updated <a href='/x'>link</a> and <b>bold</b>.</p><ul><li>one</li><li>two</li></ul>"
 _SET_TEXT = "Replacement text, escaped & verbatim."
@@ -13,7 +15,7 @@ _SET_TEXT = "Replacement text, escaped & verbatim."
 
 @functools.cache
 def _parsed(text: str) -> PyQuery:
-    """Return a document parsed once, cached so the content setters time only the mutation."""
+    """Return a document parsed once, cached so the read-path operations time only the query."""
     return PyQuery(text)
 
 
@@ -32,14 +34,14 @@ def strip_tags(text: str) -> None:
     _ = str(page)
 
 
-def set_html(text: str) -> None:
-    """Replace the body's children with pyquery's html(markup)."""
-    _parsed(text)("body").html(_SET_HTML)
+def set_html(page: PyQuery) -> None:
+    """Replace a freshly parsed body's children with pyquery's html(markup)."""
+    page("body").html(_SET_HTML)
 
 
-def set_text(text: str) -> None:
-    """Replace the body's children with pyquery's text(value)."""
-    _parsed(text)("body").text(_SET_TEXT)
+def set_text(page: PyQuery) -> None:
+    """Replace a freshly parsed body's children with pyquery's text(value)."""
+    page("body").text(_SET_TEXT)
 
 
 def chain(text: str) -> None:
@@ -62,8 +64,8 @@ def extract_text(text: str) -> None:
 OPERATIONS = {
     "strip-remove": (strip_remove, "pyquery"),
     "strip-tags": (strip_tags, "pyquery"),
-    "set-html": (set_html, "pyquery"),
-    "set-text": (set_text, "pyquery"),
+    "set-html": (Mutating(PyQuery, set_html), "pyquery"),
+    "set-text": (Mutating(PyQuery, set_text), "pyquery"),
     "chain": (chain, "pyquery"),
     "extract-attr": (extract_attr, "pyquery"),
     "extract-text": (extract_text, "pyquery"),

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -12,6 +12,7 @@ import re
 from typing import TYPE_CHECKING, cast
 
 import turbohtml
+from bench.timing import Mutating
 from turbohtml import sanitizer as _sanitizer
 from turbohtml.build import E
 from turbohtml.linkify import Detector as _Detector
@@ -138,9 +139,9 @@ def serialize(text: str) -> None:
     _ = _parsed(text).html
 
 
-def edit(text: str) -> None:
-    """Tag every link with rel=nofollow through turbohtml's live attribute mapping."""
-    for anchor in _parsed(text).find_all("a"):
+def edit(document: turbohtml.Document) -> None:
+    """Tag every link with rel=nofollow on a freshly parsed tree through turbohtml's live attribute mapping."""
+    for anchor in document.find_all("a"):
         anchor.attrs["rel"] = "nofollow"
 
 
@@ -160,14 +161,14 @@ def strip_tags(text: str) -> None:
     _ = turbohtml.parse(text).strip_tags(_STRIP).html
 
 
-def set_html(text: str) -> None:
-    """Replace the body's children by reparsing a fragment in context with turbohtml's set_inner_html."""
-    _parsed(text).find_all("body")[0].set_inner_html(_SET_HTML)
+def set_html(document: turbohtml.Document) -> None:
+    """Replace a freshly parsed body's children by reparsing a fragment in context with turbohtml's set_inner_html."""
+    document.find_all("body")[0].set_inner_html(_SET_HTML)
 
 
-def set_text(text: str) -> None:
-    """Replace the body's children with one verbatim text node through turbohtml's set_text."""
-    _parsed(text).find_all("body")[0].set_text(_SET_TEXT)
+def set_text(document: turbohtml.Document) -> None:
+    """Replace a freshly parsed body's children with one verbatim text node through turbohtml's set_text."""
+    document.find_all("body")[0].set_text(_SET_TEXT)
 
 
 def navigate(text: str) -> None:
@@ -186,9 +187,9 @@ def links_extract(text: str) -> None:
     _parsed(text).links()
 
 
-def links_absolutize(text: str) -> None:
-    """Resolve every relative link against a base with turbohtml's resolve_links()."""
-    _parsed(text).resolve_links(_LINKS_BASE)
+def links_absolutize(document: turbohtml.Document) -> None:
+    """Resolve every relative link on a freshly parsed tree against a base with turbohtml's resolve_links()."""
+    document.resolve_links(_LINKS_BASE)
 
 
 def links_rewrite(text: str) -> None:
@@ -424,16 +425,16 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "find-text": (find_text, "turbohtml"),
     "text-content": (text_content, "turbohtml"),
     "serialize": (serialize, "turbohtml"),
-    "edit": (edit, "turbohtml"),
+    "edit": (Mutating(turbohtml.parse, edit), "turbohtml"),
     "class-edit": (class_edit, "turbohtml"),
     "strip-remove": (strip_remove, "turbohtml"),
     "strip-tags": (strip_tags, "turbohtml"),
-    "set-html": (set_html, "turbohtml"),
-    "set-text": (set_text, "turbohtml"),
+    "set-html": (Mutating(turbohtml.parse, set_html), "turbohtml"),
+    "set-text": (Mutating(turbohtml.parse, set_text), "turbohtml"),
     "navigate": (navigate, "turbohtml"),
     "chain": (chain, "turbohtml"),
     "links-extract": (links_extract, "turbohtml"),
-    "links-absolutize": (links_absolutize, "turbohtml"),
+    "links-absolutize": (Mutating(turbohtml.parse, links_absolutize), "turbohtml"),
     "links-rewrite": (links_rewrite, "turbohtml"),
     "socialcard": (socialcard, "turbohtml"),
     "structured": (structured, "turbohtml"),

--- a/tools/bench/orchestrator.py
+++ b/tools/bench/orchestrator.py
@@ -77,8 +77,10 @@ def _venv_python(workdir: Path, name: str, reqs: tuple[str, ...]) -> Path:
     return python
 
 
-def _run_worker(python: Path, target: str, operation: str, workdir: Path) -> dict[str, float]:
-    """Run the worker for one (target, operation) in the given venv and return its means."""
+def _run_worker(
+    python: Path, target: str, operation: str, workdir: Path, pyperf_args: tuple[str, ...]
+) -> dict[str, dict[str, float]]:
+    """Run the worker for one (target, operation) in the given venv and return its per-case stats."""
     out = workdir / f"{target}-{operation}.json"
     env = {
         **os.environ,
@@ -87,11 +89,13 @@ def _run_worker(python: Path, target: str, operation: str, workdir: Path) -> dic
         "BENCH_OPERATION": operation,
         "BENCH_OUT": str(out),
     }
-    subprocess.run([str(python), "-m", "bench.worker"], check=True, env=env)
+    subprocess.run([str(python), "-m", "bench.worker", *pyperf_args], check=True, env=env)
     return json.loads(out.read_text(encoding="utf-8"))
 
 
-def _try_competitor(workdir: Path, competitor: str, operation: str) -> dict[str, float]:
+def _try_competitor(
+    workdir: Path, competitor: str, operation: str, pyperf_args: tuple[str, ...]
+) -> dict[str, dict[str, float]]:
     """
     Run the competitor in its venv, returning empty (with a skip note) if provisioning or the run fails.
 
@@ -101,24 +105,24 @@ def _try_competitor(workdir: Path, competitor: str, operation: str) -> dict[str,
     """
     try:
         python = _venv_python(workdir, competitor, COMPETITORS[competitor][0])
-        return _run_worker(python, competitor, operation, workdir)
+        return _run_worker(python, competitor, operation, workdir, pyperf_args)
     except subprocess.CalledProcessError:
         print(f"skipping {competitor}: it did not install or run in its isolated venv", file=sys.stderr)
         return {}
 
 
-def report_operation(operation: str) -> None:
+def report_operation(operation: str, pyperf_args: tuple[str, ...]) -> None:
     """Render one operation: the turbohtml baseline against every competitor that implements it, each isolated."""
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)
         wheel = _build_wheel(workdir)
-        means = _run_worker(_venv_python(workdir, "core", (str(wheel),)), "core", operation, workdir)
+        stats = _run_worker(_venv_python(workdir, "core", (str(wheel),)), "core", operation, workdir, pyperf_args)
         for competitor in _packages_for(operation):
-            means.update(_try_competitor(workdir, competitor, operation))
-        report.render(operation, means)
+            stats.update(_try_competitor(workdir, competitor, operation, pyperf_args))
+        report.render(operation, stats)
 
 
-def report_package(competitor: str) -> None:
+def report_package(competitor: str, pyperf_args: tuple[str, ...]) -> None:
     """Render one competitor's report: it against the turbohtml baseline across every operation it implements."""
     reqs, operation_names = COMPETITORS[competitor]
     with tempfile.TemporaryDirectory() as tmp:
@@ -126,31 +130,36 @@ def report_package(competitor: str) -> None:
         core_python = _venv_python(workdir, "core", (str(_build_wheel(workdir)),))
         competitor_python = _venv_python(workdir, competitor, reqs)
         for operation in operation_names:
-            means = _run_worker(core_python, "core", operation, workdir)
-            means.update(_run_worker(competitor_python, competitor, operation, workdir))
-            report.render(operation, means)
+            stats = _run_worker(core_python, "core", operation, workdir, pyperf_args)
+            stats.update(_run_worker(competitor_python, competitor, operation, workdir, pyperf_args))
+            report.render(operation, stats)
 
 
-def report_core() -> None:
+def report_core(pyperf_args: tuple[str, ...]) -> None:
     """Render turbohtml's own baseline for every operation in a turbohtml-only venv."""
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)
         python = _venv_python(workdir, "core", (str(_build_wheel(workdir)),))
         for operation in operations.OPERATIONS:
-            report.render(operation, _run_worker(python, "core", operation, workdir))
+            report.render(operation, _run_worker(python, "core", operation, workdir, pyperf_args))
 
 
-def run(command: str) -> None:
-    """Dispatch a CLI command to the matching report."""
+def run(command: str, pyperf_args: tuple[str, ...] = ()) -> None:
+    """Dispatch a CLI command to the matching report, forwarding any extra pyperf options to every worker."""
+    print(
+        "tip: for low-noise results run `pyperf system tune` first (and `sudo pyperf system reset` after); pass "
+        "pyperf options like --rigorous or --affinity=<cpu> after the command to control sampling and CPU pinning.",
+        file=sys.stderr,
+    )
     if command == "core":
-        report_core()
+        report_core(pyperf_args)
     elif command == "all":
         for operation in operations.OPERATIONS:
-            report_operation(operation)
+            report_operation(operation, pyperf_args)
     elif command in COMPETITORS:
-        report_package(command)
+        report_package(command, pyperf_args)
     elif command in operations.OPERATIONS:
-        report_operation(command)
+        report_operation(command, pyperf_args)
     else:
         choices = ", ".join(["core", "all", *operations.OPERATIONS, *COMPETITORS])
         msg = f"unknown command {command!r}; choose one of: {choices}"

--- a/tools/bench/report.py
+++ b/tools/bench/report.py
@@ -1,9 +1,10 @@
 """
-Render one operation's speedup table from a merged means mapping.
+Render one operation's speedup table from a merged stats mapping.
 
 Standard library only: the orchestrator imports this to print, so it must not pull in turbohtml or any competitor. A
-benchmark name is ``"<operation>|<case>|<label>"`` and a mean is seconds; turbohtml is the baseline every competitor
-column divides into.
+benchmark name is ``"<operation>|<case>|<label>"`` and a stat is ``{"mean": seconds, "stdev": seconds}``; turbohtml is
+the baseline every competitor column divides into. Each cell shows the mean, the relative standard deviation as ``±N%``
+so a reader can tell a real gap from run-to-run noise, and (for competitors) the slowdown factor against turbohtml.
 """
 
 from __future__ import annotations
@@ -11,40 +12,53 @@ from __future__ import annotations
 from bench import operations
 
 _SCALE: dict[str, float] = {"ns": 1e9, "us": 1e6, "ms": 1e3}
+_TURBO_COL = 18
+_COMPETITOR_COL = 26
 
 
-def _labels(operation: str, means: dict[str, float]) -> list[str]:
+def _labels(operation: str, stats: dict[str, dict[str, float]]) -> list[str]:
     """Return the labels present for an operation, turbohtml first, then competitors in first-seen order."""
     seen: list[str] = []
-    for key in means:
+    for key in stats:
         operation_name, _, label = key.split("|")
         if operation_name == operation and label not in seen:
             seen.append(label)
     return ["turbohtml", *(label for label in seen if label != "turbohtml")]
 
 
-def _case_names(operation: str, means: dict[str, float]) -> list[str]:
+def _case_names(operation: str, stats: dict[str, dict[str, float]]) -> list[str]:
     """Return the operation's case names in run order, recovered from the turbohtml baseline keys."""
     names: list[str] = []
-    for key in means:
+    for key in stats:
         operation_name, case, label = key.split("|")
         if operation_name == operation and label == "turbohtml" and case not in names:
             names.append(case)
     return names
 
 
-def render(operation: str, means: dict[str, float]) -> None:
+def _cell(stat: dict[str, float], scale: float, unit: str) -> str:
+    """Format one measurement as ``<mean> <unit> ±<relative stdev>%``."""
+    relative = stat["stdev"] / stat["mean"] * 100 if stat["mean"] else 0.0
+    return f"{stat['mean'] * scale:8.1f} {unit} ±{relative:3.0f}%"
+
+
+def render(operation: str, stats: dict[str, dict[str, float]]) -> None:
     """Print the table for one operation: turbohtml against each competitor with its slowdown factor."""
     meta = operations.OPERATIONS[operation]
-    scale, competitors = _SCALE[meta.unit], _labels(operation, means)[1:]
+    scale, competitors = _SCALE[meta.unit], _labels(operation, stats)[1:]
     print()
-    header = f"{meta.title:32} {'turbohtml':>12}" + "".join(f"{label:>20}" for label in competitors)
+    header = f"{meta.title:32} {'turbohtml':>{_TURBO_COL}}" + "".join(
+        f"{label:>{_COMPETITOR_COL}}" for label in competitors
+    )
     print(header)
-    for case_name in _case_names(operation, means):
-        if (turbo := means.get(f"{operation}|{case_name}|turbohtml")) is None:
+    for case_name in _case_names(operation, stats):
+        if (turbo := stats.get(f"{operation}|{case_name}|turbohtml")) is None:
             continue
-        row = f"{case_name:32} {turbo * scale:8.1f} {meta.unit}"
+        row = f"{case_name:32} {_cell(turbo, scale, meta.unit):>{_TURBO_COL}}"
         for label in competitors:
-            other = means.get(f"{operation}|{case_name}|{label}")
-            row += f" {other * scale:8.1f} {meta.unit} {other / turbo:5.1f}x" if other is not None else f"{'-':>20}"
+            if (other := stats.get(f"{operation}|{case_name}|{label}")) is None:
+                row += f"{'-':>{_COMPETITOR_COL}}"
+            else:
+                cell = f"{_cell(other, scale, meta.unit)} {other['mean'] / turbo['mean']:5.1f}x"
+                row += f"{cell:>{_COMPETITOR_COL}}"
         print(row)

--- a/tools/bench/timing.py
+++ b/tools/bench/timing.py
@@ -1,0 +1,26 @@
+"""
+Per-iteration setup for operations that mutate their parsed input.
+
+An operation that changes the tree it is handed -- tagging links, replacing a body's inner HTML, absolutizing
+hrefs -- cannot reuse one cached parse across pyperf iterations: the second measurement onward would time a tree
+already altered by the first (a body left holding the small replacement, hrefs already absolute), so the number is
+neither the real workload nor stable. :class:`Mutating` pairs an untimed ``setup`` that produces a fresh tree for
+each iteration with the timed ``run`` that mutates it; the worker measures it through pyperf's ``bench_time_func`` so
+only ``run`` is on the clock. Read-path operations keep their cached parse and stay plain callables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class Mutating:
+    """A mutating operation: ``setup(case)`` builds a fresh tree (untimed), ``run(tree)`` mutates it (timed)."""
+
+    setup: Callable[..., object]
+    run: Callable[..., object]

--- a/tools/bench/worker.py
+++ b/tools/bench/worker.py
@@ -1,9 +1,10 @@
 """
-Time one (target, operation) under pyperf inside an isolated venv, then write the means to disk.
+Time one (target, operation) under pyperf inside an isolated venv, then write the per-case stats to disk.
 
 Run as ``python -m bench.worker`` with the target, operation, and output path in the environment. The target is
 ``core`` (turbohtml's baseline) or a competitor module name; only that one module -- and therefore that one library --
-is imported, which is what keeps each venv isolated.
+is imported, which is what keeps each venv isolated. Plain operations are measured with ``bench_func``; a
+:class:`~bench.timing.Mutating` operation is measured with ``bench_time_func`` so its fresh-tree setup stays untimed.
 """
 
 from __future__ import annotations
@@ -12,20 +13,50 @@ import importlib
 import json
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pyperf
 
 from bench import operations
+from bench.timing import Mutating
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _timed(mutating: Mutating, arg: object) -> Callable[[int], float]:
+    """Return a ``bench_time_func`` body: rebuild a fresh tree per iteration (untimed), clock only the mutation."""
+
+    def inner(loops: int) -> float:
+        setup, run = mutating.setup, mutating.run
+        elapsed = 0.0
+        for _ in range(loops):
+            tree = setup(arg)
+            start = pyperf.perf_counter()
+            run(tree)
+            elapsed += pyperf.perf_counter() - start
+        return elapsed
+
+    return inner
+
+
+def _bench(runner: pyperf.Runner, name: str, func: object, arg: object) -> pyperf.Benchmark | None:
+    """Measure one case: a mutating operation through ``bench_time_func``, any other through ``bench_func``."""
+    if isinstance(func, Mutating):
+        return runner.bench_time_func(name, _timed(func, arg))
+    return runner.bench_func(name, func, arg)
 
 
 def main() -> None:
-    """Benchmark every case of the operation for the target; write ``{name: mean}`` from the pyperf manager."""
+    """Benchmark every case of the operation for the target; write ``{name: {mean, stdev}}`` from the pyperf manager."""
     target = os.environ["BENCH_TARGET"]
     operation = os.environ["BENCH_OPERATION"]
     module = importlib.import_module("bench.core" if target == "core" else f"bench.competitors.{target}")
     func, label = module.OPERATIONS[operation]
     runner = pyperf.Runner()
     args = runner.parse_args()
+    # pyperf re-execs this module as forked worker processes that re-read these from the environment, so each must be
+    # inherited or the worker cannot locate the target, operation, or output path the manager set.
     args.inherit_environ = [
         *(args.inherit_environ or []),
         "PYTHONPATH",
@@ -33,13 +64,13 @@ def main() -> None:
         "BENCH_OPERATION",
         "BENCH_OUT",
     ]
-    means: dict[str, float] = {}
+    stats: dict[str, dict[str, float]] = {}
     for case_name, arg in operations.INPUTS[operation]():
         name = f"{operation}|{case_name}|{label}"
-        if (result := runner.bench_func(name, func, arg)) is not None and result.get_nvalue():
-            means[name] = result.mean()
+        if (result := _bench(runner, name, func, arg)) is not None and result.get_nvalue() > 1:
+            stats[name] = {"mean": result.mean(), "stdev": result.stdev()}
     if not args.worker:  # the pyperf manager, holding every value -- not a per-value worker
-        Path(os.environ["BENCH_OUT"]).write_text(json.dumps(means), encoding="utf-8")
+        Path(os.environ["BENCH_OUT"]).write_text(json.dumps(stats), encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The benchmark harness reused one cached parse across every pyperf iteration, which is correct for read-path queries but wrong for any operation that mutates the tree it receives. After the first measurement the tree carried the previous iteration's edits, so `set-html` and `set-text` ended up timing a body already replaced down to the small fixed fragment rather than the real page, and the figures for the editing and link-absolutization passes drifted from the actual workload. 🐛

Operations that mutate now run through pyperf's `bench_time_func` with the parse rebuilt before each iteration outside the timed region, so only the mutation itself is on the clock. A small `Mutating(setup, run)` pairing in `tools/bench/timing.py` carries the contract, and the worker dispatches on it; the genuinely idempotent passes (the class churn, the identity rewrite, the strip helpers that already reparse) stay on `bench_func`.

Two adjacent gaps in the same path get closed here. The worker kept only the mean, so the tables offered point estimates with no sense of spread; it now records the standard deviation and the report prints it next to each figure as `±N%` so a real gap reads apart from run-to-run noise. ⚡ And the harness gave no handle on sampling noise, so it now forwards pyperf options such as `--rigorous` and `--affinity` straight through to every worker and points at `pyperf system tune` for low-noise runs.

The published numbers in `docs/development/performance.rst` predate this change, so the mutating-operation rows in particular should be regenerated with `tox -e bench` on the reference machine; the prose there already describes the new methodology.