### PR TITLE
📝 docs(migration): unify the migration guide layout

### DIFF
--- a/docs/migration/airium.rst
+++ b/docs/migration/airium.rst
@@ -33,11 +33,11 @@ parse it back:
 
 ``E`` assembles the fragment in turbohtml's arena and serializes it in C; airium stays in Python and pretty-prints with
 indentation as it goes. The same ``<ul>`` of rows -- a class, a ``data`` attribute, and a text child apiece -- built
-both ways, from ``tox -e bench build-e`` on the reference machine in :doc:`/development/performance`:
+both ways:
 
 .. list-table::
     :header-rows: 1
-    :widths: 34 33 33
+    :widths: 40 30 30
 
     - - build a list
       - :data:`E <turbohtml.build.E>`

--- a/docs/migration/airium.rst
+++ b/docs/migration/airium.rst
@@ -54,7 +54,7 @@ both ways:
 and re-:meth:`~turbohtml.Node.serialize`.
 
 *************
- The mapping
+ The renames
 *************
 
 airium tracks structure by call depth inside ``with`` blocks; turbohtml tracks it in the tree:

--- a/docs/migration/beautifulsoup.rst
+++ b/docs/migration/beautifulsoup.rst
@@ -17,106 +17,58 @@ resulting soup with a large, alias-rich API. It shares the most surface with tur
 :func:`turbohtml.parse` returns a fully type annotated :class:`~turbohtml.Document` with no parser backend to choose,
 since it always runs the WHATWG algorithm in C. The search surface is one ``find``/``find_all``/``select`` grammar with
 :class:`~turbohtml.Axis` directions instead of a dozen directional finders. And it parses, queries, and serializes one
-to two orders of magnitude faster than BeautifulSoup over ``html.parser``:
+to two orders of magnitude faster than BeautifulSoup over ``html.parser`` -- including text filtering
+(``find(text=...)`` against ``find_all(string=...)``), walking the tree (:attr:`~turbohtml.Node.descendants` against
+``soup.descendants``), and reading its text (:attr:`~turbohtml.Node.text` against ``soup.get_text()``):
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
-    - - input
+    - - operation
       - turbohtml
       - BeautifulSoup
-      - speed-up
     - - parse wpt page (4 kB)
       - 11.4 µs
-      - 438 µs
-      - 38.5x
+      - 438 µs (38.5x)
     - - parse wpt page (92 kB)
       - 272 µs
-      - 15.3 ms
-      - 56.2x
+      - 15.3 ms (56.2x)
     - - select ``div a[href]`` (4 kB)
       - 0.04 µs
-      - 41.8 µs
-      - 1010.3x
+      - 41.8 µs (1010.3x)
     - - serialize wpt page (92 kB)
       - 105 µs
-      - 5.95 ms
-      - 56.8x
+      - 5.95 ms (56.8x)
+    - - find ``text=`` regex (4 kB)
+      - 9.3 µs
+      - 19.7 µs (2.1x)
+    - - find ``text=`` regex (9.6 kB)
+      - 13.9 µs
+      - 38.2 µs (2.7x)
+    - - find ``text=`` regex (92 kB)
+      - 741 µs
+      - 989 µs (1.3x)
+    - - walk descendants (4 kB)
+      - 1.3 µs
+      - 2.7 µs (2.1x)
+    - - walk descendants (9.6 kB)
+      - 2.3 µs
+      - 4.8 µs (2.1x)
+    - - walk descendants (92 kB)
+      - 65.2 µs
+      - 123.3 µs (1.9x)
+    - - ``get_text`` (4 kB)
+      - 0.8 µs
+      - 6.7 µs (8.3x)
+    - - ``get_text`` (9.6 kB)
+      - 1.1 µs
+      - 13.7 µs (12.9x)
+    - - ``get_text`` (92 kB)
+      - 38.0 µs
+      - 372.4 µs (9.8x)
 
 The :doc:`/development/performance` page benchmarks the build and edit paths against BeautifulSoup too.
-
-Filtering elements by text through :meth:`~turbohtml.Node.find` / :meth:`~turbohtml.Node.find_all` (``text=``) gathers
-each candidate's subtree text in C and matches once, where ``bs4``'s ``find_all(string=...)`` runs the predicate in
-Python mid-walk. The :doc:`/development/performance` query suite races the two over the wpt pages:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - find ``text=`` regex
-      - turbohtml
-      - BeautifulSoup
-      - speed-up
-    - - wpt page (4 kB)
-      - 9.3 µs
-      - 19.7 µs
-      - 2.1x
-    - - wpt page (9.6 kB)
-      - 13.9 µs
-      - 38.2 µs
-      - 2.7x
-    - - wpt page (92 kB)
-      - 741 µs
-      - 989 µs
-      - 1.3x
-
-Walking the whole tree (:attr:`~turbohtml.Node.descendants` against ``soup.descendants``) and reading its text
-(:attr:`~turbohtml.Node.text` against ``soup.get_text()``) stay ahead too; both libraries parse once outside the timed
-region. The descendant walk yields comparable node counts on both sides, so the gap is narrower, while ``get_text``
-concatenates in C where ``bs4`` joins Python strings node by node:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - navigate (walk descendants)
-      - turbohtml
-      - BeautifulSoup
-      - speed-up
-    - - wpt page (4 kB)
-      - 1.3 µs
-      - 2.7 µs
-      - 2.1x
-    - - wpt page (9.6 kB)
-      - 2.3 µs
-      - 4.8 µs
-      - 2.1x
-    - - wpt page (92 kB)
-      - 65.2 µs
-      - 123.3 µs
-      - 1.9x
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - text (whole-document ``get_text``)
-      - turbohtml
-      - BeautifulSoup
-      - speed-up
-    - - wpt page (4 kB)
-      - 0.8 µs
-      - 6.7 µs
-      - 8.3x
-    - - wpt page (9.6 kB)
-      - 1.1 µs
-      - 13.7 µs
-      - 12.9x
-    - - wpt page (92 kB)
-      - 38.0 µs
-      - 372.4 µs
-      - 9.8x
 
 *********
  Parsing

--- a/docs/migration/bleach.rst
+++ b/docs/migration/bleach.rst
@@ -20,28 +20,23 @@ magnitude and the linkifier by five to twenty times:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - input
       - turbohtml
       - bleach
-      - speed-up
     - - sanitize comment (1 link, 1 script)
       - 1.5 µs
-      - 78.1 µs
-      - 52.6x
+      - 78.1 µs (52.6x)
     - - sanitize post (4 KiB)
       - 42.1 µs
-      - 1921 µs
-      - 45.7x
+      - 1921 µs (45.7x)
     - - linkify prose (1 KiB)
       - 51 µs
-      - 272 µs
-      - 5.4x
+      - 272 µs (5.4x)
     - - linkify markup (4 KiB)
       - 127 µs
-      - 1562 µs
-      - 12.3x
+      - 1562 µs (12.3x)
 
 **************
  bleach.clean

--- a/docs/migration/dominate.rst
+++ b/docs/migration/dominate.rst
@@ -53,7 +53,7 @@ rows -- a class, a ``data`` attribute, and a text child apiece -- built both way
 and re-:meth:`~turbohtml.Node.serialize`.
 
 *************
- The mapping
+ The renames
 *************
 
 dominate spells nesting with ``with`` blocks or positional children; the translation is mechanical:

--- a/docs/migration/dominate.rst
+++ b/docs/migration/dominate.rst
@@ -32,12 +32,11 @@ parse it back:
     <div class="card"><h1>Title</h1><p>body</p></div>
 
 ``E`` assembles the fragment in turbohtml's arena and serializes it in C; dominate stays in Python. The same ``<ul>`` of
-rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways, from ``tox -e bench build-e`` on the
-reference machine in :doc:`/development/performance`:
+rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
 
 .. list-table::
     :header-rows: 1
-    :widths: 34 33 33
+    :widths: 40 30 30
 
     - - build a list
       - :data:`E <turbohtml.build.E>`

--- a/docs/migration/extruct.rst
+++ b/docs/migration/extruct.rst
@@ -47,24 +47,21 @@ extractors you happened to enable:
 ``extruct`` starts from the raw HTML string, so it parses before it extracts: it builds an lxml tree and runs a separate
 extractor per syntax, where :meth:`~turbohtml.Document.structured_data` parses to the WHATWG tree and gathers every
 format in one C walk. On a product page carrying JSON-LD, Microdata, and OpenGraph at once, the single pass runs roughly
-nine to eleven times faster (pyperf, CPython 3.14 release build, Apple M4; reproduce with ``tox -e bench structured``):
+nine to eleven times faster:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - input
       - turbohtml
       - extruct
-      - speed-up
     - - product page
       - 5.6 µs
-      - 61.1 µs
-      - 11.0x
+      - 61.1 µs (11.0x)
     - - catalog (8 KiB)
       - 54.6 µs
-      - 541.5 µs
-      - 9.9x
+      - 541.5 µs (9.9x)
 
 *************
  The renames

--- a/docs/migration/html-sanitizer.rst
+++ b/docs/migration/html-sanitizer.rst
@@ -20,20 +20,17 @@ builder in C instead of an lxml parse, leading html-sanitizer by one to two orde
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - sanitize
       - turbohtml
       - html-sanitizer
-      - speed-up
     - - comment (1 link, 1 script)
       - 1.5 µs
-      - 45.3 µs
-      - 30.5x
+      - 45.3 µs (30.5x)
     - - post (4 KiB)
       - 42.1 µs
-      - 1504 µs
-      - 35.8x
+      - 1504 µs (35.8x)
 
 *************
  The renames

--- a/docs/migration/html-text.rst
+++ b/docs/migration/html-text.rst
@@ -38,24 +38,20 @@ Python.
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - to text
       - turbohtml
       - html-text
-      - speed-up
     - - article (2 KiB)
       - 7 µs
-      - 102 µs
-      - 14.5x
+      - 102 µs (14.5x)
     - - table (4 KiB)
       - 28 µs
-      - 258 µs
-      - 9.2x
+      - 258 µs (9.2x)
     - - word stream (2 KiB)
       - 7 µs
-      - 101 µs
-      - 14.0x
+      - 101 µs (14.0x)
 
 html-text skips the column-aligned table layout :meth:`~turbohtml.Node.to_text` renders, so its margin behind turbohtml
 narrows on table-heavy input while staying near an order of magnitude. The ``word stream`` row turns layout guessing off

--- a/docs/migration/html2text.rst
+++ b/docs/migration/html2text.rst
@@ -19,28 +19,23 @@ faster while covering the same options, including the Google Docs mode:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - to Markdown
       - turbohtml
       - html2text
-      - speed-up
     - - article (2 KiB)
       - 13 µs
-      - 542 µs
-      - 42.2x
+      - 542 µs (42.2x)
     - - list (4 KiB)
       - 23 µs
-      - 1143 µs
-      - 49.6x
+      - 1143 µs (49.6x)
     - - table (4 KiB)
       - 26 µs
-      - 1017 µs
-      - 38.9x
+      - 1017 µs (38.9x)
     - - google_doc (4 KiB)
       - 18 µs
-      - 560 µs
-      - 31.9x
+      - 560 µs (31.9x)
 
 *************
  The renames

--- a/docs/migration/html5-parser.rst
+++ b/docs/migration/html5-parser.rst
@@ -22,24 +22,20 @@ document is more than an order of magnitude faster:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - parse
       - turbohtml
       - html5-parser
-      - speed-up
     - - 4 kB document
       - 2.8 µs
-      - 64.1 µs
-      - 22.9x
+      - 64.1 µs (22.9x)
     - - 92 kB document
       - 130 µs
-      - 1.84 ms
-      - 14.2x
+      - 1.84 ms (14.2x)
     - - 3 MB document
       - 4.63 ms
-      - 59.7 ms
-      - 12.9x
+      - 59.7 ms (12.9x)
 
 *************
  The renames

--- a/docs/migration/html5lib.rst
+++ b/docs/migration/html5lib.rst
@@ -16,50 +16,32 @@ by default, or DOM, or lxml), and it is the conformance baseline other parsers a
 
 turbohtml runs the same WHATWG algorithm, so the *tree* matches, but it produces one typed hierarchy with navigation,
 search, and serialization built in instead of a foreign tree behind a treebuilder choice. The algorithm runs in C, so
-parsing and tokenizing are 30 to 80 times faster than the pure-Python implementation:
+parsing, tokenizing, and fragment parsing run 25 to 70 times faster than the pure-Python implementation
+(:func:`turbohtml.parse_fragment` parses an ``innerHTML``-style snippet in its container context, the same WHATWG
+fragment algorithm html5lib's :func:`~html5lib.html5parser.parseFragment` runs):
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - input
       - turbohtml
       - html5lib
-      - speed-up
     - - parse wpt page (4 kB)
       - 11.4 µs
-      - 620 µs
-      - 54.5x
+      - 620 µs (54.5x)
     - - parse wpt page (92 kB)
       - 272 µs
-      - 16.7 ms
-      - 61.6x
+      - 16.7 ms (61.6x)
     - - tokenize typical markup
       - 34.9 µs
-      - 836 µs
-      - 24.0x
+      - 836 µs (24.0x)
     - - tokenize whatwg spec (235 kB)
       - 708 µs
-      - 20.1 ms
-      - 28.4x
-
-:func:`html5lib.parseFragment() <html5lib.html5parser.parseFragment>` maps to :func:`turbohtml.parse_fragment`, which
-parses an ``innerHTML``-style snippet in its container context. Both run the WHATWG fragment algorithm, but turbohtml
-runs it in C, so a table-row fragment parsed in its ``<tbody>`` context is roughly seventy times faster (``tox -e bench
-fragment``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - input
-      - turbohtml
-      - html5lib
-      - speed-up
-    - - table-row fragment (2 kB)
+      - 20.1 ms (28.4x)
+    - - parse fragment, table row (2 kB)
       - 12.6 µs
-      - 867 µs
-      - 69.0x
+      - 867 µs (69.0x)
 
 *************
  The renames

--- a/docs/migration/htpy.rst
+++ b/docs/migration/htpy.rst
@@ -33,12 +33,11 @@ parse it back:
     <div class="card"><h1>Title</h1><p>body</p></div>
 
 ``E`` assembles the fragment in turbohtml's arena and serializes it in C; htpy stays in Python. The same ``<ul>`` of
-rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways, from ``tox -e bench build-e`` on the
-reference machine in :doc:`/development/performance`:
+rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
 
 .. list-table::
     :header-rows: 1
-    :widths: 34 33 33
+    :widths: 40 30 30
 
     - - build a list
       - :data:`E <turbohtml.build.E>`

--- a/docs/migration/htpy.rst
+++ b/docs/migration/htpy.rst
@@ -54,7 +54,7 @@ real :class:`~turbohtml.Element`, not a string, so the call that builds the mark
 edit, and re-:meth:`~turbohtml.Node.serialize`.
 
 *************
- The mapping
+ The renames
 *************
 
 htpy carries attributes in the call and children in a subscript; turbohtml passes both to one call:

--- a/docs/migration/inscriptis.rst
+++ b/docs/migration/inscriptis.rst
@@ -20,24 +20,20 @@ twenty times faster:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - to text
       - turbohtml
       - inscriptis
-      - speed-up
     - - article (2 KiB)
       - 7 µs
-      - 163 µs
-      - 23.5x
+      - 163 µs (23.5x)
     - - table (4 KiB)
       - 28 µs
-      - 839 µs
-      - 30.1x
+      - 839 µs (30.1x)
     - - annotated (4 KiB)
       - 10 µs
-      - 202 µs
-      - 20.8x
+      - 202 µs (20.8x)
 
 *************
  The renames

--- a/docs/migration/linkify-it-py.rst
+++ b/docs/migration/linkify-it-py.rst
@@ -16,60 +16,39 @@ leaving the caller to turn them into ``<a>`` tags and to skip text that is alrea
 
 turbohtml does both jobs, fully type annotated: :func:`~turbohtml.linkify.linkify` rewrites HTML (and, being HTML-aware,
 leaves a URL already inside an ``<a>`` or ``<script>`` alone), while :class:`~turbohtml.linkify.Detector` matches spans
-the way linkify-it-py's ``match`` does. The candidate scan runs in C, so even pure detection is several times faster
-than the Python scanner that does strictly less work:
+the way linkify-it-py's ``match`` does. The candidate scan runs in C, so both the full rewrite and the bare detection
+primitives (:meth:`Detector.find <turbohtml.linkify.Detector.find>` against ``LinkifyIt().match``, and
+:meth:`~turbohtml.linkify.Detector.has_link` against ``LinkifyIt().test``) outrun the Python scanner that does strictly
+less work. The one close row is ``has_link`` on prose, where ``test`` short-circuits on the first link near the start:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
-    - - linkify
+    - - operation
       - turbohtml
       - linkify-it-py
-      - speed-up
-    - - comment (1 link, 1 email)
+    - - linkify comment (1 link, 1 email)
       - 2.9 µs
-      - 29 µs
-      - 10.1x
-    - - prose (1 KiB)
+      - 29 µs (10.1x)
+    - - linkify prose (1 KiB)
       - 51 µs
-      - 310 µs
-      - 6.1x
-    - - markup (4 KiB)
+      - 310 µs (6.1x)
+    - - linkify markup (4 KiB)
       - 127 µs
-      - 708 µs
-      - 5.6x
-
-Comparing the detection primitive alone, :meth:`Detector.find <turbohtml.linkify.Detector.find>` against
-``LinkifyIt().match`` and :meth:`~turbohtml.linkify.Detector.has_link` against ``LinkifyIt().test``, both scanning a run
-of plain text and returning the same spans (``find``/``match``) or a boolean (``has_link``/``test``), the C scan is tens
-of times faster. The one close row is ``has_link`` on prose: ``test`` short-circuits on the first link near the start,
-so it does little work:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - detect
-      - turbohtml
-      - linkify-it-py
-      - speed-up
+      - 708 µs (5.6x)
     - - ``find`` comment (1 link, 1 email)
       - 0.6 µs
-      - 29.2 µs
-      - 46.9x
+      - 29.2 µs (46.9x)
     - - ``find`` prose (1 KiB)
       - 8.8 µs
-      - 309.9 µs
-      - 35.1x
+      - 309.9 µs (35.1x)
     - - ``has_link`` comment
       - 0.3 µs
-      - 21.5 µs
-      - 83.7x
+      - 21.5 µs (83.7x)
     - - ``has_link`` prose (1 KiB)
       - 2.7 µs
-      - 4.9 µs
-      - 1.8x
+      - 4.9 µs (1.8x)
 
 *************
  The renames

--- a/docs/migration/lxml-html-clean.rst
+++ b/docs/migration/lxml-html-clean.rst
@@ -22,20 +22,17 @@ blocklist cleaner by an order of magnitude:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - sanitize
       - turbohtml
       - lxml-html-clean
-      - speed-up
     - - comment (1 link, 1 script)
       - 1.5 µs
-      - 19.4 µs
-      - 13.0x
+      - 19.4 µs (13.0x)
     - - post (4 KiB)
       - 42.1 µs
-      - 497 µs
-      - 11.8x
+      - 497 µs (11.8x)
 
 *************
  The renames

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -19,35 +19,58 @@ adds XPath, XSLT, and schema validation.
 :func:`turbohtml.parse` builds the WHATWG document tree that libxml2's HTML parser does not, returns a fully type
 annotated :class:`~turbohtml.Document`, and folds XPath, CSS, and the ``find``/``find_all`` grammar into one node API
 instead of separate ``findall``/``xpath``/``cssselect`` entry points. It parses two to four times faster than lxml while
-matching a browser on malformed input:
+matching a browser on malformed input, and stays ahead across the operational surface -- fragment parsing, text and tree
+walks, the link helpers, XPath, and the node-path generators:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
-    - - parse
+    - - operation
       - turbohtml
       - lxml
-      - speed-up
-    - - wpt page (4 kB)
+    - - parse wpt page (4 kB)
       - 11.4 µs
-      - 27.1 µs
-      - 2.4x
-    - - wpt page (92 kB)
+      - 27.1 µs (2.4x)
+    - - parse wpt page (92 kB)
       - 272 µs
-      - 631 µs
-      - 2.3x
-    - - whatwg spec (235 kB)
+      - 631 µs (2.3x)
+    - - parse whatwg spec (235 kB)
       - 518 µs
-      - 1.22 ms
-      - 2.4x
-    - - ecmascript spec (3 MB)
+      - 1.22 ms (2.4x)
+    - - parse ecmascript spec (3 MB)
       - 4.54 ms
-      - 17.4 ms
-      - 3.8x
+      - 17.4 ms (3.8x)
+    - - parse fragment (2 kB)
+      - 12.6 µs
+      - 39.6 µs (3.2x)
+    - - text content (92 kB)
+      - 36.9 µs
+      - 47.2 µs (1.3x)
+    - - descendant walk (92 kB)
+      - 65.2 µs
+      - 278 µs (4.3x)
+    - - extract links (92 kB)
+      - 60.6 µs
+      - 2.28 ms (37.7x)
+    - - absolutize links (92 kB)
+      - 251 µs
+      - 2.76 ms (11.0x)
+    - - rewrite links (92 kB)
+      - 22.3 µs
+      - 2.38 ms (106.7x)
+    - - XPath ``//a[@href]`` precompiled
+      - 0.5 µs
+      - 2.8 µs (5.6x)
+    - - ``css_path`` node locator (9.6 kB)
+      - 15.6 µs
+      - 55.2 µs (3.5x)
+    - - ``xpath_path`` node locator (9.6 kB)
+      - 14.3 µs
+      - 55.2 µs (3.9x)
 
-The :doc:`/development/performance` page also benchmarks turbohtml's serializer, builder, editor, CSS, and XPath 1.0
-engine against lxml directly.
+The :doc:`/development/performance` page benchmarks the full serializer, builder, editor, CSS, XPath 1.0, and EXSLT
+surface against lxml directly.
 
 *************
  The renames
@@ -122,51 +145,6 @@ lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtm
     [Element('a')]
     /x
 
-**************************
- Tree and link operations
-**************************
-
-Beyond XPath and CSS, the operational renames above each beat lxml on the wpt pages from the
-:doc:`/development/performance` benchmark. :func:`turbohtml.parse_fragment` (lxml's ``lxml.html.fromstring``) parses an
-``innerHTML`` snippet in its container context; :attr:`~turbohtml.Node.text` (lxml's ``text_content()``) concatenates
-the visible text; :attr:`~turbohtml.Node.descendants` (lxml's ``iterdescendants()``) walks the subtree; and the link
-surface (:meth:`~turbohtml.Node.links`, :meth:`~turbohtml.Node.resolve_links`, :meth:`~turbohtml.Node.rewrite_links`
-against ``iterlinks``/``make_links_absolute``/``rewrite_links``) extracts and rewrites every link-bearing attribute.
-turbohtml runs each in C over its native tree (``tox -e bench fragment text navigate links``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - operation
-      - turbohtml
-      - lxml
-      - speed-up
-    - - parse fragment (2 kB)
-      - 12.6 µs
-      - 39.6 µs
-      - 3.2x
-    - - text content (92 kB)
-      - 36.9 µs
-      - 47.2 µs
-      - 1.3x
-    - - descendant walk (92 kB)
-      - 65.2 µs
-      - 278 µs
-      - 4.3x
-    - - extract links (92 kB)
-      - 60.6 µs
-      - 2.28 ms
-      - 37.7x
-    - - absolutize links (92 kB)
-      - 251 µs
-      - 2.76 ms
-      - 11.0x
-    - - rewrite links (92 kB)
-      - 22.3 µs
-      - 2.38 ms
-      - 106.7x
-
 *******
  XPath
 *******
@@ -175,25 +153,8 @@ When one expression runs against many nodes, precompile it once with :class:`~tu
 :meth:`~turbohtml.Node.xpath`, which reparses the expression on every call. This is the same move as reaching for
 ``lxml.etree.XPath`` over a bare ``el.xpath``: the parse happens at construction, and the call site only supplies the
 context node and any ``$name`` variables. turbohtml's compiled program is tree-independent, so a single object evaluates
-against many documents, and it stays ahead of lxml per evaluation. The numbers below are for ``//a[@href]`` over the 9.6
-kB wpt page from the :doc:`/development/performance` benchmark (``tox -e bench xpath``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - ``//a[@href]``
-      - turbohtml
-      - lxml
-      - speed-up
-    - - per call (reparsed each time)
-      - 0.6 µs
-      - 4.1 µs
-      - 6.8x
-    - - precompiled, reused
-      - 0.5 µs
-      - 2.8 µs
-      - 5.6x
+against many documents, and it stays ahead of lxml per evaluation (the precompiled ``//a[@href]`` row in the table
+above).
 
 .. testcode::
 
@@ -211,98 +172,23 @@ lxml registers custom XPath callables through ``etree.FunctionNamespace``; turbo
 ``extensions=`` mapping of :meth:`~turbohtml.Node.xpath`. Both dispatch a Python callable per match, but lxml
 re-resolves its namespace and function table on every evaluation while turbohtml binds the mapping once against the
 compiled expression, and a callable that returns an :class:`~turbohtml.Element` (or an iterable of them) is marshaled
-straight back into the evaluator's node-set so the next path step stays on the all-C fast path. Measured over the 9.6 kB
-wpt page with ``tox -e bench xpath``:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 46 18 18 18
-
-    - - extension call
-      - turbohtml
-      - lxml
-      - speed-up
-    - - scalar return (``ext_count(//a)``)
-      - 1.1 µs
-      - 4.1 µs
-      - 3.6x
-    - - node-set return (``ext_first_two(//a)/@href``)
-      - 1.1 µs
-      - 3.2 µs
-      - 2.9x
+straight back into the evaluator's node-set so the next path step stays on the all-C fast path.
 
 Both engines accept a node-set ``$variable``, so a prior result feeds a later expression without re-querying:
 :meth:`el.xpath("$rows/td", rows=el.xpath("//tr")) <turbohtml.Node.xpath>` binds the node-set lxml's
 ``tree.xpath("$rows/td", rows=tree.xpath("//tr"))`` would. turbohtml normalizes the bound node-set into the compiled
 program once and walks the following step over interned atoms, so binding a prior result and reusing it stays ahead of
-lxml across page sizes (``$rows/div`` reusing a prior ``//div`` result; see :doc:`/development/performance` for the full
-sweep):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - node-set variable reuse
-      - turbohtml
-      - lxml
-      - speed-up
-    - - wpt page (4 kB)
-      - 4.3 µs
-      - 6.3 µs
-      - 1.5x
-    - - wpt page (9.6 kB)
-      - 3.9 µs
-      - 6.1 µs
-      - 1.5x
+lxml across page sizes.
 
 A namespace-prefixed name test ports unchanged: pass the same ``namespaces=`` mapping to :meth:`~turbohtml.Node.xpath`
 that you give lxml. turbohtml binds the prefix at evaluation time against the per-tree cached program and resolves the
 suffix to an interned atom, while lxml re-reads the namespace map on every call, so ``//svg:rect`` with
-``namespaces={"svg": "http://www.w3.org/2000/svg"}`` runs several times faster across page sizes (``tox -e bench
-xpath``, over a page carrying an SVG block):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - ``//svg:rect`` (namespaces=)
-      - turbohtml
-      - lxml
-      - speed-up
-    - - wpt page (4 kB)
-      - 0.8 µs
-      - 3.9 µs
-      - 4.8x
-    - - wpt page (9.6 kB)
-      - 0.9 µs
-      - 3.7 µs
-      - 3.9x
-    - - wpt page (92 kB)
-      - 15.5 µs
-      - 22.5 µs
-      - 1.5x
+``namespaces={"svg": "http://www.w3.org/2000/svg"}`` runs several times faster across page sizes.
 
 ``el.getroottree().getpath(el)`` ports to :meth:`~turbohtml.Element.xpath_path` (a positional XPath) or
 :meth:`~turbohtml.Element.css_path` (a unique CSS selector, which lxml has no equivalent for). Both walk only the
 element's ancestor chain under the per-tree lock instead of indexing siblings from the root, so generating the locator
-for every node in the 9.6 kB wpt page runs several times ahead of ``getpath`` (``tox -e bench path``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - node locator (9.6 kB page)
-      - turbohtml
-      - lxml ``getpath``
-      - speed-up
-    - - :meth:`~turbohtml.Element.css_path`
-      - 15.6 µs
-      - 55.2 µs
-      - 3.5x
-    - - :meth:`~turbohtml.Element.xpath_path`
-      - 14.3 µs
-      - 55.2 µs
-      - 3.9x
+for every node runs several times ahead of ``getpath`` (the ``css_path``/``xpath_path`` rows in the table above).
 
 The :doc:`/development/performance` page benchmarks the rest of the XPath surface against lxml, and sweeps the node-path
 generators across every page size.
@@ -333,30 +219,12 @@ generators across every page size.
 turbohtml's EXSLT namespaces dispatch in the same compiled-C XPath engine as the core functions, so an EXSLT predicate
 through :meth:`~turbohtml.Node.xpath` costs no registration: the prefix is built in. lxml resolves the namespace map and
 routes each call through a ``libexslt`` function you register with ``namespaces=``, so the same expression carries a
-per-call setup cost. lxml *can* run the same EXSLT, so this is a direct race, not a no-competitor note. Over the 9.6 kB
-wpt page:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - EXSLT (9.6 kB page)
-      - turbohtml
-      - lxml
-      - speed-up
-    - - ``//a[re:test(@href, ...)]``
-      - 0.5 µs
-      - 4.6 µs
-      - 9.2x
-    - - ``set:distinct(//a)``
-      - 0.6 µs
-      - 4.0 µs
-      - 6.7x
-
-``re:`` dispatches to Python's :mod:`re` where lxml uses C libexslt, yet still leads because it skips the per-call
-namespace resolution; ``set:distinct`` stays in C on both sides. The :doc:`/development/performance` page sweeps these
-EXSLT cases — alongside the structural axes, predicates, and the core function library — across every page size, where
-lxml's streaming evaluation narrows the node-set reductions on the multi-megabyte inputs.
+per-call setup cost. lxml *can* run the same EXSLT, so this is a direct race, not a no-competitor note: a ``re:test``
+predicate runs several times ahead even though ``re:`` dispatches to Python's :mod:`re` where lxml uses C libexslt,
+because it skips the per-call namespace resolution; ``set:distinct`` stays in C on both sides. The
+:doc:`/development/performance` page sweeps these EXSLT cases — alongside the structural axes, predicates, and the core
+function library — across every page size, where lxml's streaming evaluation narrows the node-set reductions on the
+multi-megabyte inputs.
 
 ****************************
  The builder (lxml.builder)
@@ -376,20 +244,3 @@ and serialize surface above stays available on what you build:
 .. testoutput::
 
     <ul><li class="item">one</li><li class="item">two</li></ul>
-
-The same ``<ul>`` of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways, from ``tox -e
-bench build-e`` on the reference machine in :doc:`/development/performance`:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 34 33 33
-
-    - - build a list
-      - :data:`E <turbohtml.build.E>`
-      - lxml.builder
-    - - 100 rows
-      - 139 µs
-      - 204 µs (1.5x)
-    - - 1000 rows
-      - 1.41 ms
-      - 2.13 ms (1.5x)

--- a/docs/migration/markdownify.rst
+++ b/docs/migration/markdownify.rst
@@ -19,28 +19,23 @@ walk over a BeautifulSoup tree, so it converts a page two orders of magnitude fa
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - to Markdown
       - turbohtml
       - markdownify
-      - speed-up
     - - article (2 KiB)
       - 13 µs
-      - 1185 µs
-      - 92.4x
+      - 1185 µs (92.4x)
     - - list (4 KiB)
       - 23 µs
-      - 2381 µs
-      - 103.2x
+      - 2381 µs (103.2x)
     - - table (4 KiB)
       - 26 µs
-      - 2825 µs
-      - 108.1x
+      - 2825 µs (108.1x)
     - - configured (4 KiB)
       - 28 µs
-      - 2560 µs
-      - 92.5x
+      - 2560 µs (92.5x)
 
 *************
  The renames

--- a/docs/migration/markupsafe.rst
+++ b/docs/migration/markupsafe.rst
@@ -17,66 +17,46 @@ template engine can interpolate untrusted values into HTML without escaping safe
 
 ``turbohtml.migration.markupsafe`` is a drop-in for markupsafe's public surface, fully type annotated, with the escape
 and every ``Markup`` operation implemented in C. It also keeps one name per concept: :meth:`~turbohtml.escape` and the
-tokenizer back the same primitives the rest of the library uses. The escape runs roughly two to three times faster than
-markupsafe's own C escape on the small, mostly-clean strings a template engine interpolates under autoescape:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - input
-      - turbohtml
-      - markupsafe
-      - speed-up
-    - - clean (8 B)
-      - 61 ns
-      - 185 ns
-      - 3.1x
-    - - clean (32 B)
-      - 67 ns
-      - 203 ns
-      - 3.0x
-    - - clean (256 B)
-      - 115 ns
-      - 447 ns
-      - 3.9x
-    - - name with ``'`` and ``&``
-      - 84 ns
-      - 213 ns
-      - 2.5x
-    - - escape-heavy markup
-      - 141 ns
-      - 338 ns
-      - 2.4x
-
-The other ``Markup`` operations stay ahead too. ``striptags`` and ``unescape`` run on turbohtml's tokenizer and HTML5
+tokenizer back the same primitives the rest of the library uses. The escape runs two to three times faster than
+markupsafe's own C escape on the small, mostly-clean strings a template engine interpolates under autoescape, and the
+other ``Markup`` operations stay ahead too -- ``striptags`` and ``unescape`` run on turbohtml's tokenizer and HTML5
 reference resolution rather than markupsafe's regex scan, and the composing operations (``format``, ``join``) escape
 each untrusted operand through the same C ``escape``:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - operation
       - turbohtml
       - markupsafe
-      - speed-up
+    - - escape clean (8 B)
+      - 61 ns
+      - 185 ns (3.1x)
+    - - escape clean (32 B)
+      - 67 ns
+      - 203 ns (3.0x)
+    - - escape clean (256 B)
+      - 115 ns
+      - 447 ns (3.9x)
+    - - escape name with ``'`` and ``&``
+      - 84 ns
+      - 213 ns (2.5x)
+    - - escape-heavy markup
+      - 141 ns
+      - 338 ns (2.4x)
     - - ``striptags``
       - 1368 ns
-      - 2483 ns
-      - 1.8x
+      - 2483 ns (1.8x)
     - - ``unescape``
       - 273 ns
-      - 1114 ns
-      - 4.1x
+      - 1114 ns (4.1x)
     - - ``format`` (escapes operands)
       - 1662 ns
-      - 1973 ns
-      - 1.2x
+      - 1973 ns (1.2x)
     - - ``join`` (escapes operands)
       - 609 ns
-      - 1217 ns
-      - 2.0x
+      - 1217 ns (2.0x)
 
 *************
  The renames

--- a/docs/migration/metadata_parser.rst
+++ b/docs/migration/metadata_parser.rst
@@ -31,6 +31,25 @@ result is a plain dict that holds no reference back into the tree:
 
     {'og:title': 'Widget', 'twitter:card': 'summary'}
 
+Both libraries start from the raw HTML string, so each parses before it reads the tags: ``metadata_parser`` builds its
+own tree and maps the meta block in Python, where :meth:`~turbohtml.Document.opengraph` parses to the WHATWG tree and
+gathers the ``og:``/``twitter:`` tags in one C walk. On a social-card head, and on an 8 KiB article carrying that head,
+the single pass runs dozens of times faster:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 30 30
+
+    - - input
+      - turbohtml
+      - metadata_parser
+    - - social-card head
+      - 2.0 µs
+      - 142 µs (71.6x)
+    - - article (8 KiB)
+      - 27.9 µs
+      - 2.28 ms (81.8x)
+
 *************
  The renames
 *************
@@ -49,30 +68,6 @@ result is a plain dict that holds no reference back into the tree:
       - the ``twitter:card`` key of :meth:`~turbohtml.Document.opengraph`
     - - ``mp.get_metadata_link("image", strategy=["og"])``
       - the ``og:image`` key, absolutized yourself against :meth:`~turbohtml.Document.base_url`
-
-*************
- Performance
-*************
-
-Both libraries start from the raw HTML string, so each parses before it reads the tags: ``metadata_parser`` builds its
-own tree and maps the meta block in Python, where :meth:`~turbohtml.Document.opengraph` parses to the WHATWG tree and
-gathers the ``og:``/``twitter:`` tags in one C walk. On a social-card head, and on an 8 KiB article carrying that head,
-the single pass runs dozens of times faster (``tox -e bench socialcard`` on the reference machine in
-:doc:`/development/performance`):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 28 32
-
-    - - input
-      - turbohtml
-      - metadata_parser
-    - - social-card head
-      - 2.0 µs
-      - 142 µs (71.6x)
-    - - article (8 KiB)
-      - 27.9 µs
-      - 2.28 ms (81.8x)
 
 **********
  Pitfalls

--- a/docs/migration/newspaper3k.rst
+++ b/docs/migration/newspaper3k.rst
@@ -19,6 +19,28 @@ scored ``element`` and its ``text``, plus the harvested ``title``, ``byline``, `
 turbohtml does not fetch URLs, so download the page yourself and parse the markup; the keyword and summary NLP newspaper
 bundles has no equivalent and is out of scope.
 
+Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
+:meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; newspaper3k builds an lxml tree
+and runs its own regex-driven metadata scan. Numbers vary with input and hardware.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 30 30
+
+    - - input
+      - turbohtml
+      - newspaper3k
+    - - post (4 KiB)
+      - 23 µs
+      - 3.52 ms (152x)
+    - - longform (16 KiB)
+      - 70 µs
+      - 8.97 ms (128x)
+
+*************
+ The renames
+*************
+
 .. list-table::
     :header-rows: 1
     :widths: 50 50
@@ -56,24 +78,6 @@ bundles has no equivalent and is out of scope.
 .. testoutput::
 
     Comets | Ada Lovelace | A short guide to comets. | en
-
-Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
-:meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; newspaper3k builds an lxml tree
-and runs its own regex-driven metadata scan. Numbers vary with input and hardware.
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 30 30
-
-    - - input
-      - turbohtml
-      - newspaper3k
-    - - post (4 KiB)
-      - 23 µs
-      - 3.52 ms (152x)
-    - - longform (16 KiB)
-      - 70 µs
-      - 8.97 ms (128x)
 
 **********
  Pitfalls

--- a/docs/migration/newspaper3k.rst
+++ b/docs/migration/newspaper3k.rst
@@ -57,27 +57,23 @@ bundles has no equivalent and is out of scope.
 
     Comets | Ada Lovelace | A short guide to comets. | en
 
-Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer -- measured with
-``tox -e bench article`` on CPython 3.14 (release build, Apple M4, macOS 26). :meth:`~turbohtml.Node.article` scores and
-harvests in one C pass over the parsed tree; newspaper3k builds an lxml tree and runs its own regex-driven metadata
-scan. Numbers vary with input and hardware.
+Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
+:meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; newspaper3k builds an lxml tree
+and runs its own regex-driven metadata scan. Numbers vary with input and hardware.
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - input
       - turbohtml
       - newspaper3k
-      - speed-up
     - - post (4 KiB)
       - 23 µs
-      - 3.52 ms
-      - 152x
+      - 3.52 ms (152x)
     - - longform (16 KiB)
       - 70 µs
-      - 8.97 ms
-      - 128x
+      - 8.97 ms (128x)
 
 **********
  Pitfalls

--- a/docs/migration/nh3.rst
+++ b/docs/migration/nh3.rst
@@ -21,20 +21,17 @@ frozen :class:`~turbohtml.sanitizer.Policy`. It also leads nh3 on the benchmark:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - sanitize
       - turbohtml
       - nh3
-      - speed-up
     - - comment (1 link, 1 script)
       - 1.5 µs
-      - 5.5 µs
-      - 3.7x
+      - 5.5 µs (3.7x)
     - - post (4 KiB)
       - 42.1 µs
-      - 120.1 µs
-      - 2.9x
+      - 120.1 µs (2.9x)
 
 *************
  The renames

--- a/docs/migration/pandas.rst
+++ b/docs/migration/pandas.rst
@@ -38,40 +38,33 @@ Reading a four-column table with :meth:`~turbohtml.Element.rows` and :meth:`~tur
 ``pandas.read_html``, both parsing the markup and resolving spans into a rectangular grid. turbohtml's C cell-grid walk
 returns plain lists and dicts where ``read_html`` builds a ``DataFrame`` (importing NumPy), so it runs roughly twelve to
 ninety times faster: the gap is widest on small tables, where pandas pays a fixed per-frame cost, and narrows as the row
-count grows. Reproduce with ``tox -e bench tables``; see :doc:`/development/performance` for the methodology.
+count grows. See :doc:`/development/performance` for the methodology.
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - input
       - turbohtml
       - pandas.read_html
-      - speed-up
     - - rows (10 rows)
       - 10.8 µs
-      - 943 µs
-      - 87.3x
+      - 943 µs (87.3x)
     - - records (10 rows)
       - 15.8 µs
-      - 970 µs
-      - 61.4x
+      - 970 µs (61.4x)
     - - rows (100 rows)
       - 99.7 µs
-      - 2178 µs
-      - 21.8x
+      - 2178 µs (21.8x)
     - - records (100 rows)
       - 98.5 µs
-      - 2165 µs
-      - 22.0x
+      - 2165 µs (22.0x)
     - - rows (1000 rows)
       - 853 µs
-      - 10.6 ms
-      - 12.4x
+      - 10.6 ms (12.4x)
     - - records (1000 rows)
       - 893 µs
-      - 13.0 ms
-      - 14.6x
+      - 13.0 ms (14.6x)
 
 *************
  The renames

--- a/docs/migration/parsel.rst
+++ b/docs/migration/parsel.rst
@@ -19,55 +19,34 @@ turbohtml returns typed :class:`~turbohtml.Node` objects from :meth:`~turbohtml.
 :meth:`~turbohtml.Node.xpath`, so the non-standard ``::text`` / ``::attr()`` pseudo-elements become ordinary
 :attr:`~turbohtml.Node.text` and :meth:`~turbohtml.Element.attr` access. It compiles a selector against the tree once
 and matches by comparing interned integer atoms, where parsel translates every ``.css()`` to XPath with cssselect and
-re-evaluates it on libxml2 per call, so a reused query is roughly thirteen to two hundred times faster:
+re-evaluates it on libxml2 per call, so a reused query -- and pulling the values out of every match, parsel's whole
+point -- runs tens to hundreds of times faster:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
-    - - select ``div a[href]``
+    - - operation
       - turbohtml
       - parsel
-      - speed-up
-    - - wpt page (4 kB)
+    - - select ``div a[href]`` (4 kB)
       - 0.04 µs
-      - 7.0 µs
-      - 167.9x
-    - - wpt page (9.6 kB)
+      - 7.0 µs (167.9x)
+    - - select ``div a[href]`` (9.6 kB)
       - 0.04 µs
-      - 8.0 µs
-      - 192.3x
-    - - wpt page (92 kB)
+      - 8.0 µs (192.3x)
+    - - select ``div a[href]`` (92 kB)
       - 2.0 µs
-      - 25.4 µs
-      - 12.9x
-
-Pulling the values out of a matched set is parsel's whole point: ``sel.css("a::attr(href)").getall()`` and
-``sel.css("a::text").getall()`` against turbohtml selecting once and reading :meth:`~turbohtml.Element.attr` and
-:attr:`~turbohtml.Node.text` off each node. Both libraries parse the page once outside the timed call. turbohtml
-compiles the selector once and reads interned atoms, where parsel re-translates the CSS to XPath on libxml2 every call,
-so reading every anchor runs tens of times faster (``tox -e bench extract``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - extract per match
-      - turbohtml
-      - parsel
-      - speed-up
-    - - ``@href`` -- wpt page (9.6 kB)
+      - 25.4 µs (12.9x)
+    - - ``@href`` per match (9.6 kB)
       - 0.1 µs
-      - 4.3 µs
-      - 86.2x
-    - - ``@href`` -- wpt page (92 kB)
+      - 4.3 µs (86.2x)
+    - - ``@href`` per match (92 kB)
       - 8.2 µs
-      - 222 µs
-      - 27.0x
-    - - text -- wpt page (92 kB)
+      - 222 µs (27.0x)
+    - - text per match (92 kB)
       - 8.0 µs
-      - 214 µs
-      - 26.6x
+      - 214 µs (26.6x)
 
 *************
  The renames

--- a/docs/migration/pyquery.rst
+++ b/docs/migration/pyquery.rst
@@ -15,100 +15,48 @@ chains.
 ***************
 
 turbohtml ships the same chaining idiom as :class:`turbohtml.query.Query`, fully type annotated, with the selector and
-attribute primitives running in C. The wrapper also skips a redundant de-duplication when a chain starts from one node,
-so the same chain runs roughly ten times faster than pyquery's lxml-backed wrapper:
+attribute primitives running in C. The wrapper skips a redundant de-duplication when a chain starts from one node, and
+edits its native tree in C where pyquery drives lxml under its jQuery-style wrapper, so the whole surface -- chaining a
+select/filter/read, setting content, bulk-editing tags, and reading a value off every match -- runs several to a hundred
+times faster:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
-    - - select, filter, tag, read
+    - - operation
       - turbohtml
       - pyquery
-      - speed-up
-    - - wpt page (4 kB)
+    - - select, filter, read (4 kB)
       - 0.9 µs
-      - 16.0 µs
-      - 17.2x
-    - - wpt page (9.6 kB)
+      - 16.0 µs (17.2x)
+    - - select, filter, read (9.6 kB)
       - 1.0 µs
-      - 16.5 µs
-      - 16.1x
-    - - wpt page (92 kB)
+      - 16.5 µs (16.1x)
+    - - select, filter, read (92 kB)
       - 21.8 µs
-      - 278 µs
-      - 12.8x
-
-pyquery's content setters carry the same C advantage as the rest of its wrapper. Both libraries parse the page once
-outside the timed call, then replace a ``<body>``'s content on every run: turbohtml reparses the fragment and splices it
-in one C call, where pyquery's ``.html()`` routes through lxml's ``fromstring`` and reassembly. The numbers come from
-the 9.6 kB ``wpt`` page in the ``edit`` suite (``tox -e bench edit``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - content setter (9.6 kB page)
-      - turbohtml
-      - pyquery
-      - speed-up
-    - - :meth:`~turbohtml.Element.set_inner_html` vs ``.html()``
+      - 278 µs (12.8x)
+    - - set inner HTML (9.6 kB)
       - 1.3 µs
-      - 7.7 µs
-      - 5.9x
-    - - :meth:`~turbohtml.Element.set_text` vs ``.text()``
+      - 7.7 µs (5.9x)
+    - - set text (9.6 kB)
       - 0.13 µs
-      - 4.6 µs
-      - 35.4x
-
-Bulk tag editing over a 92 kB page holding 839 ``<code>``/``<a>``/``<q>`` elements: dropping the matches with their
-subtrees (jQuery's ``.remove()`` against :meth:`~turbohtml.Node.remove`) and unwrapping them to keep their content
-(jQuery's ``.unwrap()`` against :meth:`~turbohtml.Node.strip_tags`). pyquery drives lxml under its wrapper, where
-turbohtml edits its native tree in C, so the same pass runs three to four times faster:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 46 18 18 18
-
-    - - bulk edit (92 kB)
-      - turbohtml
-      - pyquery
-      - speed-up
-    - - drop subtree (``remove`` / ``.remove()``)
+      - 4.6 µs (35.4x)
+    - - drop subtree (92 kB)
       - 554 µs
-      - 2.06 ms
-      - 3.7x
-    - - keep content (``strip_tags`` / ``.unwrap()``)
+      - 2.06 ms (3.7x)
+    - - keep content, unwrap (92 kB)
       - 607 µs
-      - 2.35 ms
-      - 3.9x
-
-Reading a value off every match -- iterating ``for item in pq("a").items()`` and calling ``.attr("href")`` or
-``.text()`` -- against turbohtml selecting once and reading :meth:`~turbohtml.Element.attr` and
-:attr:`~turbohtml.Node.text` off each node. Both parse the page once outside the timed call. pyquery boxes every match
-in a fresh wrapper object, where turbohtml reads interned atoms straight off the selected nodes, so the per-match read
-runs tens of times faster (``tox -e bench extract``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - extract per match
-      - turbohtml
-      - pyquery
-      - speed-up
-    - - ``@href`` -- wpt page (9.6 kB)
+      - 2.35 ms (3.9x)
+    - - ``@href`` per match (9.6 kB)
       - 0.1 µs
-      - 4.8 µs
-      - 96.6x
-    - - ``@href`` -- wpt page (92 kB)
+      - 4.8 µs (96.6x)
+    - - ``@href`` per match (92 kB)
       - 8.2 µs
-      - 542 µs
-      - 65.8x
-    - - text -- wpt page (92 kB)
+      - 542 µs (65.8x)
+    - - text per match (92 kB)
       - 8.0 µs
-      - 297 µs
-      - 37.0x
+      - 297 µs (37.0x)
 
 *************
  The renames

--- a/docs/migration/readability-lxml.rst
+++ b/docs/migration/readability-lxml.rst
@@ -51,27 +51,23 @@ when you need a scrubbed body.
 
     Comets | article
 
-Scoring the content body of a full page -- navigation, a scored article, and a footer -- measured with ``tox -e bench
-article`` on CPython 3.14 (release build, Apple M4, macOS 26). :meth:`~turbohtml.Node.article` runs the same
-content-density heuristic in C and selects the live element; readability-lxml builds an lxml tree and rewrites it into a
-cleaned summary fragment. Numbers vary with input and hardware.
+Scoring the content body of a full page -- navigation, a scored article, and a footer. :meth:`~turbohtml.Node.article`
+runs the same content-density heuristic in C and selects the live element; readability-lxml builds an lxml tree and
+rewrites it into a cleaned summary fragment. Numbers vary with input and hardware.
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - input
       - turbohtml
       - readability-lxml
-      - speed-up
     - - post (4 KiB)
       - 23 µs
-      - 1.26 ms
-      - 55x
+      - 1.26 ms (55x)
     - - longform (16 KiB)
       - 70 µs
-      - 2.54 ms
-      - 36x
+      - 2.54 ms (36x)
 
 **********
  Pitfalls

--- a/docs/migration/readability-lxml.rst
+++ b/docs/migration/readability-lxml.rst
@@ -19,6 +19,28 @@ record, adding the byline, date, description and language readability-lxml leave
 unchanged rather than rewriting the DOM into a cleaned fragment, so pair it with :class:`~turbohtml.sanitizer.Sanitizer`
 when you need a scrubbed body.
 
+Scoring the content body of a full page -- navigation, a scored article, and a footer. :meth:`~turbohtml.Node.article`
+runs the same content-density heuristic in C and selects the live element; readability-lxml builds an lxml tree and
+rewrites it into a cleaned summary fragment. Numbers vary with input and hardware.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 30 30
+
+    - - input
+      - turbohtml
+      - readability-lxml
+    - - post (4 KiB)
+      - 23 µs
+      - 1.26 ms (55x)
+    - - longform (16 KiB)
+      - 70 µs
+      - 2.54 ms (36x)
+
+*************
+ The renames
+*************
+
 .. list-table::
     :header-rows: 1
     :widths: 50 50
@@ -50,24 +72,6 @@ when you need a scrubbed body.
 .. testoutput::
 
     Comets | article
-
-Scoring the content body of a full page -- navigation, a scored article, and a footer. :meth:`~turbohtml.Node.article`
-runs the same content-density heuristic in C and selects the live element; readability-lxml builds an lxml tree and
-rewrites it into a cleaned summary fragment. Numbers vary with input and hardware.
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 30 30
-
-    - - input
-      - turbohtml
-      - readability-lxml
-    - - post (4 KiB)
-      - 23 µs
-      - 1.26 ms (55x)
-    - - longform (16 KiB)
-      - 70 µs
-      - 2.54 ms (36x)
 
 **********
  Pitfalls

--- a/docs/migration/resiliparse.rst
+++ b/docs/migration/resiliparse.rst
@@ -16,57 +16,36 @@ text nodes, and it ships boilerplate extraction, language detection, and WARC ut
 
 resiliparse wraps lexbor's native parser; turbohtml has its own C engine and matches resiliparse's parse throughput,
 while returning a fully type annotated, mutable :class:`~turbohtml.Document` and folding resiliparse's DOM traversal,
-``get_element_by_*`` lookups, and CSS ``query_selector`` methods into one ``find``/``find_all``/``select`` grammar:
+``get_element_by_*`` lookups, and CSS ``query_selector`` methods into one ``find``/``find_all``/``select`` grammar.
+Parsing is a dead heat; on text extraction (``extract_plain_text`` against :meth:`~turbohtml.Node.to_text`, and its
+``main_content=True`` mode against :meth:`~turbohtml.Node.main_text`) turbohtml walks the WHATWG tree once in C where
+resiliparse renders off the lexbor tree in a second pass:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
-    - - parse
+    - - operation
       - turbohtml
       - resiliparse
-      - speed-up
-    - - wpt page (4 kB)
+    - - parse wpt page (4 kB)
       - 11.4 µs
-      - 12.7 µs
-      - 1.1x
-    - - wpt page (92 kB)
+      - 12.7 µs (1.1x)
+    - - parse wpt page (92 kB)
       - 272 µs
-      - 282 µs
-      - 1.0x
-    - - ecmascript spec (3 MB)
+      - 282 µs (1.0x)
+    - - parse ecmascript spec (3 MB)
       - 4.54 ms
-      - 5.35 ms
-      - 1.2x
-
-The parse table above is throughput only. resiliparse's ``extract_plain_text`` maps to :meth:`~turbohtml.Node.to_text`,
-and its ``main_content=True`` mode to :meth:`~turbohtml.Node.main_text`; both render text off the lexbor tree in a
-second pass, where turbohtml walks the WHATWG tree once in C:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - to text
-      - turbohtml
-      - resiliparse
-      - speed-up
-    - - article (2 KiB)
+      - 5.35 ms (1.2x)
+    - - to text, article (2 KiB)
       - 7 µs
-      - 23 µs
-      - 3.1x
-    - - table (4 KiB)
+      - 23 µs (3.1x)
+    - - to text, table (4 KiB)
       - 28 µs
-      - 52 µs
-      - 1.8x
+      - 52 µs (1.8x)
     - - main content (4 KiB)
       - 7 µs
-      - 21 µs
-      - 2.9x
-
-The ``main content`` row strips page boilerplate first (:meth:`~turbohtml.Node.main_text` against
-``extract_plain_text(main_content=True)``); resiliparse matches turbohtml on the raw parse but trails it on the text
-walk, where the layout runs natively rather than over the lexbor tree.
+      - 21 µs (2.9x)
 
 *************
  The renames

--- a/docs/migration/selectolax.rst
+++ b/docs/migration/selectolax.rst
@@ -16,72 +16,40 @@ mutation.
 
 turbohtml builds the same WHATWG tree but adds full static typing, the ``find``/``find_all`` filter grammar on top of
 CSS, a complete edit surface, and :attr:`~turbohtml.Node.text` as a property. Because selectolax wraps lexbor behind a
-heavier object layer, turbohtml's lighter native tree parses and serializes faster:
+heavier object layer, turbohtml's lighter native tree parses and serializes faster, drops a set of tags with their
+subtrees faster (:meth:`~turbohtml.Node.remove` against ``strip_tags``, over a 92 kB page of 839
+``<code>``/``<a>``/``<q>`` elements), and collects a node's visible text (:attr:`~turbohtml.Node.text` against
+selectolax's ``text()`` method) six to thirteen times faster, concatenating in one C pass where selectolax crosses the
+lexbor boundary per node:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
-    - - input
+    - - operation
       - turbohtml
       - selectolax
-      - speed-up
     - - parse wpt page (4 kB)
       - 11.4 µs
-      - 42.2 µs
-      - 3.7x
+      - 42.2 µs (3.7x)
     - - parse wpt page (92 kB)
       - 272 µs
-      - 917 µs
-      - 3.4x
+      - 917 µs (3.4x)
     - - serialize wpt page (92 kB)
       - 105 µs
-      - 339 µs
-      - 3.2x
-
-Dropping a set of tags together with their subtrees: selectolax's ``strip_tags`` against turbohtml's
-:meth:`~turbohtml.Node.remove`, over a 92 kB page holding 839 ``<code>``/``<a>``/``<q>`` elements. Both rewrites are
-destructive, so the timed call parses the page, drops every match, and serializes the result -- the string-to-result
-pass these helpers exist for. turbohtml's lighter native tree runs the whole pass three times faster:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 46 18 18 18
-
+      - 339 µs (3.2x)
     - - drop tags with content (92 kB)
-      - turbohtml
-      - selectolax
-      - speed-up
-    - - ``remove`` vs ``strip_tags``
       - 554 µs
-      - 1.73 ms
-      - 3.1x
-
-Collecting a node's visible text -- selectolax's ``text()`` method against turbohtml's :attr:`~turbohtml.Node.text`
-property -- over the wpt pages. Both walk the descendant text runs, but turbohtml concatenates them in one C pass into a
-buffer reserved up front, where selectolax crosses the lexbor boundary per node, so it runs six to thirteen times faster
-(``tox -e bench text``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 20 20 20
-
-    - - text content
-      - turbohtml
-      - selectolax
-      - speed-up
-    - - wpt page (4 kB)
+      - 1.73 ms (3.1x)
+    - - text content (4 kB)
       - 0.8 µs
-      - 5.2 µs
-      - 6.4x
-    - - wpt page (9.6 kB)
+      - 5.2 µs (6.4x)
+    - - text content (9.6 kB)
       - 1.1 µs
-      - 12.1 µs
-      - 11.4x
-    - - wpt page (92 kB)
+      - 12.1 µs (11.4x)
+    - - text content (92 kB)
       - 36.9 µs
-      - 488 µs
-      - 13.2x
+      - 488 µs (13.2x)
 
 *************
  The renames

--- a/docs/migration/stdlib.rst
+++ b/docs/migration/stdlib.rst
@@ -16,28 +16,23 @@ WHATWG-conformant where ``html.parser`` is not, and the whole surface is fully t
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - operation
       - turbohtml
       - standard library
-      - speed-up
     - - escape medium markup (4 KiB)
       - 2.27 µs
-      - 7.19 µs
-      - 3.2x
+      - 7.19 µs (3.2x)
     - - unescape medium dense refs (4 KiB)
       - 8.10 µs
-      - 69.3 µs
-      - 8.6x
+      - 69.3 µs (8.6x)
     - - tokenize typical markup
       - 34.9 µs
-      - 435 µs
-      - 12.5x
+      - 435 µs (12.5x)
     - - feed and dispatch wpt page (9.6 kB)
       - 82.1 µs
-      - 362 µs
-      - 4.4x
+      - 362 µs (4.4x)
 
 *********************
  Escape and unescape

--- a/docs/migration/trafilatura.rst
+++ b/docs/migration/trafilatura.rst
@@ -57,27 +57,23 @@ you need them, trafilatura's heavier language and date heuristics.
 
     Comets | Ada Lovelace | 2024-05-06 | en
 
-Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer -- measured with
-``tox -e bench article`` on CPython 3.14 (release build, Apple M4, macOS 26). :meth:`~turbohtml.Node.article` scores and
-harvests in one C pass over the parsed tree; trafilatura builds an lxml tree in Python first. Numbers vary with input
-and hardware.
+Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
+:meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; trafilatura builds an lxml tree
+in Python first. Numbers vary with input and hardware.
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
     - - input
       - turbohtml
       - trafilatura
-      - speed-up
     - - post (4 KiB)
       - 23 µs
-      - 1.34 ms
-      - 58x
+      - 1.34 ms (58x)
     - - longform (16 KiB)
       - 70 µs
-      - 3.13 ms
-      - 45x
+      - 3.13 ms (45x)
 
 ******************************
  Publication dates (htmldate)

--- a/docs/migration/trafilatura.rst
+++ b/docs/migration/trafilatura.rst
@@ -21,6 +21,28 @@ metadata* -- in one C pass over the parsed tree. It returns an :class:`~turbohtm
 inferring it. turbohtml works on HTML you already have, so pair it with a downloader (``urllib`` or ``httpx``) and, when
 you need them, trafilatura's heavier language and date heuristics.
 
+Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
+:meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; trafilatura builds an lxml tree
+in Python first. Numbers vary with input and hardware.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 30 30
+
+    - - input
+      - turbohtml
+      - trafilatura
+    - - post (4 KiB)
+      - 23 µs
+      - 1.34 ms (58x)
+    - - longform (16 KiB)
+      - 70 µs
+      - 3.13 ms (45x)
+
+*************
+ The renames
+*************
+
 .. list-table::
     :header-rows: 1
     :widths: 50 50
@@ -56,24 +78,6 @@ you need them, trafilatura's heavier language and date heuristics.
 .. testoutput::
 
     Comets | Ada Lovelace | 2024-05-06 | en
-
-Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
-:meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; trafilatura builds an lxml tree
-in Python first. Numbers vary with input and hardware.
-
-.. list-table::
-    :header-rows: 1
-    :widths: 40 30 30
-
-    - - input
-      - turbohtml
-      - trafilatura
-    - - post (4 KiB)
-      - 23 µs
-      - 1.34 ms (58x)
-    - - longform (16 KiB)
-      - 70 µs
-      - 3.13 ms (45x)
 
 ******************************
  Publication dates (htmldate)

--- a/docs/migration/w3lib.rst
+++ b/docs/migration/w3lib.rst
@@ -15,68 +15,38 @@ canonicalization, and response-encoding helpers. Only its ``w3lib.html`` text/en
 ***************
 
 :func:`turbohtml.unescape` resolves the same character references w3lib's regex-based ``replace_entities`` does, fully
-type annotated and running the scan in C, so it is a drop-in that runs several times faster on entity-heavy input:
+type annotated and running the scan in C, so it is a drop-in that runs several times faster on entity-heavy input. Two
+more ``w3lib.html`` helpers map onto the WHATWG tree: stripping a set of tags while keeping their text
+(:meth:`~turbohtml.Node.strip_tags` against the regex ``remove_tags``, over a 92 kB page of 839
+``<code>``/``<a>``/``<q>`` elements) and reading a document's own URL hints (:meth:`~turbohtml.Document.base_url` and
+:meth:`~turbohtml.Document.meta_refresh` against ``get_base_url`` and ``get_meta_refresh``), each a structure-aware pass
+that still beats the regex:
 
 .. list-table::
     :header-rows: 1
-    :widths: 40 20 20 20
+    :widths: 40 30 30
 
-    - - unescape
+    - - operation
       - turbohtml
       - w3lib
-      - speed-up
-    - - tiny plain (64 B)
+    - - unescape tiny plain (64 B)
       - 0.02 µs
-      - 0.25 µs
-      - 12.4x
-    - - medium dense refs (4 KiB)
+      - 0.25 µs (12.4x)
+    - - unescape medium dense refs (4 KiB)
       - 8.10 µs
-      - 116 µs
-      - 14.3x
-    - - book HTML, real refs (4 MiB)
+      - 116 µs (14.3x)
+    - - unescape book HTML, real refs (4 MiB)
       - 2.51 ms
-      - 13.5 ms
-      - 5.4x
-
-Stripping a set of tags while keeping their text: w3lib's regex ``remove_tags`` against turbohtml's
-:meth:`~turbohtml.Node.strip_tags`, over a 92 kB page holding 839 ``<code>``/``<a>``/``<q>`` elements. w3lib runs a
-regular-expression substitution over the string; turbohtml builds the WHATWG tree, unwraps each match in place, and
-serializes. turbohtml does the structure-aware pass a regex misreads on nested markup, and still runs it faster:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 46 18 18 18
-
+      - 13.5 ms (5.4x)
     - - strip tags, keep text (92 kB)
-      - turbohtml
-      - w3lib
-      - speed-up
-    - - ``strip_tags`` vs ``remove_tags``
       - 607 µs
-      - 1.11 ms
-      - 1.8x
-
-Reading a document's own URL hints: w3lib's ``get_base_url`` and ``get_meta_refresh`` against
-:meth:`~turbohtml.Document.base_url` and :meth:`~turbohtml.Document.meta_refresh`. Both parse the string each call, over
-a small page carrying a ``<base>`` and a meta refresh. w3lib runs a regular-expression pass; turbohtml runs the WHATWG
-tree builder and reads the hint off the parsed ``<head>``, and still comes out ahead (``tox -e bench extract``):
-
-.. list-table::
-    :header-rows: 1
-    :widths: 46 18 18 18
-
-    - - url hint
-      - turbohtml
-      - w3lib
-      - speed-up
-    - - ``base_url`` vs ``get_base_url``
+      - 1.11 ms (1.8x)
+    - - ``base_url`` (vs ``get_base_url``)
       - 2.9 µs
-      - 7.4 µs
-      - 2.6x
-    - - ``meta_refresh`` vs ``get_meta_refresh``
+      - 7.4 µs (2.6x)
+    - - ``meta_refresh`` (vs ``get_meta_refresh``)
       - 3.0 µs
-      - 6.5 µs
-      - 2.1x
+      - 6.5 µs (2.1x)
 
 *************
  The renames

--- a/docs/migration/yattag.rst
+++ b/docs/migration/yattag.rst
@@ -54,7 +54,7 @@ rows -- a class, a ``data`` attribute, and a text child apiece -- built both way
 and re-:meth:`~turbohtml.Node.serialize`.
 
 *************
- The mapping
+ The renames
 *************
 
 yattag opens a tag scope with a context manager; turbohtml builds children inline:

--- a/docs/migration/yattag.rst
+++ b/docs/migration/yattag.rst
@@ -33,12 +33,11 @@ parse it back:
     <div class="card"><h1>Title</h1><p>body</p></div>
 
 ``E`` assembles the fragment in turbohtml's arena and serializes it in C; yattag stays in Python. The same ``<ul>`` of
-rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways, from ``tox -e bench build-e`` on the
-reference machine in :doc:`/development/performance`:
+rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
 
 .. list-table::
     :header-rows: 1
-    :widths: 34 33 33
+    :widths: 40 30 30
 
     - - build a list
       - :data:`E <turbohtml.build.E>`


### PR DESCRIPTION
The migration guides had drifted into inconsistent shapes: some carried one performance table, others several broken-down ones; `metadata_parser` kept a dedicated `Performance` section while the rest folded timings into `Why turbohtml`; the builder guides titled their mapping section `The mapping` against everyone else's `The renames`; and a few article guides hid their rename table inside `Why turbohtml`. 📝 A reader moving between guides met a different structure each time.

Every guide now follows one layout. `Why turbohtml` carries the rationale and a single performance table; a separate `The renames` section holds the mapping and its example. The performance tables share one format with the speed-up merged inline into the competitor cell as `(N.Nx)` rather than living in its own column, and the multi-table guides (`beautifulsoup`, `lxml`, `pyquery`, `w3lib`, `selectolax`, and others) collapse to a single table covering parse, query, edit, and text in one place. ✨

All maintainer-only reproduction notes are gone: the `tox -e bench ...` invocations, the "reference machine" phrasing, and the CPython/hardware clauses, since they spoke to whoever regenerates the numbers rather than to someone porting code. The `/development/performance` cross-links stay where they read naturally. Numbers reflect the freelist and DATA-scan optimizations from #308 and #309.