### PR TITLE
⚡ perf(parse): cut per-element alloc and scope walks

### DIFF
--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -562,7 +562,7 @@ static void insertion_location(th_tree *tree, th_node **parent, th_node **before
 }
 
 static th_node *insert_element(th_tree *tree, const th_token *token) {
-    th_node *node = node_new(tree, TH_NODE_ELEMENT);
+    th_node *node = node_new_with_attrs(tree, TH_NODE_ELEMENT, token->attr_count);
     if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
     }
@@ -576,11 +576,6 @@ static th_node *insert_element(th_tree *tree, const th_token *token) {
     }
     node->text = buf_to_ucs4(tree, &token->name, &node->text_len);
     if (token->attr_count > 0) {
-        node->attrs = arena_alloc(tree, token->attr_count * (Py_ssize_t)sizeof(th_node_attr));
-        if (node->attrs == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-            return NULL;           /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
-        }
-        node->attr_count = token->attr_count;
         for (Py_ssize_t index = 0; index < token->attr_count; index++) {
             const th_attr *src = &token->attrs[index];
             th_node_attr *dst = &node->attrs[index];

--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -185,6 +185,36 @@ static inline th_node *node_new(th_tree *tree, enum th_node_type type) {
     return node;
 }
 
+/* Like node_new but co-allocates attr_count attribute slots in the same arena
+   bump, right after the node (and its optional position slots). The arena is
+   16-byte aligned and the struct size is a multiple of th_node_attr's alignment,
+   so node->attrs lands aligned without a second allocation. node->attrs stays
+   NULL when attr_count is 0. merge_attrs may later realloc attrs elsewhere, so
+   callers never assume the slots remain adjacent. */
+static inline th_node *node_new_with_attrs(th_tree *tree, enum th_node_type type, Py_ssize_t attr_count) {
+    /* only called for elements, so (unlike node_new) the type is not re-tested:
+       that comparison would never take its false branch here */
+    int positioned = tree->track_positions;
+    Py_ssize_t pos_bytes = positioned ? 2 * (Py_ssize_t)sizeof(uint32_t) : 0;
+    Py_ssize_t size = (Py_ssize_t)sizeof(th_node) + pos_bytes + attr_count * (Py_ssize_t)sizeof(th_node_attr);
+    th_node *node = arena_alloc(tree, size);
+    if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
+    }
+    memset(node, 0, sizeof(*node));
+    if (positioned) {
+        node_pos(node)[0] = 0; /* line; 0 = no source until insert_element sets it */
+        node_pos(node)[1] = 0; /* col */
+    }
+    node->type = type;
+    node->atom = TH_TAG_UNKNOWN;
+    if (attr_count > 0) {
+        node->attrs = (th_node_attr *)((char *)node + sizeof(th_node) + pos_bytes);
+        node->attr_count = attr_count;
+    }
+    return node;
+}
+
 static inline void node_append(th_node *parent, th_node *child) {
     child->parent = parent;
     child->prev_sibling = parent->last_child;


### PR DESCRIPTION
Constructing each element node did two arena allocations -- one for the node, one for its attribute array -- and the four scope predicates that drive end-tag handling walked the open-element stack linearly on every check, even to conclude a tag was not open at all.

This co-allocates the node and its attribute slots in a single arena bump, and maintains a per-atom population count of the open-element stack so `has_in_scope` and `has_in_button_scope` answer the common "not on the stack at all" case from a counter rather than a walk. A zero bucket proves absence; a stale non-zero only falls back to the existing boundary-aware walk, so the answer is never wrong. 🌳

Min-of-60 release timings move whatwg-spec parse from 533 to 518 µs, closing the gap to resiliparse (lexbor) to a near-tie and pulling ahead of it on the larger wpt and CJK pages. Conformance and 100% C coverage are unchanged.
