### PR TITLE
⚡ perf(find): match literal text= filters in C

### DIFF
--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -747,10 +747,11 @@ relational lookup keeps the same interned-atom comparison the flat selectors use
 
 A text-content search runs through :meth:`~turbohtml.Node.find_all` with ``text=`` (a regex matched against each
 element's collected subtree text), raced against ``BeautifulSoup.find_all(string=...)``; lxml, selectolax, and parsel
-expose no equivalent, so this is a two-way race. The predicate runs Python mid-walk, so turbohtml gathers each
-candidate's text in C and searches once, but on real pages the Python regex over every element's collected text
-dominates both sides and the two run within a small margin: turbohtml leads on the blog and the spec, ties on the
-mozilla page, and trails slightly on the news article.
+expose no equivalent, so this is a two-way race. When the ``text=`` filter is a plain string or a literal (no regex
+metacharacters, case-sensitive) compiled pattern, turbohtml gathers each candidate's collected text and matches it in C
+-- no Python ``str`` built, no per-element ``re.search`` call -- where BeautifulSoup's ``find_all(string=...)`` walks
+the tree in Python, so turbohtml now leads on every page (it previously trailed on the larger ones). A case-insensitive
+or otherwise non-literal pattern keeps the per-element Python path.
 
 .. list-table::
     :header-rows: 1
@@ -761,21 +762,21 @@ mozilla page, and trails slightly on the news article.
       - BeautifulSoup
       - speed-up
     - - daring fireball (10 kB)
-      - 42.5 µs
+      - 36.0 µs
       - 55.6 µs
-      - 1.3x
+      - 1.5x
     - - ars technica (56 kB)
-      - 250.7 µs
+      - 203 µs
       - 219.0 µs
-      - 0.9x
+      - 1.1x
     - - mozilla blog (95 kB)
-      - 455.4 µs
+      - 321 µs
       - 465.0 µs
-      - 1.0x
-    - - whatwg spec (235 kB)
-      - 1173 µs
-      - 1698 µs
       - 1.4x
+    - - whatwg spec (235 kB)
+      - 731 µs
+      - 1698 µs
+      - 2.3x
 
 XPath 1.0 evaluation runs through :meth:`~turbohtml.Node.xpath`, raced against lxml's libxml2 engine, the XPath that
 parsel, pyquery, and html5-parser all wrap (selectolax and BeautifulSoup have none). One expression per feature class

--- a/docs/migration/beautifulsoup.rst
+++ b/docs/migration/beautifulsoup.rst
@@ -40,15 +40,18 @@ to two orders of magnitude faster than BeautifulSoup over ``html.parser`` -- inc
     - - serialize wpt page (92 kB)
       - 105 µs
       - 5.95 ms (56.8x)
-    - - find ``text=`` regex (4 kB)
-      - 9.3 µs
-      - 19.7 µs (2.1x)
-    - - find ``text=`` regex (9.6 kB)
-      - 13.9 µs
-      - 38.2 µs (2.7x)
-    - - find ``text=`` regex (92 kB)
-      - 741 µs
-      - 989 µs (1.3x)
+    - - find ``text=`` regex (daring fireball, 10 kB)
+      - 36.0 µs
+      - 55.6 µs (1.5x)
+    - - find ``text=`` regex (ars technica, 56 kB)
+      - 203 µs
+      - 219.0 µs (1.1x)
+    - - find ``text=`` regex (mozilla blog, 95 kB)
+      - 321 µs
+      - 465.0 µs (1.4x)
+    - - find ``text=`` regex (whatwg spec, 235 kB)
+      - 731 µs
+      - 1698 µs (2.3x)
     - - walk descendants (4 kB)
       - 1.3 µs
       - 2.7 µs (2.1x)

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -221,6 +221,10 @@ Py_UCS4 *th_node_data(th_tree *tree, th_node *node, Py_ssize_t *out_len);
    order. PyMem-allocated; *out_len receives the length. NULL on failure. */
 Py_UCS4 *th_node_text(th_tree *tree, th_node *node, Py_ssize_t *out_len);
 
+/* Gather node's concatenated descendant text into a caller-sized, reusable UCS4
+   buffer (no allocation, no str), for the find(text=) literal/exact C scan. */
+void th_node_collect_text(th_tree *tree, th_node *node, Py_UCS4 *buf);
+
 /* Serialize node and its subtree as HTML (the WHATWG fragment serialization).
    For the document node this is the whole-document markup. PyMem-allocated;
    *out_len receives the length. NULL on failure. */

--- a/src/turbohtml/_c/query/find/find.c
+++ b/src/turbohtml/_c/query/find/find.c
@@ -3,6 +3,13 @@
 
 #include "dom/nodes.h"
 
+/* How the text= predicate is evaluated. A plain str matches the whole collected
+   text exactly and a literal (metacharacter-free, case-sensitive) regex matches a
+   substring of it, both decided in C against the gathered code points with no str
+   built and no Python call per element. Every other predicate (a non-literal regex,
+   a callable, a list) keeps the Python path that snapshots candidates under the lock. */
+enum th_text_scan { TH_TEXT_PY = 0, TH_TEXT_EQ, TH_TEXT_SUBSTR };
+
 /* A compiled find()/find_all() query: the tag and class_ filters, the resolved
    (atom, filter) pairs for the named attribute filters, the axis to search, and
    the result cap. Every filter PyObject is borrowed from the live call. */
@@ -10,6 +17,11 @@ typedef struct {
     PyObject *tag;          /* tag filter, or NULL for no tag constraint */
     PyObject *class_filter; /* class_ filter, or NULL */
     PyObject *text;         /* text predicate over each element's collected text, or NULL */
+    /* When the text predicate is a pure-C scan, text_scan is TH_TEXT_EQ/SUBSTR and
+       text_needle holds the expected/needle code points; otherwise TH_TEXT_PY. */
+    enum th_text_scan text_scan;
+    Py_UCS4 *text_needle;
+    Py_ssize_t text_needle_len;
     enum th_axis axis;
     Py_ssize_t limit; /* -1 for unlimited */
     uint32_t *atoms;  /* resolved name atoms for the attribute filters */
@@ -35,6 +47,7 @@ static void free_query(query_t *query) {
     PyMem_Free(query->filters);
     PyMem_Free(query->filter_plain);
     PyMem_Free(query->class_ucs4);
+    PyMem_Free(query->text_needle);
 }
 
 /* Whether a node's UCS4 value equals a str filter's code points, with no
@@ -332,6 +345,74 @@ static int is_reserved_key(PyObject *key, int is_find_all) {
            (is_find_all && PyUnicode_CompareWithASCIIString(key, "limit") == 0);
 }
 
+/* The re flag bits that keep a pattern off the literal fast path: IGNORECASE folds
+   case (the C scan is case-sensitive) and VERBOSE drops whitespace and starts # to
+   end-of-line comments, so a "literal-looking" verbose source is not literal. */
+#define TH_RE_IGNORECASE 2
+#define TH_RE_VERBOSE 64
+
+/* Whether a code point is a Python regex metacharacter; a source free of these and
+   not case-insensitive or verbose matches exactly as a literal substring. */
+static int is_regex_meta(Py_UCS4 character) {
+    static const char meta[] = ".^$*+?{}[]\\|()";
+    return character < 0x80 && memchr(meta, (int)character, sizeof(meta) - 1) != NULL;
+}
+
+/* When the text predicate reduces to a pure-C scan, record its needle on the query
+   so each candidate is tested against the gathered code points with no str built.
+   A plain str is an exact match; a literal compiled regex is a substring match.
+   Leaves text_scan TH_TEXT_PY for everything else. Returns -1 with an exception set
+   only on a (test-unreachable) allocation failure. */
+static int classify_text(module_state *state, query_t *query) {
+    if (PyUnicode_Check(query->text)) {
+        query->text_needle = PyUnicode_AsUCS4Copy(query->text);
+        if (query->text_needle == NULL) { /* GCOVR_EXCL_BR_LINE: allocation cannot be forced from a test */
+            return -1;                    /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        query->text_needle_len = PyUnicode_GET_LENGTH(query->text);
+        query->text_scan = TH_TEXT_EQ;
+        return 0;
+    }
+    if (!PyObject_TypeCheck(query->text, (PyTypeObject *)state->pattern_type)) {
+        return 0;
+    }
+    PyObject *source = PyObject_GetAttrString(query->text, "pattern");
+    if (source == NULL) { /* GCOVR_EXCL_BR_LINE: a Pattern always has .pattern */
+        return -1;        /* GCOVR_EXCL_LINE: attribute-error path */
+    }
+    if (!PyUnicode_Check(source)) { /* a bytes pattern never matches a str value */
+        Py_DECREF(source);
+        return 0;
+    }
+    PyObject *flags_obj = PyObject_GetAttrString(query->text, "flags");
+    if (flags_obj == NULL) { /* GCOVR_EXCL_BR_LINE: a Pattern always has .flags */
+        Py_DECREF(source);   /* GCOVR_EXCL_LINE: attribute-error path */
+        return -1;           /* GCOVR_EXCL_LINE: attribute-error path */
+    }
+    long flags = PyLong_AsLong(flags_obj); /* a RegexFlag is a small int; no overflow */
+    Py_DECREF(flags_obj);
+    Py_ssize_t len = PyUnicode_GET_LENGTH(source);
+    int kind = PyUnicode_KIND(source);
+    const void *data = PyUnicode_DATA(source);
+    int literal = (flags & (TH_RE_IGNORECASE | TH_RE_VERBOSE)) == 0;
+    for (Py_ssize_t index = 0; literal && index < len; index++) {
+        if (is_regex_meta(PyUnicode_READ(kind, data, index))) {
+            literal = 0;
+        }
+    }
+    if (literal) {
+        query->text_needle = PyUnicode_AsUCS4Copy(source);
+        if (query->text_needle == NULL) { /* GCOVR_EXCL_BR_LINE: allocation cannot be forced from a test */
+            Py_DECREF(source);            /* GCOVR_EXCL_LINE: allocation-failure path */
+            return -1;                    /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        query->text_needle_len = len;
+        query->text_scan = TH_TEXT_SUBSTR;
+    }
+    Py_DECREF(source);
+    return 0;
+}
+
 /* Compile the (tag, axis, class_, attrs, limit, **filters) arguments. Always
    leaves query in a free_query-safe state, even on error. */
 static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_find_all, query_t *query) {
@@ -340,6 +421,9 @@ static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_
     query->tag = NULL;
     query->class_filter = NULL;
     query->text = NULL;
+    query->text_scan = TH_TEXT_PY;
+    query->text_needle = NULL;
+    query->text_needle_len = 0;
     query->axis = TH_AXIS_DESCENDANTS;
     query->limit = -1;
     query->atoms = NULL;
@@ -442,6 +526,9 @@ static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_
             return -1;
         }
     }
+    if (query->text != NULL && classify_text(state, query) < 0) { /* GCOVR_EXCL_BR_LINE: only on alloc failure */
+        return -1;                                                /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
     return 0;
 }
 
@@ -536,6 +623,130 @@ static int snapshot_text_candidates(PyObject *self, const query_t *query, th_nod
     return error ? -1 : 0;
 }
 
+/* The total length of every descendant Text node of node, without realizing any
+   span, so a candidate's collected text is sized before it is gathered. */
+static Py_ssize_t subtree_text_len(th_node *node) {
+    Py_ssize_t total = 0;
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type == TH_NODE_TEXT) {
+            total += child->text_len;
+        } else if (child->type == TH_NODE_ELEMENT || child->type == TH_NODE_CONTENT) {
+            total += subtree_text_len(child);
+        }
+    }
+    return total;
+}
+
+/* Whether needle's code points occur as a contiguous run in hay (the literal-regex
+   substring test, mirroring re.search over a metacharacter-free pattern). */
+static int ucs4_contains(const Py_UCS4 *hay, Py_ssize_t hay_len, const Py_UCS4 *needle, Py_ssize_t needle_len) {
+    for (Py_ssize_t start = 0; start + needle_len <= hay_len; start++) {
+        Py_ssize_t index = 0;
+        while (index < needle_len && hay[start + index] == needle[index]) {
+            index++;
+        }
+        if (index == needle_len) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Grow scratch to hold at least need code points, reusing it across candidates so
+   one buffer serves the whole walk. */
+static int scratch_ensure(Py_UCS4 **scratch, Py_ssize_t *cap, Py_ssize_t need) {
+    if (need <= *cap) {
+        return 0;
+    }
+    Py_UCS4 *grown = PyMem_Realloc(*scratch, (size_t)need * sizeof(Py_UCS4));
+    if (grown == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    *scratch = grown;
+    *cap = need;
+    return 0;
+}
+
+/* Test one candidate's collected text against the C-scan predicate without building
+   a str: an exact length+content match for TH_TEXT_EQ, a substring search for
+   TH_TEXT_SUBSTR. Returns 1/0, or -1 on a (test-unreachable) allocation failure. */
+static int text_scan_matches(th_tree *tree, th_node *node, const query_t *query, Py_UCS4 **scratch, Py_ssize_t *cap) {
+    Py_ssize_t text_len = subtree_text_len(node);
+    if (query->text_scan == TH_TEXT_EQ && text_len != query->text_needle_len) {
+        return 0;
+    }
+    if (scratch_ensure(scratch, cap, text_len) < 0) { /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+        return -1;                                    /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    th_node_collect_text(tree, node, *scratch);
+    if (query->text_scan == TH_TEXT_EQ) {
+        return text_len == 0 || memcmp(*scratch, query->text_needle, (size_t)text_len * sizeof(Py_UCS4)) == 0;
+    }
+    return ucs4_contains(*scratch, text_len, query->text_needle, query->text_needle_len);
+}
+
+/* The text= search when the predicate is a pure-C scan (an exact str or a literal
+   regex). The collected text never becomes a Python str and no Python runs per
+   element, so the whole walk stays inside the lock. node_matches applies the
+   structural filters first, exactly as the non-text path does. */
+static PyObject *find_with_text_scan(PyObject *self, const query_t *query, int want_all) {
+    module_state *state = state_of(self);
+    PyObject *handle = ((NodeObject *)self)->handle;
+    th_node *origin = ((NodeObject *)self)->node;
+    th_tree *tree = tree_of(self);
+    PyObject *result = NULL;
+    if (want_all) {
+        result = PyList_New(0);
+        if (result == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    th_node *found = NULL;
+    int error = 0;
+    Py_UCS4 *scratch = NULL;
+    Py_ssize_t scratch_cap = 0;
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    for (th_node *node = axis_first(origin, query->axis); node != NULL; node = axis_next(node, origin, query->axis)) {
+        if (want_all && query->limit >= 0 && PyList_GET_SIZE(result) >= query->limit) {
+            break;
+        }
+        int matched = node_matches(state, node, query);
+        if (matched < 0) {
+            error = 1;
+            break;
+        }
+        if (matched == 0) {
+            continue;
+        }
+        int passed = text_scan_matches(tree, node, query, &scratch, &scratch_cap);
+        if (passed < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            error = 1;    /* GCOVR_EXCL_LINE: allocation-failure path */
+            break;        /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        if (passed == 0) {
+            continue;
+        }
+        if (!want_all) {
+            found = node;
+            break;
+        }
+        if (append_wrapped(result, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: allocation cannot fail */
+            error = 1;                                         /* GCOVR_EXCL_LINE: allocation-failure path */
+            break;                                             /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    Py_END_CRITICAL_SECTION();
+    PyMem_Free(scratch);
+    if (error) {
+        Py_XDECREF(result);
+        return NULL;
+    }
+    if (want_all) {
+        return result;
+    }
+    return node_wrap(state, handle, found);
+}
+
 /* Search along the axis for elements whose collected text satisfies the text
    predicate, composed with the tag, class, and attribute filters. The predicate
    (a str, compiled regex, or callable) runs over the snapshot taken under the lock;
@@ -544,6 +755,9 @@ static int snapshot_text_candidates(PyObject *self, const query_t *query, th_nod
    the tree. Returns the first match (want_all 0, None when nothing matches) or the
    list of matches up to the limit (want_all 1). */
 static PyObject *find_with_text(PyObject *self, const query_t *query, int want_all) {
+    if (query->text_scan != TH_TEXT_PY) {
+        return find_with_text_scan(self, query, want_all);
+    }
     module_state *state = state_of(self);
     PyObject *handle = ((NodeObject *)self)->handle;
     th_node **nodes;

--- a/src/turbohtml/_c/serialize/document.c
+++ b/src/turbohtml/_c/serialize/document.c
@@ -472,6 +472,26 @@ Py_UCS4 *th_node_text(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
     return sbuf_finish(&out, out_len);
 }
 
+/* Copy every descendant Text node's code points of node into buf at pos, realizing
+   zero-copy spans on the way; the caller sizes buf to the subtree's text length.
+   The find(text=) C scan reuses one buffer across candidates so no per-node str is
+   built; a Text or Content child of a content fragment is descended like an element. */
+static Py_ssize_t collect_text_into(th_tree *tree, th_node *node, Py_UCS4 *buf, Py_ssize_t pos) {
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type == TH_NODE_TEXT) {
+            memcpy(buf + pos, need_text(tree, child), (size_t)child->text_len * sizeof(Py_UCS4));
+            pos += child->text_len;
+        } else if (child->type == TH_NODE_ELEMENT || child->type == TH_NODE_CONTENT) {
+            pos = collect_text_into(tree, child, buf, pos);
+        }
+    }
+    return pos;
+}
+
+void th_node_collect_text(th_tree *tree, th_node *node, Py_UCS4 *buf) {
+    collect_text_into(tree, node, buf, 0);
+}
+
 /* The WHATWG-conformant defaults the html/inner_html accessors serialize under:
    minimal escaping, source attribute order, no charset injection. */
 static const th_serialize_opts ser_default_opts = {TH_FMT_WHATWG, 0, 0, NULL, 0};

--- a/tests/query/find/test_tree_find.py
+++ b/tests/query/find/test_tree_find.py
@@ -485,3 +485,144 @@ def test_text_limit(limit: int | None, count: int) -> None:
 def test_text_callable_error_propagates(query: Callable[[Document], object]) -> None:
     with pytest.raises(ZeroDivisionError):
         query(parse(_TEXT_DOC))
+
+
+# A metacharacter-free, case-sensitive regex is a plain literal: the C side searches each
+# candidate's collected text for the substring directly, never building a str or calling
+# back into Python. A literal regex matches a substring (unlike a plain str, which is the
+# whole collected text), so "now" matches both the <p> wrapper and the <b> leaf.
+@pytest.mark.parametrize(
+    ("html", "text_filter", "tags"),
+    [
+        pytest.param(
+            "<section><p>Buy <b>now</b></p></section>", re.compile(r"now"), ["p", "b"], id="literal-substring"
+        ),
+        # the needle is longer than every candidate's collected text, so nothing matches
+        pytest.param(
+            "<section><p>Buy <b>now</b></p></section>", re.compile(r"Buynow"), [], id="literal-longer-than-text"
+        ),
+        # a literal can mismatch partway in before matching at a later offset
+        pytest.param(
+            "<section><p>no not now</p></section>", re.compile(r"now"), ["p"], id="literal-partial-then-match"
+        ),
+        # a non-ASCII literal stays literal (no byte is a metacharacter)
+        pytest.param("<section><p>at the café</p></section>", re.compile(r"café"), ["p"], id="literal-non-ascii"),
+    ],
+)
+def test_text_literal_regex_searches_substring(html: str, text_filter: re.Pattern[str], tags: list[str]) -> None:
+    section = _el(parse(html).find("section"))
+    assert _tags(section.find_all(text=text_filter)) == tags
+
+
+def test_text_literal_regex_find_returns_first() -> None:
+    section = _el(parse("<section><p>a</p><p>now</p></section>").find("section"))
+    assert _el(section.find(text=re.compile(r"now"))).tag == "p"
+    assert section.find(text=re.compile(r"absent")) is None
+
+
+# A case-insensitive or verbose pattern is not a literal even with no metacharacters, so it
+# keeps the Python search path: IGNORECASE folds case and VERBOSE drops whitespace, both of
+# which a byte-for-byte C scan would get wrong.
+@pytest.mark.parametrize(
+    ("text_filter", "html", "tags"),
+    [
+        pytest.param(re.compile(r"buy", re.IGNORECASE), "<section><p>Buy now</p></section>", ["p"], id="ignorecase"),
+        pytest.param(re.compile(r"a b", re.VERBOSE), "<section><p>ab</p></section>", ["p"], id="verbose"),
+    ],
+)
+def test_text_regex_flags_keep_python_path(text_filter: re.Pattern[str], html: str, tags: list[str]) -> None:
+    section = _el(parse(html).find("section"))
+    assert _tags(section.find_all(text=text_filter)) == tags
+
+
+def test_text_scan_descends_into_template_content() -> None:
+    # a template's children live under a content fragment, which the text scan must descend into
+    matches = _tags(parse("<template>inner</template>").find_all(text="inner"))
+    assert "template" in matches
+
+
+def test_text_scan_skips_non_text_children() -> None:
+    # the gathered text concatenates only Text descendants, so a comment between them drops out
+    matches = _tags(parse("<div>a<!--c-->b</div>").find_all(text="ab"))
+    assert "div" in matches
+
+
+def test_text_bytes_pattern_raises() -> None:
+    # a bytes pattern cannot search a str value; this matches the pre-existing behavior
+    with pytest.raises(TypeError):
+        parse("<p>test</p>").find_all(text=re.compile(rb"test"))  # ty: ignore[invalid-argument-type]
+
+
+def test_text_empty_string_matches_textless_element() -> None:
+    section = _el(parse("<section><br></section>").find("section"))
+    assert _tags(section.find_all(text="")) == ["br"]
+
+
+def test_text_equal_length_different_content_does_not_match() -> None:
+    # both are three code points, so the length gate passes and the content compare decides
+    assert parse("<p>abc</p>").find_all(text="xyz") == []
+
+
+# A non-literal regex keeps the Python path that snapshots candidates under the lock, where the
+# structural filters compose the same way: the C prefilter skips by plain tag/class, then
+# node_matches re-checks (and can reject) before the regex runs over the gathered text.
+@pytest.mark.parametrize(
+    ("html", "query", "tags"),
+    [
+        pytest.param(
+            "<button>go9</button><p>go9</p>",
+            lambda doc: doc.find_all("button", text=re.compile(r"go\d")),
+            ["button"],
+            id="plain-tag-prefilter",
+        ),
+        pytest.param(
+            '<button class="buy">go9</button><button>go9</button>',
+            lambda doc: doc.find_all(class_="buy", text=re.compile(r"go\d")),
+            ["button"],
+            id="plain-class-prefilter",
+        ),
+        pytest.param(
+            "<button>go9</button><p>go9</p>",
+            lambda doc: doc.find_all(re.compile(r"^button$"), text=re.compile(r"go\d")),
+            ["button"],
+            id="regex-tag-rechecked",
+        ),
+        # a custom-element tag has no known atom, so the prefilter defers to node_matches
+        pytest.param(
+            "<my-widget>go9</my-widget><my-widget>stop</my-widget>",
+            lambda doc: doc.find_all("my-widget", text=re.compile(r"go\d")),
+            ["my-widget"],
+            id="custom-element-tag-prefilter",
+        ),
+        # a known tag absent from the tree leaves zero candidates before any text is gathered
+        pytest.param(
+            "<p>go9</p>",
+            lambda doc: doc.find_all("table", text=re.compile(r"go\d")),
+            [],
+            id="no-candidate",
+        ),
+    ],
+)
+def test_text_python_path_composes_with_structural_filter(
+    html: str, query: Callable[[Document], list[Element]], tags: list[str]
+) -> None:
+    assert _tags(query(parse(html))) == tags
+
+
+def test_text_python_path_limit_caps_results() -> None:
+    # a non-literal regex exercises the snapshot path's own result cap
+    matches = parse("<p>go9</p><p>go9</p><p>go9</p>").find_all(text=re.compile(r"go\d"), limit=2)
+    assert len(matches) == 2
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # a structural callable raises during the snapshot pass, alongside a Python-path regex
+        pytest.param(lambda doc: doc.find_all(text=re.compile(r"g\w"), id=_raise), id="structural-find-all-regex"),
+        pytest.param(lambda doc: doc.find(text=re.compile(r"g\w"), id=_raise), id="structural-find-regex"),
+    ],
+)
+def test_text_python_path_structural_error_propagates(query: Callable[[Document], object]) -> None:
+    with pytest.raises(ZeroDivisionError):
+        query(parse(_TEXT_DOC))


### PR DESCRIPTION
A `find()`/`find_all()` `text=` filter ran Python for every candidate element: it built a `str` of the element's collected subtree text and called `re.Pattern.search` on it, so a search that matched nothing still paid a Python round-trip per node, and on larger pages it trailed BeautifulSoup.

When the filter is a plain string or a literal (metacharacter-free, case-sensitive) compiled regex, the match now happens entirely in C: each candidate's text is gathered into one reused buffer and scanned for an exact match or substring, with no `str` built and no `search` call. 🔍 Case-insensitive, verbose, bytes, and other non-literal patterns keep the existing path.

A literal `find_all(text=...)` now leads BeautifulSoup on every page of the read-path corpus, where it previously trailed on the larger ones.
