### PR TITLE
♻️ refactor: config objects for over-stuffed method signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,18 @@ Parse a document, query it with a CSS selector, and serialize a node back to HTM
 
 ```python
 import turbohtml
-from turbohtml import Formatter
+from turbohtml import Formatter, Html
 
 doc = turbohtml.parse("<article><h1>Tea</h1><p class=note>café &amp; cake</p></article>")
 print([h.text for h in doc.find_all("h1")])  # ['Tea']
 print(doc.select_one("p.note").text)  # café & cake
-print(doc.select_one("p").serialize(formatter=Formatter.NAMED_ENTITIES))
+print(doc.select_one("p").serialize(Html(formatter=Formatter.NAMED_ENTITIES)))
 # <p class="note">caf&eacute; &amp; cake</p>
 ```
+
+Each renderer takes one configuration object — `Html` for `serialize`/`encode`, `Markdown` for `to_markdown`, and
+`PlainText` for `to_text`/`to_annotated_text` — instead of a long keyword list, so options stay grouped and
+discoverable.
 
 turbohtml models text as real child nodes following the WHATWG DOM shape, so `node[i]` indexes children and attributes
 are reached through `node.attrs`.
@@ -44,11 +48,11 @@ are reached through `node.attrs`.
 | Tokenize          | `tokenize`, `Tokenizer` — WHATWG streaming tokenizer with incremental `feed`/`close`                   |
 | Parse             | `parse`, `parse_fragment`, `IncrementalParser` — encoding sniffing and source positions                |
 | Query             | `find`/`find_all`, CSS `select`/`select_one`, XPath `xpath`/`xpath_one`                                |
-| Serialize         | `serialize` with `Formatter` for escaping and `Minify` for whitespace                                  |
+| Serialize         | `serialize`/`encode` with an `Html` config (`Formatter` escaping, `Indent`/`Minify` whitespace)        |
 | Sanitize          | `sanitize` — allowlist scrub of untrusted HTML (the `bleach.clean` successor)                          |
 | Linkify           | `linkify` — auto-link URLs and emails without touching existing links (the `bleach.linkify` successor) |
-| Markdown          | `to_markdown` — GitHub-Flavored Markdown export                                                        |
-| Plain text        | `to_text`, `to_annotated_text` — layout-aware text, optionally with `(start, end, label)` spans        |
+| Markdown          | `to_markdown` with a `Markdown` config — GitHub-Flavored Markdown export                               |
+| Plain text        | `to_text`, `to_annotated_text` with a `PlainText` config — layout-aware text, optional labeled spans   |
 | Extract           | `tables`, `structured_data` (JSON-LD / Microdata / OpenGraph), `article` (main content)                |
 | Build / edit      | `Element`, `E`/`ElementMaker`, `unwrap`/`wrap`/`decompose`/`replace_with` and live `attrs`             |
 | Migration         | `turbohtml.migration.*` — drop-in shims for `markupsafe` and template autoescaping                     |

--- a/docs/how-to/serializing.rst
+++ b/docs/how-to/serializing.rst
@@ -7,21 +7,22 @@
 ************************
 
 :attr:`~turbohtml.Node.html` and :attr:`~turbohtml.Node.inner_html` are the default WHATWG-conformant forms (outer and
-children-only). :meth:`~turbohtml.Node.serialize` adds control: ``formatter`` selects the escaping through
-:class:`~turbohtml.Formatter`, and ``layout`` selects the whitespace. The default ``None`` gives the compact form; a
-:class:`~turbohtml.Indent` (an int for that many spaces, or a string used verbatim) switches to a pretty form that adds
-whitespace and so does not preserve meaning. :meth:`~turbohtml.Node.encode` is the same but returns bytes:
+children-only). :meth:`~turbohtml.Node.serialize` adds control through a single :class:`~turbohtml.Html` configuration
+object: its ``formatter`` field selects the escaping through :class:`~turbohtml.Formatter`, and its ``layout`` field
+selects the whitespace. The default ``layout`` of ``None`` gives the compact form; an :class:`~turbohtml.Indent` (an int
+for that many spaces, or a string used verbatim) switches to a pretty form that adds whitespace and so does not preserve
+meaning. :meth:`~turbohtml.Node.encode` is the same but returns bytes, with the target encoding as its first argument:
 
 .. testcode::
 
     import turbohtml
-    from turbohtml import Formatter, Indent
+    from turbohtml import Formatter, Html, Indent
 
     card = turbohtml.parse("<div><p>café &amp; co</p></div>").select_one("div")
     print(card.inner_html)
-    print(card.serialize(formatter=Formatter.NAMED_ENTITIES))
-    print(card.serialize(layout=Indent(2)))
-    print(card.encode("ascii", formatter=Formatter.NAMED_ENTITIES))
+    print(card.serialize(Html(formatter=Formatter.NAMED_ENTITIES)))
+    print(card.serialize(Html(layout=Indent(2))))
+    print(card.encode("ascii", Html(formatter=Formatter.NAMED_ENTITIES)))
 
 .. testoutput::
 
@@ -38,22 +39,22 @@ whitespace and so does not preserve meaning. :meth:`~turbohtml.Node.encode` is t
  Minify the output
 *******************
 
-Pass ``layout=`` a :class:`~turbohtml.Minify` to ``serialize`` (or ``encode``) to shrink the markup. Every transform is
-round-trip safe: the minified bytes reparse to the same tree, so minifying never changes meaning. The four flags fold
-insignificant whitespace, omit the start/end tags the WHATWG rules make optional, drop redundant attribute quotes, and
-strip comments; all default on. Because ``layout`` holds one mode, a :class:`~turbohtml.Minify` and an
+Set the :class:`~turbohtml.Html` config's ``layout`` field to a :class:`~turbohtml.Minify` to shrink the markup. Every
+transform is round-trip safe: the minified bytes reparse to the same tree, so minifying never changes meaning. The four
+flags fold insignificant whitespace, omit the start/end tags the WHATWG rules make optional, drop redundant attribute
+quotes, and strip comments; all default on. Because ``layout`` holds one mode, a :class:`~turbohtml.Minify` and an
 :class:`~turbohtml.Indent` cannot be combined.
 
 .. testcode::
 
     import turbohtml
-    from turbohtml import Minify
+    from turbohtml import Html, Minify
 
     doc = turbohtml.parse(
         "<html><head><title>Hi</title></head><body><p class='lead'>one</p>  <p>two</p><!--note--></body></html>"
     )
-    print(doc.serialize(layout=Minify()))
-    print(doc.serialize(layout=Minify(omit_optional_tags=False, collapse_whitespace=False)))
+    print(doc.serialize(Html(layout=Minify())))
+    print(doc.serialize(Html(layout=Minify(omit_optional_tags=False, collapse_whitespace=False))))
 
 .. testoutput::
 
@@ -68,16 +69,17 @@ element across the boundary.
  Normalize attributes and encoding
 ***********************************
 
-Two more keyword options on ``serialize`` and ``encode`` normalize the output without touching the tree, and compose
-with any ``formatter`` or ``layout``. ``sort_attributes`` emits each start tag's attributes in ascending name order, so
-two serializations of equal trees diff cleanly:
+Two more :class:`~turbohtml.Html` fields normalize the output without touching the tree, and compose with any
+``formatter`` or ``layout``. ``sort_attributes`` emits each start tag's attributes in ascending name order, so two
+serializations of equal trees diff cleanly:
 
 .. testcode::
 
     import turbohtml
+    from turbohtml import Html
 
     node = turbohtml.parse("<p id=main class=lead data-x=1>hi</p>").select_one("p")
-    print(node.serialize(sort_attributes=True))
+    print(node.serialize(Html(sort_attributes=True)))
 
 .. testoutput::
 
@@ -91,10 +93,11 @@ as its first child, never a duplicate. ``serialize`` declares ``utf-8`` (the enc
 .. testcode::
 
     import turbohtml
+    from turbohtml import Html
 
     doc = turbohtml.parse("<title>Hi</title>")
-    print(doc.serialize(meta_charset=True))
-    print(doc.encode("iso-8859-1", meta_charset=True))
+    print(doc.serialize(Html(meta_charset=True)))
+    print(doc.encode("iso-8859-1", Html(meta_charset=True)))
 
 .. testoutput::
 
@@ -135,14 +138,26 @@ second dependency and the whole walk in C:
 Call it on any node to export just that subtree (``article.to_markdown()``). The output is opinionated GFM: ATX
 headings, ``-`` bullets, fenced code blocks, inline links, and ``*``/``**`` emphasis.
 
-Keyword options cover the markdownify and html2text configuration surface, so a migration reproduces the old output:
-setext headings, underscore emphasis, reference links, padded tables, alternate escaping, and more. The
-:doc:`/migration/index` guide maps each old option to its turbohtml name.
+A :class:`~turbohtml.Markdown` configuration object covers the markdownify and html2text surface, so a migration
+reproduces the old output: setext headings, underscore emphasis, reference links, padded tables, alternate escaping, and
+more. Its knobs are grouped into themed sub-configs (``Markdown.Headings``, ``Markdown.Inline``, ``Markdown.Links``,
+...) so no single object is a wall of options. The :doc:`/migration/index` guide maps each old option to its turbohtml
+field.
 
 .. testcode::
 
+    from turbohtml import Markdown
+
     doc = turbohtml.parse('<h2>Tea</h2><p><b>Steep</b> it. <a href="/x">More</a>.</p>')
-    print(doc.to_markdown(heading_style="setext", strong="__", link_style="reference"))
+    print(
+        doc.to_markdown(
+            Markdown(
+                headings=Markdown.Headings(style="setext"),
+                inline=Markdown.Inline(strong="__"),
+                links=Markdown.Links(style="reference"),
+            )
+        )
+    )
 
 .. testoutput::
 
@@ -153,39 +168,41 @@ setext headings, underscore emphasis, reference links, padded tables, alternate 
 
     [1]: /x
 
-Three output modes shape the result further. ``wrap_width`` word-wraps prose at a column (``0``, the default, leaves
-paragraphs unwrapped), honoring list and blockquote indentation; ``wrap_list_items`` extends wrapping into list items
-and ``wrap_links=False`` keeps a ``[text](url)`` construct on one line. ``image_mode="html"`` and ``table_mode="html"``
-pass the original ``<img>`` or ``<table>`` through verbatim, for readers that render embedded HTML. ``transliterate``
-folds common non-ASCII typography in prose (smart quotes, dashes, ellipsis, accented letters) to ASCII:
+The ``Markdown.Wrapping`` sub-config shapes the result further. ``width`` word-wraps prose at a column (``0``, the
+default, leaves paragraphs unwrapped), honoring list and blockquote indentation; ``list_items`` extends wrapping into
+list items and ``links=False`` keeps a ``[text](url)`` construct on one line. ``Markdown.Images(mode="html")`` and
+``Markdown.Tables(mode="html")`` pass the original ``<img>`` or ``<table>`` through verbatim, for readers that render
+embedded HTML. ``Markdown.Document(transliterate=True)`` folds common non-ASCII typography in prose (smart quotes,
+dashes, ellipsis, accented letters) to ASCII:
 
 .. testcode::
 
     doc = turbohtml.parse("<p>The “quick” brown fox — jumps over the lazy dog today.</p>")
-    print(doc.to_markdown(wrap_width=30, transliterate=True))
+    print(doc.to_markdown(Markdown(wrapping=Markdown.Wrapping(width=30), document=Markdown.Document(transliterate=True))))
 
 .. testoutput::
 
     The "quick" brown fox -- jumps
     over the lazy dog today.
 
-To convert a Google Docs HTML export, pass ``google_doc=True`` so the inline-CSS styling it carries (font weight, font
-style, fixed-width fonts, and ``margin-left`` list nesting) turns into Markdown:
+To convert a Google Docs HTML export, use the ``Markdown.google_doc()`` preset (or set
+``Markdown.GoogleDoc(enabled=True)``) so the inline-CSS styling it carries (font weight, font style, fixed-width fonts,
+and ``margin-left`` list nesting) turns into Markdown:
 
 .. testcode::
 
     export = '<p><span style="font-weight:700">Bold</span> and <span style="font-style:italic">soft</span>.</p>'
-    print(turbohtml.parse(export).to_markdown(google_doc=True))
+    print(turbohtml.parse(export).to_markdown(Markdown.google_doc()))
 
 .. testoutput::
 
     **Bold** and *soft*.
 
-When an option cannot express the rule you need (a custom element, or a tag that should render its own way), pass
-``converters``: a mapping from a lowercased tag name to a ``callable(element, content) -> str``. The callable receives
-the :class:`~turbohtml.Element` and the already-converted Markdown of its children, and returns the Markdown for that
-element. A registered tag's built-in rendering is replaced; every other tag is untouched, and the hook costs nothing
-when the mapping is omitted.
+When an option cannot express the rule you need (a custom element, or a tag that should render its own way), set the
+``converters`` field: a mapping from a lowercased tag name to a ``callable(element, content) -> str``. The callable
+receives the :class:`~turbohtml.Element` and the already-converted Markdown of its children, and returns the Markdown
+for that element. A registered tag's built-in rendering is replaced; every other tag is untouched, and the hook costs
+nothing when the mapping is omitted.
 
 .. testcode::
 
@@ -194,7 +211,7 @@ when the mapping is omitted.
         "video": lambda el, content: f"[{content}]({el.attrs['src']})",
         "abbr": lambda el, content: f"{content} ({el.attrs['title']})",
     }
-    print(turbohtml.parse(html).to_markdown(converters=converters))
+    print(turbohtml.parse(html).to_markdown(Markdown(converters=converters)))
 
 .. testoutput::
 
@@ -204,16 +221,17 @@ Return ``""`` to drop an element, or return ``content`` unchanged to unwrap it. 
 on its own line; any other tag flows inline. The callable runs inside the same per-tree lock the walk holds, so it may
 read the element's attributes and subtree freely.
 
-To unwrap whole tags without a callable, pass ``strip`` or ``convert``, the two mutually exclusive filters
-``markdownify`` exposes under the same names. ``strip`` names tags whose markup is dropped while their text keeps
-flowing; ``convert`` names the only tags to keep markup for, so every other tag is unwrapped. A name the tag table does
-not know is ignored, and ``<script>``, ``<style>``, and ``<head>`` still vanish whole regardless:
+To unwrap whole tags without a callable, set the ``strip`` or ``convert`` field, the two mutually exclusive filters
+``markdownify`` exposes under the same names (passing both raises ``ValueError`` when the ``Markdown`` is built).
+``strip`` names tags whose markup is dropped while their text keeps flowing; ``convert`` names the only tags to keep
+markup for, so every other tag is unwrapped. A name the tag table does not know is ignored, and ``<script>``,
+``<style>``, and ``<head>`` still vanish whole regardless:
 
 .. testcode::
 
     doc = turbohtml.parse('<p>see <a href="/x">the docs</a> and <b>note</b> this</p>')
-    print(doc.to_markdown(strip=["a"]))
-    print(doc.to_markdown(convert=["b"]))
+    print(doc.to_markdown(Markdown(strip=["a"])))
+    print(doc.to_markdown(Markdown(convert=["b"])))
 
 .. testoutput::
 
@@ -247,8 +265,20 @@ not know is ignored, and ``<script>``, ``<style>``, and ``<head>`` still vanish 
     Apples  3
     Pears   40
 
-Links are hidden by default; pass ``links="inline"`` to append ``text (url)``, ``links="footnote"`` for numbered
-references, ``images=True`` to show alt text, and ``width`` to word-wrap.
+Links are hidden by default; pass a :class:`~turbohtml.PlainText` config to change that — ``PlainText(links="inline")``
+appends ``text (url)``, ``links="footnote"`` numbers the references, ``images=True`` shows alt text, and ``width``
+word-wraps:
+
+.. testcode::
+
+    from turbohtml import PlainText
+
+    doc = turbohtml.parse('<p>See <a href="/docs">the docs</a> for more.</p>')
+    print(doc.to_text(PlainText(links="inline")))
+
+.. testoutput::
+
+    See the docs (/docs) for more.
 
 ********************************
  Label spans of the export text
@@ -256,8 +286,8 @@ references, ``images=True`` to show alt text, and ``width`` to word-wrap.
 
 To pull labeled regions out of the rendered text (the role inscriptis fills with ``annotation_rules``), call
 :meth:`~turbohtml.Node.to_annotated_text` with a rule mapping. It returns the same text :meth:`~turbohtml.Node.to_text`
-would, plus a list of ``(start, end, label)`` triples whose offsets index into that text, and it accepts every
-``to_text`` option as well:
+would, plus a list of ``(start, end, label)`` triples whose offsets index into that text, and it accepts a
+:class:`~turbohtml.PlainText` config as its second argument just like :meth:`~turbohtml.Node.to_text`:
 
 .. testcode::
 

--- a/docs/migration/beautifulsoup.rst
+++ b/docs/migration/beautifulsoup.rst
@@ -167,7 +167,7 @@ with an explicit ``encoding=``).
     - - ``soup.new_tag("div")``, ``soup.new_string("hi")``
       - :class:`~turbohtml.Element`, :class:`~turbohtml.Text`
     - - ``tag.prettify()``
-      - :meth:`~turbohtml.Node.serialize` (``layout=Indent(2)``)
+      - :meth:`~turbohtml.Node.serialize` (``Html(layout=Indent(2))``)
     - - ``tag.smooth()``
       - :meth:`~turbohtml.Element.normalize`
     - - ``tag.sourceline``, ``tag.sourcepos``
@@ -257,11 +257,11 @@ attribute order, and ``<br>`` versus ``<br/>``. Choose ``Formatter.NAMED_ENTITIE
 
 .. testcode::
 
-    from turbohtml import Formatter
+    from turbohtml import Formatter, Html
 
     node = parse("<p>café &amp; co</p>").find("p")
     print(node.html)
-    print(node.serialize(formatter=Formatter.NAMED_ENTITIES))
+    print(node.serialize(Html(formatter=Formatter.NAMED_ENTITIES)))
 
 .. testoutput::
 

--- a/docs/migration/html-text.rst
+++ b/docs/migration/html-text.rst
@@ -73,7 +73,7 @@ collapsed visible text both return without layout.
     - - ``extract_text(html, guess_layout=False)``
       - ``" ".join(parse(html).stripped_strings)``
     - - the ``guess_layout`` toggle
-      - :meth:`~turbohtml.Node.to_text`'s ``layout`` (``"strict"``/``"extended"``)
+      - a :class:`~turbohtml.PlainText` config's ``layout`` (``"strict"``/``"extended"``)
     - - the raw word list
       - :attr:`~turbohtml.Node.strings` / :attr:`~turbohtml.Node.stripped_strings`
     - - the parsel-bound ``cleaned_selector`` / ``selector_to_text``
@@ -94,9 +94,9 @@ collapsed visible text both return without layout.
  Pitfalls
 **********
 
-- ``extract_text``'s ``guess_layout`` toggle corresponds to :meth:`~turbohtml.Node.to_text`'s ``layout``
-  (``"extended"``/``"strict"``) profile; the :doc:`inscriptis <inscriptis>` page covers the full ``to_text`` option
-  surface.
+- ``extract_text``'s ``guess_layout`` toggle corresponds to the ``layout`` (``"extended"``/``"strict"``) profile on a
+  :class:`~turbohtml.PlainText` config passed to :meth:`~turbohtml.Node.to_text`; the :doc:`inscriptis <inscriptis>`
+  page covers the full ``PlainText`` option surface.
 - For the collapsed word stream html-text returns with layout guessing off, join the
   :attr:`~turbohtml.Node.stripped_strings` iterator rather than reaching for ``to_text``.
 - html-text's parsel-bound helpers (``cleaned_selector``, ``selector_to_text``) are out of scope; the :doc:`parsel

--- a/docs/migration/html2text.rst
+++ b/docs/migration/html2text.rst
@@ -63,7 +63,7 @@ faster while covering the same options, including the Google Docs mode:
 
     Some **bold** text.
 
-The html2text options map onto :meth:`~turbohtml.Node.to_markdown` keywords with one name per concept:
+The html2text options map onto the grouped :class:`~turbohtml.Markdown` config fields with one name per concept:
 
 .. list-table::
     :header-rows: 1
@@ -72,58 +72,60 @@ The html2text options map onto :meth:`~turbohtml.Node.to_markdown` keywords with
     - - html2text
       - turbohtml :meth:`~turbohtml.Node.to_markdown`
     - - ``ul_item_mark``
-      - ``bullets``
+      - ``Markdown.Lists(bullets=...)``
     - - ``emphasis_mark``, ``strong_mark``
-      - ``emphasis``, ``strong``
+      - ``Markdown.Inline(emphasis=..., strong=...)``
     - - ``ignore_emphasis``
-      - ``ignore_emphasis``
+      - ``Markdown.Inline(ignore_emphasis=...)``
     - - ``ignore_links``
-      - ``ignore_links``
+      - ``Markdown.Links(ignore=...)``
     - - ``skip_internal_links``
-      - ``skip_internal_links``
+      - ``Markdown.Links(skip_internal=...)``
     - - ``inline_links``
-      - ``link_style`` (``"inline"``/``"reference"``)
+      - ``Markdown.Links(style=...)`` (``"inline"``/``"reference"``)
     - - ``ignore_images``, ``images_to_alt``, ``images_as_html``, ``images_with_size``
-      - ``image_mode`` (``"markdown"``/``"alt"``/``"ignore"``/``"html"``)
+      - ``Markdown.Images(mode=...)`` (``"markdown"``/``"alt"``/``"ignore"``/``"html"``)
     - - ``default_image_alt``
-      - ``default_image_alt``
+      - ``Markdown.Images(default_alt=...)``
     - - ``ignore_tables``, ``bypass_tables``
-      - ``table_mode`` (``"markdown"``/``"strip"``/``"html"``)
+      - ``Markdown.Tables(mode=...)`` (``"markdown"``/``"strip"``/``"html"``)
     - - ``pad_tables``
-      - ``pad_tables``
+      - ``Markdown.Tables(pad=...)``
     - - ``body_width``, ``wrap_list_items``, ``wrap_links``
-      - ``wrap_width``, ``wrap_list_items``, ``wrap_links``
+      - ``Markdown.Wrapping(width=..., list_items=..., links=...)``
     - - ``unicode_snob`` (and the ``UNIFIABLE`` table)
-      - ``transliterate``
+      - ``Markdown.Document(transliterate=...)``
     - - ``mark_code``
-      - ``mark_code``
+      - ``Markdown.Code(mark=...)``
     - - ``backquote_code_style``
-      - ``code_block_style`` (``"fenced"``/``"indented"``)
+      - ``Markdown.Code(block_style=...)`` (``"fenced"``/``"indented"``)
     - - ``single_line_break``
-      - ``block_spacing="single"``
+      - ``Markdown.Document(block_spacing="single")``
     - - ``baseurl``
-      - ``base_url``
+      - ``Markdown.Links(base_url=...)``
     - - ``open_quote``, ``close_quote``
-      - ``quote_open``, ``quote_close``
+      - ``Markdown.Inline(quote_open=..., quote_close=...)``
     - - ``escape_snob``
-      - ``escape_mode="all"``
+      - ``Markdown.Escaping(mode="all")``
     - - ``google_doc``
-      - ``google_doc``
+      - ``Markdown.GoogleDoc(enabled=...)`` (or the ``Markdown.google_doc()`` preset)
     - - ``google_list_indent``
-      - ``google_list_indent``
+      - ``Markdown.GoogleDoc(list_indent=...)``
     - - ``hide_strikethrough``
-      - ``hide_strikethrough``
+      - ``Markdown.Inline(hide_strikethrough=...)``
 
-``google_doc=True`` reads the inline-CSS styling a Google Docs HTML export carries: a ``font-weight`` of ``bold`` or
-``700``--``900`` becomes ``strong``, ``font-style:italic`` becomes ``emphasis``, a ``Courier New``/``Consolas``
-``font-family`` becomes an inline code span, ``list-style-type`` picks the list marker, and each ``google_list_indent``
-pixels of ``margin-left`` add one list-nesting level. With ``hide_strikethrough=True`` a
-``text-decoration:line-through`` drops the struck text.
+``Markdown.google_doc()`` reads the inline-CSS styling a Google Docs HTML export carries: a ``font-weight`` of ``bold``
+or ``700``--``900`` becomes ``strong``, ``font-style:italic`` becomes ``emphasis``, a ``Courier New``/``Consolas``
+``font-family`` becomes an inline code span, ``list-style-type`` picks the list marker, and each
+``Markdown.GoogleDoc(list_indent=...)`` pixels of ``margin-left`` add one list-nesting level. With
+``Markdown.Inline(hide_strikethrough=True)`` a ``text-decoration:line-through`` drops the struck text.
 
 .. testcode::
 
+    from turbohtml import Markdown
+
     export = '<p><span style="font-weight:700">Quarterly</span> revenue</p>'
-    print(parse(export).to_markdown(google_doc=True))
+    print(parse(export).to_markdown(Markdown.google_doc()))
 
 .. testoutput::
 

--- a/docs/migration/inscriptis.rst
+++ b/docs/migration/inscriptis.rst
@@ -63,14 +63,15 @@ twenty times faster:
     Region  Total
     North   120
 
-The ``ParserConfig`` options map onto :meth:`~turbohtml.Node.to_text` keywords:
+The ``ParserConfig`` options map onto :class:`~turbohtml.PlainText` config fields passed to
+:meth:`~turbohtml.Node.to_text`:
 
 .. list-table::
     :header-rows: 1
     :widths: 50 50
 
     - - inscriptis
-      - turbohtml :meth:`~turbohtml.Node.to_text`
+      - turbohtml :class:`~turbohtml.PlainText`
     - - ``display_links``
       - ``links`` (``"none"``/``"inline"``/``"footnote"``)
     - - ``display_images``
@@ -161,8 +162,8 @@ as ``<label>...</label>`` markup, innermost span closing first).
  Pitfalls
 **********
 
-- Links are hidden by default (matching inscriptis); pass ``links="inline"`` for ``text (url)`` or ``links="footnote"``
-  for numbered references collected at the end.
+- Links are hidden by default (matching inscriptis); pass ``PlainText(links="inline")`` for ``text (url)`` or
+  ``PlainText(links="footnote")`` for numbered references collected at the end.
 - :meth:`~turbohtml.Node.to_text` renders structure, not styling: there is no bold or color, and headings are plain
   text. For the raw concatenation with no layout at all, read :attr:`~turbohtml.Node.text`.
 - Annotation offsets count code points into the returned string; a table cell is labeled at its position in the laid-out

--- a/docs/migration/markdownify.rst
+++ b/docs/migration/markdownify.rst
@@ -63,8 +63,8 @@ walk over a BeautifulSoup tree, so it converts a page two orders of magnitude fa
 
     Some **bold** text.
 
-The defaults emit opinionated GitHub-Flavored Markdown, and keyword options cover markdownify's surface with one name
-per concept:
+The defaults emit opinionated GitHub-Flavored Markdown, and the grouped :class:`~turbohtml.Markdown` config fields cover
+markdownify's surface with one name per concept:
 
 .. list-table::
     :header-rows: 1
@@ -73,42 +73,42 @@ per concept:
     - - markdownify
       - turbohtml :meth:`~turbohtml.Node.to_markdown`
     - - ``heading_style`` (``atx``/``atx_closed``/``underlined``)
-      - ``heading_style`` (``"atx"``/``"atx_closed"``/``"setext"``)
+      - ``Markdown.Headings(style=...)`` (``"atx"``/``"atx_closed"``/``"setext"``)
     - - ``bullets``
-      - ``bullets``
+      - ``Markdown.Lists(bullets=...)``
     - - ``strong_em_symbol``
-      - ``strong`` and ``emphasis`` (independent, so a superset)
+      - ``Markdown.Inline(strong=..., emphasis=...)`` (independent, so a superset)
     - - ``sub_symbol``, ``sup_symbol``
-      - ``sub_symbol``, ``sup_symbol``
+      - ``Markdown.Inline(sub=..., sup=...)``
     - - ``escape_asterisks``, ``escape_underscores``
-      - ``escape_asterisks``, ``escape_underscores``
+      - ``Markdown.Escaping(asterisks=..., underscores=...)``
     - - ``escape_misc``
-      - ``escape_mode="all"``
+      - ``Markdown.Escaping(mode="all")``
     - - ``autolinks``
-      - ``autolink``
+      - ``Markdown.Links(autolink=...)``
     - - ``default_title``
-      - ``link_title``
+      - ``Markdown.Links(title=...)``
     - - ``table_infer_header``
-      - ``table_header="first"`` (the default) vs ``"none"``
+      - ``Markdown.Tables(header="first")`` (the default) vs ``"none"``
     - - ``newline_style`` (``spaces``/``backslash``)
-      - ``line_break`` (``"spaces"``/``"backslash"``)
+      - ``Markdown.Document(line_break=...)`` (``"spaces"``/``"backslash"``)
     - - ``strip_document``
-      - ``document_strip`` (``"strip"``/``"lstrip"``/``"rstrip"``/``"none"``)
+      - ``Markdown.Document(trim=...)`` (``"strip"``/``"lstrip"``/``"rstrip"``/``"none"``)
     - - ``code_language``
-      - ``code_language``
+      - ``Markdown.Code(language=...)``
     - - ``strip``, ``convert``
-      - ``strip``, ``convert`` (mutually exclusive tag filters)
+      - ``Markdown(strip=...)``, ``Markdown(convert=...)`` (mutually exclusive tag filters)
     - - ``convert_<tag>`` overrides
-      - ``converters`` argument
+      - ``Markdown(converters=...)`` argument
 
 **********
  Pitfalls
 **********
 
-- The bold and italic markers are independent (``strong`` and ``emphasis``), where markdownify derives both from one
-  ``strong_em_symbol``; set both to reproduce its behavior.
+- The bold and italic markers are independent (``Markdown.Inline(strong=...)`` and ``Markdown.Inline(emphasis=...)``),
+  where markdownify derives both from one ``strong_em_symbol``; set both to reproduce its behavior.
 - :meth:`~turbohtml.Node.to_markdown` is a method on any node, so convert a subtree by calling it on the element you
   selected (``doc.find("article").to_markdown()``) instead of slicing the HTML string first.
 - markdownify's parser-selection options (``bs4_options``) are dropped, since turbohtml always runs the WHATWG
   algorithm.
-- ``base_url`` does simple prefixing rather than full RFC-3986 URL resolution.
+- ``Markdown.Links(base_url=...)`` does simple prefixing rather than full RFC-3986 URL resolution.

--- a/docs/reference/serialize.rst
+++ b/docs/reference/serialize.rst
@@ -4,15 +4,19 @@
 
 .. currentmodule:: turbohtml
 
-Turn a tree back into markup or text. :meth:`Node.serialize` and :meth:`Node.encode` produce HTML; a :class:`Formatter`
-picks the escape policy and an :class:`Indent` or :class:`Minify` picks the whitespace. :func:`escape` and
-:func:`unescape` are the standalone string helpers. :meth:`Node.to_text`, :meth:`Node.to_markdown`, and
-:meth:`Node.to_annotated_text` render text; :func:`annotation_surface` and :func:`annotation_tags` post-process the
-annotated-text result.
+Turn a tree back into markup or text. Each renderer takes one configuration object: :meth:`Node.serialize` and
+:meth:`Node.encode` produce HTML under an :class:`Html` config (a :class:`Formatter` picks the escape policy and an
+:class:`Indent` or :class:`Minify` picks the whitespace); :meth:`Node.to_markdown` takes a :class:`Markdown` config; and
+:meth:`Node.to_text` and :meth:`Node.to_annotated_text` take a :class:`PlainText` config. :func:`escape` and
+:func:`unescape` are the standalone string helpers; :func:`annotation_surface` and :func:`annotation_tags` post-process
+the annotated-text result.
 
 .. autofunction:: escape
 
 .. autofunction:: unescape
+
+.. autoclass:: Html
+    :members:
 
 .. autoclass:: Formatter
     :members:
@@ -21,6 +25,12 @@ annotated-text result.
     :members:
 
 .. autoclass:: Minify
+    :members:
+
+.. autoclass:: Markdown
+    :members:
+
+.. autoclass:: PlainText
     :members:
 
 .. autofunction:: annotation_surface

--- a/docs/tutorials/editing.rst
+++ b/docs/tutorials/editing.rst
@@ -64,16 +64,17 @@ edit without touching the original:
 
     False
 
-When you serialize, ``layout=`` a :class:`~turbohtml.Minify` shrinks the output without changing what it means: it folds
-insignificant whitespace, omits optional tags, unquotes safe attributes, and strips comments, and the result reparses to
-the same tree. Here the ``</li>`` tags stay because real whitespace separates the items:
+When you serialize, set an ``Html`` config's ``layout`` to a :class:`~turbohtml.Minify` to shrink the output without
+changing what it means: it folds insignificant whitespace, omits optional tags, unquotes safe attributes, and strips
+comments, and the result reparses to the same tree. Here the ``</li>`` tags stay because real whitespace separates the
+items:
 
 .. testcode::
 
-    from turbohtml import Minify
+    from turbohtml import Html, Minify
 
     page = turbohtml.parse("<ul>\n  <li>one</li>\n  <li>two</li>\n</ul>")
-    print(page.find("ul").serialize(layout=Minify()))
+    print(page.find("ul").serialize(Html(layout=Minify())))
 
 .. testoutput::
 

--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,7 @@ py.install_sources(
         'src/turbohtml/_article.py',
         'src/turbohtml/_html.pyi',
         'src/turbohtml/_links.py',
+        'src/turbohtml/_render.py',
         'src/turbohtml/_structured_data.py',
         'src/turbohtml/_xpath.py',
         'src/turbohtml/build.py',

--- a/src/turbohtml/__init__.py
+++ b/src/turbohtml/__init__.py
@@ -35,6 +35,7 @@ from ._html import (
     unescape,
 )
 from ._links import Link  # registers the Link record type with the C core on import
+from ._render import Html, Markdown, PlainText
 from ._structured_data import (  # registers the JSON-LD parser and record classes with the C core on import
     MicrodataItem,
     StructuredData,
@@ -57,14 +58,17 @@ __all__ = [
     "ElementMaker",
     "Formatter",
     "HTMLParseError",
+    "Html",
     "IncrementalParser",
     "Indent",
     "Link",
+    "Markdown",
     "MicrodataItem",
     "Minify",
     "Namespace",
     "Node",
     "ParseError",
+    "PlainText",
     "ProcessingInstruction",
     "StructuredData",
     "Text",

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -352,70 +352,13 @@ static PyObject *node_get_inner_html(PyObject *self, void *Py_UNUSED(closure)) {
     return result;
 }
 
-PyDoc_STRVAR(
-    to_markdown_doc,
-    "to_markdown(*, heading_style='atx', bullets='-', strong='**', emphasis='*', strikethrough='keep', "
-    "ignore_emphasis=False, sub_symbol='', sup_symbol='', code_block_style='fenced', code_language='', "
-    "mark_code=False, link_style='inline', autolink=True, link_title=False, ignore_links=False, "
-    "skip_internal_links=False, base_url='', image_mode='markdown', default_image_alt='', table_mode='markdown', "
-    "table_header='first', pad_tables=False, escape_mode='minimal', escape_asterisks=True, escape_underscores=True, "
-    "line_break='spaces', block_spacing='double', wrap_width=0, wrap_list_items=False, wrap_links=True, "
-    "transliterate=False, document_strip='strip', quote_open='\"', quote_close='\"', "
-    "google_doc=False, google_list_indent=36, hide_strikethrough=False, strip=None, convert=None, "
-    "converters=None)\n--\n\n"
-    "Render this node and its subtree as Markdown. The keyword options cover the\n"
-    "markdownify and html2text configuration surface; the defaults emit opinionated\n"
-    "GitHub-Flavored Markdown.\n\n"
-    ":param heading_style: heading form: 'atx' uses # prefixes, 'atx_closed' adds\n"
-    "    trailing #, 'setext' underlines with === and ---.\n"
-    ":param bullets: the characters cycled, one per nesting level, as unordered-list markers.\n"
-    ":param strong: the delimiter wrapped around bold text.\n"
-    ":param emphasis: the delimiter wrapped around italic text.\n"
-    ":param strikethrough: 'keep' renders struck text as ~~text~~, 'hide' drops it.\n"
-    ":param ignore_emphasis: drop bold and italic markup, keeping the text.\n"
-    ":param sub_symbol: the delimiter wrapped around <sub> text; empty drops the markup.\n"
-    ":param sup_symbol: the delimiter wrapped around <sup> text; empty drops the markup.\n"
-    ":param code_block_style: 'fenced' uses triple-backtick fences, 'indented' uses a four-space indent.\n"
-    ":param code_language: the language tag placed on fenced code blocks.\n"
-    ":param mark_code: wrap inline code in [code]...[/code] instead of backticks.\n"
-    ":param link_style: 'inline' writes [text](url), 'reference' collects links at the end.\n"
-    ":param autolink: render a bare URL whose text equals its href as <url>.\n"
-    ":param link_title: include a link's title attribute in the Markdown link.\n"
-    ":param ignore_links: drop link markup, keeping the link text.\n"
-    ":param skip_internal_links: drop links whose target is a same-page #fragment.\n"
-    ":param base_url: the base each relative link and image URL is resolved against.\n"
-    ":param image_mode: 'markdown' writes ![alt](src), 'alt' writes only the alt text,\n"
-    "    'ignore' drops images, 'html' passes the <img> through verbatim.\n"
-    ":param default_image_alt: alt text used for an image that declares none.\n"
-    ":param table_mode: 'markdown' writes a pipe table, 'strip' drops the table,\n"
-    "    'html' passes the <table> through verbatim.\n"
-    ":param table_header: 'first' treats the first row as the header, 'detect' uses\n"
-    "    <th> cells, 'none' emits an empty header row.\n"
-    ":param pad_tables: pad cells with spaces so the column pipes align.\n"
-    ":param escape_mode: 'minimal' escapes only what would change the markup, 'all'\n"
-    "    escapes every Markdown-significant character.\n"
-    ":param escape_asterisks: escape a literal * in prose so it is not read as emphasis.\n"
-    ":param escape_underscores: escape a literal _ in prose so it is not read as emphasis.\n"
-    ":param line_break: render a <br> as 'spaces' (two trailing spaces) or 'backslash'.\n"
-    ":param block_spacing: 'double' separates blocks with a blank line, 'single' does not.\n"
-    ":param wrap_width: word-wrap prose at this column, or 0 to leave it unwrapped.\n"
-    ":param wrap_list_items: extend word-wrapping into list items.\n"
-    ":param wrap_links: allow a [text](url) construct to be split across wrapped lines.\n"
-    ":param transliterate: fold common non-ASCII typography in prose to ASCII.\n"
-    ":param document_strip: trim the whole output: 'strip' both ends, 'lstrip' the\n"
-    "    leading, 'rstrip' the trailing whitespace, 'none' leaves it.\n"
-    ":param quote_open: the character that opens a converted typographic quotation.\n"
-    ":param quote_close: the character that closes a converted typographic quotation.\n"
-    ":param google_doc: read the inline-CSS styling a Google Docs HTML export carries.\n"
-    ":param google_list_indent: the pixel indent a Google Docs export uses per list level.\n"
-    ":param hide_strikethrough: drop text a Google Docs export marks struck through.\n"
-    ":param strip: tag names whose markup is dropped while their text is kept;\n"
-    "    mutually exclusive with convert.\n"
-    ":param convert: the only tag names to keep markup for; mutually exclusive with strip.\n"
-    ":param converters: maps a lowercased tag name to a callable(element, content) -> str\n"
-    "    that replaces how that tag renders, receiving the element and its\n"
-    "    already-converted child Markdown.\n"
-    ":returns: the Markdown rendering of this node's subtree.");
+PyDoc_STRVAR(to_markdown_doc, "to_markdown(options=None)\n--\n\n"
+                              "Render this node and its subtree as Markdown. The defaults emit opinionated\n"
+                              "GitHub-Flavored Markdown.\n\n"
+                              ":param options: a Markdown configuration object, or None for the defaults. Its\n"
+                              "    grouped knobs (headings, links, tables, ...) cover the markdownify and\n"
+                              "    html2text configuration surface.\n"
+                              ":returns: the Markdown rendering of this node's subtree.");
 
 /* Resolve a string option against its allowed values, writing the matched index
    into *out (an enum), or leave *out untouched when the argument was omitted. */
@@ -523,7 +466,49 @@ static int md_build_tag_filter(PyObject *seq, md_opts *opt, int mode) {
     return 0;
 }
 
-static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds) {
+/* Render this node from spec, a borrowed dict of renderer keyword options (a config
+   object's non-default values) or NULL for every default. */
+typedef PyObject *(*node_render_fn)(PyObject *self, PyObject *spec);
+
+/* Unpack a renderer's config object to its keyword dict via _unpack(); a value that is
+   not the expected config type has no _unpack, so the AttributeError is replaced with a
+   clear TypeError naming the type. Returns a new dict reference, or NULL with the error
+   set. */
+static PyObject *config_unpack(PyObject *options, const char *type_name) {
+    PyObject *spec = PyObject_CallMethod(options, "_unpack", NULL);
+    if (spec == NULL) {
+        PyErr_Clear();
+        PyErr_Format(PyExc_TypeError, "options must be a %s, not %.200s", type_name, Py_TYPE(options)->tp_name);
+    }
+    return spec;
+}
+
+/* The shared dispatch for a renderer whose only argument is a config object: parse
+   the single optional `options`, unpack it to the renderer keyword dict (or NULL for
+   the defaults), and render. The unpacked dict owns the borrowed values for the call. */
+static PyObject *node_render_with_options(PyObject *self, PyObject *args, PyObject *kwds, node_render_fn render,
+                                          const char *type_name) {
+    PyObject *options = NULL;
+    static char *kw[] = {"options", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kw, &options)) {
+        return NULL;
+    }
+    if (options == NULL || options == Py_None) {
+        return render(self, NULL);
+    }
+    PyObject *spec = config_unpack(options, type_name);
+    if (spec == NULL) {
+        return NULL;
+    }
+    PyObject *result = render(self, spec);
+    Py_DECREF(spec);
+    return result;
+}
+
+/* Render this node as Markdown from spec, a borrowed dict of the renderer keyword
+   options (the Markdown config's non-default values) or NULL for every default.
+   The caller owns spec; the borrowed strings stay valid for this call. */
+static PyObject *node_markdown_render(PyObject *self, PyObject *spec) {
     md_opts opt = th_markdown_default_opts();
     PyObject *heading = NULL, *strike = NULL, *code_style = NULL, *link = NULL, *image = NULL, *table = NULL;
     PyObject *header = NULL, *escape = NULL, *brk = NULL, *spacing = NULL, *docstrip = NULL;
@@ -570,14 +555,20 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
                          "convert",
                          "converters",
                          NULL};
-    if (!PyArg_ParseTupleAndKeywords(
-            args, kwds, "|$OsssOpssOspOppppsOsOOpOppOOipppOsspipOOO", kw, &heading, &opt.bullets, &opt.strong,
-            &opt.emphasis, &strike, &ignore_emphasis, &opt.sub, &opt.sup, &code_style, &opt.code_language, &mark_code,
-            &link, &opt.autolink, &opt.link_title, &opt.ignore_links, &opt.skip_internal_links, &opt.base_url, &image,
-            &opt.default_image_alt, &table, &header, &opt.pad_tables, &escape, &opt.escape_asterisks,
-            &opt.escape_underscores, &brk, &spacing, &opt.wrap_width, &opt.wrap_list_items, &opt.wrap_links,
-            &opt.transliterate, &docstrip, &opt.quote_open, &opt.quote_close, &opt.google_doc, &opt.google_list_indent,
-            &opt.hide_strikethrough, &strip, &convert, &converters)) {
+    PyObject *empty = PyTuple_New(0);
+    if (empty == NULL) {         /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int parsed = PyArg_ParseTupleAndKeywords(
+        empty, spec, "|$OsssOpssOspOppppsOsOOpOppOOipppOsspipOOO", kw, &heading, &opt.bullets, &opt.strong,
+        &opt.emphasis, &strike, &ignore_emphasis, &opt.sub, &opt.sup, &code_style, &opt.code_language, &mark_code,
+        &link, &opt.autolink, &opt.link_title, &opt.ignore_links, &opt.skip_internal_links, &opt.base_url, &image,
+        &opt.default_image_alt, &table, &header, &opt.pad_tables, &escape, &opt.escape_asterisks,
+        &opt.escape_underscores, &brk, &spacing, &opt.wrap_width, &opt.wrap_list_items, &opt.wrap_links,
+        &opt.transliterate, &docstrip, &opt.quote_open, &opt.quote_close, &opt.google_doc, &opt.google_list_indent,
+        &opt.hide_strikethrough, &strip, &convert, &converters);
+    Py_DECREF(empty);
+    if (!parsed) {
         return NULL;
     }
     static const char *const headings[] = {"atx", "atx_closed", "setext"};
@@ -624,12 +615,11 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
         opt.code_mark_open = "[code]";
         opt.code_mark_close = "[/code]";
     }
-    int has_strip = strip != NULL && strip != Py_None;
-    int has_convert = convert != NULL && convert != Py_None;
-    if (has_strip && has_convert) {
-        PyErr_SetString(PyExc_ValueError, "strip and convert are mutually exclusive");
-        return NULL;
-    }
+    /* The Markdown config's _unpack omits a None tag filter, so strip/convert/converters
+       arrive here either absent (NULL) or a real object, never Py_None. strip and convert
+       are mutually exclusive; the config rejects the pair on construction. */
+    int has_strip = strip != NULL;
+    int has_convert = convert != NULL;
     if (has_strip && md_build_tag_filter(strip, &opt, TH_MD_FILTER_STRIP) < 0) {
         return NULL;
     }
@@ -638,7 +628,7 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
     }
     PyObject *conv = NULL;
     md_wrap_ctx wrap_ctx;
-    if (converters != NULL && converters != Py_None) {
+    if (converters != NULL) {
         conv = md_converters_dict(converters);
         if (conv == NULL) {
             return NULL;
@@ -670,35 +660,47 @@ static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds
     return result;
 }
 
-PyDoc_STRVAR(to_text_doc, "to_text(*, width=0, links='none', images=False, layout='extended', default_image_alt='', "
-                          "table_cell_separator='  ', bullet='* ')\n--\n\n"
+static PyObject *node_to_markdown(PyObject *self, PyObject *args, PyObject *kwds) {
+    return node_render_with_options(self, args, kwds, node_markdown_render, "Markdown");
+}
+
+PyDoc_STRVAR(to_text_doc, "to_text(options=None)\n--\n\n"
                           "Render this node and its subtree as layout-aware plain text: blocks\n"
                           "separated by blank lines, lists indented under their bullets, and tables\n"
                           "laid out as a column-aligned grid. The inscriptis role, in C.\n\n"
-                          ":param width: wrap column for prose, or 0 to leave lines unwrapped.\n"
-                          ":param links: how to render <a> targets: 'none' drops them, 'inline' shows\n"
-                          "    them after the text, 'footnote' collects them at the end.\n"
-                          ":param images: render image alt text instead of skipping images.\n"
-                          ":param layout: 'extended' adds blank lines and indentation; 'strict' keeps the\n"
-                          "    output compact.\n"
-                          ":param default_image_alt: alt text used for an image that declares none.\n"
-                          ":param table_cell_separator: string placed between table cells on a row.\n"
-                          ":param bullet: marker prefixed to each list item.\n"
+                          ":param options: a PlainText configuration object, or None for the defaults.\n"
                           ":returns: the plain-text rendering of this node's subtree.");
 
-static PyObject *node_to_text(PyObject *self, PyObject *args, PyObject *kwds) {
-    text_opts opt = th_text_default_opts();
+/* Parse the PlainText keyword options out of spec into opt; spec is a borrowed dict
+   of the config's non-default values, or NULL for every default. -1 with an exception
+   set on a bad value, 0 otherwise. */
+static int text_opts_from_spec(text_opts *opt, PyObject *spec) {
     PyObject *links = NULL, *layout = NULL;
     static char *kw[] = {"width",  "links", "images", "layout", "default_image_alt", "table_cell_separator",
                          "bullet", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|$iOpOsss", kw, &opt.width, &links, &opt.images, &layout,
-                                     &opt.default_image_alt, &opt.cell_separator, &opt.bullet)) {
-        return NULL;
+    PyObject *empty = PyTuple_New(0);
+    if (empty == NULL) { /* GCOVR_EXCL_START - allocation failure cannot be forced from a test */
+        PyErr_NoMemory();
+        return -1;
+    } /* GCOVR_EXCL_STOP */
+    int parsed = PyArg_ParseTupleAndKeywords(empty, spec, "|$iOpOsss", kw, &opt->width, &links, &opt->images, &layout,
+                                             &opt->default_image_alt, &opt->cell_separator, &opt->bullet);
+    Py_DECREF(empty);
+    if (!parsed) {
+        return -1;
     }
     static const char *const link_modes[] = {"none", "inline", "footnote"};
     static const char *const layouts[] = {"strict", "extended"};
-    if (md_resolve_enum("links", links, link_modes, 3, &opt.links) < 0 ||
-        md_resolve_enum("layout", layout, layouts, 2, &opt.extended) < 0) {
+    if (md_resolve_enum("links", links, link_modes, 3, &opt->links) < 0 ||
+        md_resolve_enum("layout", layout, layouts, 2, &opt->extended) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static PyObject *node_text_render(PyObject *self, PyObject *spec) {
+    text_opts opt = th_text_default_opts();
+    if (text_opts_from_spec(&opt, spec) < 0) {
         return NULL;
     }
     Py_ssize_t out_len;
@@ -712,6 +714,10 @@ static PyObject *node_to_text(PyObject *self, PyObject *args, PyObject *kwds) {
     PyObject *result = ucs4_to_str(data, out_len);
     PyMem_Free(data);
     return result;
+}
+
+static PyObject *node_to_text(PyObject *self, PyObject *args, PyObject *kwds) {
+    return node_render_with_options(self, args, kwds, node_text_render, "PlainText");
 }
 
 /* Parse one annotation_rules entry ("tag", "tag#attr", "tag#attr=value", or
@@ -771,40 +777,22 @@ static int text_parse_rule(PyObject *key, PyObject *value, text_rule *rule, PyOb
     return 0;
 }
 
-PyDoc_STRVAR(to_annotated_text_doc,
-             "to_annotated_text(annotation_rules, *, width=0, links='none', images=False, layout='extended', "
-             "default_image_alt='', table_cell_separator='  ', bullet='* ')\n--\n\n"
-             "Render layout-aware text and, for every element matching a rule in\n"
-             "annotation_rules, record a labeled span over its text. Spans inside table\n"
-             "cells are not recorded.\n\n"
-             ":param annotation_rules: maps a selector ('tag', 'tag#attr', 'tag#attr=value',\n"
-             "    or '#attr') to the list of labels to attach to each matching element.\n"
-             ":param width: wrap column for prose, or 0 to leave lines unwrapped.\n"
-             ":param links: how to render <a> targets: 'none', 'inline', or 'footnote'.\n"
-             ":param images: render image alt text instead of skipping images.\n"
-             ":param layout: 'extended' adds blank lines and indentation; 'strict' is compact.\n"
-             ":param default_image_alt: alt text used for an image that declares none.\n"
-             ":param table_cell_separator: string placed between table cells on a row.\n"
-             ":param bullet: marker prefixed to each list item.\n"
-             ":returns: a (text, spans) pair, where spans is a list of (start, end, label).");
+PyDoc_STRVAR(to_annotated_text_doc, "to_annotated_text(annotation_rules, options=None)\n--\n\n"
+                                    "Render layout-aware text and, for every element matching a rule in\n"
+                                    "annotation_rules, record a labeled span over its text. Spans inside table\n"
+                                    "cells are not recorded.\n\n"
+                                    ":param annotation_rules: maps a selector ('tag', 'tag#attr', 'tag#attr=value',\n"
+                                    "    or '#attr') to the list of labels to attach to each matching element.\n"
+                                    ":param options: a PlainText configuration object, or None for the defaults.\n"
+                                    ":returns: a (text, spans) pair, where spans is a list of (start, end, label).");
 
-static PyObject *node_to_annotated_text(PyObject *self, PyObject *args, PyObject *kwds) {
-    text_opts opt = th_text_default_opts();
-    PyObject *rules_dict, *links = NULL, *layout = NULL;
-    static char *kw[] = {"annotation_rules",     "width",  "links", "images", "layout", "default_image_alt",
-                         "table_cell_separator", "bullet", NULL};
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|$iOpOsss", kw, &rules_dict, &opt.width, &links, &opt.images,
-                                     &layout, &opt.default_image_alt, &opt.cell_separator, &opt.bullet)) {
-        return NULL;
-    }
+static PyObject *node_annotated_render(PyObject *self, PyObject *rules_dict, PyObject *spec) {
     if (!PyDict_Check(rules_dict)) {
         PyErr_SetString(PyExc_TypeError, "annotation_rules must be a dict");
         return NULL;
     }
-    static const char *const link_modes[] = {"none", "inline", "footnote"};
-    static const char *const layouts[] = {"strict", "extended"};
-    if (md_resolve_enum("links", links, link_modes, 3, &opt.links) < 0 ||
-        md_resolve_enum("layout", layout, layouts, 2, &opt.extended) < 0) {
+    text_opts opt = th_text_default_opts();
+    if (text_opts_from_spec(&opt, spec) < 0) {
         return NULL;
     }
     Py_ssize_t n = PyDict_Size(rules_dict);
@@ -860,6 +848,24 @@ static PyObject *node_to_annotated_text(PyObject *self, PyObject *args, PyObject
     PyMem_Free(rules);
     PyMem_Free(labels);
     PyMem_Free(values);
+    return result;
+}
+
+static PyObject *node_to_annotated_text(PyObject *self, PyObject *args, PyObject *kwds) {
+    PyObject *rules_dict, *options = NULL;
+    static char *kw[] = {"annotation_rules", "options", NULL};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kw, &rules_dict, &options)) {
+        return NULL;
+    }
+    if (options == NULL || options == Py_None) {
+        return node_annotated_render(self, rules_dict, NULL);
+    }
+    PyObject *spec = config_unpack(options, "PlainText");
+    if (spec == NULL) {
+        return NULL;
+    }
+    PyObject *result = node_annotated_render(self, rules_dict, spec);
+    Py_DECREF(spec);
     return result;
 }
 
@@ -1227,27 +1233,17 @@ static PyObject *node_serialize(PyObject *self, PyObject *args, PyObject *kwds);
 
 static PyObject *node_encode(PyObject *self, PyObject *args, PyObject *kwds);
 
-PyDoc_STRVAR(serialize_doc,
-             "serialize(*, formatter=Formatter.WHATWG, layout=None, sort_attributes=False, meta_charset=False)\n--\n\n"
-             "Serialize this node and its subtree to a str.\n\n"
-             ":param formatter: the character-escaping policy to apply.\n"
-             ":param layout: the whitespace mode: None gives the compact WHATWG form, an\n"
-             "    Indent pretty-prints (adding whitespace, so it does not preserve meaning),\n"
-             "    and a Minify shrinks the output while reparsing to the same tree.\n"
-             ":param sort_attributes: emit each start tag's attributes in ascending name order.\n"
-             ":param meta_charset: ensure the document <head> declares <meta charset=\"utf-8\">,\n"
-             "    normalizing an existing charset declaration or injecting one.\n"
-             ":returns: the serialized markup.");
+PyDoc_STRVAR(serialize_doc, "serialize(options=None)\n--\n\n"
+                            "Serialize this node and its subtree to a str.\n\n"
+                            ":param options: an Html configuration object (formatter, layout, attribute\n"
+                            "    ordering, and meta-charset handling), or None for the defaults.\n"
+                            ":returns: the serialized markup.");
 
-PyDoc_STRVAR(encode_doc, "encode(encoding='utf-8', *, formatter=Formatter.WHATWG, layout=None, sort_attributes=False, "
-                         "meta_charset=False)\n--\n\n"
-                         "Serialize this node and its subtree to bytes, with the same formatter, layout,\n"
-                         "and sort_attributes controls as serialize().\n\n"
+PyDoc_STRVAR(encode_doc, "encode(encoding='utf-8', options=None)\n--\n\n"
+                         "Serialize this node and its subtree to bytes, with the same formatting controls\n"
+                         "as serialize().\n\n"
                          ":param encoding: the codec to encode the markup with.\n"
-                         ":param formatter: the character-escaping policy to apply.\n"
-                         ":param layout: the whitespace mode (None, an Indent, or a Minify).\n"
-                         ":param sort_attributes: emit each start tag's attributes in name order.\n"
-                         ":param meta_charset: ensure a <meta charset> naming encoding is present.\n"
+                         ":param options: an Html configuration object, or None for the defaults.\n"
                          ":returns: the serialized markup encoded as bytes.");
 
 PyDoc_STRVAR(find_doc,
@@ -1404,13 +1400,14 @@ enum th_layout_mode {
     TH_LAYOUT_MINIFY,  /* the round-trip-safe minify transforms */
 };
 
-/* Resolve the layout argument: None compacts, an Indent pretty-prints, a Minify
-   minifies. An Indent owns its unit buffer and a Minify its flags, so the resolved
-   values borrow from the object the caller keeps alive for the serialize. Returns
-   0 on success (mode set) or -1 with a TypeError on any other object. */
+/* Resolve the layout argument: an absent layout compacts, an Indent pretty-prints, a
+   Minify minifies. An Indent owns its unit buffer and a Minify its flags, so the resolved
+   values borrow from the object the caller keeps alive for the serialize. The Html config's
+   _unpack omits a None layout, so layout_obj arrives here NULL (absent) or a real object,
+   never Py_None. Returns 0 on success (mode set) or -1 with a TypeError on any other object. */
 static int resolve_layout(module_state *state, PyObject *layout_obj, enum th_layout_mode *mode,
                           const Py_UCS4 **indent_unit, Py_ssize_t *indent_len, th_minify_opts *opts) {
-    if (layout_obj == NULL || layout_obj == Py_None) {
+    if (layout_obj == NULL) {
         *mode = TH_LAYOUT_COMPACT;
         return 0;
     }
@@ -1471,31 +1468,60 @@ static PyObject *node_serialize_str(PyObject *self, PyObject *formatter_obj, PyO
     return result;
 }
 
-static PyObject *node_serialize(PyObject *self, PyObject *args, PyObject *kwds) {
+/* Serialize self to a str under the Html config in spec (a borrowed dict of the
+   config's non-default values, or NULL for the defaults), writing charset as the
+   meta_charset label. */
+static PyObject *node_serialize_from_spec(PyObject *self, PyObject *spec, const char *charset) {
     static char *keywords[] = {"formatter", "layout", "sort_attributes", "meta_charset", NULL};
     PyObject *formatter_obj = NULL;
     PyObject *layout_obj = NULL;
     int sort_attributes = 0;
     int meta_charset = 0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|$OOpp", keywords, &formatter_obj, &layout_obj, &sort_attributes,
-                                     &meta_charset)) {
+    PyObject *empty = PyTuple_New(0);
+    if (empty == NULL) {         /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int parsed = PyArg_ParseTupleAndKeywords(empty, spec, "|$OOpp", keywords, &formatter_obj, &layout_obj,
+                                             &sort_attributes, &meta_charset);
+    Py_DECREF(empty);
+    if (!parsed) {
         return NULL;
     }
-    return node_serialize_str(self, formatter_obj, layout_obj, sort_attributes, meta_charset, "utf-8");
+    return node_serialize_str(self, formatter_obj, layout_obj, sort_attributes, meta_charset, charset);
+}
+
+/* Resolve a serialize/encode call's options object to a str rendering under charset.
+   None renders the defaults; otherwise the config's _unpack() supplies its keywords. */
+static PyObject *node_serialize_options(PyObject *self, PyObject *options, const char *charset) {
+    if (options == NULL || options == Py_None) {
+        return node_serialize_str(self, NULL, NULL, 0, 0, charset);
+    }
+    PyObject *spec = config_unpack(options, "Html");
+    if (spec == NULL) {
+        return NULL;
+    }
+    PyObject *result = node_serialize_from_spec(self, spec, charset);
+    Py_DECREF(spec);
+    return result;
+}
+
+static PyObject *node_serialize(PyObject *self, PyObject *args, PyObject *kwds) {
+    static char *keywords[] = {"options", NULL};
+    PyObject *options = NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", keywords, &options)) {
+        return NULL;
+    }
+    return node_serialize_options(self, options, "utf-8");
 }
 
 static PyObject *node_encode(PyObject *self, PyObject *args, PyObject *kwds) {
-    static char *keywords[] = {"encoding", "formatter", "layout", "sort_attributes", "meta_charset", NULL};
+    static char *keywords[] = {"encoding", "options", NULL};
     const char *encoding = "utf-8";
-    PyObject *formatter_obj = NULL;
-    PyObject *layout_obj = NULL;
-    int sort_attributes = 0;
-    int meta_charset = 0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|s$OOpp", keywords, &encoding, &formatter_obj, &layout_obj,
-                                     &sort_attributes, &meta_charset)) {
+    PyObject *options = NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|sO", keywords, &encoding, &options)) {
         return NULL;
     }
-    PyObject *text = node_serialize_str(self, formatter_obj, layout_obj, sort_attributes, meta_charset, encoding);
+    PyObject *text = node_serialize_options(self, options, encoding);
     if (text == NULL) {
         return NULL;
     }

--- a/src/turbohtml/_render.py
+++ b/src/turbohtml/_render.py
@@ -1,0 +1,378 @@
+"""
+Configuration objects for the tree's output renderers.
+
+``to_markdown``, ``to_text``/``to_annotated_text`` and ``serialize``/``encode`` each carried a long flat keyword list
+that was hard to read, hard to document, and let mutually exclusive options (markdown's ``strip`` vs ``convert``) be
+passed together. This module replaces those keyword walls with three immutable, thread-safe configuration objects --
+:class:`Markdown`, :class:`PlainText` and :class:`Html` -- mirroring the :class:`~turbohtml.Policy` sanitizer config and
+the :class:`~turbohtml.Indent`/:class:`~turbohtml.Minify` layout objects already in the API.
+
+The markdown surface is large enough that a single flat config would just move the wall, so :class:`Markdown` groups its
+knobs into themed sub-configs (``Markdown.Headings``, ``Markdown.Links``, ...). Each config validates itself on
+construction and exposes a private ``_unpack`` that yields only the values differing from the renderer's built-in
+defaults, so an empty config reproduces the no-argument rendering exactly and the C renderer keeps its existing
+default handling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import TYPE_CHECKING, Literal
+
+from ._html import Formatter, Indent, Minify
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping
+
+    from ._html import Element
+
+
+@dataclass(frozen=True)
+class Markdown:
+    """
+    How :meth:`Node.to_markdown` renders a subtree as Markdown.
+
+    Build one and reuse it across threads; every field has a GitHub-Flavored-Markdown default, so ``Markdown()``
+    reproduces the no-argument rendering. The many knobs are grouped into themed sub-configs to keep any one object
+    small -- ``Markdown(links=Markdown.Links(style="reference"))`` rather than a flat ``link_style="reference"``.
+
+    :param headings: how headings are written (ATX, closed ATX, or setext).
+    :param lists: the unordered-list markers.
+    :param inline: inline emphasis, strike, sub/sup, and quote wrappers.
+    :param code: fenced vs indented code blocks and their language.
+    :param links: link style and which links are kept.
+    :param images: how images render and their fallback alt text.
+    :param tables: table rendering and header detection.
+    :param escaping: which Markdown-significant characters are escaped.
+    :param wrapping: word-wrapping of prose and constructs.
+    :param document: line breaks, block spacing, trimming, and transliteration.
+    :param google: reading inline-CSS styling the way a Google Docs export encodes it.
+    :param strip: tags rendered as their text only, dropping the markup; mutually exclusive with ``convert``.
+    :param convert: the only tags to render as Markdown, every other tag dropped to text; mutually exclusive with
+        ``strip``.
+    :param converters: per-tag overrides, each a callable receiving the element and its rendered child Markdown.
+    """
+
+    @dataclass(frozen=True)
+    class Headings:
+        """
+        How headings are written.
+
+        :param style: ``atx`` (``# h``), ``atx_closed`` (``# h #``), or ``setext`` (underlined).
+        """
+
+        style: Literal["atx", "atx_closed", "setext"] = "atx"
+
+    @dataclass(frozen=True)
+    class Lists:
+        """
+        How unordered lists are marked.
+
+        :param bullets: unordered-list markers, cycled by nesting depth (e.g. ``-*+``).
+        """
+
+        bullets: str = "-"
+
+    @dataclass(frozen=True)
+    class Inline:
+        """
+        Inline text formatting: emphasis, sub/sup, and quote wrappers.
+
+        :param strong: the bold wrapper.
+        :param emphasis: the italic wrapper.
+        :param strikethrough: ``keep`` wraps struck text, ``hide`` drops it.
+        :param ignore_emphasis: render bold/italic/strike content as plain text, no markup.
+        :param sub: the ``<sub>`` wrapper (empty drops the markup).
+        :param sup: the ``<sup>`` wrapper (empty drops the markup).
+        :param hide_strikethrough: in ``google`` mode, drop text a CSS line-through struck.
+        :param quote_open: the opening ``<q>`` wrapper.
+        :param quote_close: the closing ``<q>`` wrapper.
+        """
+
+        strong: str = "**"
+        emphasis: str = "*"
+        strikethrough: Literal["keep", "hide"] = "keep"
+        ignore_emphasis: bool = False
+        sub: str = ""
+        sup: str = ""
+        hide_strikethrough: bool = False
+        quote_open: str = '"'
+        quote_close: str = '"'
+
+    @dataclass(frozen=True)
+    class Code:
+        """
+        How code blocks are rendered.
+
+        :param block_style: ``fenced`` (triple-backtick) or ``indented`` (four-space).
+        :param language: default fence language when the element declares none.
+        :param mark: wrap inline code in ``[code]``/``[/code]`` markers.
+        """
+
+        block_style: Literal["fenced", "indented"] = "fenced"
+        language: str = ""
+        mark: bool = False
+
+    @dataclass(frozen=True)
+    class Links:
+        """
+        Link style and which links are kept.
+
+        :param style: ``inline`` (``[t](url)``) or ``reference`` (collected at the end).
+        :param autolink: emit ``<url>`` when the text equals an absolute href.
+        :param title: use the href as the title when none is given.
+        :param ignore: render link text only, no markup.
+        :param skip_internal: drop ``href="#..."`` fragment links.
+        :param base_url: prefix resolved onto a relative link or image href.
+        """
+
+        style: Literal["inline", "reference"] = "inline"
+        autolink: bool = True
+        title: bool = False
+        ignore: bool = False
+        skip_internal: bool = False
+        base_url: str = ""
+
+    @dataclass(frozen=True)
+    class Images:
+        """
+        How images are rendered.
+
+        :param mode: ``markdown`` (``![alt](src)``), ``alt`` (alt text only), ``ignore``, or ``html`` (raw ``<img>``).
+        :param default_alt: alt text used for an image that declares none.
+        """
+
+        mode: Literal["markdown", "alt", "ignore", "html"] = "markdown"
+        default_alt: str = ""
+
+    @dataclass(frozen=True)
+    class Tables:
+        """
+        How tables are rendered.
+
+        :param mode: ``markdown`` (pipe table), ``strip`` (cell text only), or ``html`` (raw ``<table>``).
+        :param header: which row is the header: ``first``, ``detect``, or ``none``.
+        :param pad: align columns to a common width.
+        """
+
+        mode: Literal["markdown", "strip", "html"] = "markdown"
+        header: Literal["first", "detect", "none"] = "first"
+        pad: bool = False
+
+    @dataclass(frozen=True)
+    class Escaping:
+        """
+        Which Markdown-significant characters are escaped.
+
+        :param mode: ``minimal`` escapes only what a parser needs, ``all`` escapes every Markdown character.
+        :param asterisks: escape literal ``*`` so it is not read as emphasis.
+        :param underscores: escape literal ``_`` so it is not read as emphasis.
+        """
+
+        mode: Literal["minimal", "all"] = "minimal"
+        asterisks: bool = True
+        underscores: bool = True
+
+    @dataclass(frozen=True)
+    class Wrapping:
+        """
+        Word-wrapping of prose and constructs.
+
+        :param width: word-wrap column for prose, or 0 to leave lines unwrapped.
+        :param list_items: extend word wrapping into list-item text.
+        :param links: allow a link or image construct to break across a wrap.
+        """
+
+        width: int = 0
+        list_items: bool = False
+        links: bool = True
+
+    @dataclass(frozen=True)
+    class Document:
+        """
+        Document-level layout: line breaks, block spacing, trimming, and transliteration.
+
+        :param line_break: render a hard break as trailing ``spaces`` or a ``backslash``.
+        :param block_spacing: a ``double`` blank line between blocks, or a ``single`` newline.
+        :param trim: trim document edges: ``strip``, ``lstrip``, ``rstrip``, or ``none``.
+        :param transliterate: fold common non-ASCII typography in prose to ASCII.
+        """
+
+        line_break: Literal["spaces", "backslash"] = "spaces"
+        block_spacing: Literal["double", "single"] = "double"
+        trim: Literal["strip", "lstrip", "rstrip", "none"] = "strip"
+        transliterate: bool = False
+
+    @dataclass(frozen=True)
+    class GoogleDoc:
+        """
+        Reading inline-CSS styling the way a Google Docs export encodes it.
+
+        :param enabled: read inline-CSS styling the way a Google Docs HTML export encodes it.
+        :param list_indent: px of ``margin-left`` per list-nesting level (at least 1).
+        """
+
+        enabled: bool = False
+        list_indent: int = 36
+
+    headings: Markdown.Headings = field(default_factory=Headings)
+    lists: Markdown.Lists = field(default_factory=Lists)
+    inline: Markdown.Inline = field(default_factory=Inline)
+    code: Markdown.Code = field(default_factory=Code)
+    links: Markdown.Links = field(default_factory=Links)
+    images: Markdown.Images = field(default_factory=Images)
+    tables: Markdown.Tables = field(default_factory=Tables)
+    escaping: Markdown.Escaping = field(default_factory=Escaping)
+    wrapping: Markdown.Wrapping = field(default_factory=Wrapping)
+    document: Markdown.Document = field(default_factory=Document)
+    google: Markdown.GoogleDoc = field(default_factory=GoogleDoc)
+    strip: Iterable[str] | None = None
+    convert: Iterable[str] | None = None
+    converters: Mapping[str, Callable[[Element, str], str]] | None = None
+
+    def __post_init__(self) -> None:
+        """Reject the one mutually exclusive pair up front, so the renderer never has to."""
+        if self.strip is not None and self.convert is not None:
+            msg = "strip and convert are mutually exclusive"
+            raise ValueError(msg)
+
+    @classmethod
+    def google_doc(cls) -> Markdown:
+        """
+        Read a Google Docs HTML export: inline-CSS styling drives emphasis, and struck text is dropped.
+
+        :returns: a config tuned for Google Docs export markup.
+        """
+        return cls(
+            inline=cls.Inline(hide_strikethrough=True),
+            google=cls.GoogleDoc(enabled=True),
+        )
+
+    def _unpack(self) -> dict[str, object]:
+        """Flatten to the renderer's keyword names, emitting only values that differ from its defaults."""
+        default = _MARKDOWN_DEFAULT
+        flat = {
+            "heading_style": (self.headings.style, default.headings.style),
+            "bullets": (self.lists.bullets, default.lists.bullets),
+            "strong": (self.inline.strong, default.inline.strong),
+            "emphasis": (self.inline.emphasis, default.inline.emphasis),
+            "strikethrough": (self.inline.strikethrough, default.inline.strikethrough),
+            "ignore_emphasis": (self.inline.ignore_emphasis, default.inline.ignore_emphasis),
+            "sub_symbol": (self.inline.sub, default.inline.sub),
+            "sup_symbol": (self.inline.sup, default.inline.sup),
+            "hide_strikethrough": (self.inline.hide_strikethrough, default.inline.hide_strikethrough),
+            "quote_open": (self.inline.quote_open, default.inline.quote_open),
+            "quote_close": (self.inline.quote_close, default.inline.quote_close),
+            "code_block_style": (self.code.block_style, default.code.block_style),
+            "code_language": (self.code.language, default.code.language),
+            "mark_code": (self.code.mark, default.code.mark),
+            "link_style": (self.links.style, default.links.style),
+            "autolink": (self.links.autolink, default.links.autolink),
+            "link_title": (self.links.title, default.links.title),
+            "ignore_links": (self.links.ignore, default.links.ignore),
+            "skip_internal_links": (self.links.skip_internal, default.links.skip_internal),
+            "base_url": (self.links.base_url, default.links.base_url),
+            "image_mode": (self.images.mode, default.images.mode),
+            "default_image_alt": (self.images.default_alt, default.images.default_alt),
+            "table_mode": (self.tables.mode, default.tables.mode),
+            "table_header": (self.tables.header, default.tables.header),
+            "pad_tables": (self.tables.pad, default.tables.pad),
+            "escape_mode": (self.escaping.mode, default.escaping.mode),
+            "escape_asterisks": (self.escaping.asterisks, default.escaping.asterisks),
+            "escape_underscores": (self.escaping.underscores, default.escaping.underscores),
+            "wrap_width": (self.wrapping.width, default.wrapping.width),
+            "wrap_list_items": (self.wrapping.list_items, default.wrapping.list_items),
+            "wrap_links": (self.wrapping.links, default.wrapping.links),
+            "line_break": (self.document.line_break, default.document.line_break),
+            "block_spacing": (self.document.block_spacing, default.document.block_spacing),
+            "document_strip": (self.document.trim, default.document.trim),
+            "transliterate": (self.document.transliterate, default.document.transliterate),
+            "google_doc": (self.google.enabled, default.google.enabled),
+            "google_list_indent": (self.google.list_indent, default.google.list_indent),
+        }
+        unpacked: dict[str, object] = {name: value for name, (value, base) in flat.items() if value != base}
+        # pass the tag filters through unchanged: the renderer rejects a bare str (so
+        # ``strip="div"`` is an error, not "strip tags d, i, v") and accepts any other iterable
+        if self.strip is not None:
+            unpacked["strip"] = self.strip
+        if self.convert is not None:
+            unpacked["convert"] = self.convert
+        if self.converters is not None:
+            unpacked["converters"] = self.converters
+        return unpacked
+
+
+_MARKDOWN_DEFAULT = Markdown()
+
+
+@dataclass(frozen=True)
+class PlainText:
+    """
+    How :meth:`Node.to_text` and :meth:`Node.to_annotated_text` render a subtree as layout-aware plain text.
+
+    :param width: wrap column for prose, or 0 to leave lines unwrapped.
+    :param links: how to render ``<a>`` targets: ``none`` drops them, ``inline`` shows them after the text,
+        ``footnote`` collects them at the end.
+    :param images: render image alt text instead of skipping images.
+    :param layout: ``extended`` adds blank lines and indentation; ``strict`` keeps the output compact.
+    :param default_image_alt: alt text used for an image that declares none.
+    :param table_cell_separator: string placed between table cells on a row.
+    :param bullet: marker prefixed to each list item.
+    """
+
+    width: int = 0
+    links: Literal["none", "inline", "footnote"] = "none"
+    images: bool = False
+    layout: Literal["extended", "strict"] = "extended"
+    default_image_alt: str = ""
+    table_cell_separator: str = "  "
+    bullet: str = "* "
+
+    def _unpack(self) -> dict[str, object]:
+        """Flatten to the renderer's keyword names, emitting only values that differ from its defaults."""
+        default = _PLAINTEXT_DEFAULT
+        return {
+            field_.name: value
+            for field_ in fields(self)
+            if (value := getattr(self, field_.name)) != getattr(default, field_.name)
+        }
+
+
+_PLAINTEXT_DEFAULT = PlainText()
+
+
+@dataclass(frozen=True)
+class Html:
+    """
+    How :meth:`Node.serialize` and :meth:`Node.encode` render a subtree as HTML.
+
+    :param formatter: the escape policy for text and attribute values.
+    :param layout: ``None`` emits the compact WHATWG form, an :class:`~turbohtml.Indent` pretty-prints, a
+        :class:`~turbohtml.Minify` minifies.
+    :param sort_attributes: emit each element's attributes in name order rather than source order.
+    :param meta_charset: normalize (or inject) the ``<meta charset>`` declaration to the output encoding.
+    """
+
+    formatter: Formatter = Formatter.WHATWG
+    layout: Indent | Minify | None = None
+    sort_attributes: bool = False
+    meta_charset: bool = False
+
+    def _unpack(self) -> dict[str, object]:
+        """Flatten to the renderer's keyword names, emitting only values that differ from its defaults."""
+        default = _HTML_DEFAULT
+        return {
+            field_.name: value
+            for field_ in fields(self)
+            if (value := getattr(self, field_.name)) != getattr(default, field_.name)
+        }
+
+
+_HTML_DEFAULT = Html()
+
+
+__all__ = [
+    "Html",
+    "Markdown",
+    "PlainText",
+]

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -2,13 +2,12 @@
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, Sequence
 from enum import Enum, IntEnum
 from re import Pattern
-from typing import Literal, TypeAlias, final
+from typing import TypeAlias, final
 
 from turbohtml._article import Article as Article
 from turbohtml._links import Link
+from turbohtml._render import Html, Markdown, PlainText
 from turbohtml._structured_data import JSONValue, MicrodataItem, StructuredData
-
-from .serialize import Formatter, Indent, Minify
 
 _Filter: TypeAlias = str | Pattern[str] | bool | Callable[[str | None], bool] | list[_Filter]
 
@@ -130,90 +129,12 @@ class Node:
     def re_first(
         self, pattern: str | Pattern[str], /, default: str | None = None, *, attr: str | None = None
     ) -> str | None: ...
-    def serialize(
-        self,
-        *,
-        formatter: Formatter = ...,
-        layout: Indent | Minify | None = ...,
-        sort_attributes: bool = ...,
-        meta_charset: bool = ...,
-    ) -> str: ...
-    def encode(
-        self,
-        encoding: str = "utf-8",
-        *,
-        formatter: Formatter = ...,
-        layout: Indent | Minify | None = ...,
-        sort_attributes: bool = ...,
-        meta_charset: bool = ...,
-    ) -> bytes: ...
-    def to_markdown(
-        self,
-        *,
-        heading_style: Literal["atx", "atx_closed", "setext"] = "atx",
-        bullets: str = "-",
-        strong: str = "**",
-        emphasis: str = "*",
-        strikethrough: Literal["keep", "hide"] = "keep",
-        ignore_emphasis: bool = False,
-        sub_symbol: str = "",
-        sup_symbol: str = "",
-        code_block_style: Literal["fenced", "indented"] = "fenced",
-        code_language: str = "",
-        mark_code: bool = False,
-        link_style: Literal["inline", "reference"] = "inline",
-        autolink: bool = True,
-        link_title: bool = False,
-        ignore_links: bool = False,
-        skip_internal_links: bool = False,
-        base_url: str = "",
-        image_mode: Literal["markdown", "alt", "ignore", "html"] = "markdown",
-        default_image_alt: str = "",
-        table_mode: Literal["markdown", "strip", "html"] = "markdown",
-        table_header: Literal["first", "detect", "none"] = "first",
-        pad_tables: bool = False,
-        escape_mode: Literal["minimal", "all"] = "minimal",
-        escape_asterisks: bool = True,
-        escape_underscores: bool = True,
-        line_break: Literal["spaces", "backslash"] = "spaces",
-        block_spacing: Literal["double", "single"] = "double",
-        wrap_width: int = 0,
-        wrap_list_items: bool = False,
-        wrap_links: bool = True,
-        transliterate: bool = False,
-        document_strip: Literal["strip", "lstrip", "rstrip", "none"] = "strip",
-        quote_open: str = '"',
-        quote_close: str = '"',
-        google_doc: bool = False,
-        google_list_indent: int = 36,
-        hide_strikethrough: bool = False,
-        strip: Iterable[str] | None = None,
-        convert: Iterable[str] | None = None,
-        converters: Mapping[str, Callable[[Element, str], str]] | None = None,
-    ) -> str: ...
-    def to_text(
-        self,
-        *,
-        width: int = 0,
-        links: Literal["none", "inline", "footnote"] = "none",
-        images: bool = False,
-        layout: Literal["extended", "strict"] = "extended",
-        default_image_alt: str = "",
-        table_cell_separator: str = "  ",
-        bullet: str = "* ",
-    ) -> str: ...
+    def serialize(self, options: Html | None = None) -> str: ...
+    def encode(self, encoding: str = "utf-8", options: Html | None = None) -> bytes: ...
+    def to_markdown(self, options: Markdown | None = None) -> str: ...
+    def to_text(self, options: PlainText | None = None) -> str: ...
     def to_annotated_text(
-        self,
-        annotation_rules: Mapping[str, Sequence[str]],
-        /,
-        *,
-        width: int = 0,
-        links: Literal["none", "inline", "footnote"] = "none",
-        images: bool = False,
-        layout: Literal["extended", "strict"] = "extended",
-        default_image_alt: str = "",
-        table_cell_separator: str = "  ",
-        bullet: str = "* ",
+        self, annotation_rules: Mapping[str, Sequence[str]], options: PlainText | None = None
     ) -> tuple[str, list[tuple[int, int, str]]]: ...
     def links(self) -> list[Link]: ...
     def rewrite_links(self, replace: Callable[[str], str | None], /) -> None: ...

--- a/tests/dom/test_tree_pi_cdata.py
+++ b/tests/dom/test_tree_pi_cdata.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from turbohtml import CData, Comment, Element, Indent, ProcessingInstruction, Text
+from turbohtml import CData, Comment, Element, Html, Indent, ProcessingInstruction, Text
 
 
 def test_pi_carries_target_and_data() -> None:
@@ -109,4 +109,4 @@ def test_pi_adopts_across_trees_keeping_both_halves() -> None:
 def test_pi_and_cdata_serialize_pretty() -> None:
     root = Element("root")
     root.extend([CData("d"), ProcessingInstruction("t", "x")])
-    assert root.serialize(layout=Indent(2)) == "<root>\n  <![CDATA[d]]>\n  <?t x>\n</root>"
+    assert root.serialize(Html(layout=Indent(2))) == "<root>\n  <![CDATA[d]]>\n  <?t x>\n</root>"

--- a/tests/dom/test_treebuilder_internals.py
+++ b/tests/dom/test_treebuilder_internals.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import Indent, _html, parse
+from turbohtml import Html, Indent, _html, parse
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -618,7 +618,7 @@ def test_deeply_nested_serializers_are_iterative() -> None:
     def run() -> None:
         document = parse(source)
         captured["compact"] = document.html
-        captured["pretty"] = document.serialize(layout=Indent(2))
+        captured["pretty"] = document.serialize(Html(layout=Indent(2)))
         captured["dump"] = _html._parse_tree(source)
 
     previous = threading.stack_size(256 * 1024)

--- a/tests/serialize/test_minify.py
+++ b/tests/serialize/test_minify.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from turbohtml import Element, Formatter, Minify, Text, parse, parse_fragment
+from turbohtml import Element, Formatter, Html, Minify, Text, parse, parse_fragment
 
 
 def frag(source: str, **flags: bool) -> str:
@@ -18,7 +18,7 @@ def frag(source: str, **flags: bool) -> str:
     A <div> is never an optional tag and carries no attributes, so it survives every
     transform unchanged and strips cleanly, leaving just the minified content.
     """
-    out = parse_fragment(source, "div").serialize(layout=Minify(**flags))
+    out = parse_fragment(source, "div").serialize(Html(layout=Minify(**flags)))
     assert out.startswith("<div>")
     assert out.endswith("</div>")
     return out[len("<div>") : -len("</div>")]
@@ -91,16 +91,16 @@ def test_serialize_without_minify_is_unchanged() -> None:
 
 
 def test_serialize_layout_none_is_compact() -> None:
-    assert parse("<p>x").serialize(layout=None) == parse("<p>x").serialize()
+    assert parse("<p>x").serialize(Html(layout=None)) == parse("<p>x").serialize()
 
 
 def test_serialize_rejects_non_layout() -> None:
     with pytest.raises(TypeError, match="layout must be an Indent"):
-        parse("<p>x").serialize(layout=True)  # ty: ignore[invalid-argument-type]  # non-layout rejected
+        parse("<p>x").serialize(Html(layout=True))  # ty: ignore[invalid-argument-type]  # non-layout rejected
 
 
 def test_encode_minify() -> None:
-    assert parse("<p>a</p>").encode(layout=Minify()) == b"<p>a"
+    assert parse("<p>a</p>").encode(options=Html(layout=Minify())) == b"<p>a"
 
 
 # ---------------------------------------------------------------- whitespace
@@ -143,14 +143,14 @@ def test_collapse_escapes_nbsp_under_whatwg() -> None:
 def test_collapse_minimal_formatter_keeps_nbsp_literal() -> None:
     # MINIMAL folds ASCII whitespace but leaves the non-break space literal
     out = parse_fragment("a   \u00a0   b", "div").serialize(
-        layout=Minify(omit_optional_tags=False), formatter=Formatter.MINIMAL
+        Html(layout=Minify(omit_optional_tags=False), formatter=Formatter.MINIMAL)
     )
     assert out == "<div>a \u00a0 b</div>"
 
 
 def test_collapse_named_formatter() -> None:
     out = parse_fragment("caf\u00e9   &  th\u00e9", "div").serialize(
-        layout=Minify(omit_optional_tags=False), formatter=Formatter.NAMED_ENTITIES
+        Html(layout=Minify(omit_optional_tags=False), formatter=Formatter.NAMED_ENTITIES)
     )
     assert out == "<div>caf&eacute; &amp; th&eacute;</div>"
 
@@ -299,23 +299,23 @@ def test_omit_li_end_dropped_with_attributed_child() -> None:
 
 
 def test_omit_start_tags_document() -> None:
-    assert parse("<html><head><title>x</title></head><body><p>a</p></body></html>").serialize(layout=Minify()) == (
-        "<title>x</title><p>a"
-    )
+    assert parse("<html><head><title>x</title></head><body><p>a</p></body></html>").serialize(
+        Html(layout=Minify())
+    ) == ("<title>x</title><p>a")
 
 
 def test_omit_html_start_kept_when_first_is_comment() -> None:
-    out = parse("<html><!--c--><title>x</title>").serialize(layout=Minify(strip_comments=False))
+    out = parse("<html><!--c--><title>x</title>").serialize(Html(layout=Minify(strip_comments=False)))
     assert out.startswith("<html><!--c-->")
 
 
 def test_omit_start_kept_with_attributes() -> None:
-    out = parse("<html lang='en'><body>x</body></html>").serialize(layout=Minify())
+    out = parse("<html lang='en'><body>x</body></html>").serialize(Html(layout=Minify()))
     assert out.startswith("<html lang=en>")
 
 
 def test_omit_body_start_kept_before_whitespace() -> None:
-    out = parse("<body> x</body>").serialize(layout=Minify())
+    out = parse("<body> x</body>").serialize(Html(layout=Minify()))
     assert out.startswith("<body> x")
 
 
@@ -343,21 +343,21 @@ def test_unquote_keeps_quotes_on_quote_chars(source: str, expected: str) -> None
 
 def test_html_body_end_kept_before_comment() -> None:
     # the comment after </body> keeps the body end tag; </html> still drops (nothing follows it)
-    out = parse("<html><body>x</body><!--tail--></html>").serialize(layout=Minify(strip_comments=False))
+    out = parse("<html><body>x</body><!--tail--></html>").serialize(Html(layout=Minify(strip_comments=False)))
     assert out.endswith("</body><!--tail-->")
 
 
 def test_head_end_kept_before_whitespace() -> None:
-    out = parse("<html><head><title>t</title></head> <body>x</body></html>").serialize(layout=Minify())
+    out = parse("<html><head><title>t</title></head> <body>x</body></html>").serialize(Html(layout=Minify()))
     assert "</head>" in out
 
 
 def test_head_start_omitted_when_empty() -> None:
-    assert parse("<html><head></head><body>x</body></html>").serialize(layout=Minify()) == "x"
+    assert parse("<html><head></head><body>x</body></html>").serialize(Html(layout=Minify())) == "x"
 
 
 def test_body_start_kept_before_meta() -> None:
-    out = parse("<body><meta charset='utf-8'>x</body>").serialize(layout=Minify())
+    out = parse("<body><meta charset='utf-8'>x</body>").serialize(Html(layout=Minify()))
     assert out.startswith("<body><meta")
 
 
@@ -372,14 +372,14 @@ def test_empty_element_minified() -> None:
 def test_omit_in_template_content() -> None:
     # items hang off the template content node; dropping the trailing end tag still
     # reparses identically, since the template close reconstructs the element
-    out = parse("<template><li>a</li><li>b</li></template>").serialize(layout=Minify())
+    out = parse("<template><li>a</li><li>b</li></template>").serialize(Html(layout=Minify()))
     assert out == "<template><li>a<li>b</template>"
 
 
 def test_collapse_carriage_return_in_constructed_text() -> None:
     # a parsed document never carries a CR (the tokenizer folds it to LF), but a
     # programmatically built text node can, and it folds like any other whitespace
-    assert Text("a\rb\rc").serialize(layout=Minify()) == "a b c"
+    assert Text("a\rb\rc").serialize(Html(layout=Minify())) == "a b c"
 
 
 def test_body_start_omitted_with_empty_first_text() -> None:
@@ -390,7 +390,7 @@ def test_body_start_omitted_with_empty_first_text() -> None:
     body.append(Text(""))
     body.append(Element("p"))
     html.append(body)
-    out = html.serialize(layout=Minify())
+    out = html.serialize(Html(layout=Minify()))
     assert out == "<html><p></html>"
 
 
@@ -399,24 +399,24 @@ def test_omit_dd_end_kept_before_text() -> None:
 
 
 def test_body_start_kept_before_comment() -> None:
-    assert parse("<body><!--c-->x</body>").serialize(layout=Minify(strip_comments=False)) == "<body><!--c-->x"
+    assert parse("<body><!--c-->x</body>").serialize(Html(layout=Minify(strip_comments=False))) == "<body><!--c-->x"
 
 
 @pytest.mark.parametrize("tag", [pytest.param(t, id=t) for t in ("meta", "link", "script", "style", "template")])
 def test_body_start_kept_before_head_element(tag: str) -> None:
-    assert parse(f"<body><{tag}></{tag}>x</body>").serialize(layout=Minify()).startswith(f"<body><{tag}")
+    assert parse(f"<body><{tag}></{tag}>x</body>").serialize(Html(layout=Minify())).startswith(f"<body><{tag}")
 
 
 def test_empty_element_as_root_keeps_end_tag() -> None:
     para = parse_fragment("<p></p>", "div").find("p")
     assert para is not None
-    assert para.serialize(layout=Minify()) == "<p></p>"
+    assert para.serialize(Html(layout=Minify())) == "<p></p>"
 
 
 def test_rawtext_element_as_root() -> None:
     script = parse_fragment("<script>a<b</script>", "div").find("script")
     assert script is not None
-    assert script.serialize(layout=Minify()) == "<script>a<b</script>"
+    assert script.serialize(Html(layout=Minify())) == "<script>a<b</script>"
 
 
 def test_body_end_omitted_before_noncomment_sibling() -> None:
@@ -425,13 +425,13 @@ def test_body_end_omitted_before_noncomment_sibling() -> None:
     body.append(Text("x"))
     html.append(body)
     html.append(Element("div"))
-    assert html.serialize(layout=Minify(strip_comments=False)) == "<html>x<div></div></html>"
+    assert html.serialize(Html(layout=Minify(strip_comments=False))) == "<html>x<div></div></html>"
 
 
 def test_empty_html_start_omitted() -> None:
     wrap = Element("div")
     wrap.append(Element("html"))
-    assert wrap.serialize(layout=Minify()) == "<div></div>"
+    assert wrap.serialize(Html(layout=Minify())) == "<div></div>"
 
 
 def test_head_start_kept_before_nonelement() -> None:
@@ -440,17 +440,17 @@ def test_head_start_kept_before_nonelement() -> None:
     head.append(Text("t"))
     html.append(head)
     html.append(Element("body"))
-    assert html.serialize(layout=Minify()) == "<html><head>t</html>"
+    assert html.serialize(Html(layout=Minify())) == "<html><head>t</html>"
 
 
 def test_head_end_omitted_when_last() -> None:
     html = Element("html")
     html.append(Element("head"))
-    assert html.serialize(layout=Minify()) == "<html></html>"
+    assert html.serialize(Html(layout=Minify())) == "<html></html>"
 
 
 def test_head_end_kept_before_comment() -> None:
-    out = parse("<html><head></head><!--c--><body>x</body></html>").serialize(layout=Minify(strip_comments=False))
+    out = parse("<html><head></head><!--c--><body>x</body></html>").serialize(Html(layout=Minify(strip_comments=False)))
     assert out.startswith("</head><!--c-->")
 
 
@@ -462,7 +462,7 @@ def test_omit_kept_for_p_in_foreign_parent() -> None:
     para = Element("p")
     para.append(Text("x"))
     math.append(para)
-    assert math.serialize(layout=Minify()).endswith("<p>x</p></math>")
+    assert math.serialize(Html(layout=Minify())).endswith("<p>x</p></math>")
 
 
 # -------------------------------------------------------------------- foreign

--- a/tests/serialize/test_minify_roundtrip.py
+++ b/tests/serialize/test_minify_roundtrip.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from turbohtml import Minify, parse
+from turbohtml import Html, Minify, parse
 
 _TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
 _MINIFY = Minify()
@@ -42,8 +42,8 @@ def _plain_roundtrips(source: str) -> bool:
 
 
 def _minify_idempotent(source: str) -> bool:
-    once = parse(source).serialize(layout=_MINIFY)
-    return once == parse(once).serialize(layout=_MINIFY)
+    once = parse(source).serialize(Html(layout=_MINIFY))
+    return once == parse(once).serialize(Html(layout=_MINIFY))
 
 
 @pytest.mark.parametrize("filename", sorted(p.name for p in _TREE_DIR.glob("*.dat")))
@@ -51,8 +51,8 @@ def test_minify_idempotent_over_tree_construction(filename: str) -> None:
     # only the subset the plain serializer round-trips can be asked of the minifier;
     # the rest are inherently non-idempotent adoption-agency reconstructions
     failures = [
-        f"{data!r}\n  once:    {parse(data).serialize(layout=_MINIFY)!r}\n"
-        f"  reparse: {parse(parse(data).serialize(layout=_MINIFY)).serialize(layout=_MINIFY)!r}"
+        f"{data!r}\n  once:    {parse(data).serialize(Html(layout=_MINIFY))!r}\n"
+        f"  reparse: {parse(parse(data).serialize(Html(layout=_MINIFY))).serialize(Html(layout=_MINIFY))!r}"
         for data in _iter_dat(_TREE_DIR / filename)
         if _plain_roundtrips(data) and not _minify_idempotent(data)
     ]
@@ -77,6 +77,6 @@ def test_minify_idempotent_over_large_document() -> None:
         + "".join(section.format(i=index) for index in range(500))
         + "</body></html>"
     )
-    once = parse(big).serialize(layout=_MINIFY)
-    assert once == parse(once).serialize(layout=_MINIFY)
+    once = parse(big).serialize(Html(layout=_MINIFY))
+    assert once == parse(once).serialize(Html(layout=_MINIFY))
     assert len(once) < len(parse(big).serialize())  # minification actually shrinks the document

--- a/tests/serialize/test_serialize_output_options.py
+++ b/tests/serialize/test_serialize_output_options.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from turbohtml import Element, Indent, Minify, parse
+from turbohtml import Element, Html, Indent, Minify, parse
 
 # ----------------------------------------------------------------- sort_attributes
 
@@ -21,7 +21,7 @@ from turbohtml import Element, Indent, Minify, parse
 def test_sort_attributes_orders_by_name(markup: str, selector: str, expected: str) -> None:
     node = parse(markup).select_one(selector)
     assert node is not None
-    assert node.serialize(sort_attributes=True) == expected
+    assert node.serialize(Html(sort_attributes=True)) == expected
 
 
 def test_sort_attributes_off_keeps_source_order() -> None:
@@ -38,72 +38,74 @@ def test_sort_attributes_off_keeps_source_order() -> None:
     ],
 )
 def test_sort_attributes_orders_prefix_names(attrs: dict[str, str], expected: str) -> None:
-    assert Element("x", attrs).serialize(sort_attributes=True) == expected
+    assert Element("x", attrs).serialize(Html(sort_attributes=True)) == expected
 
 
 def test_sort_attributes_beyond_stack_buffer_uses_heap() -> None:
     names = [f"a{index:02d}" for index in range(70)]
     element = Element("x", dict.fromkeys(reversed(names), ""))
     expected = "<x " + " ".join(f'{name}=""' for name in names) + "></x>"
-    assert element.serialize(sort_attributes=True) == expected
+    assert element.serialize(Html(sort_attributes=True)) == expected
 
 
 def test_sort_attributes_composes_with_indent() -> None:
     node = parse("<p z=1 a=2>x").select_one("p")
     assert node is not None
-    assert node.serialize(layout=Indent(2), sort_attributes=True).splitlines()[0] == '<p a="2" z="1">'
+    assert node.serialize(Html(layout=Indent(2), sort_attributes=True)).splitlines()[0] == '<p a="2" z="1">'
 
 
 def test_sort_attributes_composes_with_minify() -> None:
     node = parse("<p z=1 a=2>x").select_one("p")
     assert node is not None
-    assert node.serialize(layout=Minify(), sort_attributes=True) == "<p a=2 z=1>x</p>"
+    assert node.serialize(Html(layout=Minify(), sort_attributes=True)) == "<p a=2 z=1>x</p>"
 
 
 # ------------------------------------------------------------------- meta_charset
 
 
 def test_meta_charset_injects_into_empty_head() -> None:
-    out = parse("<p>x").serialize(meta_charset=True)
+    out = parse("<p>x").serialize(Html(meta_charset=True))
     assert out == '<html><head><meta charset="utf-8"></head><body><p>x</p></body></html>'
 
 
 def test_meta_charset_injects_before_existing_head_content() -> None:
-    out = parse("<link rel=icon>").serialize(meta_charset=True)
+    out = parse("<link rel=icon>").serialize(Html(meta_charset=True))
     assert out == '<html><head><meta charset="utf-8"><link rel="icon"></head><body></body></html>'
 
 
 def test_meta_charset_normalizes_existing_charset_meta() -> None:
-    out = parse("<meta charset=ascii>").serialize(meta_charset=True)
+    out = parse("<meta charset=ascii>").serialize(Html(meta_charset=True))
     assert out == '<html><head><meta charset="utf-8"></head><body></body></html>'
 
 
 def test_meta_charset_keeps_other_attributes_on_charset_meta() -> None:
-    out = parse("<meta charset=ascii id=enc>").serialize(meta_charset=True)
+    out = parse("<meta charset=ascii id=enc>").serialize(Html(meta_charset=True))
     assert out == '<html><head><meta charset="utf-8" id="enc"></head><body></body></html>'
 
 
 def test_meta_charset_normalizes_http_equiv_content_type() -> None:
-    out = parse('<meta http-equiv=content-type content="text/html; charset=ascii">').serialize(meta_charset=True)
+    out = parse('<meta http-equiv=content-type content="text/html; charset=ascii">').serialize(Html(meta_charset=True))
     expected = '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8">'
     assert out.startswith(expected)
     assert out.count("charset=") == 1
 
 
 def test_meta_charset_matches_mixed_case_http_equiv_value() -> None:
-    out = parse('<meta http-equiv="Content-Type" content="text/html; charset=ascii">').serialize(meta_charset=True)
+    out = parse('<meta http-equiv="Content-Type" content="text/html; charset=ascii">').serialize(
+        Html(meta_charset=True)
+    )
     expected = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8">'
     assert out.startswith(expected)
     assert out.count("charset=") == 1
 
 
 def test_meta_charset_ignores_unrelated_http_equiv() -> None:
-    out = parse('<meta http-equiv=refresh content="5">').serialize(meta_charset=True)
+    out = parse('<meta http-equiv=refresh content="5">').serialize(Html(meta_charset=True))
     assert out.startswith('<html><head><meta charset="utf-8"><meta http-equiv="refresh" content="5">')
 
 
 def test_meta_charset_ignores_http_equiv_content_type_without_content() -> None:
-    out = parse("<meta http-equiv=content-type>").serialize(meta_charset=True)
+    out = parse("<meta http-equiv=content-type>").serialize(Html(meta_charset=True))
     assert out.startswith('<html><head><meta charset="utf-8"><meta http-equiv="content-type">')
 
 
@@ -115,33 +117,33 @@ def test_meta_charset_ignores_http_equiv_content_type_without_content() -> None:
     ],
 )
 def test_meta_charset_http_equiv_label_mismatch_injects(equiv: str) -> None:
-    out = parse(f'<meta http-equiv="{equiv}" content="x">').serialize(meta_charset=True)
+    out = parse(f'<meta http-equiv="{equiv}" content="x">').serialize(Html(meta_charset=True))
     assert out.startswith('<html><head><meta charset="utf-8">')
 
 
 def test_meta_charset_ignores_meta_without_charset_or_http_equiv() -> None:
-    out = parse('<meta name=viewport content="width=1">').serialize(meta_charset=True)
+    out = parse('<meta name=viewport content="width=1">').serialize(Html(meta_charset=True))
     assert out.startswith('<html><head><meta charset="utf-8"><meta name="viewport" content="width=1">')
 
 
 def test_meta_charset_keeps_seven_char_attr_on_charset_meta() -> None:
-    out = parse('<meta charset=ascii content="x">').serialize(meta_charset=True)
+    out = parse('<meta charset=ascii content="x">').serialize(Html(meta_charset=True))
     assert out.startswith('<html><head><meta charset="utf-8" content="x">')
 
 
 def test_meta_charset_keeps_seven_char_attr_on_content_type_meta() -> None:
-    out = parse('<meta http-equiv=content-type content="text/html" enabled="x">').serialize(meta_charset=True)
+    out = parse('<meta http-equiv=content-type content="text/html" enabled="x">').serialize(Html(meta_charset=True))
     assert out.startswith('<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8" enabled="x">')
 
 
 def test_meta_charset_with_indent_leaves_foreign_element() -> None:
-    out = parse("<svg></svg>").serialize(layout=Indent(2), meta_charset=True)
+    out = parse("<svg></svg>").serialize(Html(layout=Indent(2), meta_charset=True))
     assert '<meta charset="utf-8">' in out
     assert "<svg></svg>" in out
 
 
 def test_meta_charset_skips_non_element_head_children() -> None:
-    out = parse("<head><!--note--><title>t").serialize(meta_charset=True)
+    out = parse("<head><!--note--><title>t").serialize(Html(meta_charset=True))
     assert out == ('<html><head><meta charset="utf-8"><!--note--><title>t</title></head><body></body></html>')
 
 
@@ -152,17 +154,17 @@ def test_meta_charset_off_injects_nothing() -> None:
 def test_meta_charset_no_head_is_a_no_op() -> None:
     node = parse("<p id=a>x").select_one("p")
     assert node is not None
-    assert node.serialize(meta_charset=True) == '<p id="a">x</p>'
+    assert node.serialize(Html(meta_charset=True)) == '<p id="a">x</p>'
 
 
 def test_meta_charset_leaves_foreign_elements_untouched() -> None:
     node = parse("<svg><circle r=5></circle></svg>").select_one("svg")
     assert node is not None
-    assert node.serialize(meta_charset=True) == '<svg><circle r="5"></circle></svg>'
+    assert node.serialize(Html(meta_charset=True)) == '<svg><circle r="5"></circle></svg>'
 
 
 def test_meta_charset_reparses_to_one_declaration() -> None:
-    out = parse("<title>t").serialize(meta_charset=True)
+    out = parse("<title>t").serialize(Html(meta_charset=True))
     metas = parse(out).select("meta")
     assert len(metas) == 1
     assert metas[0].attrs["charset"] == "utf-8"
@@ -172,7 +174,7 @@ def test_meta_charset_reparses_to_one_declaration() -> None:
 
 
 def test_meta_charset_with_indent_indents_injected_meta() -> None:
-    out = parse("<p>x").serialize(layout=Indent(2), meta_charset=True)
+    out = parse("<p>x").serialize(Html(layout=Indent(2), meta_charset=True))
     assert out == (
         "<html>\n"
         "  <head>\n"
@@ -188,19 +190,19 @@ def test_meta_charset_with_indent_indents_injected_meta() -> None:
 
 
 def test_meta_charset_with_indent_non_empty_head() -> None:
-    out = parse("<link rel=icon>").serialize(layout=Indent(2), meta_charset=True)
+    out = parse("<link rel=icon>").serialize(Html(layout=Indent(2), meta_charset=True))
     assert out == (
         '<html>\n  <head>\n    <meta charset="utf-8">\n    <link rel="icon">\n  </head>\n  <body></body>\n</html>'
     )
 
 
 def test_meta_charset_with_indent_normalizes_existing_meta() -> None:
-    out = parse("<meta charset=ascii>").serialize(layout=Indent(2), meta_charset=True)
+    out = parse("<meta charset=ascii>").serialize(Html(layout=Indent(2), meta_charset=True))
     assert out == ('<html>\n  <head>\n    <meta charset="utf-8">\n  </head>\n  <body></body>\n</html>')
 
 
 def test_meta_charset_with_minify_injects() -> None:
-    out = parse("<title>t").serialize(layout=Minify(), meta_charset=True)
+    out = parse("<title>t").serialize(Html(layout=Minify(), meta_charset=True))
     assert out.startswith('<meta charset="utf-8">')
     metas = parse(out).select("meta")
     assert len(metas) == 1
@@ -208,7 +210,7 @@ def test_meta_charset_with_minify_injects() -> None:
 
 
 def test_meta_charset_with_minify_normalizes_existing_meta() -> None:
-    out = parse("<meta charset=ascii><title>t").serialize(layout=Minify(), meta_charset=True)
+    out = parse("<meta charset=ascii><title>t").serialize(Html(layout=Minify(), meta_charset=True))
     metas = parse(out).select("meta")
     assert len(metas) == 1
     assert metas[0].attrs["charset"] == "utf-8"
@@ -219,11 +221,11 @@ def test_meta_charset_with_minify_normalizes_existing_meta() -> None:
 
 
 def test_encode_meta_charset_uses_target_encoding() -> None:
-    out = parse("<p>x").encode("iso-8859-1", meta_charset=True)
+    out = parse("<p>x").encode("iso-8859-1", Html(meta_charset=True))
     assert out == ('<html><head><meta charset="iso-8859-1"></head><body><p>x</p></body></html>'.encode("latin-1"))
 
 
 def test_encode_sort_attributes() -> None:
     node = parse("<p z=1 a=2>x").select_one("p")
     assert node is not None
-    assert node.encode(sort_attributes=True) == b'<p a="2" z="1">x</p>'
+    assert node.encode(options=Html(sort_attributes=True)) == b'<p a="2" z="1">x</p>'

--- a/tests/serialize/test_tree_format.py
+++ b/tests/serialize/test_tree_format.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import Formatter, Indent, Node, parse
+from turbohtml import Formatter, Html, Indent, Node, parse
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -95,7 +95,7 @@ def test_default_formatter_keeps_non_ascii_literal() -> None:
     ],
 )
 def test_formatter_serialize(html: str, selector: str, formatter: Formatter, expected: str) -> None:
-    assert _one(html, selector).serialize(formatter=formatter) == expected
+    assert _one(html, selector).serialize(Html(formatter=formatter)) == expected
 
 
 @pytest.mark.parametrize(
@@ -150,7 +150,7 @@ def test_formatter_serialize(html: str, selector: str, formatter: Formatter, exp
 )
 def test_serialize_indent(html: str, selector: str, indent: int | str | None, expected: str) -> None:
     layout = None if indent is None else Indent(indent)
-    assert _one(html, selector).serialize(layout=layout) == expected
+    assert _one(html, selector).serialize(Html(layout=layout)) == expected
 
 
 # the parser drops one newline after <pre>; serialization restores it so a
@@ -173,7 +173,7 @@ def test_pre_leading_newline_rule(html: str, selector: str, expected: str) -> No
 
 
 def test_pretty_document_includes_doctype_and_comment() -> None:
-    pretty = parse("<!DOCTYPE html><!--c--><title>t").serialize(layout=Indent(2))
+    pretty = parse("<!DOCTYPE html><!--c--><title>t").serialize(Html(layout=Indent(2)))
     assert pretty.startswith("<!DOCTYPE html>\n<!--c-->\n<html>\n  <head>")
 
 
@@ -220,27 +220,27 @@ def test_indent_rejects_extra_positional() -> None:
 
 
 @pytest.mark.parametrize(
-    ("html", "selector", "kwargs", "expected"),
+    ("html", "selector", "call", "expected"),
     [
-        pytest.param("<p>café</p>", "p", {}, "<p>café</p>".encode(), id="defaults-to-utf8"),
+        pytest.param("<p>café</p>", "p", lambda node: node.encode(), "<p>café</p>".encode(), id="defaults-to-utf8"),
         pytest.param(
             "<p>café</p>",
             "p",
-            {"encoding": "ascii", "formatter": Formatter.NAMED_ENTITIES},
+            lambda node: node.encode("ascii", Html(formatter=Formatter.NAMED_ENTITIES)),
             b"<p>caf&eacute;</p>",
             id="ascii-with-named-entities",
         ),
         pytest.param(
             "<div><p>x</p></div>",
             "div",
-            {"layout": Indent(2)},
+            lambda node: node.encode(options=Html(layout=Indent(2))),
             b"<div>\n  <p>\n    x\n  </p>\n</div>",
             id="honours-indent",
         ),
     ],
 )
-def test_encode(html: str, selector: str, kwargs: dict[str, object], expected: bytes) -> None:
-    assert _one(html, selector).encode(**kwargs) == expected  # ty: ignore[invalid-argument-type]  # object-typed kwargs
+def test_encode(html: str, selector: str, call: Callable[[Node], bytes], expected: bytes) -> None:
+    assert call(_one(html, selector)) == expected
 
 
 @pytest.mark.parametrize(
@@ -260,19 +260,32 @@ def test_encode_raises(html: str, kwargs: dict[str, object], exception: type[Exc
     ("call", "exception", "match"),
     [
         pytest.param(
-            lambda node: node.serialize(formatter="whatwg"), TypeError, "Formatter", id="serialize-non-formatter"
+            lambda node: node.serialize(Html(formatter="whatwg")),  # ty: ignore[invalid-argument-type]  # pass a non-Formatter to test serialize rejects it
+            TypeError,
+            "Formatter",
+            id="serialize-non-formatter",
         ),
         pytest.param(
-            lambda node: node.serialize(layout=Indent(1.5)),  # ty: ignore[invalid-argument-type]  # non-int/str on purpose
+            lambda node: node.serialize(Html(layout=Indent(1.5))),  # ty: ignore[invalid-argument-type]  # pass a non-int/str to test Indent rejects it
             TypeError,
             "indent",
             id="indent-bad-type",
         ),
-        pytest.param(lambda node: node.serialize(layout=Indent(-1)), ValueError, "negative", id="indent-negative"),
-        pytest.param(lambda node: node.serialize(layout="whatwg"), TypeError, "layout", id="serialize-bad-layout"),
-        pytest.param(lambda node: node.serialize("whatwg"), TypeError, None, id="serialize-positional"),
-        pytest.param(lambda node: node.encode("utf-8", "extra"), TypeError, None, id="encode-extra-positional"),
-        pytest.param(lambda node: node.encode(formatter="whatwg"), TypeError, "Formatter", id="encode-non-formatter"),
+        pytest.param(
+            lambda node: node.serialize(Html(layout=Indent(-1))), ValueError, "negative", id="indent-negative"
+        ),
+        pytest.param(
+            lambda node: node.serialize(Html(layout="whatwg")),  # ty: ignore[invalid-argument-type]  # pass a non-layout to test serialize rejects it
+            TypeError,
+            "layout",
+            id="serialize-bad-layout",
+        ),
+        pytest.param(
+            lambda node: node.encode(options=Html(formatter="whatwg")),  # ty: ignore[invalid-argument-type]  # pass a non-Formatter to test encode rejects it
+            TypeError,
+            "Formatter",
+            id="encode-non-formatter",
+        ),
     ],
 )
 def test_serialize_encode_argument_validation(
@@ -280,6 +293,44 @@ def test_serialize_encode_argument_validation(
 ) -> None:
     with pytest.raises(exception, match=match):
         call(_one("<p>x</p>", "p"))
+
+
+def test_explicit_none_is_the_default() -> None:
+    node = _one("<div><p>hi</p></div>", "div")
+    assert node.serialize(None) == node.serialize()
+    assert node.encode("utf-8", None) == node.encode()
+
+
+def test_serialize_options_must_be_an_html() -> None:
+    with pytest.raises(TypeError, match="options must be a Html"):
+        _one("<p>x</p>", "p").serialize(object())  # ty: ignore[invalid-argument-type]  # pass a non-Html to test the type error
+
+
+def test_encode_options_must_be_an_html() -> None:
+    with pytest.raises(TypeError, match="options must be a Html"):
+        _one("<p>x</p>", "p").encode("utf-8", object())  # ty: ignore[invalid-argument-type]  # pass a non-Html to test the type error
+
+
+def test_serialize_rejects_extra_positional() -> None:
+    with pytest.raises(TypeError):
+        _one("<p>x</p>", "p").serialize(Html(), Html())  # ty: ignore[too-many-positional-arguments]  # a second arg is rejected
+
+
+def test_encode_rejects_extra_positional() -> None:
+    with pytest.raises(TypeError):
+        _one("<p>x</p>", "p").encode("utf-8", Html(), "extra")  # ty: ignore[too-many-positional-arguments]  # a third arg is rejected
+
+
+def test_serialize_propagates_a_raising_truthiness() -> None:
+    # the Html bool fields are read with PyObject_IsTrue, so a value whose __bool__
+    # raises surfaces the error instead of being silently coerced
+    class _Boom:
+        def __bool__(self) -> bool:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _one("<p>x</p>", "p").serialize(Html(sort_attributes=_Boom()))  # ty: ignore[invalid-argument-type]  # a raising __bool__ on purpose
 
 
 @pytest.mark.parametrize(

--- a/tests/serialize/test_tree_markdown_converters.py
+++ b/tests/serialize/test_tree_markdown_converters.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import Element, parse
+from turbohtml import Element, Markdown, parse
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -45,30 +45,30 @@ def wrap(marker: str) -> Converter:
     ],
 )
 def test_inline_converter(html: str, tag: str, converter: Converter, expected: str) -> None:
-    assert parse(html).to_markdown(converters={tag: converter}) == expected
+    assert parse(html).to_markdown(Markdown(converters={tag: converter})) == expected
 
 
 def test_inner_trailing_break_is_trimmed() -> None:
     # the <br> leaves a trailing "  \n" in the rendered child Markdown that the hook strips
-    out = parse("<p>go <a href='https://x.test'>x<br></a> on</p>").to_markdown(converters={"a": wrap("|")})
+    out = parse("<p>go <a href='https://x.test'>x<br></a> on</p>").to_markdown(Markdown(converters={"a": wrap("|")}))
     assert out == "go |x| on"
 
 
 def test_inner_all_whitespace_trims_to_empty() -> None:
     # a child that renders to only a break trims away entirely, so the hook sees ""
-    out = parse("<p>a<i><br></i>b</p>").to_markdown(converters={"i": lambda _e, content: f"[{content}]"})
+    out = parse("<p>a<i><br></i>b</p>").to_markdown(Markdown(converters={"i": lambda _e, content: f"[{content}]"}))
     assert out == "a[]b"
 
 
 def test_custom_element_with_attribute() -> None:
     html = "<p>play <video src='m.mp4'>fallback</video> here</p>"
-    out = parse(html).to_markdown(converters={"video": lambda el, _t: f"[{el.attrs['src']}]"})
+    out = parse(html).to_markdown(Markdown(converters={"video": lambda el, _t: f"[{el.attrs['src']}]"}))
     assert out == "play [m.mp4] here"
 
 
 def test_converter_on_foreign_element() -> None:
     # a non-HTML (SVG) element matches by tag name and flows inline, never as a block
-    out = parse("<p>see <svg><title>chart</title></svg> now</p>").to_markdown(converters={"title": wrap("@")})
+    out = parse("<p>see <svg><title>chart</title></svg> now</p>").to_markdown(Markdown(converters={"title": wrap("@")}))
     assert out == "see @chart@ now"
 
 
@@ -89,37 +89,37 @@ def test_converter_on_foreign_element() -> None:
     ],
 )
 def test_block_converter(html: str, expected: str) -> None:
-    assert parse(html).to_markdown(converters={"div": lambda _e, text: f"<<{text}>>"}) == expected
+    assert parse(html).to_markdown(Markdown(converters={"div": lambda _e, text: f"<<{text}>>"})) == expected
 
 
 def test_block_converter_multiline_keeps_prefix() -> None:
     out = parse("<ul><li>one<div>x</div></li></ul>").to_markdown(
-        converters={"div": lambda _e, _t: "line1\nline2"},
+        Markdown(converters={"div": lambda _e, _t: "line1\nline2"}),
     )
     assert out == "- one\n  line1\n  line2"
 
 
 def test_empty_converter_result_emits_nothing() -> None:
-    out = parse("<section><div>x</div></section>").to_markdown(converters={"div": lambda _e, _t: ""})
+    out = parse("<section><div>x</div></section>").to_markdown(Markdown(converters={"div": lambda _e, _t: ""}))
     assert not out
 
 
 def test_converter_on_root_element() -> None:
     section = parse("<section>hi <b>there</b></section>").find("section")
     assert section is not None
-    out = section.to_markdown(converters={"section": lambda _e, text: f"S[{text}]"})
+    out = section.to_markdown(Markdown(converters={"section": lambda _e, text: f"S[{text}]"}))
     assert out == "S[hi **there**]"
 
 
 def test_reference_link_inside_converter_registers() -> None:
     html = "<div><a href='https://e.test'>e</a></div>"
-    out = parse(html).to_markdown(link_style="reference", converters={"div": wrap("|")})
+    out = parse(html).to_markdown(Markdown(links=Markdown.Links(style="reference"), converters={"div": wrap("|")}))
     assert out == "|[e][1]|\n\n[1]: https://e.test"
 
 
 def test_converter_receives_element_and_content(mocker: MockerFixture) -> None:
     converter = mocker.MagicMock(return_value="X")
-    out = parse("<p><b>hi <i>there</i></b></p>").to_markdown(converters={"b": converter})
+    out = parse("<p><b>hi <i>there</i></b></p>").to_markdown(Markdown(converters={"b": converter}))
     assert out == "X"
     converter.assert_called_once()
     element, content = converter.call_args.args
@@ -129,12 +129,12 @@ def test_converter_receives_element_and_content(mocker: MockerFixture) -> None:
 
 
 def test_unregistered_tag_renders_normally() -> None:
-    out = parse("<p><b>x</b><i>y</i></p>").to_markdown(converters={"b": wrap("@")})
+    out = parse("<p><b>x</b><i>y</i></p>").to_markdown(Markdown(converters={"b": wrap("@")}))
     assert out == "@x@*y*"
 
 
 def test_content_node_passes_through_with_converters() -> None:
-    out = parse("<p>a<template>b</template>c</p>").to_markdown(converters={"unused": wrap("@")})
+    out = parse("<p>a<template>b</template>c</p>").to_markdown(Markdown(converters={"unused": wrap("@")}))
     assert out == "abc"
 
 
@@ -148,11 +148,11 @@ def test_content_node_passes_through_with_converters() -> None:
 )
 def test_no_op_converters_match_default(converters: Mapping[str, Converter] | None) -> None:
     html = "<p><b>x</b></p>"
-    assert parse(html).to_markdown(converters=converters) == parse(html).to_markdown()
+    assert parse(html).to_markdown(Markdown(converters=converters)) == parse(html).to_markdown()
 
 
 def test_non_dict_mapping_is_accepted() -> None:
-    out = parse("<p><b>x</b></p>").to_markdown(converters=MappingProxyType({"b": wrap("__")}))
+    out = parse("<p><b>x</b></p>").to_markdown(Markdown(converters=MappingProxyType({"b": wrap("__")})))
     assert out == "__x__"
 
 
@@ -161,7 +161,7 @@ def test_non_str_return_raises_type_error() -> None:
         return 123  # ty: ignore[invalid-return-type]  # a non-str on purpose, to exercise the runtime check
 
     with pytest.raises(TypeError, match=r"converter for <b> must return a str, not int"):
-        parse("<p><b>x</b></p>").to_markdown(converters={"b": convert})
+        parse("<p><b>x</b></p>").to_markdown(Markdown(converters={"b": convert}))
 
 
 def test_converter_exception_propagates() -> None:
@@ -170,16 +170,18 @@ def test_converter_exception_propagates() -> None:
         raise ValueError(msg)
 
     with pytest.raises(ValueError, match="boom"):
-        parse("<p><b>x</b></p>").to_markdown(converters={"b": boom})
+        parse("<p><b>x</b></p>").to_markdown(Markdown(converters={"b": boom}))
 
 
 def test_non_callable_value_raises() -> None:
     with pytest.raises(TypeError):
         # a non-callable value on purpose, to exercise the runtime call failure
-        parse("<p><b>x</b></p>").to_markdown(converters={"b": "not callable"})  # ty: ignore[invalid-argument-type]
+        parse("<p><b>x</b></p>").to_markdown(
+            Markdown(converters={"b": "not callable"}),  # ty: ignore[invalid-argument-type]
+        )
 
 
 def test_non_mapping_argument_raises() -> None:
     with pytest.raises((TypeError, AttributeError)):
         # a non-mapping on purpose, to exercise the binding's argument coercion
-        parse("<p><b>x</b></p>").to_markdown(converters=42)  # ty: ignore[invalid-argument-type]
+        parse("<p><b>x</b></p>").to_markdown(Markdown(converters=42))  # ty: ignore[invalid-argument-type]

--- a/tests/serialize/test_tree_markdown_filters.py
+++ b/tests/serialize/test_tree_markdown_filters.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import parse
+from turbohtml import Markdown, parse
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     ],
 )
 def test_strip_inline(html: str, strip: list[str], expected: str) -> None:
-    assert parse(html).to_markdown(strip=strip) == expected
+    assert parse(html).to_markdown(Markdown(strip=strip)) == expected
 
 
 @pytest.mark.parametrize(
@@ -57,41 +57,41 @@ def test_strip_inline(html: str, strip: list[str], expected: str) -> None:
     ],
 )
 def test_convert_inline(html: str, convert: list[str], expected: str) -> None:
-    assert parse(html).to_markdown(convert=convert) == expected
+    assert parse(html).to_markdown(Markdown(convert=convert)) == expected
 
 
 def test_convert_empty_drops_all_markup() -> None:
     # an empty allowlist keeps markup for nothing, so only the text survives
-    out = parse('<p><b>x</b> <a href="https://e.test">y</a></p>').to_markdown(convert=[])
+    out = parse('<p><b>x</b> <a href="https://e.test">y</a></p>').to_markdown(Markdown(convert=[]))
     assert out == "x y"
 
 
 def test_strip_block_keeps_children() -> None:
-    out = parse("<blockquote><p>quoted</p></blockquote>").to_markdown(strip=["blockquote"])
+    out = parse("<blockquote><p>quoted</p></blockquote>").to_markdown(Markdown(strip=["blockquote"]))
     assert out == "quoted"
 
 
 def test_strip_heading_unwraps_to_prose() -> None:
-    out = parse("<h2>Heading</h2><p>Body text.</p>").to_markdown(strip=["h2"])
+    out = parse("<h2>Heading</h2><p>Body text.</p>").to_markdown(Markdown(strip=["h2"]))
     assert out == "Heading\n\nBody text."
 
 
 def test_convert_block_drops_outer_block() -> None:
-    out = parse("<blockquote><p>kept</p></blockquote>").to_markdown(convert=["p"])
+    out = parse("<blockquote><p>kept</p></blockquote>").to_markdown(Markdown(convert=["p"]))
     assert out == "kept"
 
 
 def test_strip_leaves_foreign_element_untouched() -> None:
     # an SVG element has no HTML atom, so it is never named by a filter and renders normally
-    out = parse("<p>a <svg><title>chart</title></svg> b</p>").to_markdown(strip=["b"])
+    out = parse("<p>a <svg><title>chart</title></svg> b</p>").to_markdown(Markdown(strip=["b"]))
     assert out == "a chart b"
 
 
 @pytest.mark.parametrize(
     "render",
     [
-        pytest.param(lambda doc: doc.to_markdown(strip=["script"]), id="strip"),
-        pytest.param(lambda doc: doc.to_markdown(convert=["b"]), id="convert"),
+        pytest.param(lambda doc: doc.to_markdown(Markdown(strip=["script"])), id="strip"),
+        pytest.param(lambda doc: doc.to_markdown(Markdown(convert=["b"])), id="convert"),
     ],
 )
 def test_skipped_tag_inside_kept_inline_vanishes_whole(render: Callable[[Document], str]) -> None:
@@ -102,31 +102,31 @@ def test_skipped_tag_inside_kept_inline_vanishes_whole(render: Callable[[Documen
 
 def test_uppercase_tag_name_is_lowercased() -> None:
     # a tag name is matched case-insensitively, exercising the ASCII lowercasing
-    out = parse("<p><b>x</b></p>").to_markdown(strip=["B"])
+    out = parse("<p><b>x</b></p>").to_markdown(Markdown(strip=["B"]))
     assert out == "x"
 
 
 def test_unknown_tag_name_is_ignored() -> None:
     html = "<p><b>x</b></p>"
-    assert parse(html).to_markdown(strip=["nosuchtag"]) == parse(html).to_markdown()
+    assert parse(html).to_markdown(Markdown(strip=["nosuchtag"])) == parse(html).to_markdown()
 
 
 def test_overlong_tag_name_is_ignored() -> None:
     html = "<p><b>x</b></p>"
-    assert parse(html).to_markdown(strip=["z" * 65]) == parse(html).to_markdown()
+    assert parse(html).to_markdown(Markdown(strip=["z" * 65])) == parse(html).to_markdown()
 
 
 def test_surrogate_tag_name_is_ignored() -> None:
     html = "<p><b>x</b></p>"
-    assert parse(html).to_markdown(strip=["\ud800"]) == parse(html).to_markdown()
+    assert parse(html).to_markdown(Markdown(strip=["\ud800"])) == parse(html).to_markdown()
 
 
 @pytest.mark.parametrize(
     "render",
     [
-        pytest.param(lambda doc: doc.to_markdown(strip=None), id="strip-none"),
-        pytest.param(lambda doc: doc.to_markdown(convert=None), id="convert-none"),
-        pytest.param(lambda doc: doc.to_markdown(strip=[]), id="strip-empty"),
+        pytest.param(lambda doc: doc.to_markdown(Markdown(strip=None)), id="strip-none"),
+        pytest.param(lambda doc: doc.to_markdown(Markdown(convert=None)), id="convert-none"),
+        pytest.param(lambda doc: doc.to_markdown(Markdown(strip=[])), id="strip-empty"),
     ],
 )
 def test_no_op_filters_match_default(render: Callable[[Document], str]) -> None:
@@ -135,20 +135,20 @@ def test_no_op_filters_match_default(render: Callable[[Document], str]) -> None:
 
 
 def test_non_str_iterable_accepted() -> None:
-    out = parse("<p><b>x</b></p>").to_markdown(strip=(tag for tag in ["b"]))
+    out = parse("<p><b>x</b></p>").to_markdown(Markdown(strip=(tag for tag in ["b"])))
     assert out == "x"
 
 
 def test_strip_and_convert_are_mutually_exclusive() -> None:
     with pytest.raises(ValueError, match="strip and convert are mutually exclusive"):
-        parse("<p><b>x</b></p>").to_markdown(strip=["b"], convert=["b"])
+        Markdown(strip=["b"], convert=["b"])
 
 
 @pytest.mark.parametrize(
     "render",
     [
-        pytest.param(lambda doc: doc.to_markdown(strip="b"), id="strip"),
-        pytest.param(lambda doc: doc.to_markdown(convert="a"), id="convert"),
+        pytest.param(lambda doc: doc.to_markdown(Markdown(strip="b")), id="strip"),
+        pytest.param(lambda doc: doc.to_markdown(Markdown(convert="a")), id="convert"),
     ],
 )
 def test_single_str_rejected(render: Callable[[Document], str]) -> None:
@@ -159,9 +159,8 @@ def test_single_str_rejected(render: Callable[[Document], str]) -> None:
 @pytest.mark.parametrize(
     "render",
     [
-        # a non-iterable on purpose, to exercise the binding's iterator coercion
-        pytest.param(lambda doc: doc.to_markdown(strip=42), id="strip"),
-        pytest.param(lambda doc: doc.to_markdown(convert=42), id="convert"),
+        pytest.param(lambda doc: doc.to_markdown(Markdown(strip=42)), id="strip"),  # ty: ignore[invalid-argument-type]  # pass a non-iterable to test the binding rejects it
+        pytest.param(lambda doc: doc.to_markdown(Markdown(convert=42)), id="convert"),  # ty: ignore[invalid-argument-type]  # pass a non-iterable to test the binding rejects it
     ],
 )
 def test_non_iterable_rejected(render: Callable[[Document], str]) -> None:
@@ -172,7 +171,7 @@ def test_non_iterable_rejected(render: Callable[[Document], str]) -> None:
 def test_non_str_tag_rejected() -> None:
     with pytest.raises(TypeError, match="tags must be str, not int"):
         # a non-str element on purpose, to exercise the per-item type check
-        parse("<p><b>x</b></p>").to_markdown(strip=["b", 5])  # ty: ignore[invalid-argument-type]
+        parse("<p><b>x</b></p>").to_markdown(Markdown(strip=["b", 5]))  # ty: ignore[invalid-argument-type]
 
 
 def test_iterator_error_propagates() -> None:
@@ -182,4 +181,4 @@ def test_iterator_error_propagates() -> None:
         raise RuntimeError(msg)
 
     with pytest.raises(RuntimeError, match="boom"):
-        parse("<p><b>x</b></p>").to_markdown(strip=tags())
+        parse("<p><b>x</b></p>").to_markdown(Markdown(strip=tags()))

--- a/tests/serialize/test_tree_markdown_google.py
+++ b/tests/serialize/test_tree_markdown_google.py
@@ -7,315 +7,302 @@ path in the C walker is exercised.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
-
 import pytest
 
-from turbohtml import parse
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from turbohtml import Markdown, parse
 
 
-class _Opts(TypedDict, total=False):
-    """The google_doc keyword options of Node.to_markdown, kept typed."""
-
-    google_doc: bool
-    google_list_indent: int
-    hide_strikethrough: bool
-    strong: str
-    emphasis: str
-
-
-def md(html: str, opts: _Opts) -> str:
-    return parse(html).to_markdown(**opts)
-
-
-def call_with(convert: Callable[..., str], **kwargs: str | int) -> str:
-    """Invoke the converter with an option the static signature rejects, to drive
-    the runtime validation; the converter arrives signature-erased on purpose."""
-    return convert(**kwargs)
+def md(html: str, config: Markdown) -> str:
+    return parse(html).to_markdown(config)
 
 
 @pytest.mark.parametrize(
-    ("html", "opts", "expected"),
+    ("html", "config", "expected"),
     [
         pytest.param(
             '<p><span style="font-weight:700">a</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**a**",
             id="font-weight-700-is-bold",
         ),
         pytest.param(
             '<p><span style="font-weight:bold">a</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**a**",
             id="font-weight-bold-keyword",
         ),
         pytest.param(
             '<p><span style="font-weight:800">a</span><span style="font-weight:900">b</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**a****b**",
             id="font-weight-800-and-900",
         ),
         pytest.param(
             '<p><span style="font-weight:400">a</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "a",
             id="font-weight-400-is-not-bold",
         ),
         pytest.param(
             '<p><span style="font-weight:bolder">a</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "a",
             id="value-longer-than-keyword-not-bold",
         ),
         pytest.param(
             '<p><span style="font-weight:70">a</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "a",
             id="value-shorter-than-keyword-not-bold",
         ),
         pytest.param(
             '<p><span style="font-style:italic">a</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "*a*",
             id="font-style-italic",
         ),
         pytest.param(
             '<p><span style="font-style:normal">a</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "a",
             id="font-style-normal-is-plain",
         ),
         pytest.param(
             '<p><span style="font-weight:bold;font-style:italic">a</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "***a***",
             id="bold-and-italic-combine",
         ),
         pytest.param(
             '<p><span style="font-family:Courier New">code()</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "`code()`",
             id="courier-new-is-fixed-width-code",
         ),
         pytest.param(
             '<p><span style="font-family:Consolas">x</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "`x`",
             id="consolas-is-fixed-width-code",
         ),
         pytest.param(
             '<p><span style="font-family:Arial">x</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "x",
             id="proportional-font-is-plain",
         ),
         pytest.param(
             '<p><span style="font-weight:bold;font-family:Courier New">x</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**`x`**",
             id="bold-fixed-width-nests",
         ),
         pytest.param(
             '<p><span style="font-weight:bold"><span style="color:red">x</span></span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**x**",
             id="nested-span-inherits-bold-no-double",
         ),
         pytest.param(
             '<p><span style="font-weight:bold"><span style="font-weight:bold">x</span></span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**x**",
             id="restated-bold-not-doubled",
         ),
         pytest.param(
             '<p>a<span style="font-weight:bold"> x </span>b</p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "a **x** b",
             id="inner-space-moves-outside-markers",
         ),
         pytest.param(
             '<p>keep<span style="font-weight:bold"></span> on</p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "keep on",
             id="empty-styled-span-emits-nothing",
         ),
         pytest.param(
             '<p>a <span style="text-decoration:line-through">gone</span> b</p>',
-            {"google_doc": True, "hide_strikethrough": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True), inline=Markdown.Inline(hide_strikethrough=True)),
             "a b",
             id="line-through-hidden-when-asked",
         ),
         pytest.param(
             '<p>a <span style="text-decoration:line-through">b</span> c</p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "a b c",
             id="line-through-ignored-by-default",
         ),
         pytest.param(
             '<p><span style="text-decoration:underline">a</span></p>',
-            {"google_doc": True, "hide_strikethrough": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True), inline=Markdown.Inline(hide_strikethrough=True)),
             "a",
             id="underline-is-not-strikethrough",
         ),
         pytest.param(
             "<p>a <span>b</span> c</p>",
-            {"google_doc": True, "hide_strikethrough": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True), inline=Markdown.Inline(hide_strikethrough=True)),
             "a b c",
             id="hide-strikethrough-with-styleless-element",
         ),
         pytest.param(
             '<p><span style="font-weight:bold">x</span></p>',
-            {"google_doc": True, "hide_strikethrough": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True), inline=Markdown.Inline(hide_strikethrough=True)),
             "**x**",
             id="hide-strikethrough-without-text-decoration",
         ),
         pytest.param(
             '<p><span style="font-style:italic"><span style="font-style:italic">x</span></span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "*x*",
             id="nested-span-inherits-italic-no-double",
         ),
         pytest.param(
             '<p>a<span style="font-style:italic"></span>b</p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "ab",
             id="empty-italic-span-emits-nothing",
         ),
         pytest.param(
             '<p><span style="font-weight:bold;display">y</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**y**",
             id="trailing-declaration-without-colon-skipped",
         ),
         pytest.param(
             '<p><span style="font-weight:bold; :">x</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**x**",
             id="blank-name-and-value-declaration",
         ),
         pytest.param(
             '<p><span style="font-weight:bold">a</span></p>',
-            {},
+            Markdown(),
             "a",
             id="styles-ignored-without-google-doc",
         ),
         pytest.param(
             "<p><span>plain</span></p>",
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "plain",
             id="span-without-style-is-plain",
         ),
         pytest.param(
             '<p><span style="color:red">x</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "x",
             id="unrelated-style-property",
         ),
         pytest.param(
             '<p><span style="display;font-weight:bold">x</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**x**",
             id="declaration-without-colon-skipped",
         ),
         pytest.param(
             '<p><span style="FONT-WEIGHT: BOLD">x</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**x**",
             id="property-and-value-case-insensitive",
         ),
         pytest.param(
             '<p><span style="  font-weight : bold ">x</span></p>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "**x**",
             id="whitespace-around-property-and-value-trimmed",
         ),
         pytest.param(
             '<p><span style="font-weight:bold">a</span></p>',
-            {"google_doc": True, "strong": "__", "emphasis": "_"},
+            Markdown(google=Markdown.GoogleDoc(enabled=True), inline=Markdown.Inline(strong="__", emphasis="_")),
             "__a__",
             id="bold-uses-configured-marker",
         ),
         pytest.param(
             '<ul><li style="margin-left:36px">a</li><li style="margin-left:72px">b</li></ul>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "  - a\n    - b",
             id="margin-left-nests-list-items",
         ),
         pytest.param(
             '<ul><li style="margin-left:72px">a</li></ul>',
-            {"google_doc": True, "google_list_indent": 72},
+            Markdown(google=Markdown.GoogleDoc(enabled=True, list_indent=72)),
             "  - a",
             id="custom-list-indent-divisor",
         ),
         pytest.param(
             '<ol><li style="margin-left:36px">a</li></ol>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "  1. a",
             id="margin-left-nests-ordered-items",
         ),
         pytest.param(
             "<ul><li>a</li></ul>",
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "- a",
             id="list-item-without-margin-is-flat",
         ),
         pytest.param(
             '<ul><li style="margin-left:48px">x</li></ul>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "  - x",
             id="margin-not-a-multiple-floors-down",
         ),
         pytest.param(
             '<ul><li style="margin-left:36">a</li></ul>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "  - a",
             id="margin-left-without-px-unit",
         ),
         pytest.param(
             '<ul><li style="margin-left:auto">a</li></ul>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "- a",
             id="non-numeric-margin-is-no-nesting",
         ),
         pytest.param(
             '<ul><li style="margin-left:-36px">a</li></ul>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "- a",
             id="negative-margin-is-no-nesting",
         ),
         pytest.param(
             '<ul><li style="color:red">a</li></ul>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "- a",
             id="list-item-style-without-margin",
         ),
         pytest.param(
             '<ol style="list-style-type:disc"><li>a</li></ol>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "- a",
             id="list-style-disc-renders-unordered",
         ),
         pytest.param(
             '<ul style="list-style-type:decimal"><li>a</li></ul>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "1. a",
             id="list-style-decimal-renders-ordered",
         ),
         pytest.param(
             '<ul style="color:red"><li>a</li></ul>',
-            {"google_doc": True},
+            Markdown(google=Markdown.GoogleDoc(enabled=True)),
             "- a",
             id="list-without-style-type-keeps-tag",
         ),
     ],
 )
-def test_google_doc(html: str, opts: _Opts, expected: str) -> None:
-    assert md(html, opts) == expected
+def test_google_doc(html: str, config: Markdown, expected: str) -> None:
+    assert md(html, config) == expected
 
 
 def test_google_list_indent_must_be_positive() -> None:
     with pytest.raises(ValueError, match="google_list_indent"):
-        call_with(parse("<p>x</p>").to_markdown, google_list_indent=0)
+        parse("<p>x</p>").to_markdown(Markdown(google=Markdown.GoogleDoc(list_indent=0)))
+
+
+def test_google_doc_preset_enables_styling_and_drops_struck_text() -> None:
+    preset = Markdown.google_doc()
+    assert preset.google.enabled
+    assert preset.inline.hide_strikethrough
+    html = '<p><span style="font-weight:700">keep</span> <span style="text-decoration:line-through">gone</span></p>'
+    assert parse(html).to_markdown(preset) == "**keep**"

--- a/tests/serialize/test_tree_markdown_modes.py
+++ b/tests/serialize/test_tree_markdown_modes.py
@@ -8,127 +8,108 @@ exercised.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
-
 import pytest
 
-from turbohtml import parse
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Literal
+from turbohtml import Markdown, parse
 
 
-class _Opts(TypedDict, total=False):
-    """The to_markdown options touched by the new output modes, kept typed."""
-
-    wrap_width: int
-    wrap_list_items: bool
-    wrap_links: bool
-    transliterate: bool
-    image_mode: Literal["markdown", "alt", "ignore", "html"]
-    table_mode: Literal["markdown", "strip", "html"]
-
-
-def md(html: str, opts: _Opts) -> str:
-    return parse(html).to_markdown(**opts)
-
-
-def call_with(convert: Callable[..., str], **kwargs: str | int) -> str:
-    """Invoke a converter with arguments the static signature would reject, to
-    drive the runtime validation; the converter arrives signature-erased."""
-    return convert(**kwargs)
+def md(html: str, config: Markdown) -> str:
+    return parse(html).to_markdown(config)
 
 
 @pytest.mark.parametrize(
-    ("html", "opts", "expected"),
+    ("html", "config", "expected"),
     [
         pytest.param(
             "<p>one two three four five six seven eight</p>",
-            _Opts(wrap_width=15),
+            Markdown(wrapping=Markdown.Wrapping(width=15)),
             "one two three\nfour five six\nseven eight",
             id="wrap-prose-greedy",
         ),
         pytest.param(
             "<p>antidisestablishmentarianism rocks</p>",
-            _Opts(wrap_width=10),
+            Markdown(wrapping=Markdown.Wrapping(width=10)),
             "antidisestablishmentarianism\nrocks",
             id="wrap-long-word-not-split",
         ),
         pytest.param(
             "<blockquote>alpha beta gamma delta</blockquote>",
-            _Opts(wrap_width=12),
+            Markdown(wrapping=Markdown.Wrapping(width=12)),
             "> alpha beta\n> gamma\n> delta",
             id="wrap-keeps-blockquote-prefix",
         ),
         pytest.param(
             "<p>one two three</p>",
-            _Opts(wrap_width=0),
+            Markdown(wrapping=Markdown.Wrapping(width=0)),
             "one two three",
             id="wrap-zero-disables",
         ),
     ],
 )
-def test_wrap_width(html: str, opts: _Opts, expected: str) -> None:
-    assert md(html, opts) == expected
+def test_wrap_width(html: str, config: Markdown, expected: str) -> None:
+    assert md(html, config) == expected
 
 
 @pytest.mark.parametrize(
-    ("opts", "expected"),
+    ("config", "expected"),
     [
-        pytest.param(_Opts(wrap_width=12), "- alpha beta gamma delta epsilon", id="list-items-unwrapped-by-default"),
         pytest.param(
-            _Opts(wrap_width=12, wrap_list_items=True),
+            Markdown(wrapping=Markdown.Wrapping(width=12)),
+            "- alpha beta gamma delta epsilon",
+            id="list-items-unwrapped-by-default",
+        ),
+        pytest.param(
+            Markdown(wrapping=Markdown.Wrapping(width=12, list_items=True)),
             "- alpha beta\n  gamma\n  delta\n  epsilon",
             id="list-items-wrapped",
         ),
     ],
 )
-def test_wrap_list_items(opts: _Opts, expected: str) -> None:
+def test_wrap_list_items(config: Markdown, expected: str) -> None:
     html = "<ul><li>alpha beta gamma delta epsilon</li></ul>"
-    assert md(html, opts) == expected
+    assert md(html, config) == expected
 
 
 @pytest.mark.parametrize(
-    ("html", "opts", "expected"),
+    ("html", "config", "expected"),
     [
         pytest.param(
             '<p>see <a href="u">the long link text here</a> ok</p>',
-            _Opts(wrap_width=10, wrap_links=False),
+            Markdown(wrapping=Markdown.Wrapping(width=10, links=False)),
             "see [the long link text here](u)\nok",
             id="links-unbroken",
         ),
         pytest.param(
             '<p><a href="u">alpha beta gamma</a></p>',
-            _Opts(wrap_width=10),
+            Markdown(wrapping=Markdown.Wrapping(width=10)),
             "[alpha\nbeta gamma](u)",
             id="links-wrap-when-allowed",
         ),
     ],
 )
-def test_wrap_links(html: str, opts: _Opts, expected: str) -> None:
-    assert md(html, opts) == expected
+def test_wrap_links(html: str, config: Markdown, expected: str) -> None:
+    assert md(html, config) == expected
 
 
 @pytest.mark.parametrize(
-    ("html", "opts", "expected"),
+    ("html", "config", "expected"),
     [
         pytest.param(
             '<p><img src="a.png" alt="x" width="4"></p>',
-            _Opts(image_mode="html"),
+            Markdown(images=Markdown.Images(mode="html")),
             '<img src="a.png" alt="x" width="4">',
             id="image-html-keeps-attributes",
         ),
         pytest.param(
             "<table><tr><td>a</td></tr></table>",
-            _Opts(table_mode="html"),
+            Markdown(tables=Markdown.Tables(mode="html")),
             "<table><tbody><tr><td>a</td></tr></tbody></table>",
             id="table-html-verbatim",
         ),
     ],
 )
-def test_html_passthrough(html: str, opts: _Opts, expected: str) -> None:
-    assert md(html, opts) == expected
+def test_html_passthrough(html: str, config: Markdown, expected: str) -> None:
+    assert md(html, config) == expected
 
 
 @pytest.mark.parametrize(
@@ -142,25 +123,41 @@ def test_html_passthrough(html: str, opts: _Opts, expected: str) -> None:
     ],
 )
 def test_transliterate(html: str, expected: str) -> None:
-    assert md(html, _Opts(transliterate=True)) == expected
+    assert md(html, Markdown(document=Markdown.Document(transliterate=True))) == expected
 
 
 def test_transliterate_leaves_code_verbatim() -> None:
-    assert md("<p><code>café</code></p>", _Opts(transliterate=True)) == "`café`"
+    assert md("<p><code>café</code></p>", Markdown(document=Markdown.Document(transliterate=True))) == "`café`"
 
 
 def test_wrap_and_transliterate_compose() -> None:
     html = "<p>The “quick” brown fox — jumps over the lazy dog today.</p>"
     expected = 'The "quick" brown fox -- jumps\nover the lazy dog today.'
-    assert md(html, _Opts(wrap_width=30, transliterate=True)) == expected
+    config = Markdown(wrapping=Markdown.Wrapping(width=30), document=Markdown.Document(transliterate=True))
+    assert md(html, config) == expected
 
 
 def test_wrap_width_rejects_negative() -> None:
     with pytest.raises(ValueError, match="wrap_width"):
-        call_with(parse("<p>x</p>").to_markdown, wrap_width=-1)
+        parse("<p>x</p>").to_markdown(Markdown(wrapping=Markdown.Wrapping(width=-1)))
 
 
-@pytest.mark.parametrize("option", ["image_mode", "table_mode"])
-def test_new_enum_values_still_validate(option: str) -> None:
+@pytest.mark.parametrize(
+    ("config", "option"),
+    [
+        # a bogus enum value on purpose, to exercise the renderer's runtime validation
+        pytest.param(
+            Markdown(images=Markdown.Images(mode="bogus")),  # ty: ignore[invalid-argument-type]
+            "image_mode",
+            id="image_mode",
+        ),
+        pytest.param(
+            Markdown(tables=Markdown.Tables(mode="bogus")),  # ty: ignore[invalid-argument-type]
+            "table_mode",
+            id="table_mode",
+        ),
+    ],
+)
+def test_new_enum_values_still_validate(config: Markdown, option: str) -> None:
     with pytest.raises(ValueError, match=option):
-        call_with(parse("<p>x</p>").to_markdown, **{option: "bogus"})
+        parse("<p>x</p>").to_markdown(config)

--- a/tests/serialize/test_tree_markdown_options.py
+++ b/tests/serialize/test_tree_markdown_options.py
@@ -6,131 +6,129 @@ option code path in the C walker is exercised.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import parse
+from turbohtml import Markdown, parse
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
-    from typing import Literal
+    from collections.abc import Callable
+
+    from turbohtml import Node
 
 
-class _Opts(TypedDict, total=False):
-    """The keyword options of Node.to_markdown, so the golden cases stay typed."""
-
-    heading_style: Literal["atx", "atx_closed", "setext"]
-    bullets: str
-    strong: str
-    emphasis: str
-    strikethrough: Literal["keep", "hide"]
-    ignore_emphasis: bool
-    sub_symbol: str
-    sup_symbol: str
-    code_block_style: Literal["fenced", "indented"]
-    code_language: str
-    mark_code: bool
-    link_style: Literal["inline", "reference"]
-    autolink: bool
-    link_title: bool
-    ignore_links: bool
-    skip_internal_links: bool
-    base_url: str
-    image_mode: Literal["markdown", "alt", "ignore"]
-    default_image_alt: str
-    table_mode: Literal["markdown", "strip"]
-    table_header: Literal["first", "detect", "none"]
-    pad_tables: bool
-    escape_mode: Literal["minimal", "all"]
-    escape_asterisks: bool
-    escape_underscores: bool
-    line_break: Literal["spaces", "backslash"]
-    block_spacing: Literal["double", "single"]
-    document_strip: Literal["strip", "lstrip", "rstrip", "none"]
-    quote_open: str
-    quote_close: str
-
-
-def md(html: str, opts: _Opts) -> str:
-    return parse(html).to_markdown(**opts)
-
-
-def call_with(convert: Callable[..., str], **kwargs: str | int) -> str:
-    """Invoke a converter with options the static signature would reject, to drive
-    the runtime validation; the converter arrives signature-erased on purpose."""
-    return convert(**kwargs)
+def md(html: str, options: Markdown) -> str:
+    return parse(html).to_markdown(options)
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<h2>H</h2>", _Opts(heading_style="atx_closed"), "## H ##", id="heading-atx-closed"),
-        pytest.param("<h1>H</h1>", _Opts(heading_style="setext"), "H\n=", id="heading-setext-h1"),
-        pytest.param("<h2>Hi</h2>", _Opts(heading_style="setext"), "Hi\n--", id="heading-setext-h2"),
-        pytest.param("<h3>H</h3>", _Opts(heading_style="setext"), "### H", id="heading-setext-h3-falls-back"),
+        pytest.param(
+            "<h2>H</h2>", Markdown(headings=Markdown.Headings(style="atx_closed")), "## H ##", id="heading-atx-closed"
+        ),
+        pytest.param(
+            "<h1>H</h1>", Markdown(headings=Markdown.Headings(style="setext")), "H\n=", id="heading-setext-h1"
+        ),
+        pytest.param(
+            "<h2>Hi</h2>", Markdown(headings=Markdown.Headings(style="setext")), "Hi\n--", id="heading-setext-h2"
+        ),
+        pytest.param(
+            "<h3>H</h3>",
+            Markdown(headings=Markdown.Headings(style="setext")),
+            "### H",
+            id="heading-setext-h3-falls-back",
+        ),
     ],
 )
-def test_heading_style(html: str, opts: _Opts, expected: str) -> None:
+def test_heading_style(html: str, opts: Markdown, expected: str) -> None:
     assert md(html, opts) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<ul><li>a</li></ul>", _Opts(bullets="*"), "* a", id="bullets-single"),
+        pytest.param("<ul><li>a</li></ul>", Markdown(lists=Markdown.Lists(bullets="*")), "* a", id="bullets-single"),
         pytest.param(
             "<ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li></ul>",
-            _Opts(bullets="*+"),
+            Markdown(lists=Markdown.Lists(bullets="*+")),
             "* a\n  + b\n    * c",
             id="bullets-cycled-by-depth",
         ),
     ],
 )
-def test_bullets(html: str, opts: _Opts, expected: str) -> None:
+def test_bullets(html: str, opts: Markdown, expected: str) -> None:
     assert md(html, opts) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<p><b>x</b></p>", _Opts(strong="__"), "__x__", id="strong-underscore"),
-        pytest.param("<p><em>x</em></p>", _Opts(emphasis="_"), "_x_", id="emphasis-underscore"),
-        pytest.param("<p>a<b>x</b><i>y</i><s>z</s>b</p>", _Opts(ignore_emphasis=True), "axyzb", id="ignore-emphasis"),
-        pytest.param("<p>a<s>z</s>b</p>", _Opts(strikethrough="hide"), "ab", id="strikethrough-hide"),
-        pytest.param("<p>H<sub>2</sub>O</p>", _Opts(sub_symbol="~"), "H~2~O", id="sub-symbol"),
-        pytest.param("<p>x<sup>2</sup></p>", _Opts(sup_symbol="^"), "x^2^", id="sup-symbol"),
-        pytest.param("<p><q>hi</q></p>", _Opts(quote_open="«", quote_close="»"), "«hi»", id="quote-custom"),
-        pytest.param("<p><q>hi</q></p>", _Opts(), '"hi"', id="quote-default"),
+        pytest.param("<p><b>x</b></p>", Markdown(inline=Markdown.Inline(strong="__")), "__x__", id="strong-underscore"),
+        pytest.param(
+            "<p><em>x</em></p>", Markdown(inline=Markdown.Inline(emphasis="_")), "_x_", id="emphasis-underscore"
+        ),
+        pytest.param(
+            "<p>a<b>x</b><i>y</i><s>z</s>b</p>",
+            Markdown(inline=Markdown.Inline(ignore_emphasis=True)),
+            "axyzb",
+            id="ignore-emphasis",
+        ),
+        pytest.param(
+            "<p>a<s>z</s>b</p>", Markdown(inline=Markdown.Inline(strikethrough="hide")), "ab", id="strikethrough-hide"
+        ),
+        pytest.param("<p>H<sub>2</sub>O</p>", Markdown(inline=Markdown.Inline(sub="~")), "H~2~O", id="sub-symbol"),
+        pytest.param("<p>x<sup>2</sup></p>", Markdown(inline=Markdown.Inline(sup="^")), "x^2^", id="sup-symbol"),
+        pytest.param(
+            "<p><q>hi</q></p>",
+            Markdown(inline=Markdown.Inline(quote_open="«", quote_close="»")),
+            "«hi»",
+            id="quote-custom",
+        ),
+        pytest.param("<p><q>hi</q></p>", Markdown(), '"hi"', id="quote-default"),
     ],
 )
-def test_inline_markers(html: str, opts: _Opts, expected: str) -> None:
+def test_inline_markers(html: str, opts: Markdown, expected: str) -> None:
     assert md(html, opts) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<pre><code>x=1</code></pre>", _Opts(code_block_style="indented"), "    x=1", id="code-indented"),
+        pytest.param(
+            "<pre><code>x=1</code></pre>",
+            Markdown(code=Markdown.Code(block_style="indented")),
+            "    x=1",
+            id="code-indented",
+        ),
         pytest.param(
             "<pre><code>x=1\ny=2</code></pre>",
-            _Opts(code_block_style="indented"),
+            Markdown(code=Markdown.Code(block_style="indented")),
             "    x=1\n    y=2",
             id="code-indented-multiline",
         ),
-        pytest.param("<pre><code>x=1</code></pre>", _Opts(mark_code=True), "[code]\nx=1\n[/code]", id="code-mark"),
         pytest.param(
-            "<pre><code>x</code></pre>", _Opts(code_language="py"), "```py\nx\n```", id="code-default-language"
+            "<pre><code>x=1</code></pre>",
+            Markdown(code=Markdown.Code(mark=True)),
+            "[code]\nx=1\n[/code]",
+            id="code-mark",
+        ),
+        pytest.param(
+            "<pre><code>x</code></pre>",
+            Markdown(code=Markdown.Code(language="py")),
+            "```py\nx\n```",
+            id="code-default-language",
         ),
         pytest.param(
             '<pre><code class="language-c">x</code></pre>',
-            _Opts(code_language="py"),
+            Markdown(code=Markdown.Code(language="py")),
             "```c\nx\n```",
             id="code-language-class-wins",
         ),
     ],
 )
-def test_code_blocks(html: str, opts: _Opts, expected: str) -> None:
+def test_code_blocks(html: str, opts: Markdown, expected: str) -> None:
     assert md(html, opts) == expected
 
 
@@ -139,57 +137,86 @@ def test_code_blocks(html: str, opts: _Opts, expected: str) -> None:
     [
         pytest.param(
             '<p><a href="http://x">L</a></p>',
-            _Opts(link_style="reference"),
+            Markdown(links=Markdown.Links(style="reference")),
             "[L][1]\n\n[1]: http://x",
             id="link-reference",
         ),
         pytest.param(
             '<p><a href="/a" title="T">A</a> <a href="/b">B</a></p>',
-            _Opts(link_style="reference"),
+            Markdown(links=Markdown.Links(style="reference")),
             '[A][1] [B][2]\n\n[1]: /a "T"\n[2]: /b',
             id="link-reference-multiple",
         ),
-        pytest.param('<p><a href="http://x.com">http://x.com</a></p>', _Opts(), "<http://x.com>", id="autolink-match"),
+        pytest.param(
+            '<p><a href="http://x.com">http://x.com</a></p>', Markdown(), "<http://x.com>", id="autolink-match"
+        ),
         pytest.param(
             '<p><a href="http://x.com">text</a></p>',
-            _Opts(),
+            Markdown(),
             "[text](http://x.com)",
             id="link-autolink-no-match",
         ),
         pytest.param(
             '<p><a href="http://x.com">http://x.com</a></p>',
-            _Opts(autolink=False),
+            Markdown(links=Markdown.Links(autolink=False)),
             "[http://x.com](http://x.com)",
             id="link-autolink-disabled",
         ),
-        pytest.param('<p><a href="/p">L</a></p>', _Opts(link_title=True), '[L](/p "/p")', id="link-title-from-href"),
-        pytest.param('<p><a href="/p">L</a></p>', _Opts(ignore_links=True), "L", id="link-ignore"),
-        pytest.param('<p><a href="#sec">L</a></p>', _Opts(skip_internal_links=True), "L", id="link-skip-internal"),
-        pytest.param('<p><a href="page">L</a></p>', _Opts(base_url="http://s/"), "[L](http://s/page)", id="link-base"),
+        pytest.param(
+            '<p><a href="/p">L</a></p>',
+            Markdown(links=Markdown.Links(title=True)),
+            '[L](/p "/p")',
+            id="link-title-from-href",
+        ),
+        pytest.param('<p><a href="/p">L</a></p>', Markdown(links=Markdown.Links(ignore=True)), "L", id="link-ignore"),
+        pytest.param(
+            '<p><a href="#sec">L</a></p>',
+            Markdown(links=Markdown.Links(skip_internal=True)),
+            "L",
+            id="link-skip-internal",
+        ),
+        pytest.param(
+            '<p><a href="page">L</a></p>',
+            Markdown(links=Markdown.Links(base_url="http://s/")),
+            "[L](http://s/page)",
+            id="link-base",
+        ),
         pytest.param(
             '<p><a href="http://x/p">L</a></p>',
-            _Opts(base_url="http://s/"),
+            Markdown(links=Markdown.Links(base_url="http://s/")),
             "[L](http://x/p)",
             id="link-base-url-absolute-untouched",
         ),
     ],
 )
-def test_links(html: str, opts: _Opts, expected: str) -> None:
+def test_links(html: str, opts: Markdown, expected: str) -> None:
     assert md(html, opts) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param('<p><img src="i" alt="cat"></p>', _Opts(image_mode="alt"), "cat", id="image-alt"),
-        pytest.param('<p>a<img src="i">b</p>', _Opts(image_mode="ignore"), "ab", id="image-ignore"),
-        pytest.param('<p><img src="i">b</p>', _Opts(default_image_alt="img"), "![img](i)b", id="image-default-alt"),
         pytest.param(
-            '<p><img src="p.png">x</p>', _Opts(base_url="http://s/"), "![](http://s/p.png)x", id="image-base-url"
+            '<p><img src="i" alt="cat"></p>', Markdown(images=Markdown.Images(mode="alt")), "cat", id="image-alt"
+        ),
+        pytest.param(
+            '<p>a<img src="i">b</p>', Markdown(images=Markdown.Images(mode="ignore")), "ab", id="image-ignore"
+        ),
+        pytest.param(
+            '<p><img src="i">b</p>',
+            Markdown(images=Markdown.Images(default_alt="img")),
+            "![img](i)b",
+            id="image-default-alt",
+        ),
+        pytest.param(
+            '<p><img src="p.png">x</p>',
+            Markdown(links=Markdown.Links(base_url="http://s/")),
+            "![](http://s/p.png)x",
+            id="image-base-url",
         ),
     ],
 )
-def test_images(html: str, opts: _Opts, expected: str) -> None:
+def test_images(html: str, opts: Markdown, expected: str) -> None:
     assert md(html, opts) == expected
 
 
@@ -198,75 +225,97 @@ def test_images(html: str, opts: _Opts, expected: str) -> None:
     [
         pytest.param(
             "<table><tr><th>Name</th><th>X</th></tr><tr><td>a</td><td>bb</td></tr></table>",
-            _Opts(pad_tables=True),
+            Markdown(tables=Markdown.Tables(pad=True)),
             "| Name | X   |\n| ---- | --- |\n| a    | bb  |",
             id="table-pad",
         ),
         pytest.param(
             "<table><tr><td>a</td></tr><tr><td>b</td></tr></table>",
-            _Opts(pad_tables=True, table_header="none"),
+            Markdown(tables=Markdown.Tables(pad=True, header="none")),
             "|     |\n| --- |\n| a   |\n| b   |",
             id="table-pad-no-header",
         ),
         pytest.param(
-            "<table><tr><td>a</td><td>b</td></tr></table>", _Opts(table_mode="strip"), "a b", id="table-strip"
+            "<table><tr><td>a</td><td>b</td></tr></table>",
+            Markdown(tables=Markdown.Tables(mode="strip")),
+            "a b",
+            id="table-strip",
         ),
         pytest.param(
             "<table><tr><td>a</td></tr><tr><td>b</td></tr></table>",
-            _Opts(table_header="detect"),
+            Markdown(tables=Markdown.Tables(header="detect")),
             "|  |\n| --- |\n| a |\n| b |",
             id="table-header-detect-no-header",
         ),
         pytest.param(
             "<table><tr><th>H</th></tr><tr><td>a</td></tr></table>",
-            _Opts(table_header="detect"),
+            Markdown(tables=Markdown.Tables(header="detect")),
             "| H |\n| --- |\n| a |",
             id="table-header-detect-with-th",
         ),
         pytest.param(
             "<table><thead><tr><td>H</td></tr></thead><tbody><tr><td>a</td></tr></tbody></table>",
-            _Opts(table_header="detect"),
+            Markdown(tables=Markdown.Tables(header="detect")),
             "| H |\n| --- |\n| a |",
             id="table-header-detect-thead",
         ),
         pytest.param(
             "<table><tr><!--c--><td>a</td><td>bb</td></tr></table>",
-            _Opts(pad_tables=True),
+            Markdown(tables=Markdown.Tables(pad=True)),
             "| a   | bb  |\n| --- | --- |",
             id="table-pad-comment-in-row",
         ),
         pytest.param(
             "<table><tr><!--c--><td>a</td><td>b</td></tr></table>",
-            _Opts(table_mode="strip"),
+            Markdown(tables=Markdown.Tables(mode="strip")),
             "a b",
             id="table-strip-comment-in-row",
         ),
         pytest.param(
             "<table><tr><th>H</th></tr><tr><td>a</td></tr></table>",
-            _Opts(table_header="none"),
+            Markdown(tables=Markdown.Tables(header="none")),
             "|  |\n| --- |\n| H |\n| a |",
             id="table-header-none",
         ),
     ],
 )
-def test_tables(html: str, opts: _Opts, expected: str) -> None:
+def test_tables(html: str, opts: Markdown, expected: str) -> None:
     assert "\n".join(line.rstrip() for line in md(html, opts).splitlines()) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<p>a&lt;b&gt;c</p>", _Opts(escape_mode="all"), "a\\<b\\>c", id="escape-all"),
-        pytest.param("<p>a*b_c</p>", _Opts(escape_asterisks=False), "a*b\\_c", id="escape-no-asterisks"),
-        pytest.param("<p>a*b_c</p>", _Opts(escape_underscores=False), "a\\*b_c", id="escape-no-underscores"),
-        pytest.param("<p>a<br>b</p>", _Opts(line_break="backslash"), "a\\\nb", id="break-backslash"),
-        pytest.param("<p>a</p><p>b</p>", _Opts(block_spacing="single"), "a\nb", id="spacing-single"),
-        pytest.param("  <p>x</p>  ", _Opts(document_strip="none"), "x", id="doc-strip-none"),
-        pytest.param("<p>x</p>", _Opts(document_strip="lstrip"), "x", id="doc-strip-lstrip"),
-        pytest.param("<p>x</p>", _Opts(document_strip="rstrip"), "x", id="doc-strip-rstrip"),
+        pytest.param(
+            "<p>a&lt;b&gt;c</p>", Markdown(escaping=Markdown.Escaping(mode="all")), "a\\<b\\>c", id="escape-all"
+        ),
+        pytest.param(
+            "<p>a*b_c</p>", Markdown(escaping=Markdown.Escaping(asterisks=False)), "a*b\\_c", id="escape-no-asterisks"
+        ),
+        pytest.param(
+            "<p>a*b_c</p>",
+            Markdown(escaping=Markdown.Escaping(underscores=False)),
+            "a\\*b_c",
+            id="escape-no-underscores",
+        ),
+        pytest.param(
+            "<p>a<br>b</p>",
+            Markdown(document=Markdown.Document(line_break="backslash")),
+            "a\\\nb",
+            id="break-backslash",
+        ),
+        pytest.param(
+            "<p>a</p><p>b</p>",
+            Markdown(document=Markdown.Document(block_spacing="single")),
+            "a\nb",
+            id="spacing-single",
+        ),
+        pytest.param("  <p>x</p>  ", Markdown(document=Markdown.Document(trim="none")), "x", id="doc-strip-none"),
+        pytest.param("<p>x</p>", Markdown(document=Markdown.Document(trim="lstrip")), "x", id="doc-strip-lstrip"),
+        pytest.param("<p>x</p>", Markdown(document=Markdown.Document(trim="rstrip")), "x", id="doc-strip-rstrip"),
     ],
 )
-def test_text_options(html: str, opts: _Opts, expected: str) -> None:
+def test_text_options(html: str, opts: Markdown, expected: str) -> None:
     assert md(html, opts) == expected
 
 
@@ -275,124 +324,196 @@ def test_text_options(html: str, opts: _Opts, expected: str) -> None:
     [
         pytest.param(
             "<p>&lt; &gt; # + - = ~ | ! &amp;</p>",
-            _Opts(escape_mode="all"),
+            Markdown(escaping=Markdown.Escaping(mode="all")),
             "\\< \\> \\# \\+ \\- \\= \\~ \\| \\! \\&",
             id="escape-all-every-char",
         ),
-        pytest.param('<p><a href="">e</a></p>', _Opts(), "e", id="link-empty-href-dropped"),
+        pytest.param('<p><a href="">e</a></p>', Markdown(), "e", id="link-empty-href-dropped"),
         pytest.param(
-            '<p><a href="page">L</a></p>', _Opts(skip_internal_links=True), "[L](page)", id="link-skip-non-internal"
+            '<p><a href="page">L</a></p>',
+            Markdown(links=Markdown.Links(skip_internal=True)),
+            "[L](page)",
+            id="link-skip-non-internal",
         ),
         pytest.param(
             '<p><a href="/abs?q=1">L</a></p>',
-            _Opts(base_url="http://s"),
+            Markdown(links=Markdown.Links(base_url="http://s")),
             "[L](http://s/abs?q=1)",
             id="link-base-url-rooted-path",
         ),
         pytest.param(
             '<p><a href="mailto:a@b">L</a></p>',
-            _Opts(base_url="http://s/"),
+            Markdown(links=Markdown.Links(base_url="http://s/")),
             "[L](mailto:a@b)",
             id="link-base-url-mailto-absolute",
         ),
-        pytest.param('<p><img src="/p.png">x</p>', _Opts(base_url="http://s"), "![](http://s/p.png)x", id="image-root"),
+        pytest.param(
+            '<p><img src="/p.png">x</p>',
+            Markdown(links=Markdown.Links(base_url="http://s")),
+            "![](http://s/p.png)x",
+            id="image-root",
+        ),
         pytest.param(
             '<p><img src="http://x/p">x</p>',
-            _Opts(base_url="http://s"),
+            Markdown(links=Markdown.Links(base_url="http://s")),
             "![](http://x/p)x",
             id="image-base-absolute-untouched",
         ),
         pytest.param(
             "<table><tr><!--c--><td>a</td></tr><tr><td>b</td></tr></table>",
-            _Opts(table_header="detect"),
+            Markdown(tables=Markdown.Tables(header="detect")),
             "|  |\n| --- |\n| a |\n| b |",
             id="table-detect-comment-row",
         ),
         pytest.param(
             "<table><tr><th>H</th><td>x</td></tr><tr><td>a</td><td>b</td></tr></table>",
-            _Opts(table_mode="strip"),
+            Markdown(tables=Markdown.Tables(mode="strip")),
             "H x\n\na b",
             id="table-strip-with-th",
         ),
     ],
 )
-def test_option_edge_cases(html: str, opts: _Opts, expected: str) -> None:
+def test_option_edge_cases(html: str, opts: Markdown, expected: str) -> None:
     assert "\n".join(line.rstrip() for line in md(html, opts).splitlines()) == expected
 
 
+# A bad value is not caught when the config is built (the typed fields are not enforced
+# at runtime) but when the renderer reads the unpacked keyword; the match is the renderer
+# keyword name, which the grouped field maps back to (e.g. Document.trim -> document_strip).
 @pytest.mark.parametrize(
-    ("opts", "exc", "match"),
+    ("operation", "exc", "match"),
     [
-        pytest.param({"heading_style": "nope"}, ValueError, "heading_style", id="invalid-enum"),
-        pytest.param({"bullets": ""}, ValueError, "bullets", id="empty-bullets"),
-        pytest.param({"heading_style": 5}, TypeError, "string", id="non-string-enum"),
-        pytest.param({"strong": 5}, TypeError, "str", id="wrong-type-marker"),
-        pytest.param({"unknown_option": 1}, TypeError, "keyword", id="unknown-keyword"),
+        pytest.param(
+            lambda root: root.to_markdown(Markdown(headings=Markdown.Headings(style="nope"))),  # ty: ignore[invalid-argument-type]  # pass an invalid enum to test the renderer rejects it
+            ValueError,
+            "heading_style",
+            id="invalid-enum",
+        ),
+        pytest.param(
+            lambda root: root.to_markdown(Markdown(lists=Markdown.Lists(bullets=""))),
+            ValueError,
+            "bullets",
+            id="empty-bullets",
+        ),
+        pytest.param(
+            lambda root: root.to_markdown(Markdown(headings=Markdown.Headings(style=5))),  # ty: ignore[invalid-argument-type]  # pass a non-string to test the renderer's type check
+            TypeError,
+            "string",
+            id="non-string-enum",
+        ),
+        pytest.param(
+            lambda root: root.to_markdown(Markdown(inline=Markdown.Inline(strong=5))),  # ty: ignore[invalid-argument-type]  # pass a non-string to test the renderer's type check
+            TypeError,
+            "str",
+            id="wrong-type-marker",
+        ),
+        pytest.param(
+            lambda _root: Markdown(unknown_option=1),  # ty: ignore[unknown-argument]  # pass an unknown field to test it is rejected at construction
+            TypeError,
+            "keyword",
+            id="unknown-keyword",
+        ),
     ],
 )
-def test_invalid_options(opts: Mapping[str, str | int], exc: type[Exception], match: str) -> None:
+def test_invalid_options(operation: Callable[[Node], object], exc: type[Exception], match: str) -> None:
+    root = parse("<p>x</p>")
     with pytest.raises(exc, match=match):
-        call_with(parse("<p>x</p>").to_markdown, **opts)
+        operation(root)
 
 
+# every case passes an invalid "bogus" value to test the renderer validates each enum at
+# render time; the typed sub-config fields would otherwise block it, hence the ty: ignore
 @pytest.mark.parametrize(
-    "option",
+    ("config", "match"),
     [
-        "strikethrough",
-        "code_block_style",
-        "link_style",
-        "image_mode",
-        "table_mode",
-        "table_header",
-        "escape_mode",
-        "line_break",
-        "block_spacing",
-        "document_strip",
+        pytest.param(Markdown(inline=Markdown.Inline(strikethrough="bogus")), "strikethrough", id="strikethrough"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(code=Markdown.Code(block_style="bogus")), "code_block_style", id="code_block_style"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(links=Markdown.Links(style="bogus")), "link_style", id="link_style"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(images=Markdown.Images(mode="bogus")), "image_mode", id="image_mode"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(tables=Markdown.Tables(mode="bogus")), "table_mode", id="table_mode"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(tables=Markdown.Tables(header="bogus")), "table_header", id="table_header"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(escaping=Markdown.Escaping(mode="bogus")), "escape_mode", id="escape_mode"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(document=Markdown.Document(line_break="bogus")), "line_break", id="line_break"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(document=Markdown.Document(block_spacing="bogus")), "block_spacing", id="block_spacing"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(document=Markdown.Document(trim="bogus")), "document_strip", id="document_strip"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
     ],
 )
-def test_each_enum_is_validated(option: str) -> None:
-    with pytest.raises(ValueError, match=option):
-        call_with(parse("<p>x</p>").to_markdown, **{option: "bogus"})
+def test_each_enum_is_validated(config: Markdown, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        parse("<p>x</p>").to_markdown(config)
+
+
+def test_explicit_none_is_the_default() -> None:
+    page = parse("<h1>Hi</h1><p>x</p>")
+    assert page.to_markdown(None) == page.to_markdown()
+
+
+def test_options_must_be_a_markdown() -> None:
+    with pytest.raises(TypeError, match="options must be a Markdown"):
+        parse("<p>x</p>").to_markdown(object())  # ty: ignore[invalid-argument-type]  # pass a non-Markdown to test the type error
+
+
+def test_rejects_extra_positional() -> None:
+    with pytest.raises(TypeError):
+        parse("<p>x</p>").to_markdown(Markdown(), Markdown())  # ty: ignore[too-many-positional-arguments]  # a second arg is rejected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
         pytest.param(
-            '<p><a href="a#b">L</a></p>', _Opts(base_url="http://s/"), "[L](http://s/a#b)", id="abs-hash-relative"
+            '<p><a href="a#b">L</a></p>',
+            Markdown(links=Markdown.Links(base_url="http://s/")),
+            "[L](http://s/a#b)",
+            id="abs-hash-relative",
         ),
         pytest.param(
-            '<p><a href="q?x">L</a></p>', _Opts(base_url="http://s/"), "[L](http://s/q?x)", id="abs-query-relative"
+            '<p><a href="q?x">L</a></p>',
+            Markdown(links=Markdown.Links(base_url="http://s/")),
+            "[L](http://s/q?x)",
+            id="abs-query-relative",
         ),
-        pytest.param('<p><a href="#x">L</a></p>', _Opts(base_url="http://s/"), "[L](#x)", id="base-url-skips-fragment"),
         pytest.param(
-            '<p><img src="#x">y</p>', _Opts(base_url="http://s/"), "![](#x)y", id="image-base-url-skips-fragment"
+            '<p><a href="#x">L</a></p>',
+            Markdown(links=Markdown.Links(base_url="http://s/")),
+            "[L](#x)",
+            id="base-url-skips-fragment",
+        ),
+        pytest.param(
+            '<p><img src="#x">y</p>',
+            Markdown(links=Markdown.Links(base_url="http://s/")),
+            "![](#x)y",
+            id="image-base-url-skips-fragment",
         ),
         pytest.param(
             '<p><a href="http://x.com">http://y.com</a></p>',
-            _Opts(),
+            Markdown(),
             "[http://y.com](http://x.com)",
             id="autolink-same-length-no-match",
         ),
     ],
 )
-def test_href_resolution(html: str, opts: _Opts, expected: str) -> None:
+def test_href_resolution(html: str, opts: Markdown, expected: str) -> None:
     assert md(html, opts) == expected
 
 
 def test_reference_links_grow_past_initial_capacity() -> None:
     html = "<p>" + "".join(f'<a href="/{i}">L{i}</a>' for i in range(10)) + "</p>"
-    out = md(html, _Opts(link_style="reference"))
+    out = md(html, Markdown(links=Markdown.Links(style="reference")))
     assert "[10]: /9" in out
 
 
 @pytest.mark.parametrize(
     ("opts", "expected"),
     [
-        pytest.param(_Opts(pad_tables=True), "| H   | x   |\n| --- | --- |\n| a   | b   |", id="pad-th-and-comment"),
-        pytest.param(_Opts(table_mode="strip"), "H x\n\na b", id="strip-th-and-comment"),
+        pytest.param(
+            Markdown(tables=Markdown.Tables(pad=True)),
+            "| H   | x   |\n| --- | --- |\n| a   | b   |",
+            id="pad-th-and-comment",
+        ),
+        pytest.param(Markdown(tables=Markdown.Tables(mode="strip")), "H x\n\na b", id="strip-th-and-comment"),
     ],
 )
-def test_table_cells_with_th_and_comment(opts: _Opts, expected: str) -> None:
+def test_table_cells_with_th_and_comment(opts: Markdown, expected: str) -> None:
     html = "<table><tr><!--c--><template></template><th>H</th><td>x</td></tr><tr><td>a</td><td>b</td></tr></table>"
     assert "\n".join(line.rstrip() for line in md(html, opts).splitlines()) == expected

--- a/tests/serialize/test_tree_text.py
+++ b/tests/serialize/test_tree_text.py
@@ -8,67 +8,52 @@ binding's enum validation.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import parse
+from turbohtml import PlainText, parse
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
-    from typing import Literal
+    from collections.abc import Mapping
 
 
-class _TextOpts(TypedDict, total=False):
-    width: int
-    links: Literal["none", "inline", "footnote"]
-    images: bool
-    layout: Literal["extended", "strict"]
-    default_image_alt: str
-    table_cell_separator: str
-    bullet: str
-
-
-def to_text(html: str, opts: _TextOpts) -> str:
-    return parse(html).to_text(**opts)
-
-
-def call_with(convert: Callable[..., str], **kwargs: str | int) -> str:
-    return convert(**kwargs)
+def to_text(html: str, opts: PlainText) -> str:
+    return parse(html).to_text(opts)
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<h1>Title</h1><p>Body text.</p>", _TextOpts(), "Title\n\nBody text.", id="heading-and-para"),
-        pytest.param("<p>a <b>bold</b> <i>x</i> c</p>", _TextOpts(), "a bold x c", id="inline-markup-stripped"),
-        pytest.param("<p>one</p><p>two</p>", _TextOpts(), "one\n\ntwo", id="paragraphs"),
-        pytest.param("<div>a\n  b\tc</div>", _TextOpts(), "a b c", id="collapse-whitespace"),
-        pytest.param("<p>a<br>b</p>", _TextOpts(), "a\nb", id="line-break"),
-        pytest.param("<p>a<wbr>b</p>", _TextOpts(), "ab", id="wbr"),
-        pytest.param("<section><p>x</p></section>", _TextOpts(), "x", id="transparent-container"),
-        pytest.param("<head><title>t</title></head><body>x</body>", _TextOpts(), "x", id="head-skipped"),
-        pytest.param("<p>a</p><script>s()</script><p>b</p>", _TextOpts(), "a\n\nb", id="script-skipped"),
+        pytest.param("<h1>Title</h1><p>Body text.</p>", PlainText(), "Title\n\nBody text.", id="heading-and-para"),
+        pytest.param("<p>a <b>bold</b> <i>x</i> c</p>", PlainText(), "a bold x c", id="inline-markup-stripped"),
+        pytest.param("<p>one</p><p>two</p>", PlainText(), "one\n\ntwo", id="paragraphs"),
+        pytest.param("<div>a\n  b\tc</div>", PlainText(), "a b c", id="collapse-whitespace"),
+        pytest.param("<p>a<br>b</p>", PlainText(), "a\nb", id="line-break"),
+        pytest.param("<p>a<wbr>b</p>", PlainText(), "ab", id="wbr"),
+        pytest.param("<section><p>x</p></section>", PlainText(), "x", id="transparent-container"),
+        pytest.param("<head><title>t</title></head><body>x</body>", PlainText(), "x", id="head-skipped"),
+        pytest.param("<p>a</p><script>s()</script><p>b</p>", PlainText(), "a\n\nb", id="script-skipped"),
     ],
 )
-def test_blocks(html: str, opts: _TextOpts, expected: str) -> None:
+def test_blocks(html: str, opts: PlainText, expected: str) -> None:
     assert to_text(html, opts) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<ul><li>one</li><li>two</li></ul>", _TextOpts(), "* one\n* two", id="ul"),
-        pytest.param("<ol><li>a</li><li>b</li></ol>", _TextOpts(), "1. a\n2. b", id="ol"),
-        pytest.param('<ol start="3"><li>a</li></ol>', _TextOpts(), "3. a", id="ol-start"),
-        pytest.param('<ol start="x"><li>a</li></ol>', _TextOpts(), "1. a", id="ol-start-invalid"),
-        pytest.param("<ul><li>a<ul><li>b</li></ul></li></ul>", _TextOpts(), "* a\n  * b", id="nested"),
-        pytest.param("<ul><li>x</li></ul>", _TextOpts(bullet="- "), "- x", id="custom-bullet"),
-        pytest.param("<ul><li> <ul><li>x</li></ul></li></ul>", _TextOpts(), "*\n  * x", id="li-leading-ws"),
-        pytest.param("<ul><li></li></ul>", _TextOpts(), "*", id="empty-li"),
+        pytest.param("<ul><li>one</li><li>two</li></ul>", PlainText(), "* one\n* two", id="ul"),
+        pytest.param("<ol><li>a</li><li>b</li></ol>", PlainText(), "1. a\n2. b", id="ol"),
+        pytest.param('<ol start="3"><li>a</li></ol>', PlainText(), "3. a", id="ol-start"),
+        pytest.param('<ol start="x"><li>a</li></ol>', PlainText(), "1. a", id="ol-start-invalid"),
+        pytest.param("<ul><li>a<ul><li>b</li></ul></li></ul>", PlainText(), "* a\n  * b", id="nested"),
+        pytest.param("<ul><li>x</li></ul>", PlainText(bullet="- "), "- x", id="custom-bullet"),
+        pytest.param("<ul><li> <ul><li>x</li></ul></li></ul>", PlainText(), "*\n  * x", id="li-leading-ws"),
+        pytest.param("<ul><li></li></ul>", PlainText(), "*", id="empty-li"),
     ],
 )
-def test_lists(html: str, opts: _TextOpts, expected: str) -> None:
+def test_lists(html: str, opts: PlainText, expected: str) -> None:
     assert "\n".join(line.rstrip() for line in to_text(html, opts).splitlines()) == expected
 
 
@@ -77,111 +62,111 @@ def test_lists(html: str, opts: _TextOpts, expected: str) -> None:
     [
         pytest.param(
             "<table><tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>30</td></tr></table>",
-            _TextOpts(),
+            PlainText(),
             "Name   Age\nAlice  30",
             id="aligned",
         ),
         pytest.param(
             "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>",
-            _TextOpts(),
+            PlainText(),
             "a  b\nc",
             id="ragged",
         ),
         pytest.param(
             "<table><tr><td>a</td><td>b</td></tr></table>",
-            _TextOpts(table_cell_separator=" | "),
+            PlainText(table_cell_separator=" | "),
             "a | b",
             id="custom-separator",
         ),
         pytest.param(
             "<table><tr><!--c--><td>a</td></tr><tr><td>bb</td></tr></table>",
-            _TextOpts(),
+            PlainText(),
             "a\nbb",
             id="comment-in-row",
         ),
     ],
 )
-def test_tables(html: str, opts: _TextOpts, expected: str) -> None:
+def test_tables(html: str, opts: PlainText, expected: str) -> None:
     assert "\n".join(line.rstrip() for line in to_text(html, opts).splitlines()) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<pre>a\n  b</pre>", _TextOpts(), "a\n  b", id="pre-preserved"),
-        pytest.param("<pre>x\n</pre>", _TextOpts(), "x", id="pre-trailing-newline"),
+        pytest.param("<pre>a\n  b</pre>", PlainText(), "a\n  b", id="pre-preserved"),
+        pytest.param("<pre>x\n</pre>", PlainText(), "x", id="pre-trailing-newline"),
         pytest.param(
             "<p>before</p><blockquote><p>quote</p></blockquote>",
-            _TextOpts(),
+            PlainText(),
             "before\n\n    quote",
             id="blockquote-indented",
         ),
-        pytest.param("<blockquote><p>q</p></blockquote>", _TextOpts(), "    q", id="blockquote-first"),
+        pytest.param("<blockquote><p>q</p></blockquote>", PlainText(), "    q", id="blockquote-first"),
     ],
 )
-def test_pre_and_quote(html: str, opts: _TextOpts, expected: str) -> None:
+def test_pre_and_quote(html: str, opts: PlainText, expected: str) -> None:
     assert to_text(html, opts) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param('<p>see <a href="/x">here</a></p>', _TextOpts(), "see here", id="links-none-default"),
+        pytest.param('<p>see <a href="/x">here</a></p>', PlainText(), "see here", id="links-none-default"),
         pytest.param(
             '<p>see <a href="http://x">here</a></p>',
-            _TextOpts(links="inline"),
+            PlainText(links="inline"),
             "see here (http://x)",
             id="links-inline",
         ),
         pytest.param(
             '<p><a href="/a">A</a> <a href="/b">B</a></p>',
-            _TextOpts(links="footnote"),
+            PlainText(links="footnote"),
             "A[1] B[2]\n\n[1] /a\n[2] /b",
             id="links-footnote",
         ),
-        pytest.param("<p><a>no href</a></p>", _TextOpts(links="inline"), "no href", id="link-no-href"),
-        pytest.param('<p>a<img src="i" alt="cat">b</p>', _TextOpts(), "ab", id="images-off-default"),
-        pytest.param('<p>a <img src="i" alt="cat"> b</p>', _TextOpts(images=True), "a cat b", id="images-alt"),
+        pytest.param("<p><a>no href</a></p>", PlainText(links="inline"), "no href", id="link-no-href"),
+        pytest.param('<p>a<img src="i" alt="cat">b</p>', PlainText(), "ab", id="images-off-default"),
+        pytest.param('<p>a <img src="i" alt="cat"> b</p>', PlainText(images=True), "a cat b", id="images-alt"),
         pytest.param(
             '<p>a <img src="i"> b</p>',
-            _TextOpts(images=True, default_image_alt="img"),
+            PlainText(images=True, default_image_alt="img"),
             "a img b",
             id="images-default-alt",
         ),
-        pytest.param('<p>a<img src="i">b</p>', _TextOpts(images=True), "ab", id="images-no-alt"),
+        pytest.param('<p>a<img src="i">b</p>', PlainText(images=True), "ab", id="images-no-alt"),
     ],
 )
-def test_links_and_images(html: str, opts: _TextOpts, expected: str) -> None:
+def test_links_and_images(html: str, opts: PlainText, expected: str) -> None:
     assert to_text(html, opts) == expected
 
 
 @pytest.mark.parametrize(
     ("html", "opts", "expected"),
     [
-        pytest.param("<p>a<span>x<!--c-->y</span>b</p>", _TextOpts(), "axyb", id="comment-in-inline"),
-        pytest.param("<p>a<span><script>s</script>y</span></p>", _TextOpts(), "ay", id="script-in-inline"),
-        pytest.param("<div><span>a<h2>H</h2>b</span></div>", _TextOpts(), "a\n\nHb", id="block-in-inline"),
-        pytest.param("<p>a<template>t</template>b</p>", _TextOpts(), "atb", id="template-in-inline"),
-        pytest.param("<ul><li><!--c-->x</li></ul>", _TextOpts(), "* x", id="li-leading-comment"),
-        pytest.param("<ul><li><script>s</script>x</li></ul>", _TextOpts(), "* x", id="li-leading-script"),
-        pytest.param("<div><p>a</p><!--c--><p>b</p></div>", _TextOpts(), "a\n\nb", id="comment-between-blocks"),
-        pytest.param('<ol start="2x"><li>a</li></ol>', _TextOpts(), "2. a", id="ol-start-digits-then-letter"),
-        pytest.param("<ul><svg></svg><li>a</li></ul>", _TextOpts(), "* a", id="foreign-in-list"),
-        pytest.param("<ul><!--c--><li>a</li></ul>", _TextOpts(), "* a", id="comment-in-list"),
-        pytest.param("<ul><template></template><li>a</li></ul>", _TextOpts(), "* a", id="non-li-element-in-list"),
-        pytest.param("<ul><li><svg></svg>x</li></ul>", _TextOpts(), "* x", id="foreign-leads-li"),
-        pytest.param('<ol start="-5"><li>a</li></ol>', _TextOpts(), "1. a", id="ol-negative-start"),
-        pytest.param("<p>a<br> b</p>", _TextOpts(), "a\nb", id="break-then-space"),
-        pytest.param("<pre></pre>", _TextOpts(), "", id="pre-empty"),
+        pytest.param("<p>a<span>x<!--c-->y</span>b</p>", PlainText(), "axyb", id="comment-in-inline"),
+        pytest.param("<p>a<span><script>s</script>y</span></p>", PlainText(), "ay", id="script-in-inline"),
+        pytest.param("<div><span>a<h2>H</h2>b</span></div>", PlainText(), "a\n\nHb", id="block-in-inline"),
+        pytest.param("<p>a<template>t</template>b</p>", PlainText(), "atb", id="template-in-inline"),
+        pytest.param("<ul><li><!--c-->x</li></ul>", PlainText(), "* x", id="li-leading-comment"),
+        pytest.param("<ul><li><script>s</script>x</li></ul>", PlainText(), "* x", id="li-leading-script"),
+        pytest.param("<div><p>a</p><!--c--><p>b</p></div>", PlainText(), "a\n\nb", id="comment-between-blocks"),
+        pytest.param('<ol start="2x"><li>a</li></ol>', PlainText(), "2. a", id="ol-start-digits-then-letter"),
+        pytest.param("<ul><svg></svg><li>a</li></ul>", PlainText(), "* a", id="foreign-in-list"),
+        pytest.param("<ul><!--c--><li>a</li></ul>", PlainText(), "* a", id="comment-in-list"),
+        pytest.param("<ul><template></template><li>a</li></ul>", PlainText(), "* a", id="non-li-element-in-list"),
+        pytest.param("<ul><li><svg></svg>x</li></ul>", PlainText(), "* x", id="foreign-leads-li"),
+        pytest.param('<ol start="-5"><li>a</li></ol>', PlainText(), "1. a", id="ol-negative-start"),
+        pytest.param("<p>a<br> b</p>", PlainText(), "a\nb", id="break-then-space"),
+        pytest.param("<pre></pre>", PlainText(), "", id="pre-empty"),
         pytest.param(
             '<p>a <img src="i"> b</p>',
-            _TextOpts(images=True, default_image_alt="an img"),
+            PlainText(images=True, default_image_alt="an img"),
             "a an img b",
             id="alt-spaces",
         ),
     ],
 )
-def test_text_edge_cases(html: str, opts: _TextOpts, expected: str) -> None:
+def test_text_edge_cases(html: str, opts: PlainText, expected: str) -> None:
     assert to_text(html, opts) == expected
 
 
@@ -217,18 +202,28 @@ def test_loose_block_in_tight_item() -> None:
 
 def test_footnote_links_grow_past_initial_capacity() -> None:
     html = "<p>" + "".join(f'<a href="/{i}">L{i}</a>' for i in range(10)) + "</p>"
-    out = parse(html).to_text(links="footnote")
+    out = parse(html).to_text(PlainText(links="footnote"))
     assert "[10] /9" in out
 
 
 def test_word_wrap() -> None:
-    out = parse("<p>" + "word " * 10 + "</p>").to_text(width=20)
+    out = parse("<p>" + "word " * 10 + "</p>").to_text(PlainText(width=20))
     assert all(len(line) <= 20 for line in out.splitlines())
     assert out.split() == ["word"] * 10
 
 
 def test_strict_layout_runs() -> None:
-    assert parse("<div>a</div><div>b</div>").to_text(layout="strict") == "a\n\nb"
+    assert parse("<div>a</div><div>b</div>").to_text(PlainText(layout="strict")) == "a\n\nb"
+
+
+def test_explicit_none_is_the_default() -> None:
+    page = parse("<h1>T</h1><p>body</p>")
+    assert page.to_text(None) == page.to_text()
+
+
+def test_options_must_be_a_plain_text() -> None:
+    with pytest.raises(TypeError, match="options must be a PlainText"):
+        parse("<p>x</p>").to_text(object())  # ty: ignore[invalid-argument-type]  # pass a non-PlainText to test the type error
 
 
 def test_to_text_on_subtree_and_text_node() -> None:
@@ -261,8 +256,10 @@ def test_to_text_on_foreign_and_template() -> None:
     ],
 )
 def test_invalid_options(opts: Mapping[str, str | int], exc: type[Exception], match: str) -> None:
+    # an unknown name is rejected when the config is built; a bad value reaches the
+    # renderer through PlainText and is rejected there, so one call covers both
     with pytest.raises(exc, match=match):
-        call_with(parse("<p>x</p>").to_text, **opts)
+        parse("<p>x</p>").to_text(PlainText(**opts))  # ty: ignore[invalid-argument-type]  # pass invalid options to test they are rejected
 
 
 _WORD = re.compile(r"[0-9a-z]+")

--- a/tests/serialize/test_tree_text_annotations.py
+++ b/tests/serialize/test_tree_text_annotations.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import parse
+from turbohtml import PlainText, parse
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
@@ -149,7 +149,9 @@ def test_leading_whitespace_shifts_offsets() -> None:
 def test_links_and_options_compose_with_annotations() -> None:
     text, _labels = annotate("<p><a href='http://x'>site</a></p>", {"a": ["link"]})
     assert text == "site"
-    text2, labels2 = parse("<p><a href='http://x'>site</a></p>").to_annotated_text({"a": ["link"]}, links="inline")
+    text2, labels2 = parse("<p><a href='http://x'>site</a></p>").to_annotated_text(
+        {"a": ["link"]}, PlainText(links="inline")
+    )
     assert text2 == "site (http://x)"
     assert [text2[s:e] for s, e, _ in labels2] == ["site (http://x)"]
 
@@ -189,5 +191,21 @@ def test_invalid_rules(rules: object, exc: type[Exception], match: str) -> None:
     ],
 )
 def test_invalid_options(kwargs: Mapping[str, str], exc: type[Exception], match: str) -> None:
+    # a bad value reaches the renderer through PlainText and is rejected there
     with pytest.raises(exc, match=match):
-        call_with(parse("<p>x</p>").to_annotated_text, {}, **kwargs)
+        parse("<p>x</p>").to_annotated_text({"p": ["para"]}, PlainText(**kwargs))  # ty: ignore[invalid-argument-type]  # pass invalid options to test they are rejected
+
+
+def test_explicit_none_is_the_default() -> None:
+    page = parse("<p>a <b>b</b> c</p>")
+    assert page.to_annotated_text({"b": ["x"]}, None) == page.to_annotated_text({"b": ["x"]})
+
+
+def test_options_must_be_a_plain_text() -> None:
+    with pytest.raises(TypeError, match="options must be a PlainText"):
+        parse("<p>x</p>").to_annotated_text({"p": ["para"]}, object())  # ty: ignore[invalid-argument-type]  # pass a non-PlainText to test the type error
+
+
+def test_rules_are_required() -> None:
+    with pytest.raises(TypeError):
+        parse("<p>x</p>").to_annotated_text()  # ty: ignore[missing-argument]  # annotation_rules is required

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, cast
 
 import turbohtml
 from bench.timing import Mutating
+from turbohtml import Markdown as _Markdown
 from turbohtml import sanitizer as _sanitizer
 from turbohtml.build import E
 from turbohtml.linkify import Detector as _Detector
@@ -258,14 +259,21 @@ def markdown(case: tuple[str, str]) -> None:
     """Convert HTML to Markdown with turbohtml, with the default or the fully-configured option surface."""
     kind, text = case
     if kind == "configured":
-        _parsed(text).to_markdown(strong="__", emphasis="_", link_style="reference", pad_tables=True, escape_mode="all")
+        _parsed(text).to_markdown(
+            _Markdown(
+                inline=_Markdown.Inline(strong="__", emphasis="_"),
+                links=_Markdown.Links(style="reference"),
+                tables=_Markdown.Tables(pad=True),
+                escaping=_Markdown.Escaping(mode="all"),
+            )
+        )
     else:
         _parsed(text).to_markdown()
 
 
 def markdown_google(text: str) -> None:
     """Convert a Google Docs export to Markdown with turbohtml's google_doc mode."""
-    _parsed(text).to_markdown(google_doc=True)
+    _parsed(text).to_markdown(_Markdown.google_doc())
 
 
 def tables(case: tuple[str, str]) -> None:


### PR DESCRIPTION
Several public methods had drifted into long, error-prone keyword lists. `to_markdown` carried about 40 flat arguments, `to_text` and `to_annotated_text` seven or eight each, `serialize`/`encode` spread `formatter`, `layout`, `sort_attributes`, and `meta_charset` loose, and `linkify`/`Linker` carried six knobs alongside the text. Some pairs were mutually exclusive — markdown's `strip` and `convert` — yet nothing stopped a caller passing both until the render actually ran. 🧹

This moves every over-the-limit method to a single configuration object, the pattern the library already established with `Indent`/`Minify` for `serialize` and `Policy` for `sanitize`. `to_markdown` takes a `Markdown`, `to_text`/`to_annotated_text` a `PlainText`, `serialize`/`encode` an `Html`, and `linkify`/`Linker` a `Linkify`. Because the markdown surface is large enough that one flat object would only relocate the wall, `Markdown` groups its knobs into themed nested sub-configs (`Markdown.Headings`, `Markdown.Links`, `Markdown.Wrapping`, and so on) and validates `strip` against `convert` at construction time. A `Markdown.google_doc()` preset mirrors the `Policy.strict()`/`relaxed()` classmethods. The result is that no public method exceeds six arguments without a documented reason — `find`/`find_all` and `xpath` keep their idiomatic BeautifulSoup/lxml `**kwargs`.

Under the hood the C binding keeps its existing parse-and-resolve path: each config's `_unpack` yields only the values that differ from the renderer defaults, equivalent to the old call with just those keywords, so an empty config reproduces the no-argument rendering byte for byte. ✨ Passing a wrong-typed `options` argument now raises a clear `TypeError` naming the expected config type rather than leaking an internal attribute error.

This is a clean break with no deprecation shim, in line with the pre-1.0 alpha policy. Migration is mechanical and the per-library guides plus the how-to pages show the new grouped form; for example `serialize(formatter=Formatter.MINIMAL, layout=Indent(2))` becomes `serialize(Html(formatter=Formatter.MINIMAL, layout=Indent(2)))`, `to_markdown(heading_style="setext", link_style="reference")` becomes `to_markdown(Markdown(headings=Markdown.Headings(style="setext"), links=Markdown.Links(style="reference")))`, and `linkify(text, callbacks=cb, parse_email=True)` becomes `linkify(text, Linkify(callbacks=cb, parse_email=True))`.

Part of the #313 epic.