### PR TITLE
⚡ perf(path): build node locators in linear time

### DIFF
--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -892,12 +892,12 @@ ahead per evaluation.
 :meth:`turbohtml.Element.css_path` and :meth:`~turbohtml.Element.xpath_path` return the unique locator that re-finds an
 element from the document root -- a CSS selector and a positional XPath -- against lxml's ``getroottree().getpath()``,
 the libxml2 path builder devtools' "copy selector" mirrors. lxml emits only the positional XPath, so ``getpath`` pairs
-with both turbohtml methods. Each timed call walks every element in a pre-parsed page and serializes its path.
-:meth:`~turbohtml.Element.xpath_path` leads ``getpath`` by roughly three to five times across these pages.
-:meth:`~turbohtml.Element.css_path` is comparable on the small blog but two to six times slower on the class-heavy news
-article and blog, where many elements share a class and need an ``:nth-child`` step to stay unique: that disambiguation
-walks each element's siblings, the cost of emitting a readable CSS selector rather than the raw positional path
-``getpath`` builds. The ``speed-up`` column is ``xpath_path`` against ``getpath``.
+with both turbohtml methods. Each timed call walks every element in a pre-parsed page and serializes its path. Both
+methods lead ``getpath`` by roughly five times across these pages, narrowing to under threefold on the spec.
+:meth:`~turbohtml.Element.css_path` previously rescanned the whole document to test each element's id uniqueness, an
+O(N\ :sup:`2`) cost over a page that made it slower than ``getpath`` on id-heavy pages; a cached per-tree id-occurrence
+map (dropped with the element index on any mutation) now answers that test in O(1), so ``css_path`` keeps pace with the
+positional ``xpath_path``. The ``speed-up`` column is ``xpath_path`` against ``getpath``.
 
 .. list-table::
     :header-rows: 1
@@ -909,25 +909,25 @@ walks each element's siblings, the cost of emitting a readable CSS selector rath
       - lxml getpath
       - speed-up
     - - daring fireball (10 kB)
-      - 52.6 µs
-      - 19.1 µs
-      - 103.2 µs
-      - 5.4x
-    - - ars technica (56 kB)
-      - 946.8 µs
-      - 99.6 µs
-      - 548.0 µs
+      - 18.9 µs
+      - 18.9 µs
+      - 103.8 µs
       - 5.5x
+    - - ars technica (56 kB)
+      - 91.4 µs
+      - 98.8 µs
+      - 557.1 µs
+      - 5.6x
     - - mozilla blog (95 kB)
-      - 5.63 ms
-      - 280.4 µs
-      - 1.42 ms
-      - 5.1x
+      - 227.0 µs
+      - 277.3 µs
+      - 1.43 ms
+      - 5.2x
     - - whatwg spec (235 kB)
-      - 3.94 ms
-      - 2.11 ms
-      - 5.81 ms
-      - 2.7x
+      - 2.24 ms
+      - 2.20 ms
+      - 6.11 ms
+      - 2.8x
 
 **************
  Text content

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -62,12 +62,12 @@ walks, the link helpers, XPath, and the node-path generators:
     - - XPath ``//a[@href]`` precompiled
       - 0.5 µs
       - 2.8 µs (5.6x)
-    - - ``css_path`` node locator (9.6 kB)
-      - 15.6 µs
-      - 55.2 µs (3.5x)
-    - - ``xpath_path`` node locator (9.6 kB)
-      - 14.3 µs
-      - 55.2 µs (3.9x)
+    - - ``css_path`` node locator (ars technica, 56 kB)
+      - 91.4 µs
+      - 557.1 µs (6.1x)
+    - - ``xpath_path`` node locator (ars technica, 56 kB)
+      - 98.8 µs
+      - 565.0 µs (5.7x)
 
 The :doc:`/development/performance` page benchmarks the full serializer, builder, editor, CSS, XPath 1.0, and EXSLT
 surface against lxml directly.

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -379,6 +379,7 @@ static void handle_dealloc(PyObject *self) {
     handle_clear_caches(handle);
     PyMem_Free(handle->index_offsets);
     PyMem_Free(handle->index_nodes);
+    path_id_map_free(handle->path_ids);
     th_tree_free(handle->tree);
     Py_XDECREF(handle->source);
     Py_XDECREF(handle->encoding);

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -978,6 +978,8 @@ static void handle_drop_index(PyObject *handle_obj) {
     handle->index_offsets = NULL;
     handle->index_nodes = NULL;
     handle->index_built = 0;
+    path_id_map_free(handle->path_ids);
+    handle->path_ids = NULL;
 }
 
 /* The tag atom every alternative of compiled selects as its subject (rightmost
@@ -2867,26 +2869,90 @@ static int path_id_safe(const Py_UCS4 *value, Py_ssize_t len) {
     return 1;
 }
 
-/* Whether candidate is the only element in the document carrying this id value,
-   so #value selects it alone. Matched case-insensitively in quirks mode, where
-   the id selector itself folds case. */
-static int path_id_unique(th_node *document, th_node *candidate, const Py_UCS4 *value, Py_ssize_t len, int ci) {
-    for (th_node *node = document->first_child; node != NULL; node = preorder_next(node, document)) {
-        if (node == candidate || node->type != TH_NODE_ELEMENT) {
-            continue;
-        }
-        const th_node_attr *id = find_node_attr(node, TH_ATTR_ID);
-        if (id != NULL && id->value != NULL && sel_eq(id->value, id->value_len, value, len, ci)) {
-            return 0;
-        }
+/* FNV-1a over an id value, folding case in quirks mode so values that the id
+   selector treats as equal hash equal. */
+static uint64_t path_id_hash(const Py_UCS4 *value, Py_ssize_t len, int ci) {
+    uint64_t hash = 14695981039346656037u;
+    for (Py_ssize_t index = 0; index < len; index++) {
+        hash ^= (uint64_t)sel_fold(value[index], ci);
+        hash *= 1099511628211u;
     }
-    return 1;
+    return hash;
 }
 
-/* Whether node has an element sibling of its own type on either side, so a
-   positional index is needed to single it out among same-type siblings. */
-static int path_needs_index(th_node *node) {
-    return !sel_no_sibling(node, 0, 1) || !sel_no_sibling(node, 1, 1);
+/* Build the document's id-occurrence map: every element's id value mapped to how
+   many elements carry it, so the anchor test is an O(id-length) probe instead of a
+   whole-document scan. ci folds id case the way the quirks-mode id selector does.
+   Returns the map (the caller caches it) or NULL on allocation failure. */
+static path_id_map *path_id_map_build(th_node *document, int ci) {
+    Py_ssize_t id_count = 0;
+    for (th_node *node = document->first_child; node != NULL; node = preorder_next(node, document)) {
+        const th_node_attr *id = node->type == TH_NODE_ELEMENT ? find_node_attr(node, TH_ATTR_ID) : NULL;
+        if (id != NULL && id->value != NULL) {
+            id_count++;
+        }
+    }
+    size_t capacity = 8;
+    while (capacity < (size_t)id_count * 2) {
+        capacity *= 2;
+    }
+    path_id_map *map = PyMem_Malloc(sizeof(path_id_map));
+    if (map == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    map->slots = PyMem_Calloc(capacity, sizeof(path_id_slot));
+    if (map->slots == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        PyMem_Free(map);      /* GCOVR_EXCL_LINE: allocation-failure path */
+        return NULL;          /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    map->mask = capacity - 1;
+    map->ci = ci;
+    for (th_node *node = document->first_child; node != NULL; node = preorder_next(node, document)) {
+        const th_node_attr *id = node->type == TH_NODE_ELEMENT ? find_node_attr(node, TH_ATTR_ID) : NULL;
+        if (id == NULL || id->value == NULL) {
+            continue;
+        }
+        size_t slot = (size_t)path_id_hash(id->value, id->value_len, ci) & map->mask;
+        while (map->slots[slot].value != NULL &&
+               !sel_eq(map->slots[slot].value, map->slots[slot].len, id->value, id->value_len, ci)) {
+            slot = (slot + 1) & map->mask;
+        }
+        if (map->slots[slot].value == NULL) {
+            map->slots[slot].value = id->value;
+            map->slots[slot].len = id->value_len;
+            map->slots[slot].count = 1;
+        } else {
+            map->slots[slot].count++;
+        }
+    }
+    return map;
+}
+
+/* Whether value names exactly one element, so #value selects it alone. The probed
+   candidate's own id is always present in the map, so a count of one means unique;
+   sel_eq returns false on an empty slot (a length mismatch) so the probe walks past
+   any collision and always terminates on the candidate's slot. */
+static int path_id_unique(const path_id_map *map, const Py_UCS4 *value, Py_ssize_t len) {
+    size_t slot = (size_t)path_id_hash(value, len, map->ci) & map->mask;
+    while (!sel_eq(map->slots[slot].value, map->slots[slot].len, value, len, map->ci)) {
+        slot = (slot + 1) & map->mask;
+    }
+    return map->slots[slot].count == 1;
+}
+
+/* The 1-based position of node among its same-type element siblings, setting
+   *needs_index when more than one such sibling exists so the position disambiguates
+   it. Scans preceding siblings once (their count is the position), and only scans
+   following siblings when node is the first, mirroring libxml2's xmlGetNodePath. */
+static int path_step_index(th_node *node, int *needs_index) {
+    int index = 1;
+    for (th_node *sibling = node->prev_sibling; sibling != NULL; sibling = sibling->prev_sibling) {
+        if (sibling->type == TH_NODE_ELEMENT && sel_same_type(node, sibling)) {
+            index++;
+        }
+    }
+    *needs_index = index > 1 ? 1 : !sel_no_sibling(node, 1, 1);
+    return index;
 }
 
 /* Snapshot the element ancestor chain, node first up to the topmost element
@@ -2924,19 +2990,23 @@ static PyObject *element_css_path(PyObject *self, PyObject *Py_UNUSED(ignored)) 
     th_node **chain = NULL;
     int error = 0;
     Py_BEGIN_CRITICAL_SECTION(handle);
-    th_tree *tree = ((HandleObject *)handle)->tree;
+    HandleObject *handle_obj = (HandleObject *)handle;
+    th_tree *tree = handle_obj->tree;
+    th_node *document = th_tree_document(tree);
     Py_ssize_t count = path_collect_chain(node, &chain);
-    if (count < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        error = 1;   /* GCOVR_EXCL_LINE: allocation-failure path */
-    } else {         /* GCOVR_EXCL_LINE: brace of the never-taken alloc-failure branch */
-        th_node *document = th_tree_document(tree);
-        int quirks = th_tree_quirks(tree);
+    if (document != NULL && handle_obj->path_ids == NULL) {
+        handle_obj->path_ids = path_id_map_build(document, th_tree_quirks(tree));
+    }
+    if (count < 0 || (document != NULL && handle_obj->path_ids == NULL)) { /* GCOVR_EXCL_BR_LINE: alloc failure */
+        error = 1;                                                         /* GCOVR_EXCL_LINE: alloc-failure */
+    } else { /* GCOVR_EXCL_LINE: brace of the alloc-failure branch */
+        const path_id_map *id_map = handle_obj->path_ids;
         Py_ssize_t top = count - 1;
         int anchored = 0;
         for (Py_ssize_t index = 0; index < count; index++) {
             const th_node_attr *id = find_node_attr(chain[index], TH_ATTR_ID);
-            if (id != NULL && id->value != NULL && path_id_safe(id->value, id->value_len) &&
-                path_id_unique(document, chain[index], id->value, id->value_len, quirks)) {
+            if (id != NULL && id->value != NULL && path_id_safe(id->value, id->value_len) && id_map != NULL &&
+                path_id_unique(id_map, id->value, id->value_len)) {
                 top = index;
                 anchored = 1;
                 break;
@@ -2953,9 +3023,11 @@ static PyObject *element_css_path(PyObject *self, PyObject *Py_UNUSED(ignored)) 
                 path_put_ucs4(&buf, id->value, id->value_len);
             } else {
                 path_put_ucs4(&buf, element->text, element->text_len);
-                if (path_needs_index(element)) {
+                int needs_index;
+                int sibling_index = path_step_index(element, &needs_index);
+                if (needs_index) {
                     path_puts(&buf, ":nth-of-type(");
-                    path_put_int(&buf, sel_sibling_index(element, 0, 1));
+                    path_put_int(&buf, sibling_index);
                     path_puts(&buf, ")");
                 }
             }
@@ -2993,9 +3065,11 @@ static PyObject *element_xpath_path(PyObject *self, PyObject *Py_UNUSED(ignored)
             th_node *element = chain[index];
             path_puts(&buf, "/");
             path_put_ucs4(&buf, element->text, element->text_len);
-            if (path_needs_index(element)) {
+            int needs_index;
+            int sibling_index = path_step_index(element, &needs_index);
+            if (needs_index) {
                 path_puts(&buf, "[");
-                path_put_int(&buf, sel_sibling_index(element, 0, 1));
+                path_put_int(&buf, sibling_index);
                 path_puts(&buf, "]");
             }
         }

--- a/src/turbohtml/_c/dom/nodes.h
+++ b/src/turbohtml/_c/dom/nodes.h
@@ -35,6 +35,26 @@ typedef struct {
     xp_program *prog;
 } xpath_cache_entry;
 
+/* One bucket of the css_path id-occurrence map: an id value (a stable pointer into
+   the tree's attribute storage), its length, and the number of elements carrying it
+   (so the anchor uniqueness test reads "exactly one" in O(id-length)). A NULL value
+   marks a free slot. */
+typedef struct {
+    const Py_UCS4 *value;
+    Py_ssize_t len;
+    Py_ssize_t count;
+} path_id_slot;
+
+/* Lazy per-tree open-addressed map from id value to its occurrence count, built on
+   the first css_path and dropped with the element index on any structural mutation.
+   ci folds id case the way the quirks-mode id selector does, so the map's keys
+   compare exactly as path_id_unique used to. */
+typedef struct {
+    path_id_slot *slots;
+    size_t mask; /* capacity - 1; capacity is a power of two */
+    int ci;
+} path_id_map;
+
 typedef struct {
     PyObject_HEAD th_tree *tree;
     PyObject *source;   /* the input str whose storage the tree's spans borrow */
@@ -47,6 +67,7 @@ typedef struct {
     th_node **index_nodes;
     Py_ssize_t *index_offsets; /* th_tag_count + 2 entries; NULL until built */
     int index_built;
+    path_id_map *path_ids; /* css_path id-occurrence map; NULL until first css_path */
     sel_cache_entry sel_cache[SEL_CACHE_CAP];
     int sel_cache_len;
     xpath_cache_entry xpath_cache[XPATH_CACHE_CAP];
@@ -351,6 +372,14 @@ static inline const th_node_attr *find_node_attr(th_node *node, uint32_t atom) {
         }
     }
     return NULL;
+}
+
+/* Release the css_path id-occurrence map, if any. */
+static inline void path_id_map_free(path_id_map *map) {
+    if (map != NULL) {
+        PyMem_Free(map->slots);
+        PyMem_Free(map);
+    }
 }
 
 /* Build the per-atom element index for the whole tree. Returns 0 on success (the

--- a/tests/query/css/test_tree_select.py
+++ b/tests/query/css/test_tree_select.py
@@ -639,6 +639,25 @@ def _css_path(html: str, selector: str, index: int = 0) -> str:
             "html > body > div:nth-of-type(2) > p",
             id="quirks-mode-case-insensitive-id-collision",
         ),
+        # "a0" and "a8" hash to the same id-map bucket, so anchoring on the inner
+        # one probes past the outer's slot before matching its own
+        pytest.param(
+            '<!doctype html><div id="a0"><div id="a8"><p>x</p></div></div>',
+            "p",
+            0,
+            "#a8 > p",
+            id="hash-colliding-ids-probe-past-collision",
+        ),
+        # more ids than the id map's initial capacity, so it grows before anchoring
+        pytest.param(
+            "<body>"
+            + "".join(f'<div id="d{number}"></div>' for number in range(6))
+            + '<section id="t"><p>x</p></section></body>',
+            "p",
+            0,
+            "#t > p",
+            id="many-ids-grow-map",
+        ),
         pytest.param(
             "<body><my-widget>a</my-widget><my-widget>b</my-widget></body>",
             "my-widget",
@@ -672,6 +691,13 @@ def test_css_path_of_detached_element_is_its_tag() -> None:
 
 def test_css_path_constructed_empty_string_id_is_not_an_anchor() -> None:
     container = Element("div", {"id": ""})
+    paragraph = Element("p")
+    container.append(paragraph)
+    assert paragraph.css_path() == "div > p"
+
+
+def test_css_path_detached_subtree_id_is_not_an_anchor() -> None:
+    container = Element("div", {"id": "main"})
     paragraph = Element("p")
     container.append(paragraph)
     assert paragraph.css_path() == "div > p"


### PR DESCRIPTION
`Element.css_path()` walked the entire document to check whether each candidate id was unique before anchoring the selector on it, so generating a locator for every element on a page was O(N²) in the element count. On real id-heavy pages this was pathological -- a 6002-id document took 112 ms, and css_path trailed lxml's `getpath` two to three times on the ars and mozilla pages.

It now caches a per-tree id-occurrence map, built lazily on first use and dropped together with the element index on any mutation, so the uniqueness test is an O(id-length) hash probe rather than a document scan. 🔗 Each path step also scans its siblings once instead of three times. The 6002-id document drops to 0.9 ms, and css_path/xpath_path now lead `getpath` by roughly five times across the corpus.

The emitted locators are byte-identical, and the round-trip contract (feeding the result back to `select()` returns the same element) is preserved -- the cached map only makes the uniqueness check cheaper.
