### PR TITLE
♻️ refactor(linkify): config object for linkify and Linker

### DIFF
--- a/docs/how-to/links.rst
+++ b/docs/how-to/links.rst
@@ -31,27 +31,29 @@ returning ``None`` leaves a link untouched.
 
 To linkify user-entered text the way `bleach.linkify <https://github.com/mozilla/bleach>`_ did, use
 :func:`turbohtml.linkify.linkify`. It parses the HTML, so it links only in text the reader sees, never inside an
-existing ``<a>``, a ``<script>``, or a tag you list in ``skip_tags``. Email autolinking is behind ``parse_email``
-because not every page wants it. The default ``nofollow`` callback marks web links, and leaves a ``mailto:`` link alone:
+existing ``<a>``, a ``<script>``, or a tag you list in the ``Linkify.skip_tags`` field. Email autolinking is behind the
+``Linkify.parse_email`` field because not every page wants it. The default ``nofollow`` callback marks web links, and
+leaves a ``mailto:`` link alone:
 
 .. testcode::
 
-    from turbohtml.linkify import linkify
+    from turbohtml.linkify import Linkify, linkify
 
-    print(linkify("email bob@example.com or visit https://example.com", parse_email=True))
+    print(linkify("email bob@example.com or visit https://example.com", Linkify(parse_email=True)))
 
 .. testoutput::
 
     email <a href="mailto:bob@example.com">bob@example.com</a> or visit <a href="https://example.com" rel="nofollow">https://example.com</a>
 
-By default the callbacks only see freshly detected links; pass ``process_existing=True`` to also run them over ``<a>``
-tags already in the input. A callback reads ``link.existing`` to tell an author's anchor from a detected one, and
-returning ``None`` for an existing anchor unwraps it to its text. Use ``extra_tlds`` to link bare domains on a private
-suffix the IANA table does not know, and ``schemes`` to autolink only an allowlist of explicit URL schemes:
+By default the callbacks only see freshly detected links; set the ``Linkify.process_existing`` field to ``True`` to also
+run them over ``<a>`` tags already in the input. A callback reads ``link.existing`` to tell an author's anchor from a
+detected one, and returning ``None`` for an existing anchor unwraps it to its text. Use the ``Linkify.extra_tlds`` field
+to link bare domains on a private suffix the IANA table does not know, and ``Linkify.schemes`` to autolink only an
+allowlist of explicit URL schemes:
 
 .. testcode::
 
-    from turbohtml.linkify import Link, linkify
+    from turbohtml.linkify import Link, Linkify, linkify
 
 
     def annotate(link: Link) -> Link:
@@ -60,7 +62,8 @@ suffix the IANA table does not know, and ``schemes`` to autolink only an allowli
 
 
     html = '<a href="https://docs.example">docs</a>, ping app.internal, skip ftp://x.example'
-    print(linkify(html, callbacks=[annotate], process_existing=True, extra_tlds=["internal"], schemes=["https"]))
+    config = Linkify(callbacks=[annotate], process_existing=True, extra_tlds=["internal"], schemes=["https"])
+    print(linkify(html, config))
 
 .. testoutput::
 

--- a/docs/migration/bleach.rst
+++ b/docs/migration/bleach.rst
@@ -111,7 +111,7 @@ The entry points keep bleach's names, so the import changes and the common case 
     from bleach.callbacks import nofollow, target_blank
 
     # turbohtml
-    from turbohtml.linkify import linkify, Linker, DEFAULT_CALLBACKS, nofollow, target_blank
+    from turbohtml.linkify import linkify, Linker, Linkify, DEFAULT_CALLBACKS, nofollow, target_blank
 
 .. list-table::
     :header-rows: 1
@@ -132,11 +132,12 @@ The entry points keep bleach's names, so the import changes and the common case 
     - - ``new`` flag
       - ``Link.existing`` (inverted)
     - - ``protocols=``
-      - ``schemes=``
+      - ``Linkify.schemes``
 
-``linkify(text, callbacks=..., skip_tags=..., parse_email=...)``, the reusable :class:`~turbohtml.linkify.Linker`, and
-the ``nofollow``/``target_blank`` defaults work as before. Only custom callbacks change shape. bleach passed ``(attrs,
-new)`` where ``attrs`` was keyed by ``(namespace, name)`` tuples with a ``"_text"`` pseudo-key for the visible text;
+``linkify(text, Linkify(callbacks=..., skip_tags=..., parse_email=...))``, the reusable
+:class:`~turbohtml.linkify.Linker`, and the ``nofollow``/``target_blank`` defaults work as before: the six knobs are now
+fields of a frozen :class:`~turbohtml.linkify.Linkify` config. Only custom callbacks change shape. bleach passed
+``(attrs, new)`` where ``attrs`` was keyed by ``(namespace, name)`` tuples with a ``"_text"`` pseudo-key for the text;
 turbohtml passes a single :class:`~turbohtml.linkify.Link` with plain ``url``, ``text``, and ``attrs`` (a ``dict[str,
 str]``), and a callback returns it to keep the link or ``None`` to leave the text bare. bleach's ``new`` flag becomes
 ``Link.existing`` (inverted: ``new=True`` is ``existing=False``). Porting a callback means reading fields instead of
@@ -144,7 +145,7 @@ tuple keys:
 
 .. testcode::
 
-    from turbohtml.linkify import linkify, Link
+    from turbohtml.linkify import Link, Linkify, linkify
 
 
     def shorten(link: Link) -> Link | None:
@@ -152,19 +153,19 @@ tuple keys:
         return link
 
 
-    print(linkify("read https://example.com/page", callbacks=[shorten]))
+    print(linkify("read https://example.com/page", Linkify(callbacks=[shorten])))
 
 .. testoutput::
 
     read <a href="https://example.com/page">example.com/page</a>
 
-bleach's ``protocols`` maps to ``schemes``, which restricts the explicit URL schemes that autolink, and bleach's
-custom-TLD support maps to ``extra_tlds``, on top of a current IANA table you can regenerate where bleach shipped a
-frozen list. A bare domain such as ``example.com`` still links only when its last label is a known TLD.
+bleach's ``protocols`` maps to the ``Linkify.schemes`` field, which restricts the explicit URL schemes that autolink,
+and bleach's custom-TLD support maps to ``Linkify.extra_tlds``, on top of a current IANA table you can regenerate where
+bleach shipped a frozen list. A bare domain such as ``example.com`` still links only when its last label is a known TLD.
 
 Pitfalls
 ========
 
 - turbohtml leaves an existing ``<a>`` untouched so linkifying is idempotent, where bleach always reprocessed present
-  links. Opt back in with ``process_existing=True`` to run the callbacks over author-written anchors too (the callback
-  reads ``Link.existing`` to branch).
+  links. Opt back in with the ``Linkify.process_existing`` field to run the callbacks over author-written anchors too
+  (the callback reads ``Link.existing`` to branch).

--- a/docs/reference/linkify.rst
+++ b/docs/reference/linkify.rst
@@ -6,12 +6,16 @@
 
 Find URLs and email addresses in HTML and wrap them in ``<a>`` links, a successor to `bleach.linkify
 <https://github.com/mozilla/bleach>`_. It is HTML-aware, so it never links inside an existing ``<a>``, a raw-text
-element, or a caller's ``skip_tags``. A callback receives each generated :class:`Link` and returns it to keep the link
-or ``None`` to leave the text bare. ``process_existing`` runs the callbacks over ``<a>`` tags already in the input (a
-callback reads ``Link.existing`` to tell the two apart), ``extra_tlds`` extends bare-domain detection beyond the
-built-in IANA table, and ``schemes`` restricts which explicit-scheme URLs autolink.
+element, or a caller's ``skip_tags``. A :class:`Linkify` configuration object carries the knobs: a callback receives
+each generated :class:`Link` and returns it to keep the link or ``None`` to leave the text bare, ``process_existing``
+runs the callbacks over ``<a>`` tags already in the input (a callback reads ``Link.existing`` to tell the two apart),
+``extra_tlds`` extends bare-domain detection beyond the built-in IANA table, and ``schemes`` restricts which
+explicit-scheme URLs autolink.
 
 .. autofunction:: linkify
+
+.. autoclass:: Linkify
+    :members:
 
 .. autoclass:: Linker
     :members: linkify

--- a/src/turbohtml/linkify.py
+++ b/src/turbohtml/linkify.py
@@ -12,6 +12,7 @@ mutate or veto before it is written as an ``<a>``, and the tree serializes back 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias
 
 from ._html import Element, Text, _linkify_find, _linkify_scan, parse_fragment
@@ -116,9 +117,12 @@ def target_blank(link: Link) -> Link | None:
 DEFAULT_CALLBACKS = (nofollow,)
 
 
-class Linker:
+@dataclass(frozen=True)
+class Linkify:
     """
-    A reusable linkifier; build it once with a configuration and call :meth:`linkify` per document.
+    An immutable, thread-safe description of how :func:`linkify` and :class:`Linker` find and rewrite links.
+
+    Build one and reuse it across threads.
 
     :param callbacks: callables run on each detected link to adjust or veto it (defaults to ``DEFAULT_CALLBACKS``).
     :param skip_tags: tags whose text is left untouched, such as ``pre`` and ``code``.
@@ -129,23 +133,30 @@ class Linker:
         always treated as ``http`` and is governed by the TLD table, not ``schemes``.
     """
 
-    def __init__(  # noqa: PLR0913  # configuration knobs, each independent, not a refactor candidate
-        self,
-        callbacks: Iterable[Callback] = DEFAULT_CALLBACKS,
-        skip_tags: Iterable[str] | None = None,
-        parse_email: bool = False,  # noqa: FBT001, FBT002  # parse_email is a flag, not a boolean trap, and stays positional
-        *,
-        process_existing: bool = False,
-        extra_tlds: Iterable[str] | None = None,
-        schemes: Iterable[str] | None = None,
-    ) -> None:
-        """Build a reusable linkifier."""
-        self.callbacks = list(callbacks)
-        self.skip_tags = frozenset(skip_tags or ())
-        self.parse_email = parse_email
-        self.process_existing = process_existing
-        self.extra_tlds = tuple(sorted({tld.lower() for tld in extra_tlds})) if extra_tlds else ()
-        self.schemes = frozenset(scheme.lower() for scheme in schemes) if schemes is not None else None
+    callbacks: Iterable[Callback] = DEFAULT_CALLBACKS
+    skip_tags: Iterable[str] | None = None
+    parse_email: bool = False
+    process_existing: bool = False
+    extra_tlds: Iterable[str] | None = None
+    schemes: Iterable[str] | None = None
+
+
+class Linker:
+    """
+    A reusable linkifier; build it once from a :class:`Linkify` configuration and call :meth:`linkify` per document.
+
+    :param config: the configuration to apply; None uses ``DEFAULT_CALLBACKS`` and detects nothing else.
+    """
+
+    def __init__(self, config: Linkify | None = None) -> None:
+        """Compile a configuration into the form the walk consumes."""
+        config = config if config is not None else Linkify()
+        self.callbacks = list(config.callbacks)
+        self.skip_tags = frozenset(config.skip_tags or ())
+        self.parse_email = config.parse_email
+        self.process_existing = config.process_existing
+        self.extra_tlds = tuple(sorted({tld.lower() for tld in config.extra_tlds})) if config.extra_tlds else ()
+        self.schemes = frozenset(scheme.lower() for scheme in config.schemes) if config.schemes is not None else None
 
     def linkify(self, text: str) -> str:
         """
@@ -234,36 +245,15 @@ class Linker:
         return anchor
 
 
-def linkify(  # noqa: PLR0913  # configuration knobs, each independent, not a refactor candidate
-    text: str,
-    callbacks: Iterable[Callback] = DEFAULT_CALLBACKS,
-    skip_tags: Iterable[str] | None = None,
-    parse_email: bool = False,  # noqa: FBT001, FBT002  # parse_email is a flag, not a boolean trap, and stays positional
-    *,
-    process_existing: bool = False,
-    extra_tlds: Iterable[str] | None = None,
-    schemes: Iterable[str] | None = None,
-) -> str:
+def linkify(text: str, config: Linkify | None = None) -> str:
     """
     Find URLs and email addresses in HTML and wrap them in ``<a>`` links, leaving existing markup untouched.
 
     :param text: the HTML to linkify.
-    :param callbacks: callables run on each detected link to adjust or veto it.
-    :param skip_tags: tags whose text is left untouched, such as ``pre`` and ``code``.
-    :param parse_email: also autolink bare email addresses as ``mailto:`` links.
-    :param process_existing: also run the callbacks over ``<a>`` tags already in the input.
-    :param extra_tlds: top-level domains that make a bare domain a link, on top of the built-in IANA table.
-    :param schemes: restrict which explicit-scheme URLs autolink; None keeps every scheme.
+    :param config: the configuration to apply; None uses ``DEFAULT_CALLBACKS`` and detects nothing else.
     :returns: the linkified HTML.
     """
-    return Linker(
-        callbacks,
-        skip_tags,
-        parse_email,
-        process_existing=process_existing,
-        extra_tlds=extra_tlds,
-        schemes=schemes,
-    ).linkify(text)
+    return Linker(config).linkify(text)
 
 
 class LinkSpan:
@@ -374,6 +364,7 @@ __all__ = [
     "Link",
     "LinkSpan",
     "Linker",
+    "Linkify",
     "linkify",
     "nofollow",
     "target_blank",

--- a/tests/features/test_linkify.py
+++ b/tests/features/test_linkify.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from turbohtml._html import _linkify_scan
-from turbohtml.linkify import DEFAULT_CALLBACKS, Link, Linker, linkify, nofollow, target_blank
+from turbohtml.linkify import DEFAULT_CALLBACKS, Link, Linker, Linkify, linkify, nofollow, target_blank
 
 if TYPE_CHECKING:
     from turbohtml.linkify import Callback
@@ -103,7 +103,7 @@ def _no_callbacks() -> list[Callback]:
     ],
 )
 def test_linkify_plain(text: str, expected: str) -> None:
-    assert linkify(text, callbacks=_no_callbacks()) == expected
+    assert linkify(text, Linkify(callbacks=_no_callbacks())) == expected
 
 
 @pytest.mark.parametrize(
@@ -115,7 +115,7 @@ def test_linkify_plain(text: str, expected: str) -> None:
 )  # fmt: skip
 def test_linkify_each_unicode_space_ends_url(cp: int) -> None:
     # every Unicode White_Space code point bounds the host the way an ASCII space does
-    out = linkify(f"http://x.com{chr(cp)}y", callbacks=_no_callbacks())
+    out = linkify(f"http://x.com{chr(cp)}y", Linkify(callbacks=_no_callbacks()))
     assert out.startswith('<a href="http://x.com">http://x.com</a>')
 
 
@@ -125,7 +125,7 @@ def test_linkify_default_callback_adds_nofollow() -> None:
 
 def test_linkify_leaves_existing_anchor_untouched() -> None:
     html = '<a href="http://x.com">http://y.com</a> and http://z.com'
-    assert linkify(html, callbacks=_no_callbacks()) == (
+    assert linkify(html, Linkify(callbacks=_no_callbacks())) == (
         '<a href="http://x.com">http://y.com</a> and <a href="http://z.com">http://z.com</a>'
     )
 
@@ -133,25 +133,25 @@ def test_linkify_leaves_existing_anchor_untouched() -> None:
 @pytest.mark.parametrize("tag", ["script", "style"])
 def test_linkify_skips_raw_text_elements(tag: str) -> None:
     html = f"<{tag}>http://x.com</{tag}>http://y.com"
-    out = linkify(html, callbacks=_no_callbacks())
+    out = linkify(html, Linkify(callbacks=_no_callbacks()))
     assert f"<{tag}>http://x.com</{tag}>" in out
     assert '<a href="http://y.com">' in out
 
 
 def test_linkify_skip_tags() -> None:
     html = "<code>http://x.com</code> http://y.com"
-    out = linkify(html, skip_tags=["code"], callbacks=_no_callbacks())
+    out = linkify(html, Linkify(skip_tags=["code"], callbacks=_no_callbacks()))
     assert out == '<code>http://x.com</code> <a href="http://y.com">http://y.com</a>'
 
 
 def test_linkify_nested_skip_tag_stays_skipped() -> None:
     html = "<code><span>http://x.com</span></code>"
-    assert linkify(html, skip_tags=["code"], callbacks=_no_callbacks()) == html
+    assert linkify(html, Linkify(skip_tags=["code"], callbacks=_no_callbacks())) == html
 
 
 def test_linkify_leaves_comment_nodes_untouched() -> None:
     html = "<!-- http://skip.com --> http://link.com"
-    out = linkify(html, callbacks=_no_callbacks())
+    out = linkify(html, Linkify(callbacks=_no_callbacks()))
     assert out == '<!-- http://skip.com --> <a href="http://link.com">http://link.com</a>'
 
 
@@ -160,23 +160,23 @@ def test_linkify_email_off_by_default() -> None:
 
 
 def test_linkify_email_when_enabled() -> None:
-    out = linkify("reach bob@example.com now", parse_email=True, callbacks=_no_callbacks())
+    out = linkify("reach bob@example.com now", Linkify(parse_email=True, callbacks=_no_callbacks()))
     assert out == 'reach <a href="mailto:bob@example.com">bob@example.com</a> now'
 
 
 def test_linkify_email_local_part_ends_at_unicode_space() -> None:
     # Unicode whitespace bounds the email local part the way an ASCII space does (issue #53)
-    out = linkify("foo\xa0bar@example.com", parse_email=True, callbacks=_no_callbacks())
+    out = linkify("foo\xa0bar@example.com", Linkify(parse_email=True, callbacks=_no_callbacks()))
     assert out == 'foo&nbsp;<a href="mailto:bar@example.com">bar@example.com</a>'
 
 
 def test_linkify_email_keeps_non_ascii_local_part() -> None:
-    out = linkify("naïve@example.com", parse_email=True, callbacks=_no_callbacks())
+    out = linkify("naïve@example.com", Linkify(parse_email=True, callbacks=_no_callbacks()))
     assert out == '<a href="mailto:naïve@example.com">naïve@example.com</a>'
 
 
 def test_linkify_veto_callback_keeps_plain_text() -> None:
-    assert linkify("http://x.com", callbacks=[lambda link: None]) == "http://x.com"  # noqa: ARG005
+    assert linkify("http://x.com", Linkify(callbacks=[lambda link: None])) == "http://x.com"  # noqa: ARG005
 
 
 def test_linkify_callback_can_change_text() -> None:
@@ -184,7 +184,7 @@ def test_linkify_callback_can_change_text() -> None:
         link.text = "link"
         return link
 
-    assert linkify("http://x.com", callbacks=[shorten]) == '<a href="http://x.com">link</a>'
+    assert linkify("http://x.com", Linkify(callbacks=[shorten])) == '<a href="http://x.com">link</a>'
 
 
 def test_linkify_callback_can_add_attribute() -> None:
@@ -192,16 +192,17 @@ def test_linkify_callback_can_add_attribute() -> None:
         link.attrs["class"] = "ext"
         return link
 
-    assert linkify("http://x.com", callbacks=[add_class]) == '<a href="http://x.com" class="ext">http://x.com</a>'
+    out = linkify("http://x.com", Linkify(callbacks=[add_class]))
+    assert out == '<a href="http://x.com" class="ext">http://x.com</a>'
 
 
 def test_linkify_callback_chain_runs_in_order() -> None:
-    out = linkify("http://x.com", callbacks=[nofollow, target_blank])
+    out = linkify("http://x.com", Linkify(callbacks=[nofollow, target_blank]))
     assert out == '<a href="http://x.com" rel="nofollow" target="_blank">http://x.com</a>'
 
 
 def test_linker_is_reusable() -> None:
-    linker = Linker(callbacks=_no_callbacks())
+    linker = Linker(Linkify(callbacks=_no_callbacks()))
     assert linker.linkify("http://a.example.com") == '<a href="http://a.example.com">http://a.example.com</a>'
     assert linker.linkify("http://b.example.com") == '<a href="http://b.example.com">http://b.example.com</a>'
 
@@ -242,7 +243,7 @@ def test_target_blank(url: str, attrs: dict[str, str], expected: dict[str, str])
 
 
 def test_bare_domain_path_with_embedded_scheme_keeps_http_prefix() -> None:
-    out = linkify("go example.com/r?u=http://evil.com end", callbacks=_no_callbacks())
+    out = linkify("go example.com/r?u=http://evil.com end", Linkify(callbacks=_no_callbacks()))
     assert out == 'go <a href="http://example.com/r?u=http://evil.com">example.com/r?u=http://evil.com</a> end'
 
 

--- a/tests/features/test_linkify_detection.py
+++ b/tests/features/test_linkify_detection.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from turbohtml._html import _linkify_scan
-from turbohtml.linkify import linkify
+from turbohtml.linkify import Linkify, linkify
 
 if TYPE_CHECKING:
     from turbohtml.linkify import Callback
@@ -16,41 +16,41 @@ def _no_callbacks() -> list[Callback]:
 
 
 def test_extra_tlds_links_custom_bare_domain() -> None:
-    out = linkify("visit foo.internal here", callbacks=_no_callbacks(), extra_tlds=["internal"])
+    out = linkify("visit foo.internal here", Linkify(callbacks=_no_callbacks(), extra_tlds=["internal"]))
     assert out == 'visit <a href="http://foo.internal">foo.internal</a> here'
 
 
 def test_extra_tlds_is_case_insensitive() -> None:
-    out = linkify("foo.LOCAL", callbacks=_no_callbacks(), extra_tlds=["local"])
+    out = linkify("foo.LOCAL", Linkify(callbacks=_no_callbacks(), extra_tlds=["local"]))
     assert out == '<a href="http://foo.LOCAL">foo.LOCAL</a>'
 
 
 def test_extra_tlds_absent_leaves_unknown_tld_plain() -> None:
-    assert linkify("foo.internal here", callbacks=_no_callbacks()) == "foo.internal here"
+    assert linkify("foo.internal here", Linkify(callbacks=_no_callbacks())) == "foo.internal here"
 
 
 def test_extra_tlds_still_links_builtin_tld() -> None:
-    out = linkify("example.com", callbacks=_no_callbacks(), extra_tlds=["internal"])
+    out = linkify("example.com", Linkify(callbacks=_no_callbacks(), extra_tlds=["internal"]))
     assert out == '<a href="http://example.com">example.com</a>'
 
 
 def test_schemes_blocks_unlisted_scheme() -> None:
-    out = linkify("ftp://x.com and http://y.com", callbacks=_no_callbacks(), schemes=["http"])
+    out = linkify("ftp://x.com and http://y.com", Linkify(callbacks=_no_callbacks(), schemes=["http"]))
     assert out == 'ftp://x.com and <a href="http://y.com">http://y.com</a>'
 
 
 def test_schemes_is_case_insensitive() -> None:
-    out = linkify("HTTP://x.com", callbacks=_no_callbacks(), schemes=["http"])
+    out = linkify("HTTP://x.com", Linkify(callbacks=_no_callbacks(), schemes=["http"]))
     assert out == '<a href="HTTP://x.com">HTTP://x.com</a>'
 
 
 def test_schemes_does_not_gate_bare_domains() -> None:
-    out = linkify("see example.com", callbacks=_no_callbacks(), schemes=["https"])
+    out = linkify("see example.com", Linkify(callbacks=_no_callbacks(), schemes=["https"]))
     assert out == 'see <a href="http://example.com">example.com</a>'
 
 
 def test_schemes_none_allows_every_scheme() -> None:
-    out = linkify("ftp://x.com", callbacks=_no_callbacks())
+    out = linkify("ftp://x.com", Linkify(callbacks=_no_callbacks()))
     assert out == '<a href="ftp://x.com">ftp://x.com</a>'
 
 

--- a/tests/features/test_linkify_process_existing.py
+++ b/tests/features/test_linkify_process_existing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from turbohtml.linkify import Link, linkify, nofollow, target_blank
+from turbohtml.linkify import Link, Linkify, linkify, nofollow, target_blank
 
 if TYPE_CHECKING:
     from turbohtml.linkify import Callback
@@ -22,17 +22,17 @@ def test_link_existing_can_be_set() -> None:
 
 def test_existing_anchor_untouched_without_flag() -> None:
     html = '<a href="http://x.com">x</a>'
-    assert linkify(html, callbacks=[nofollow]) == html
+    assert linkify(html, Linkify(callbacks=[nofollow])) == html
 
 
 def test_process_existing_runs_callbacks_over_anchor() -> None:
     html = '<a href="http://x.com">x</a>'
-    assert linkify(html, process_existing=True) == '<a href="http://x.com" rel="nofollow">x</a>'
+    assert linkify(html, Linkify(process_existing=True)) == '<a href="http://x.com" rel="nofollow">x</a>'
 
 
 def test_process_existing_veto_unwraps_anchor() -> None:
     html = '<a href="http://x.com">click</a>'
-    assert linkify(html, callbacks=[lambda _link: None], process_existing=True) == "click"
+    assert linkify(html, Linkify(callbacks=[lambda _link: None], process_existing=True)) == "click"
 
 
 def test_process_existing_can_change_text() -> None:
@@ -41,7 +41,7 @@ def test_process_existing_can_change_text() -> None:
         return link
 
     html = '<a href="http://x.com">original</a>'
-    assert linkify(html, callbacks=[relabel], process_existing=True) == '<a href="http://x.com">link</a>'
+    assert linkify(html, Linkify(callbacks=[relabel], process_existing=True)) == '<a href="http://x.com">link</a>'
 
 
 def test_process_existing_keeps_inner_markup_when_text_unchanged() -> None:
@@ -50,28 +50,31 @@ def test_process_existing_keeps_inner_markup_when_text_unchanged() -> None:
         return link
 
     html = '<a href="http://x.com"><b>x</b></a>'
-    assert linkify(html, callbacks=[add_rel], process_existing=True) == '<a href="http://x.com" rel="ext"><b>x</b></a>'
+    out = linkify(html, Linkify(callbacks=[add_rel], process_existing=True))
+    assert out == '<a href="http://x.com" rel="ext"><b>x</b></a>'
 
 
 def test_process_existing_callback_can_remove_attr() -> None:
     html = '<a href="mailto:a@b.com" target="_blank">mail</a>'
-    assert linkify(html, callbacks=[target_blank], process_existing=True) == '<a href="mailto:a@b.com">mail</a>'
+    out = linkify(html, Linkify(callbacks=[target_blank], process_existing=True))
+    assert out == '<a href="mailto:a@b.com">mail</a>'
 
 
 def test_process_existing_preserves_token_list_attr() -> None:
     html = '<a href="http://x.com" class="a b">x</a>'
-    assert linkify(html, callbacks=_no_callbacks(), process_existing=True) == '<a href="http://x.com" class="a b">x</a>'
+    out = linkify(html, Linkify(callbacks=_no_callbacks(), process_existing=True))
+    assert out == '<a href="http://x.com" class="a b">x</a>'
 
 
 def test_process_existing_flattens_valueless_attr() -> None:
     html = "<a download>x</a>"
-    out = linkify(html, callbacks=_no_callbacks(), process_existing=True)
+    out = linkify(html, Linkify(callbacks=_no_callbacks(), process_existing=True))
     assert out == '<a download="">x</a>'
 
 
 def test_process_existing_anchor_without_href_stays_bare() -> None:
     html = "<a>plain</a>"
-    assert linkify(html, callbacks=[nofollow], process_existing=True) == "<a>plain</a>"
+    assert linkify(html, Linkify(callbacks=[nofollow], process_existing=True)) == "<a>plain</a>"
 
 
 def test_existing_flag_distinguishes_existing_from_detected() -> None:
@@ -80,20 +83,20 @@ def test_existing_flag_distinguishes_existing_from_detected() -> None:
         return link
 
     html = '<a href="http://x.com">x</a> see http://y.com'
-    out = linkify(html, callbacks=[mark], process_existing=True)
+    out = linkify(html, Linkify(callbacks=[mark], process_existing=True))
     assert '<a href="http://x.com" data-kind="existing">x</a>' in out
     assert 'data-kind="new"' in out
 
 
 def test_process_existing_still_detects_links_in_other_tags() -> None:
     html = "<p>see http://x.com</p>"
-    out = linkify(html, callbacks=_no_callbacks(), process_existing=True)
+    out = linkify(html, Linkify(callbacks=_no_callbacks(), process_existing=True))
     assert out == '<p>see <a href="http://x.com">http://x.com</a></p>'
 
 
 def test_process_existing_leaves_anchor_in_skip_tag_alone() -> None:
     html = '<code><a href="http://x.com">x</a></code>'
-    assert linkify(html, callbacks=[nofollow], skip_tags=["code"], process_existing=True) == html
+    assert linkify(html, Linkify(callbacks=[nofollow], skip_tags=["code"], process_existing=True)) == html
 
 
 def test_how_to_doctest_scenario() -> None:
@@ -102,7 +105,9 @@ def test_how_to_doctest_scenario() -> None:
         return link
 
     html = '<a href="https://docs.example">docs</a>, ping app.internal, skip ftp://x.example'
-    out = linkify(html, callbacks=[annotate], process_existing=True, extra_tlds=["internal"], schemes=["https"])
+    out = linkify(
+        html, Linkify(callbacks=[annotate], process_existing=True, extra_tlds=["internal"], schemes=["https"])
+    )
     assert out == (
         '<a href="https://docs.example" data-seen="author">docs</a>, '
         'ping <a href="http://app.internal" data-seen="auto">app.internal</a>, skip ftp://x.example'


### PR DESCRIPTION
Following the config-object sweep in #328, `linkify` and `Linker` were the last public surface still over six arguments: six independent knobs (`callbacks`, `skip_tags`, `parse_email`, `process_existing`, `extra_tlds`, `schemes`) alongside the input text, with the same list duplicated across the free function and the reusable class. 🧹

This folds the knobs into a frozen `Linkify` configuration object, the way `sanitize` uses `Policy`, so `linkify(text, config)` and `Linker(config)` each take a single configuration argument and share one definition of what the knobs mean. `Linkify` is immutable and reusable across threads.

The trade-off is dropping the `bleach`-style flat signature for the library's own config-object convention, consistent with the rest of the renderers. ✨ Migration is mechanical — wrap the former keyword arguments in `Linkify(...)`, so `linkify(text, callbacks=cb, parse_email=True)` becomes `linkify(text, Linkify(callbacks=cb, parse_email=True))`. The bleach migration guide and the linkify how-to show the new form.

With this, no public method exceeds six arguments without a documented reason; `find`/`find_all` and `xpath` keep their idiomatic BeautifulSoup/lxml `**kwargs`.

Part of the #313 epic.