### PR TITLE
✨ feat(clean): expose HTML minify (minify-html/htmlmin)

### DIFF
--- a/docs/changelog/318.feature.rst
+++ b/docs/changelog/318.feature.rst
@@ -1,0 +1,3 @@
+Add :func:`turbohtml.clean.minify`, a one-call HTML minifier that parses then serializes through the round-trip-safe
+:class:`~turbohtml.Minify` layout, folding insignificant whitespace, omitting optional tags, unquoting attributes, and
+stripping comments. It is idempotent (``minify(minify(x)) == minify(x)``) and replaces ``minify-html`` and ``htmlmin``.

--- a/docs/how-to/serializing.rst
+++ b/docs/how-to/serializing.rst
@@ -65,6 +65,19 @@ Whitespace-significant elements (``pre``, ``textarea``, ``listing``) and raw-tex
 their content verbatim, and a tag is never dropped when omitting it would let the reparse reconstruct a formatting
 element across the boundary.
 
+When the input is a string rather than a built tree -- the ``minify-html`` and ``htmlmin`` use case --
+:func:`turbohtml.clean.minify` parses and minifies in one call, taking the same :class:`~turbohtml.Minify` options:
+
+.. testcode::
+
+    from turbohtml.clean import minify
+
+    print(minify("<html><head><title>Hi</title></head><body><p class='lead'>one</p>  <p>two</p><!--note--></body></html>"))
+
+.. testoutput::
+
+    <title>Hi</title><p class=lead>one</p> <p>two
+
 ***********************************
  Normalize attributes and encoding
 ***********************************

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -54,6 +54,23 @@ each match and accepts custom ``tlds`` and scheme-less ``schemes``.
 .. autoclass:: LinkSpan
     :members:
 
+***********
+ Minifying
+***********
+
+:func:`minify` shrinks an HTML document in one call -- it parses the input and serializes it through the round-trip-safe
+:class:`~turbohtml.Minify` layout, so the output reparses to the same tree and minifying is idempotent
+(``minify(minify(x)) == minify(x)``). It replaces ``minify-html`` and ``htmlmin``. The four transforms (fold
+insignificant whitespace, omit optional tags, unquote attributes, strip comments) default on; pass a
+:class:`~turbohtml.Minify` to turn any off.
+
+.. autofunction:: minify
+
+turbohtml does not bundle a CSS or JavaScript minifier, so ``minify-html``'s ``minify_css`` / ``minify_js`` have no
+counterpart; ``<style>`` and ``<script>`` bodies are emitted verbatim. The doctype is always normalized to ``<!doctype
+html>`` (``minify-html``'s ``minify_doctype`` is implicit), and HTML has no processing instructions to drop
+(``remove_processing_instructions`` is moot under the WHATWG parser, which reads them as bogus comments).
+
 turbohtml.migration.bleach
 ==========================
 

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ py.install_sources(
         'src/turbohtml/_html.pyi',
         'src/turbohtml/_linkify.py',
         'src/turbohtml/_links.py',
+        'src/turbohtml/_minify.py',
         'src/turbohtml/_render.py',
         'src/turbohtml/_sanitizer.py',
         'src/turbohtml/_structured_data.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ bench = [
   "html2text>=2025.4.15",
   "html5-parser>=0.4.12",
   "html5lib>=1.1",
+  "htmlmin2>=0.1.13",
   "htpy>=26.5.1",
   "inscriptis>=2.7.2",
   "linkify-it-py>=2.1",

--- a/src/turbohtml/_minify.py
+++ b/src/turbohtml/_minify.py
@@ -1,0 +1,37 @@
+"""
+Minify HTML the way ``minify-html`` and ``htmlmin`` did, by parsing then serializing through the shipped C minifier.
+
+The minifier already lives in ``_c/serialize/minify.c`` and is reachable as the :class:`~turbohtml.Minify` layout passed
+to :meth:`~turbohtml.Node.serialize`; this module is the one-call convenience those libraries expose. The model is the
+one every safe minifier converged on: parse the input into a real WHATWG tree, then emit it once with the folds engaged,
+so every transform is round-trip safe -- the output reparses to the same tree. That is the property the acceptance gate
+checks as idempotence: ``minify(minify(x)) == minify(x)``.
+
+This module is a thin facade; the whitespace fold, optional-tag omission, attribute unquoting, and comment stripping all
+run in C below :func:`minify`, configured by the existing immutable :class:`~turbohtml.Minify` options object.
+"""
+
+from __future__ import annotations
+
+from ._html import Minify, parse
+from ._render import Html
+
+_DEFAULT = Minify()
+
+
+def minify(html: str, options: Minify | None = None) -> str:
+    """
+    Minify an HTML document.
+
+    Parse ``html`` into a tree and serialize it with the minifying layout, folding insignificant whitespace, omitting
+    the start/end tags the WHATWG rules make optional, dropping redundant attribute quotes, and stripping comments. Each
+    transform is round-trip safe, so the result reparses to the same tree and minifying is idempotent.
+
+    :param html: the HTML document to minify.
+    :param options: which folds to apply; ``None`` engages every transform (the :class:`~turbohtml.Minify` default).
+    :returns: the minified HTML.
+    """
+    return parse(html).serialize(Html(layout=options if options is not None else _DEFAULT))
+
+
+__all__ = ["Minify", "minify"]

--- a/src/turbohtml/clean.py
+++ b/src/turbohtml/clean.py
@@ -2,12 +2,13 @@
 turbohtml.clean: scrub and tidy HTML -- sanitize against an allowlist, auto-link plain URLs, and minify.
 
 The sanitizer replaces `bleach <https://github.com/mozilla/bleach>`__/``nh3``/``html-sanitizer``, the linkifier
-replaces ``bleach.linkify``/``linkify-it-py``, and (with #318) ``minify`` replaces ``minify-html``/``htmlmin``. Every
-configurable entry point takes a frozen, thread-safe config object (:class:`Policy`, :class:`Linkify`).
+replaces ``bleach.linkify``/``linkify-it-py``, and ``minify`` replaces ``minify-html``/``htmlmin``. Every configurable
+entry point takes a frozen, thread-safe config object (:class:`Policy`, :class:`Linkify`, :class:`Minify`).
 """
 
 from __future__ import annotations
 
+from ._html import Minify
 from ._linkify import (
     DEFAULT_CALLBACKS,
     Callback,
@@ -20,6 +21,7 @@ from ._linkify import (
     nofollow,
     target_blank,
 )
+from ._minify import minify
 from ._sanitizer import (
     DEFAULT_ATTRIBUTES,
     DEFAULT_CSS_PROPERTIES,
@@ -43,10 +45,12 @@ __all__ = [
     "LinkSpan",
     "Linker",
     "Linkify",
+    "Minify",
     "OnDisallowed",
     "Policy",
     "Sanitizer",
     "linkify",
+    "minify",
     "nofollow",
     "sanitize",
     "target_blank",

--- a/tests/features/test_minify.py
+++ b/tests/features/test_minify.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import pytest
 
 from turbohtml import Minify
-from turbohtml.clean import minify
 from turbohtml.clean import Minify as CleanMinify
+from turbohtml.clean import minify
 
 _DOC = "<html><head><title>Hi</title></head><body><p class='lead'>one</p>  <p>two</p><!--note--></body></html>"
 
@@ -42,7 +42,8 @@ def test_minify_keep_comments_retains_comment() -> None:
 
 def test_minify_keep_optional_tags_retains_html_and_body() -> None:
     out = minify(_DOC, Minify(omit_optional_tags=False))
-    assert out.startswith("<html><head>") and "<body>" in out
+    assert out.startswith("<html><head>")
+    assert "<body>" in out
 
 
 def test_minify_keep_quotes_retains_attribute_quotes() -> None:

--- a/tests/features/test_minify.py
+++ b/tests/features/test_minify.py
@@ -1,0 +1,70 @@
+"""Tests for turbohtml.clean.minify, the one-call HTML minifier over the Minify layout."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Minify
+from turbohtml.clean import minify
+from turbohtml.clean import Minify as CleanMinify
+
+_DOC = "<html><head><title>Hi</title></head><body><p class='lead'>one</p>  <p>two</p><!--note--></body></html>"
+
+
+def test_minify_collapses_whitespace_and_omits_tags() -> None:
+    assert minify(_DOC) == "<title>Hi</title><p class=lead>one</p> <p>two"
+
+
+def test_minify_none_matches_default_options() -> None:
+    assert minify(_DOC) == minify(_DOC, Minify())
+
+
+def test_clean_reexports_minify_config() -> None:
+    assert CleanMinify is Minify
+
+
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        pytest.param(Minify(omit_optional_tags=False), True, id="keep-optional-tags"),
+        pytest.param(Minify(collapse_whitespace=False), True, id="keep-whitespace"),
+        pytest.param(Minify(unquote_attributes=False), True, id="keep-quotes"),
+        pytest.param(Minify(strip_comments=False), True, id="keep-comments"),
+    ],
+)
+def test_minify_options_thread_through(options: Minify, expected: bool) -> None:
+    assert (minify(_DOC, options) != minify(_DOC)) is expected
+
+
+def test_minify_keep_comments_retains_comment() -> None:
+    assert "<!--note-->" in minify(_DOC, Minify(strip_comments=False))
+
+
+def test_minify_keep_optional_tags_retains_html_and_body() -> None:
+    out = minify(_DOC, Minify(omit_optional_tags=False))
+    assert out.startswith("<html><head>") and "<body>" in out
+
+
+def test_minify_keep_quotes_retains_attribute_quotes() -> None:
+    assert 'class="lead"' in minify(_DOC, Minify(unquote_attributes=False))
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(_DOC, id="document"),
+        pytest.param("<pre>  keep   spaces  </pre>", id="preformatted"),
+        pytest.param("<p>one</p><script>let x = 1 + 2;</script>", id="raw-text"),
+        pytest.param("<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>", id="table"),
+        pytest.param("<!doctype html><html><body><p>x</p></body></html>", id="doctyped"),
+        pytest.param("", id="empty"),
+    ],
+)
+def test_minify_is_idempotent(source: str) -> None:
+    once = minify(source)
+    assert minify(once) == once
+
+
+def test_minify_shrinks_documents() -> None:
+    big = "<!doctype html><html><body>" + "<p class='x'>  text  </p>\n" * 200 + "</body></html>"
+    assert len(minify(big)) < len(big)

--- a/tools/bench/competitors/htmlmin.py
+++ b/tools/bench/competitors/htmlmin.py
@@ -1,0 +1,15 @@
+"""htmlmin: a pure-Python regex/parser minifier (the maintained htmlmin2 fork runs on current Pythons)."""
+
+from __future__ import annotations
+
+import htmlmin
+
+REQUIREMENTS = ("htmlmin2>=0.1.13",)
+
+
+def minify(text: str) -> None:
+    """Minify with the whitespace and comment folds comparable to turbohtml's Minify defaults."""
+    htmlmin.minify(text, remove_comments=True, remove_empty_space=True)
+
+
+OPERATIONS = {"minify": (minify, "htmlmin")}

--- a/tools/bench/competitors/minify_html.py
+++ b/tools/bench/competitors/minify_html.py
@@ -1,0 +1,15 @@
+"""minify-html: the Rust minify-html (formerly hyperbuild) binding."""
+
+from __future__ import annotations
+
+import minify_html
+
+REQUIREMENTS = ("minify-html>=0.18.1",)
+
+
+def minify(text: str) -> None:
+    """Minify with the folds turbohtml's Minify performs, leaving CSS/JS untouched for a like-for-like comparison."""
+    minify_html.minify(text, keep_comments=False, minify_css=False, minify_js=False)
+
+
+OPERATIONS = {"minify": (minify, "minify-html")}

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -18,6 +18,7 @@ from turbohtml import clean as _clean
 from turbohtml.build import E
 from turbohtml.clean import Detector as _Detector
 from turbohtml.clean import linkify as _linkify
+from turbohtml.clean import minify as _minify
 from turbohtml.migration.markupsafe import Markup as _Markup
 from turbohtml.migration.markupsafe import escape as _markup_escape
 from turbohtml.migration.stdlib import HTMLParser as _TurboHTMLParser
@@ -138,6 +139,11 @@ def text_content(text: str) -> None:
 def serialize(text: str) -> None:
     """Serialize a parsed document back to HTML with turbohtml's html property."""
     _ = _parsed(text).html
+
+
+def minify(text: str) -> None:
+    """Minify an HTML document with turbohtml, parsing then serializing through the round-trip-safe Minify layout."""
+    _minify(text)
 
 
 def edit(document: turbohtml.Document) -> None:
@@ -433,6 +439,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "find-text": (find_text, "turbohtml"),
     "text-content": (text_content, "turbohtml"),
     "serialize": (serialize, "turbohtml"),
+    "minify": (minify, "turbohtml"),
     "edit": (Mutating(turbohtml.parse, edit), "turbohtml"),
     "class-edit": (class_edit, "turbohtml"),
     "strip-remove": (strip_remove, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -87,6 +87,7 @@ OPERATIONS: dict[str, Operation] = {
     "find-text": Operation("find by text content", "us"),
     "text-content": Operation("collect visible text", "us"),
     "serialize": Operation("serialize a parsed tree", "us"),
+    "minify": Operation("minify a document", "us"),
     "edit": Operation("tag every link rel=nofollow", "us"),
     "class-edit": Operation("class add/remove on every link", "us"),
     "strip-remove": Operation("drop tags with content (remove)", "us"),
@@ -308,6 +309,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "find-text": _readpath_cases,
     "text-content": _readpath_cases,
     "serialize": _readpath_cases,
+    "minify": _readpath_cases,
     "socialcard": lambda: (
         ("head", _SOCIAL_HEAD),
         ("article 8 KiB", f"{_SOCIAL_HEAD}<body>{'<p>filler text</p>' * 400}</body>"),


### PR DESCRIPTION
The HTML minifier already ships in `_c/serialize/minify.c` and is reachable as the `Minify` formatter, but there was no `minify(html) -> str` convenience, so `minify-html` and `htmlmin` refugees had no one-call migration target. ✨

This adds `turbohtml.clean.minify(html, options: Minify | None = None)`, which parses the input into a real WHATWG tree and serializes it through the existing C minifier. It reuses the existing immutable `Minify` config object rather than introducing a parallel flag surface, so the four folds (collapse whitespace, omit optional tags, unquote attributes, strip comments) carry over unchanged. Because every transform is round-trip safe, the result reparses to the same tree and minifying is idempotent: `minify(minify(x)) == minify(x)`.

turbohtml bundles no CSS or JavaScript minifier, so `minify-html`'s `minify_css` / `minify_js` have no counterpart and `<style>` / `<script>` bodies stay verbatim; the doctype is always normalized and HTML has no processing instructions to drop. 📝 The benchmark gains a `minify` operation with turbohtml timing and isolated competitor modules for `minify-html` and `htmlmin` (the maintained `htmlmin2` fork, which runs on current Pythons). The new API is documented in the clean reference and the serializing how-to with a changelog fragment.

Per the coordinator's scope split, the per-library migration guides and the competitor numbers in `performance.rst` are deferred to separate dedicated migration PRs that consume the benchmark machinery added here.

closes #318