### PR TITLE
✨ feat(extract): URL clean/normalize/extract helpers (courlan/w3lib)

### DIFF
--- a/docs/changelog/321.feature.rst
+++ b/docs/changelog/321.feature.rst
@@ -1,8 +1,8 @@
-Clean, canonicalize, and harvest URLs with :func:`turbohtml.extract.clean_url`,
-:func:`turbohtml.extract.normalize_url`, and :func:`turbohtml.extract.extract_links`, the successors to `courlan
-<https://github.com/adbar/courlan>`__ and ``w3lib.url``. They layer a small normalization pass over the existing link
-engine: ``clean_url`` scrubs tracking parameters and stray markup off a raw href, ``normalize_url`` canonicalizes a
-single absolute URL, and ``extract_links`` returns a page's cleaned, deduplicated ``http``/``https`` links (internal by
-default, ``external_only`` for the rest). A shared, immutable :class:`turbohtml.extract.UrlCleaning` config -- with an
+Clean, canonicalize, and harvest URLs with :func:`turbohtml.extract.clean_url`, :func:`turbohtml.extract.normalize_url`,
+and :func:`turbohtml.extract.extract_links`, the successors to `courlan <https://github.com/adbar/courlan>`__ and
+``w3lib.url``. They layer a small normalization pass over the existing link engine: ``clean_url`` scrubs tracking
+parameters and stray markup off a raw href, ``normalize_url`` canonicalizes a single absolute URL, and ``extract_links``
+returns a page's cleaned, deduplicated ``http``/``https`` links (internal by default, ``external_only`` for the rest). A
+shared, immutable :class:`turbohtml.extract.UrlCleaning` config -- with an
 :meth:`~turbohtml.extract.UrlCleaning.aggressive` preset -- controls how hard each one rewrites. Unlike courlan, they do
 not guess a page's language or rank a link's crawl-worthiness.

--- a/docs/changelog/321.feature.rst
+++ b/docs/changelog/321.feature.rst
@@ -1,0 +1,8 @@
+Clean, canonicalize, and harvest URLs with :func:`turbohtml.extract.clean_url`,
+:func:`turbohtml.extract.normalize_url`, and :func:`turbohtml.extract.extract_links`, the successors to `courlan
+<https://github.com/adbar/courlan>`__ and ``w3lib.url``. They layer a small normalization pass over the existing link
+engine: ``clean_url`` scrubs tracking parameters and stray markup off a raw href, ``normalize_url`` canonicalizes a
+single absolute URL, and ``extract_links`` returns a page's cleaned, deduplicated ``http``/``https`` links (internal by
+default, ``external_only`` for the rest). A shared, immutable :class:`turbohtml.extract.UrlCleaning` config -- with an
+:meth:`~turbohtml.extract.UrlCleaning.aggressive` preset -- controls how hard each one rewrites. Unlike courlan, they do
+not guess a page's language or rank a link's crawl-worthiness.

--- a/docs/how-to/links.rst
+++ b/docs/how-to/links.rst
@@ -101,3 +101,63 @@ their opaque URLs are found too (every ``scheme://`` URL is detected without reg
 .. testoutput::
 
     ['http://wiki.corp', 'tel:+1-800-555-0100']
+
+**************************************
+ Clean tracking junk off a single URL
+**************************************
+
+A URL copied out of a page often carries tracking parameters, an escaped ``&amp;``, or stray markup.
+:func:`turbohtml.extract.clean_url` scrubs and canonicalizes it the way ``courlan``'s ``clean_url`` did, returning
+``None`` when nothing usable is left so you can filter a stream of dirty hrefs in one pass:
+
+.. testcode::
+
+    from turbohtml.extract import clean_url
+
+    print(clean_url("  https://Example.COM:443/a//b/?utm_source=news&id=7#sec  "))
+    print(clean_url("   "))
+
+.. testoutput::
+
+    https://example.com/a/b/?id=7#sec
+    None
+
+When the URL is already absolute and you only want it in a canonical form -- lowercased host, default port dropped,
+query sorted -- use :func:`turbohtml.extract.normalize_url`. Share one :class:`~turbohtml.extract.UrlCleaning` config
+across both; :meth:`~turbohtml.extract.UrlCleaning.aggressive` keeps only content-bearing query parameters and drops the
+fragment and trailing slash, which is what you want to deduplicate a crawl frontier:
+
+.. testcode::
+
+    from turbohtml.extract import UrlCleaning, normalize_url
+
+    raw = "http://example.com/p/?id=3&utm_campaign=promo&color=red#frag"
+    print(normalize_url(raw))
+    print(normalize_url(raw, UrlCleaning.aggressive()))
+
+.. testoutput::
+
+    http://example.com/p/?color=red&id=3#frag
+    http://example.com/p/?id=3
+
+*******************************************
+ Harvest the clean web links out of a page
+*******************************************
+
+:func:`turbohtml.extract.extract_links` rolls the whole pipeline into one call: it parses the HTML, finds every link
+(``srcset`` and CSS ``url()`` included, not only ``<a href>``), absolutizes each against ``base_url``, then returns the
+cleaned ``http``/``https`` links as a deduplicated set. Like ``courlan``'s ``extract_links``, it keeps the page's own
+internal links by default; pass ``external_only=True`` for the links that leave the host:
+
+.. testcode::
+
+    from turbohtml.extract import extract_links
+
+    page = "<a href='/a?utm_source=x'>a</a><a href='/a?utm_source=y'>dup</a><a href='https://other.example/z'>out</a>"
+    print(sorted(extract_links(page, "https://example.com/")))
+    print(sorted(extract_links(page, "https://example.com/", external_only=True)))
+
+.. testoutput::
+
+    ['https://example.com/a']
+    ['https://other.example/z']

--- a/docs/reference/extract.rst
+++ b/docs/reference/extract.rst
@@ -7,4 +7,24 @@
 Pull content and data out of HTML. Extraction runs through the node methods, and the records those methods return are
 re-exported from this namespace for discoverability -- :class:`~turbohtml.Article`, :class:`~turbohtml.Link`,
 :class:`~turbohtml.StructuredData`, and :class:`~turbohtml.MicrodataItem` -- while staying importable from the package
-root. The content, date, and URL helpers that round out this namespace land with their feature work.
+root. The content and date helpers that round out this namespace land with their feature work.
+
+******
+ URLs
+******
+
+Clean, canonicalize, and harvest the URLs in a document, the successor to ``courlan`` and ``w3lib.url``. These layer a
+small normalization pass over the link engine (:meth:`~turbohtml.Node.links` / :meth:`~turbohtml.Node.resolve_links`):
+:func:`clean_url` scrubs tracking junk and stray markup off a raw href, :func:`normalize_url` canonicalizes a single
+absolute URL, and :func:`extract_links` returns the cleaned, deduplicated web links of a page. A shared
+:class:`UrlCleaning` configuration controls how aggressively each one rewrites. Unlike ``courlan``, these helpers do not
+guess a page's language or rank a link's crawl-worthiness; they normalize and deduplicate only.
+
+.. autofunction:: clean_url
+
+.. autofunction:: normalize_url
+
+.. autofunction:: extract_links
+
+.. autoclass:: UrlCleaning
+    :members: aggressive

--- a/meson.build
+++ b/meson.build
@@ -66,6 +66,7 @@ py.install_sources(
         'src/turbohtml/_render.py',
         'src/turbohtml/_sanitizer.py',
         'src/turbohtml/_structured_data.py',
+        'src/turbohtml/_urls.py',
         'src/turbohtml/_xpath.py',
         'src/turbohtml/build.py',
         'src/turbohtml/clean.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ bench = [
   "airium>=0.2.7",
   "beautifulsoup4>=4.15",
   "bleach>=6.4",
+  "courlan>=1.4",
   "cssselect>=1.4",
   "dominate>=2.9.1",
   "extruct>=0.18",

--- a/src/turbohtml/_urls.py
+++ b/src/turbohtml/_urls.py
@@ -1,0 +1,229 @@
+"""
+Clean, normalize, and harvest the URLs in a document, the way ``courlan`` and ``w3lib.url`` do.
+
+``courlan`` (a ``trafilatura`` dependency) scrubs tracking junk off a URL, canonicalizes it, and pulls the filtered
+links out of a page; ``w3lib.url`` canonicalizes a single URL. turbohtml already finds and absolutizes links in C
+(:meth:`~turbohtml.Node.links` / :meth:`~turbohtml.Node.resolve_links`); this module adds the small pure-Python
+normalization pass that turns those raw links into a clean, deduplicated set.
+
+What is deliberately left out of ``courlan``: the language heuristics (``TARGET_LANGS``/``hreflang`` filtering) and the
+spam/quality heuristics (navigation-page detection, redirect probing over HTTP). turbohtml normalizes and deduplicates
+URLs; it does not guess a page's language or rank a link's crawl-worthiness.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from urllib.parse import SplitResult, parse_qsl, quote, urlencode, urlsplit, urlunsplit
+
+from ._html import parse
+
+__all__ = ["UrlCleaning", "clean_url", "extract_links", "normalize_url"]
+
+# Control characters (everything below U+0020) are stripped from a scrubbed URL's ends, matching courlan's scrub_url.
+_CONTROL_CHARS = "".join(map(chr, range(0x20)))
+
+# Short markup remnants (``</p>``, ``{...}``) that survive a sloppy copy-paste of an href out of a page.
+_REMAINING_MARKUP = re.compile(r"</?[a-z]{,4}?>|{.+?}")
+
+# A URL ends at the first whitespace, quote, or angle bracket: everything past it is the surrounding markup, not the URL.
+_TRAILING_PARTS = re.compile(r'(.*?)[<>"\s]')
+
+# A scheme's default port carries no information once the scheme is known, so ``:80``/``:443`` is dropped after a host.
+_DEFAULT_PORT = re.compile(r"(?<=\w):(?:80|443)$")
+
+# Runs of slashes in a path collapse to one; a leading ``/../`` cannot climb above the root and is removed.
+_DUP_SLASH = re.compile(r"/+")
+_LEADING_PARENT = re.compile(r"^(?:/\.\.(?![^/]))+")
+
+# Tracking query parameters (ad-click ids, analytics campaign tags) carry no content and are dropped from a clean URL.
+# Ported from courlan's TRACKERS_RE, itself drawn from the AdGuard and ClearURLs rule sets.
+_TRACKERS = re.compile(
+    r"^(?:dc|fbc|gc|twc|yc|ysc)lid|"
+    r"^(?:click|gbra|msclk|igsh|partner|wbra)id|"
+    r"^(?:ads?|mc|ga|gs|itm|mc|mkt|ml|mtm|oly|pk|utm|vero)_|"
+    r"(?:\b|_)(?:aff|affi|affiliate|campaign|cl?id|eid|ga|gl|"
+    r"kwd|keyword|medium|ref|referr?er|session|source|uid|xtor)"
+)
+
+# Under strict cleaning only these content-bearing identifiers survive in the query string; every other parameter goes.
+_ALLOWED_PARAMS = frozenset(
+    {
+        "aid",
+        "article_id",
+        "artnr",
+        "id",
+        "itemid",
+        "objectid",
+        "p",
+        "page",
+        "pagenum",
+        "page_id",
+        "pid",
+        "post",
+        "postid",
+        "product_id",
+    }
+)
+
+# Only web links survive extraction and normalization; mailto/tel/javascript and bare fragments are not crawlable URLs.
+_WEB_SCHEMES = frozenset({"http", "https"})
+
+
+@dataclass(frozen=True)
+class UrlCleaning:
+    """
+    How :func:`clean_url`, :func:`normalize_url`, and :func:`extract_links` canonicalize a URL.
+
+    Immutable and thread-safe: build one and reuse it across threads. Every field has a default that reproduces the
+    no-argument behaviour, so ``UrlCleaning()`` is the same as passing nothing.
+
+    :param strict: keep only the small allowlist of content-bearing query parameters (``id``, ``page``, ...) and drop
+        every other parameter and the fragment; the strongest canonicalization, for deduplicating crawl frontiers.
+    :param trailing_slash: keep a path's trailing slash; set to ``False`` to trim it so ``/a/`` and ``/a`` collapse.
+    :param strip_fragment: drop the ``#fragment``; ``strict`` already implies this.
+    :param strip_trackers: drop tracking query parameters (ad-click ids, ``utm_*`` campaign tags) in non-strict mode;
+        meaningless under ``strict`` (which already keeps only the allowlist) so the two cannot be combined.
+    """
+
+    strict: bool = False
+    trailing_slash: bool = True
+    strip_fragment: bool = False
+    strip_trackers: bool = True
+
+    def __post_init__(self) -> None:
+        """Reject the contradiction of asking to keep trackers while strict mode drops everything but the allowlist."""
+        if self.strict and not self.strip_trackers:
+            message = "strip_trackers=False is meaningless with strict=True, which keeps only the allowlist"
+            raise ValueError(message)
+
+    @classmethod
+    def aggressive(cls) -> UrlCleaning:
+        """The strongest canonicalization: allowlist-only query, no fragment, no trailing slash (courlan's strict mode)."""
+        return cls(strict=True, trailing_slash=False, strip_fragment=True)
+
+
+_DEFAULT = UrlCleaning()
+
+
+def _clean_query(query: str, options: UrlCleaning) -> str:
+    """Sort the query parameters and drop the unwanted ones, returning a canonical query string."""
+    if not query:
+        return ""
+    kept = []
+    for name, value in sorted(parse_qsl(query, keep_blank_values=True)):
+        lowered = name.lower()
+        if options.strict:
+            if lowered not in _ALLOWED_PARAMS:
+                continue
+        elif options.strip_trackers and _TRACKERS.search(lowered):
+            continue
+        kept.append((name, value))
+    return urlencode(kept)
+
+
+def _normalize_fragment(fragment: str, options: UrlCleaning) -> str:
+    """Drop a fragment that is itself a tracker, otherwise percent-encode it; empty when fragments are stripped."""
+    if options.strict or options.strip_fragment:
+        return ""
+    if "=" in fragment and "&" not in fragment and options.strip_trackers and _TRACKERS.search(fragment):
+        return ""
+    return quote(fragment, safe="/%!=:,-")
+
+
+def normalize_url(url: str | SplitResult, options: UrlCleaning | None = None, /) -> str:
+    """
+    Canonicalize a single URL: lowercase the scheme and host, sort and filter the query, and tidy the path.
+
+    This is the ``courlan.normalize_url`` / ``w3lib.url.canonicalize_url`` mapping. It assumes an already-absolute URL
+    (run it through :func:`clean_url` or :meth:`~turbohtml.Node.resolve_links` first if it might be relative or dirty).
+
+    :param url: the URL string, or a pre-split :class:`urllib.parse.SplitResult`.
+    :param options: the cleaning configuration; ``None`` uses the defaults.
+    :returns: the canonical URL string.
+    """
+    options = options if options is not None else _DEFAULT
+    parsed = url if isinstance(url, SplitResult) else urlsplit(url)
+    scheme = parsed.scheme.lower()
+    netloc = _DEFAULT_PORT.sub("", parsed.netloc.lower()) if scheme in _WEB_SCHEMES else parsed.netloc.lower()
+    path = quote(_LEADING_PARENT.sub("", _DUP_SLASH.sub("/", parsed.path)), safe="/%!=:,-")
+    query = _clean_query(parsed.query, options)
+    if query and not path:
+        path = "/"
+    elif not options.trailing_slash and not query and len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+    fragment = _normalize_fragment(parsed.fragment, options)
+    return urlunsplit((scheme, netloc, path, query, fragment))
+
+
+def _scrub(url: str) -> str:
+    """Strip whitespace, control characters, CDATA wrappers, and stray markup off a raw href."""
+    url = "".join(url.split()).strip(_CONTROL_CHARS)
+    if url.startswith("<![CDATA[") and url.endswith("]]>"):
+        url = url[len("<![CDATA[") : -len("]]>")]
+    url = _REMAINING_MARKUP.sub("", url)
+    url = url.replace("&amp;", "&")
+    if url.endswith("/&"):
+        url = url[:-2]
+    if (match := _TRAILING_PARTS.match(url)) is not None:
+        url = match[1]
+    if url.count("/") == 3 or url.count("://") > 1:
+        url = url.rstrip("/")
+    return url
+
+
+def clean_url(url: str, options: UrlCleaning | None = None, /) -> str | None:
+    """
+    Scrub tracking junk and stray markup off a URL, then canonicalize it; the ``courlan.clean_url`` mapping.
+
+    Returns ``None`` when the input cannot be made into a usable URL (it is empty after scrubbing), so a caller can
+    filter a stream of dirty hrefs in one pass.
+
+    :param url: the raw URL, possibly carrying surrounding markup, escaped ampersands, or tracking parameters.
+    :param options: the cleaning configuration; ``None`` uses the defaults.
+    :returns: the cleaned, canonical URL, or ``None`` when nothing usable remains.
+    """
+    scrubbed = _scrub(url)
+    if not scrubbed:
+        return None
+    return normalize_url(scrubbed, options)
+
+
+def extract_links(
+    html: str,
+    base_url: str | None = None,
+    *,
+    external_only: bool = False,
+    options: UrlCleaning | None = None,
+) -> set[str]:
+    """
+    Harvest every web link in a document as a clean, absolute, deduplicated set; the ``courlan.extract_links`` mapping.
+
+    Parses ``html`` with the WHATWG tree builder, finds every link the way :meth:`~turbohtml.Node.links` does (so it
+    sees ``srcset``, ``<meta refresh>``, and CSS ``url()`` too, not only ``<a href>``), absolutizes each against
+    ``base_url``, then keeps only the ``http``/``https`` links, cleaned and canonicalized through :func:`clean_url`.
+
+    :param html: the page source.
+    :param base_url: the document's own URL, used to absolutize relative links; without it relative links are dropped.
+    :param external_only: keep only links whose host differs from ``base_url``'s (``True``) or only same-host links
+        (``False``); ignored when ``base_url`` is ``None``.
+    :param options: the cleaning configuration applied to each link; ``None`` uses the defaults.
+    :returns: the set of cleaned absolute URLs.
+    """
+    document = parse(html)
+    if base_url is not None:
+        document.resolve_links(base_url)
+    reference_host = urlsplit(base_url).netloc.lower() if base_url is not None else None
+    links: set[str] = set()
+    for link in document.links():
+        cleaned = clean_url(link.url, options)
+        if cleaned is None:
+            continue
+        parsed = urlsplit(cleaned)
+        if parsed.scheme not in _WEB_SCHEMES or not parsed.netloc:
+            continue
+        if reference_host is not None and external_only == (parsed.netloc.lower() == reference_host):
+            continue
+        links.add(cleaned)
+    return links

--- a/src/turbohtml/_urls.py
+++ b/src/turbohtml/_urls.py
@@ -48,24 +48,22 @@ _TRACKERS = re.compile(
 )
 
 # Under strict cleaning only these content-bearing identifiers survive in the query string; every other parameter goes.
-_ALLOWED_PARAMS = frozenset(
-    {
-        "aid",
-        "article_id",
-        "artnr",
-        "id",
-        "itemid",
-        "objectid",
-        "p",
-        "page",
-        "pagenum",
-        "page_id",
-        "pid",
-        "post",
-        "postid",
-        "product_id",
-    }
-)
+_ALLOWED_PARAMS = frozenset({
+    "aid",
+    "article_id",
+    "artnr",
+    "id",
+    "itemid",
+    "objectid",
+    "p",
+    "page",
+    "pagenum",
+    "page_id",
+    "pid",
+    "post",
+    "postid",
+    "product_id",
+})
 
 # Only web links survive extraction and normalization; mailto/tel/javascript and bare fragments are not crawlable URLs.
 _WEB_SCHEMES = frozenset({"http", "https"})
@@ -164,8 +162,7 @@ def _scrub(url: str) -> str:
         url = url[len("<![CDATA[") : -len("]]>")]
     url = _REMAINING_MARKUP.sub("", url)
     url = url.replace("&amp;", "&")
-    if url.endswith("/&"):
-        url = url[:-2]
+    url = url.removesuffix("/&")
     if (match := _TRAILING_PARTS.match(url)) is not None:
         url = match[1]
     if url.count("/") == 3 or url.count("://") > 1:

--- a/src/turbohtml/extract.py
+++ b/src/turbohtml/extract.py
@@ -13,10 +13,15 @@ from __future__ import annotations
 from ._article import Article
 from ._links import Link
 from ._structured_data import MicrodataItem, StructuredData
+from ._urls import UrlCleaning, clean_url, extract_links, normalize_url
 
 __all__ = [
     "Article",
     "Link",
     "MicrodataItem",
     "StructuredData",
+    "UrlCleaning",
+    "clean_url",
+    "extract_links",
+    "normalize_url",
 ]

--- a/tests/features/test_url_clean.py
+++ b/tests/features/test_url_clean.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from turbohtml.extract import clean_url
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param(
+            "  https://Example.COM:443/a//b/?utm_source=x&id=7&ref=feed#sec  ",
+            "https://example.com/a/b/?id=7#sec",
+            id="scrub-and-normalize",
+        ),
+        pytest.param("<![CDATA[http://x.com/a]]>", "http://x.com/a", id="cdata-wrapper"),
+        pytest.param("http://x.com/a</p>", "http://x.com/a", id="markup-remnant"),
+        pytest.param("http://x.com/a?b=1&amp;c=2", "http://x.com/a?b=1&c=2", id="escaped-ampersand"),
+        pytest.param("http://x.com/a/&", "http://x.com/a", id="trailing-amp"),
+        pytest.param('http://x.com/a"junk', "http://x.com/a", id="trailing-quote"),
+        pytest.param("http://x.com/", "http://x.com", id="bare-host-trailing-slash"),
+        pytest.param(
+            "https://web.archive.org/save/http://x.com/",
+            "https://web.archive.org/save/http:/x.com",
+            id="double-scheme-rstrip",
+        ),
+    ],
+)
+def test_clean_url_scrubs_then_normalizes(raw: str, expected: str) -> None:
+    assert clean_url(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        pytest.param("   ", id="whitespace-only"),
+        pytest.param("<p>", id="markup-only"),
+        pytest.param("\x00\x01", id="control-only"),
+    ],
+)
+def test_clean_url_returns_none_when_nothing_usable_remains(raw: str) -> None:
+    assert clean_url(raw) is None

--- a/tests/features/test_url_cleaning_config.py
+++ b/tests/features/test_url_cleaning_config.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from turbohtml.extract import UrlCleaning
+
+
+def test_defaults_reproduce_no_argument_behaviour() -> None:
+    options = UrlCleaning()
+    assert (options.strict, options.trailing_slash, options.strip_fragment, options.strip_trackers) == (
+        False,
+        True,
+        False,
+        True,
+    )
+
+
+def test_aggressive_preset_is_the_strongest_canonicalization() -> None:
+    options = UrlCleaning.aggressive()
+    assert options.strict
+    assert not options.trailing_slash
+    assert options.strip_fragment
+
+
+def test_keeping_trackers_under_strict_is_rejected() -> None:
+    with pytest.raises(ValueError, match="strip_trackers=False is meaningless with strict=True"):
+        UrlCleaning(strict=True, strip_trackers=False)

--- a/tests/features/test_url_extract_links.py
+++ b/tests/features/test_url_extract_links.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from turbohtml.extract import UrlCleaning, extract_links
+
+_PAGE = (
+    "<html><body>"
+    "<a href='/p/1?utm_source=ad'>one</a>"
+    "<a href='/p/1?utm_source=other'>dup</a>"
+    "<a href='https://other.example.org/y'>external</a>"
+    "<a href='mailto:hi@example.com'>mail</a>"
+    "<p style='background:url(hero.png)'>x</p>"
+    "</body></html>"
+)
+
+
+def test_extract_links_keeps_internal_absolutized_cleaned_and_deduplicated() -> None:
+    links = extract_links(_PAGE, "https://example.com/blog/")
+    assert links == {"https://example.com/p/1", "https://example.com/blog/hero.png"}
+
+
+def test_external_only_keeps_only_other_hosts() -> None:
+    assert extract_links(_PAGE, "https://example.com/blog/", external_only=True) == {"https://other.example.org/y"}
+
+
+def test_without_a_base_url_no_host_filter_runs_and_relative_links_drop() -> None:
+    assert extract_links(_PAGE) == {"https://other.example.org/y"}
+
+
+def test_options_apply_to_each_link() -> None:
+    page = "<a href='https://example.com/dir/?utm_source=ad&id=3#frag'>x</a>"
+    links = extract_links(page, "https://example.com/", options=UrlCleaning.aggressive())
+    assert links == {"https://example.com/dir/?id=3"}
+
+
+def test_links_that_scrub_to_nothing_are_skipped() -> None:
+    assert extract_links("<a href='<p>'>x</a>") == set()
+
+
+def test_empty_document_yields_no_links() -> None:
+    assert extract_links("", "https://example.com/") == set()

--- a/tests/features/test_url_normalize.py
+++ b/tests/features/test_url_normalize.py
@@ -38,7 +38,9 @@ def test_non_web_scheme_keeps_its_port_but_lowercases_host() -> None:
 
 def test_keep_tracker_when_stripping_is_off() -> None:
     options = UrlCleaning(strip_trackers=False)
-    assert normalize_url("http://example.com/p?utm_source=ad&id=9", options) == "http://example.com/p?id=9&utm_source=ad"
+    assert (
+        normalize_url("http://example.com/p?utm_source=ad&id=9", options) == "http://example.com/p?id=9&utm_source=ad"
+    )
 
 
 def test_trailing_slash_trimmed_only_when_no_query() -> None:
@@ -53,4 +55,6 @@ def test_strict_keeps_only_the_allowlist_and_drops_the_fragment() -> None:
 
 
 def test_strip_fragment_without_strict() -> None:
-    assert normalize_url("http://example.com/p?a=1#frag", UrlCleaning(strip_fragment=True)) == "http://example.com/p?a=1"
+    assert (
+        normalize_url("http://example.com/p?a=1#frag", UrlCleaning(strip_fragment=True)) == "http://example.com/p?a=1"
+    )

--- a/tests/features/test_url_normalize.py
+++ b/tests/features/test_url_normalize.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+import pytest
+
+from turbohtml.extract import UrlCleaning, normalize_url
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("https://EXAMPLE.com/p", "https://example.com/p", id="lowercase-host"),
+        pytest.param("https://example.com:443/p", "https://example.com/p", id="strip-default-https-port"),
+        pytest.param("http://example.com:80/p", "http://example.com/p", id="strip-default-http-port"),
+        pytest.param("https://example.com:8443/p", "https://example.com:8443/p", id="keep-nonstandard-port"),
+        pytest.param("http://example.com/p?b=2&a=1", "http://example.com/p?a=1&b=2", id="sort-query"),
+        pytest.param("http://example.com/a//b///c", "http://example.com/a/b/c", id="collapse-slashes"),
+        pytest.param("http://example.com/../a", "http://example.com/a", id="strip-leading-parent"),
+        pytest.param("http://example.com?a=1", "http://example.com/?a=1", id="query-forces-root-path"),
+        pytest.param("http://example.com/p?utm_source=ad&id=9", "http://example.com/p?id=9", id="drop-tracker"),
+        pytest.param("http://example.com/p#frag", "http://example.com/p#frag", id="keep-fragment"),
+        pytest.param("http://example.com/p#utm_source=ad", "http://example.com/p", id="drop-tracker-fragment"),
+        pytest.param("http://example.com/p#a=1&b=2", "http://example.com/p#a=1%26b=2", id="encode-fragment"),
+    ],
+)
+def test_normalize_url_default(raw: str, expected: str) -> None:
+    assert normalize_url(raw) == expected
+
+
+def test_normalize_url_accepts_a_pre_split_result() -> None:
+    assert normalize_url(urlsplit("https://EXAMPLE.com:443/p")) == "https://example.com/p"
+
+
+def test_non_web_scheme_keeps_its_port_but_lowercases_host() -> None:
+    assert normalize_url("ftp://EXAMPLE.com:80/file") == "ftp://example.com:80/file"
+
+
+def test_keep_tracker_when_stripping_is_off() -> None:
+    options = UrlCleaning(strip_trackers=False)
+    assert normalize_url("http://example.com/p?utm_source=ad&id=9", options) == "http://example.com/p?id=9&utm_source=ad"
+
+
+def test_trailing_slash_trimmed_only_when_no_query() -> None:
+    options = UrlCleaning(trailing_slash=False)
+    assert normalize_url("http://example.com/dir/", options) == "http://example.com/dir"
+    assert normalize_url("http://example.com/dir/?a=1", options) == "http://example.com/dir/?a=1"
+
+
+def test_strict_keeps_only_the_allowlist_and_drops_the_fragment() -> None:
+    raw = "http://example.com/p?id=3&color=red&page=2#frag"
+    assert normalize_url(raw, UrlCleaning.aggressive()) == "http://example.com/p?id=3&page=2"
+
+
+def test_strip_fragment_without_strict() -> None:
+    assert normalize_url("http://example.com/p?a=1#frag", UrlCleaning(strip_fragment=True)) == "http://example.com/p?a=1"

--- a/tools/bench/competitors/courlan.py
+++ b/tools/bench/competitors/courlan.py
@@ -1,0 +1,24 @@
+"""courlan: the URL cleaning/normalization/extraction layer turbohtml.extract's URL helpers replace."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import courlan
+
+REQUIREMENTS = ("courlan>=1.4",)
+
+
+def urls(case: tuple[str, object]) -> None:
+    """Clean, normalize, or extract URLs with courlan's three regex-and-urllib calls."""
+    kind, payload = case
+    if kind == "clean":
+        courlan.clean_url(cast("str", payload))
+    elif kind == "normalize":
+        courlan.normalize_url(cast("str", payload))
+    else:
+        html, base_url = cast("tuple[str, str]", payload)
+        courlan.extract_links(html, base_url)
+
+
+OPERATIONS = {"urls": (urls, "courlan")}

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -18,6 +18,9 @@ from turbohtml import clean as _clean
 from turbohtml.build import E
 from turbohtml.clean import Detector as _Detector
 from turbohtml.clean import linkify as _linkify
+from turbohtml.extract import clean_url as _clean_url
+from turbohtml.extract import extract_links as _extract_links
+from turbohtml.extract import normalize_url as _normalize_url
 from turbohtml.migration.markupsafe import Markup as _Markup
 from turbohtml.migration.markupsafe import escape as _markup_escape
 from turbohtml.migration.stdlib import HTMLParser as _TurboHTMLParser
@@ -331,6 +334,18 @@ def extract_url(case: tuple[str, str]) -> None:
         turbohtml.parse(text).meta_refresh(_URL_HINT_BASE)
 
 
+def urls(case: tuple[str, object]) -> None:
+    """Clean, normalize, or extract URLs with turbohtml's extract helpers, matching courlan's three calls."""
+    kind, payload = case
+    if kind == "clean":
+        _clean_url(cast("str", payload))
+    elif kind == "normalize":
+        _normalize_url(cast("str", payload))
+    else:
+        html, base_url = cast("tuple[str, str]", payload)
+        _extract_links(html, base_url)
+
+
 class _Counter(_TurboHTMLParser):
     """A turbohtml html.parser adapter subclass whose handler does minimal, identical work."""
 
@@ -462,6 +477,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "extract-attr": (extract_attr, "turbohtml"),
     "extract-text": (extract_text, "turbohtml"),
     "extract-url": (extract_url, "turbohtml"),
+    "urls": (urls, "turbohtml"),
     "htmlparser": (htmlparser, "turbohtml"),
     "path": (css_path, "turbohtml"),
     "path-xpath": (xpath_path, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -116,6 +116,7 @@ OPERATIONS: dict[str, Operation] = {
     "extract-attr": Operation("extract @href per match", "us"),
     "extract-text": Operation("extract text per match", "us"),
     "extract-url": Operation("extract URL hints", "us"),
+    "urls": Operation("clean/normalize/extract URLs", "us"),
     "htmlparser": Operation("feed and dispatch a page", "us"),
     "path": Operation("css_path for every element", "us"),
     "path-xpath": Operation("xpath_path for every element", "us"),
@@ -205,6 +206,15 @@ _URL_HINT_HTML = (
     "<html><head><base href='/sub/'>"
     "<meta http-equiv='refresh' content='5; url=next.html'>"
     "<title>Doc</title></head><body><p>Body copy.</p></body></html>"
+)
+
+_DIRTY_URL = "  https://Example.COM:443/a//b/../c/?utm_source=news&id=7&ref=feed#section  "
+_URL_PAGE_BASE = "https://example.com/blog/"
+_URL_PAGE = (
+    "<html><body><nav>"
+    + "".join(f"<a href='/post/{index}?utm_campaign=promo'>post {index}</a>" for index in range(40))
+    + "<a href='https://other.example.org/x?gclid=abc'>external</a>"
+    "<a href='mailto:hi@example.com'>mail</a></nav></body></html>"
 )
 
 _SVG_FRAGMENT = "<svg><rect/><rect/></svg>"
@@ -356,6 +366,11 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "extract-url": lambda: (
         ("base_url / get_base_url", ("base", _URL_HINT_HTML)),
         ("meta_refresh / get_meta_refresh", ("refresh", _URL_HINT_HTML)),
+    ),
+    "urls": lambda: (
+        ("clean dirty URL", ("clean", _DIRTY_URL)),
+        ("normalize URL", ("normalize", _DIRTY_URL.strip())),
+        ("extract links (page)", ("extract", (_URL_PAGE, _URL_PAGE_BASE))),
     ),
     "htmlparser": _readpath_cases,
     "path": _readpath_cases,


### PR DESCRIPTION
turbohtml already finds and absolutizes the links in a page, but a scraping pipeline still reaches for `courlan` (a `trafilatura` dependency) or `w3lib.url` to scrub tracking junk off a URL, canonicalize it, and dedupe a crawl frontier. 🔗 This adds those URL utilities natively so the whole job stays in one library.

`turbohtml.extract` gains `clean_url`, `normalize_url`, and `extract_links`, a thin normalization pass layered over the existing `links()`/`resolve_links()` engine rather than a second parser. `clean_url` scrubs stray markup and tracking parameters off a raw href, `normalize_url` canonicalizes a single absolute URL, and `extract_links` returns a page's cleaned, deduplicated `http`/`https` links, internal by default and `external_only` for the rest. A shared frozen `UrlCleaning` config carries the knobs (`strict`, `trailing_slash`, `strip_fragment`, `strip_trackers`) with an `aggressive()` preset that maps to courlan's strict mode, following the config-object convention the rest of the namespace uses. ✨

The helpers stay scoped to normalization and deduplication: courlan's language heuristics and spam/crawl-worthiness ranking are deliberately left out, which the module and reference call out. A `courlan` benchmark module plus a `urls` operation measure the three calls like-for-like.

closes #321