### PR TITLE
✨ feat(extract): publication-date extraction (htmldate)

### DIFF
--- a/docs/changelog/320.feature.rst
+++ b/docs/changelog/320.feature.rst
@@ -1,0 +1,7 @@
+Extract a document's publication date with :func:`turbohtml.dates`, a standalone successor to ``htmldate.find_date``. It
+reuses the declared-metadata path :meth:`~turbohtml.Node.article` already walks -- ``<time>`` elements,
+``article:published_time`` and common date ``<meta>`` tags -- and layers JSON-LD ``datePublished``/``dateModified``,
+last-modified metas, and a ``/YYYY/MM/DD/`` date in the canonical or OpenGraph URL on top. A frozen
+:class:`turbohtml.DateExtraction` config carries the knobs (``original``, ``output_format``, ``min_date``, ``max_date``,
+``extensive_search``), with :meth:`~turbohtml.DateExtraction.published` and :meth:`~turbohtml.DateExtraction.fast`
+presets mirroring htmldate's modes.

--- a/docs/how-to/dates.rst
+++ b/docs/how-to/dates.rst
@@ -1,0 +1,62 @@
+############################
+ Extract a publication date
+############################
+
+*******************************
+ Read the date a page declares
+*******************************
+
+Scrapers want one thing from a news or blog page: *when was this published*, the job of ``htmldate.find_date``.
+:func:`turbohtml.dates` answers it from the markup the page declares -- ``<meta>`` tags, JSON-LD, ``<time>`` elements,
+and the URL -- and returns a ``YYYY-MM-DD`` string:
+
+.. testcode::
+
+    from turbohtml import dates
+
+    html = (
+        "<head><meta property='article:published_time' content='2024-05-06T08:00:00Z'>"
+        "<meta property='article:modified_time' content='2024-06-18T11:30:00Z'></head>"
+    )
+    print(dates(html))
+
+.. testoutput::
+
+    2024-06-18
+
+The default returns the *most recent* date, the last modification, exactly as htmldate's ``find_date`` does. It pulls
+from JSON-LD ``datePublished``/``dateModified`` and a ``/YYYY/MM/DD/`` date in the canonical or OpenGraph URL too, so a
+page that declares its date in any of those places needs no extra configuration.
+
+************************
+ Choose what to extract
+************************
+
+The knobs live on a :class:`~turbohtml.DateExtraction` config, mirroring htmldate's ``find_date`` arguments. Pass
+``DateExtraction.published()`` (htmldate's ``original_date=True``) to prefer the first-published date over later
+modifications, set ``output_format`` to re-render the result, and bound the result with ``min_date``/``max_date`` to
+reject dates outside the range you trust:
+
+.. testcode::
+
+    from datetime import date
+
+    from turbohtml import DateExtraction, dates
+
+    html = (
+        "<head><meta property='article:published_time' content='2024-05-06'>"
+        "<meta property='article:modified_time' content='2024-06-18'></head>"
+    )
+    print(dates(html, DateExtraction.published()))
+    print(dates(html, DateExtraction(output_format="%d %B %Y")))
+    print(dates(html, DateExtraction(min_date=date(2025, 1, 1))))
+
+.. testoutput::
+
+    2024-05-06
+    18 June 2024
+    None
+
+``DateExtraction.fast()`` turns off the URL-pattern fallback when you trust only the structured ``<meta>``, JSON-LD, and
+``<time>`` signals. A page that declares no valid date -- or whose only date falls outside the window -- yields ``None``,
+so branch on the result rather than assuming a date.

--- a/docs/how-to/dates.rst
+++ b/docs/how-to/dates.rst
@@ -58,5 +58,5 @@ reject dates outside the range you trust:
     None
 
 ``DateExtraction.fast()`` turns off the URL-pattern fallback when you trust only the structured ``<meta>``, JSON-LD, and
-``<time>`` signals. A page that declares no valid date -- or whose only date falls outside the window -- yields ``None``,
-so branch on the result rather than assuming a date.
+``<time>`` signals. A page that declares no valid date -- or whose only date falls outside the window -- yields
+``None``, so branch on the result rather than assuming a date.

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -20,4 +20,5 @@ page is a short, self-contained walkthrough you can lift straight into your own 
     serializing
     links
     structured-data
+    dates
     sanitizing

--- a/docs/reference/extract.rst
+++ b/docs/reference/extract.rst
@@ -7,4 +7,23 @@
 Pull content and data out of HTML. Extraction runs through the node methods, and the records those methods return are
 re-exported from this namespace for discoverability -- :class:`~turbohtml.Article`, :class:`~turbohtml.Link`,
 :class:`~turbohtml.StructuredData`, and :class:`~turbohtml.MicrodataItem` -- while staying importable from the package
-root. The content, date, and URL helpers that round out this namespace land with their feature work.
+root. The remaining content and URL helpers land with their feature work.
+
+******************
+ Publication date
+******************
+
+:func:`~turbohtml.dates` is the standalone publication-date entry point, a successor to `htmldate
+<https://htmldate.readthedocs.io>`_'s ``find_date``. It reuses the declared-metadata path
+:meth:`~turbohtml.Node.article` already walks -- ``<time>`` elements, ``article:published_time`` and common date
+``<meta>`` tags -- and layers JSON-LD ``datePublished``/``dateModified``, last-modified metas, and a ``/YYYY/MM/DD/``
+date in the canonical or OpenGraph URL on top, validating the result against an optional window. A
+:class:`DateExtraction` config carries the knobs (it is also importable as :class:`turbohtml.DateExtraction`); ``None``
+returns the most recent date as ``YYYY-MM-DD``.
+
+.. currentmodule:: turbohtml
+
+.. autofunction:: dates
+
+.. autoclass:: DateExtraction
+    :members: published, fast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ bench = [
   "html2text>=2025.4.15",
   "html5-parser>=0.4.12",
   "html5lib>=1.1",
+  "htmldate>=1.9",
   "htpy>=26.5.1",
   "inscriptis>=2.7.2",
   "linkify-it-py>=2.1",

--- a/src/turbohtml/__init__.py
+++ b/src/turbohtml/__init__.py
@@ -42,6 +42,7 @@ from ._structured_data import (  # registers the JSON-LD parser and record class
 )
 from ._xpath import XPathString  # registers the smart-string type with the C core on import
 from .build import E, ElementMaker
+from .extract import DateExtraction, dates
 
 __version__ = version("turbohtml")
 """The installed package version."""
@@ -51,6 +52,7 @@ __all__ = [
     "Axis",
     "CData",
     "Comment",
+    "DateExtraction",
     "Doctype",
     "Document",
     "E",
@@ -80,6 +82,7 @@ __all__ = [
     "__version__",
     "annotation_surface",
     "annotation_tags",
+    "dates",
     "escape",
     "parse",
     "parse_fragment",

--- a/src/turbohtml/extract.py
+++ b/src/turbohtml/extract.py
@@ -6,17 +6,301 @@ Home for the extraction result types and (as the campaign lands) the content/dat
 The extraction itself runs through the node methods (``node.article()``, ``node.links()``, ``node.tables()``,
 ``node.structured_data()``); the records they return are re-exported here for discoverability and also stay
 importable from the package root.
+
+:func:`dates` is the standalone publication-date entry point that replaces ``htmldate.find_date``. It reuses the same
+declared-metadata scoring as :meth:`~turbohtml.Node.article` -- the ``<time>``, ``article:published_time`` meta, and
+common date metas the article harvester already reads -- and layers JSON-LD, last-modified metas, and URL-pattern dates
+on top so a single call answers *when was this published* without inferring a date the page never declared.
 """
 
 from __future__ import annotations
 
+import re
+from contextlib import suppress
+from dataclasses import dataclass, fields
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
 from ._article import Article
+from ._html import Document, parse
 from ._links import Link
 from ._structured_data import MicrodataItem, StructuredData
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from ._structured_data import JSONValue
+
+
+@dataclass(frozen=True)
+class DateExtraction:
+    """
+    How :func:`dates` chooses and formats a document's publication date.
+
+    Build one and reuse it across threads; every field has a default, so ``DateExtraction()`` reproduces the
+    no-argument call. The knobs mirror ``htmldate.find_date`` -- ``original`` is its ``original_date``,
+    ``output_format`` its ``outputformat``, and ``min_date``/``max_date`` its window -- bundled into one config the way
+    :class:`~turbohtml.Markdown` and :class:`~turbohtml.clean.Policy` bundle theirs.
+
+    :param original: prefer the first-published date over the last-modified date, the way htmldate's ``original_date``
+        does. ``False`` (the default) returns the most recent date the page declares, ``True`` the earliest.
+    :param output_format: the :meth:`~datetime.date.strftime` pattern the returned string is rendered with.
+    :param min_date: drop any candidate earlier than this date, or ``None`` to leave the lower bound open.
+    :param max_date: drop any candidate later than this date, or ``None`` to leave the upper bound open.
+    :param extensive_search: also mine the canonical/OpenGraph URL for a ``/YYYY/MM/DD/`` date when the markup declares
+        none; turning it off keeps only the structured ``<meta>``, JSON-LD, and ``<time>`` signals.
+    """
+
+    original: bool = False
+    output_format: str = "%Y-%m-%d"
+    min_date: date | None = None
+    max_date: date | None = None
+    extensive_search: bool = True
+
+    def __post_init__(self) -> None:
+        """Reject an empty validity window up front, so the search never has to."""
+        if self.min_date is not None and self.max_date is not None and self.min_date > self.max_date:
+            msg = "min_date must not be after max_date"
+            raise ValueError(msg)
+
+    @classmethod
+    def published(cls) -> DateExtraction:
+        """
+        Prefer the original publication date over later modifications, htmldate's ``original_date=True`` mode.
+
+        :returns: a config that returns the earliest declared date.
+        """
+        return cls(original=True)
+
+    @classmethod
+    def fast(cls) -> DateExtraction:
+        """
+        Skip the URL-pattern fallback and read only the structured ``<meta>``/JSON-LD/``<time>`` signals.
+
+        :returns: a config that never inspects the page URL.
+        """
+        return cls(extensive_search=False)
+
+    def _unpack(self) -> dict[str, object]:
+        """Flatten to the search's keyword names, emitting only values that differ from its defaults."""
+        default = _DATE_DEFAULT
+        return {
+            field_.name: value
+            for field_ in fields(self)
+            if (value := getattr(self, field_.name)) != getattr(default, field_.name)
+        }
+
+
+_DATE_DEFAULT = DateExtraction()
+
+_PUBLISHED_META = frozenset({
+    "article:published_time",
+    "og:article:published_time",
+    "og:published_time",
+    "published_time",
+    "datepublished",
+    "date",
+    "pubdate",
+    "publishdate",
+    "publish-date",
+    "dc.date",
+    "dc.date.issued",
+    "dcterms.date",
+    "dcterms.created",
+    "sailthru.date",
+    "parsely-pub-date",
+    "article:published",
+    "rnews:datepublished",
+    "timestamp",
+})
+_MODIFIED_META = frozenset({
+    "article:modified_time",
+    "og:updated_time",
+    "og:article:modified_time",
+    "datemodified",
+    "dc.date.modified",
+    "dcterms.modified",
+    "lastmod",
+    "last-modified",
+    "revised",
+})
+_JSON_PUBLISHED = frozenset({"datepublished", "datecreated", "uploaddate"})
+_JSON_MODIFIED = frozenset({"datemodified"})
+
+_ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
+_YMD = re.compile(r"(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})")
+_DMY = re.compile(r"(\d{1,2})[-/.](\d{1,2})[-/.](\d{4})")
+_COMPACT = re.compile(r"\b(\d{8})\b")
+_URL_DMY = re.compile(r"/(\d{4})/(\d{1,2})/(\d{1,2})(?:/|\b)")
+_URL_YM = re.compile(r"/(\d{4})/(\d{1,2})/")
+_TEXT_FORMATS = ("%B %d, %Y", "%b %d, %Y", "%d %B %Y", "%d %b %Y", "%B %d %Y")
+
+
+def dates(html: str | bytes, options: DateExtraction | None = None) -> str | None:
+    """
+    Extract a document's publication date, the standalone replacement for ``htmldate.find_date``.
+
+    The date is read from the markup the page declares -- ``<meta>`` tags (``article:published_time`` and its kin),
+    JSON-LD ``datePublished``/``dateModified``, ``<time>`` elements, and (when ``extensive_search`` is on) a
+    ``/YYYY/MM/DD/`` date in the canonical or OpenGraph URL -- and validated against the configured window. It reuses
+    the same declared-metadata path as :meth:`~turbohtml.Node.article`, never inferring a date from prose.
+
+    :param html: the page markup, the same ``str`` or ``bytes`` :func:`turbohtml.parse` accepts.
+    :param options: a :class:`DateExtraction` config, or ``None`` for the default (most-recent date, ``%Y-%m-%d``).
+    :returns: the chosen date rendered with ``output_format``, or ``None`` when the page declares no valid date.
+    """
+    config = options if options is not None else _DATE_DEFAULT
+    return _find_date(parse(html), config)
+
+
+def _find_date(document: Document, config: DateExtraction) -> str | None:
+    """Gather every declared date, drop the out-of-range ones, and return the earliest or latest as a string."""
+    published: list[date] = []
+    modified: list[date] = []
+    generic: list[date] = []
+    _collect_meta(document, published, modified)
+    _collect_json_ld(document.json_ld(), published, modified)
+    _collect_time(document, published, modified, generic)
+    if (article_date := document.article().date) is not None:
+        _add_text(generic, article_date)
+    if config.extensive_search:
+        _collect_url(document, published)
+    pools = (published, generic, modified) if config.original else (modified, published, generic)
+    pick = min if config.original else max
+    for pool in pools:
+        if bounded := [value for value in pool if _within(value, config.min_date, config.max_date)]:
+            return pick(bounded).strftime(config.output_format)
+    return None
+
+
+def _collect_meta(document: Document, published: list[date], modified: list[date]) -> None:
+    """Read every ``<meta>`` whose name/property/itemprop is a known publish or modify key into its pool."""
+    for meta in document.find_all("meta"):
+        key = meta.attr("property") or meta.attr("name") or meta.attr("itemprop")
+        content = meta.attr("content")
+        if key is None or content is None:
+            continue
+        lowered = key.strip().lower()
+        if lowered in _PUBLISHED_META:
+            _add_text(published, content)
+        elif lowered in _MODIFIED_META:
+            _add_text(modified, content)
+
+
+def _collect_json_ld(values: list[JSONValue], published: list[date], modified: list[date]) -> None:
+    """Walk the decoded JSON-LD blocks, routing every ``datePublished``/``dateModified`` string to its pool."""
+    stack: list[JSONValue] = list(values)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, dict):
+            for key, value in node.items():
+                lowered = key.lower()
+                if isinstance(value, str) and lowered in _JSON_PUBLISHED:
+                    _add_text(published, value)
+                elif isinstance(value, str) and lowered in _JSON_MODIFIED:
+                    _add_text(modified, value)
+                elif isinstance(value, (dict, list)):
+                    stack.append(value)
+        elif isinstance(node, list):
+            stack.extend(node)
+
+
+def _collect_time(document: Document, published: list[date], modified: list[date], generic: list[date]) -> None:
+    """Read every ``<time>`` element, routing it by its ``pubdate``/``itemprop`` hint to the matching pool."""
+    for element in document.find_all("time"):
+        value = element.attr("datetime") or element.text
+        itemprop = (element.attr("itemprop") or "").strip().lower()
+        if element.attr("pubdate") is not None or itemprop == "datepublished":
+            _add_text(published, value)
+        elif itemprop == "datemodified":
+            _add_text(modified, value)
+        else:
+            _add_text(generic, value)
+
+
+def _collect_url(document: Document, published: list[date]) -> None:
+    """Mine the canonical and OpenGraph URLs for a ``/YYYY/MM/DD/`` (or ``/YYYY/MM/``) publication date."""
+    published.extend(found for url in _candidate_urls(document) if (found := _date_from_url(url)) is not None)
+
+
+def _candidate_urls(document: Document) -> Iterable[str]:
+    """Yield the document's own URLs: the ``rel=canonical`` link href and the ``og:url`` meta content."""
+    for link in document.find_all("link"):
+        rel = link.attr("rel")
+        href = link.attr("href")
+        if rel is not None and href is not None and "canonical" in rel.lower().split():
+            yield href
+    for meta in document.find_all("meta"):
+        if meta.attr("property") == "og:url" and (content := meta.attr("content")) is not None:
+            yield content
+
+
+def _date_from_url(url: str) -> date | None:
+    """Pull a date out of a ``/YYYY/MM/DD/`` or ``/YYYY/MM/`` URL path, the latter dated to the first of the month."""
+    if (match := _URL_DMY.search(url)) is not None:
+        return _safe_date(int(match[1]), int(match[2]), int(match[3]))
+    if (match := _URL_YM.search(url)) is not None:
+        return _safe_date(int(match[1]), int(match[2]), 1)
+    return None
+
+
+def _add_text(pool: list[date], text: str) -> None:
+    """Parse ``text`` to a date and append it to ``pool`` when it reads as one."""
+    if (parsed := _parse_date(text)) is not None:
+        pool.append(parsed)
+
+
+def _parse_date(value: str) -> date | None:
+    """Parse one declared date string -- ISO, slash/dot numeric, compact, or month-name -- to a :class:`date`."""
+    text = value.strip()
+    if not text:
+        return None
+    if _ISO_DATE.fullmatch(text[:10]):
+        with suppress(ValueError):
+            return date.fromisoformat(text[:10])
+        return None
+    return _parse_numeric(text) or _parse_textual(text)
+
+
+def _parse_numeric(text: str) -> date | None:
+    """Parse a numeric date: ``YYYY-MM-DD`` order, day-first (then month-first) ``DD/MM/YYYY``, or compact 8-digit."""
+    if (match := _YMD.search(text)) is not None:
+        return _safe_date(int(match[1]), int(match[2]), int(match[3]))
+    if (match := _DMY.search(text)) is not None:
+        year, first, second = int(match[3]), int(match[1]), int(match[2])
+        return _safe_date(year, second, first) or _safe_date(year, first, second)
+    if (match := _COMPACT.search(text)) is not None:
+        digits = match[1]
+        return _safe_date(int(digits[:4]), int(digits[4:6]), int(digits[6:8]))
+    return None
+
+
+def _parse_textual(text: str) -> date | None:
+    """Parse a month-name date (``May 6, 2024`` / ``6 May 2024``) by trying each known textual format in turn."""
+    for text_format in _TEXT_FORMATS:
+        with suppress(ValueError):
+            return datetime.strptime(text, text_format).date()  # noqa: DTZ007  # a calendar date, no time zone
+    return None
+
+
+def _safe_date(year: int, month: int, day: int) -> date | None:
+    """Build a :class:`date`, returning ``None`` when the components do not form a real calendar day."""
+    try:
+        return date(year, month, day)
+    except ValueError:
+        return None
+
+
+def _within(value: date, min_date: date | None, max_date: date | None) -> bool:
+    """Report whether ``value`` falls inside the (possibly open-ended) validity window."""
+    return (min_date is None or value >= min_date) and (max_date is None or value <= max_date)
+
+
 __all__ = [
     "Article",
+    "DateExtraction",
     "Link",
     "MicrodataItem",
     "StructuredData",
+    "dates",
 ]

--- a/tests/features/test_extract_dates.py
+++ b/tests/features/test_extract_dates.py
@@ -112,18 +112,12 @@ def test_dates_original_falls_back_to_modified_when_unpublished() -> None:
 
 
 def test_dates_picks_latest_within_a_pool() -> None:
-    html = (
-        "<head><meta property=article:published_time content=2019-01-01>"
-        "<meta name=date content=2021-12-31></head>"
-    )
+    html = "<head><meta property=article:published_time content=2019-01-01><meta name=date content=2021-12-31></head>"
     assert dates(html) == "2021-12-31"
 
 
 def test_dates_ignores_metas_without_a_key_or_content() -> None:
-    html = (
-        "<head><meta charset=utf-8><meta name=date>"
-        "<meta property=article:published_time content=2024-05-06></head>"
-    )
+    html = "<head><meta charset=utf-8><meta name=date><meta property=article:published_time content=2024-05-06></head>"
     assert dates(html) == "2024-05-06"
 
 
@@ -161,8 +155,5 @@ def test_dates_ignores_dateless_urls() -> None:
 
 
 def test_dates_original_prefers_generic_time_over_modified() -> None:
-    html = (
-        "<head><meta property=article:modified_time content=2022-03-04></head>"
-        "<body><time>2010-01-01</time></body>"
-    )
+    html = "<head><meta property=article:modified_time content=2022-03-04></head><body><time>2010-01-01</time></body>"
     assert dates(html, DateExtraction.published()) == "2010-01-01"

--- a/tests/features/test_extract_dates.py
+++ b/tests/features/test_extract_dates.py
@@ -1,0 +1,168 @@
+"""The :func:`turbohtml.extract.dates` publication-date entry point across every declared source."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import DateExtraction, dates
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param(
+            "<head><meta property=article:published_time content=2024-05-06></head>",
+            "2024-05-06",
+            id="meta-article-published",
+        ),
+        pytest.param(
+            "<head><meta name=date content=2023-02-03></head>",
+            "2023-02-03",
+            id="meta-name-date",
+        ),
+        pytest.param(
+            "<head><meta itemprop=datePublished content=2022-08-09></head>",
+            "2022-08-09",
+            id="meta-itemprop-published",
+        ),
+        pytest.param(
+            '<script type="application/ld+json">{"datePublished": "2019-07-08T10:00:00Z"}</script>',
+            "2019-07-08",
+            id="json-ld-published",
+        ),
+        pytest.param(
+            '<script type="application/ld+json">[{"dateCreated": "2017-06-05"}]</script>',
+            "2017-06-05",
+            id="json-ld-array-block",
+        ),
+        pytest.param(
+            '<script type="application/ld+json">{"a": {"uploadDate": "2016-05-04"}}</script>',
+            "2016-05-04",
+            id="json-ld-nested-dict",
+        ),
+        pytest.param(
+            '<script type="application/ld+json">{"a": [{"datePublished": "2015-04-03"}]}</script>',
+            "2015-04-03",
+            id="json-ld-nested-list",
+        ),
+        pytest.param(
+            "<article><time datetime=2018-11-12>shown</time></article>",
+            "2018-11-12",
+            id="time-datetime-attr",
+        ),
+        pytest.param(
+            "<article><time>2016-04-05</time></article>",
+            "2016-04-05",
+            id="time-text-fallback",
+        ),
+        pytest.param(
+            "<time datetime=2017-01-02 pubdate>x</time>",
+            "2017-01-02",
+            id="time-pubdate-flag",
+        ),
+        pytest.param(
+            "<time datetime=2014-03-04 itemprop=datePublished>x</time>",
+            "2014-03-04",
+            id="time-itemprop-published",
+        ),
+        pytest.param(
+            "<link rel=canonical href=https://x.test/2021/09/14/post>",
+            "2021-09-14",
+            id="url-canonical-ymd",
+        ),
+        pytest.param(
+            "<head><meta property=og:url content=https://x.test/2020/03/story></head>",
+            "2020-03-01",
+            id="url-og-year-month",
+        ),
+        pytest.param(
+            "<p>no date anywhere in this body</p>",
+            None,
+            id="no-date",
+        ),
+    ],
+)
+def test_dates_sources(html: str, expected: str | None) -> None:
+    assert dates(html) == expected
+
+
+def test_dates_accepts_bytes() -> None:
+    assert dates(b"<meta property=article:published_time content=2024-05-06>") == "2024-05-06"
+
+
+def test_dates_default_prefers_most_recent_modification() -> None:
+    html = (
+        "<head><meta property=article:published_time content=2020-01-01>"
+        "<meta property=article:modified_time content=2022-03-04></head>"
+    )
+    assert dates(html) == "2022-03-04"
+
+
+def test_dates_original_prefers_first_published() -> None:
+    html = (
+        "<head><meta property=article:published_time content=2020-01-01>"
+        "<meta property=article:modified_time content=2022-03-04></head>"
+    )
+    assert dates(html, DateExtraction.published()) == "2020-01-01"
+
+
+def test_dates_original_falls_back_to_modified_when_unpublished() -> None:
+    html = "<head><meta property=article:modified_time content=2021-06-07></head>"
+    assert dates(html, DateExtraction.published()) == "2021-06-07"
+
+
+def test_dates_picks_latest_within_a_pool() -> None:
+    html = (
+        "<head><meta property=article:published_time content=2019-01-01>"
+        "<meta name=date content=2021-12-31></head>"
+    )
+    assert dates(html) == "2021-12-31"
+
+
+def test_dates_ignores_metas_without_a_key_or_content() -> None:
+    html = (
+        "<head><meta charset=utf-8><meta name=date>"
+        "<meta property=article:published_time content=2024-05-06></head>"
+    )
+    assert dates(html) == "2024-05-06"
+
+
+def test_dates_ignores_unrelated_links_and_metas_for_urls() -> None:
+    html = (
+        "<head><link rel=stylesheet href=https://x.test/2021/09/14/style.css>"
+        "<link rel=canonical>"
+        "<meta property=og:title content=https://x.test/2019/01/02/post>"
+        "<meta property=og:url content=https://x.test/2020/06/07/post></head>"
+    )
+    assert dates(html) == "2020-06-07"
+
+
+def test_dates_skips_non_date_json_ld_keys() -> None:
+    html = '<script type="application/ld+json">{"@type": "Article", "datePublished": "2018-03-04"}</script>'
+    assert dates(html) == "2018-03-04"
+
+
+def test_dates_reads_json_ld_modified() -> None:
+    assert dates('<script type="application/ld+json">{"dateModified": "2021-08-09"}</script>') == "2021-08-09"
+
+
+def test_dates_tolerates_scalar_json_ld_blocks() -> None:
+    html = '<script type="application/ld+json">"just a string"</script><meta name=date content=2020-01-01>'
+    assert dates(html) == "2020-01-01"
+
+
+def test_dates_reads_time_modified() -> None:
+    assert dates("<time itemprop=dateModified datetime=2021-08-09>x</time>") == "2021-08-09"
+
+
+def test_dates_ignores_dateless_urls() -> None:
+    html = "<head><link rel=canonical href=https://x.test/about><meta name=date content=2020-01-01></head>"
+    assert dates(html) == "2020-01-01"
+
+
+def test_dates_original_prefers_generic_time_over_modified() -> None:
+    html = (
+        "<head><meta property=article:modified_time content=2022-03-04></head>"
+        "<body><time>2010-01-01</time></body>"
+    )
+    assert dates(html, DateExtraction.published()) == "2010-01-01"

--- a/tests/features/test_extract_dates_config.py
+++ b/tests/features/test_extract_dates_config.py
@@ -1,0 +1,69 @@
+"""The :class:`turbohtml.DateExtraction` config: presets, validation, formatting, and the validity window."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from turbohtml import DateExtraction, dates
+
+_TWO_DATES = (
+    "<head><meta property=article:published_time content=2020-01-01>"
+    "<meta property=article:modified_time content=2022-03-04></head>"
+)
+
+
+def test_default_is_most_recent_iso() -> None:
+    config = DateExtraction()
+    assert config.original is False
+    assert config.output_format == "%Y-%m-%d"
+    assert config.extensive_search is True
+
+
+def test_published_preset_sets_original() -> None:
+    assert DateExtraction.published() == DateExtraction(original=True)
+
+
+def test_fast_preset_disables_extensive_search() -> None:
+    assert DateExtraction.fast() == DateExtraction(extensive_search=False)
+
+
+def test_fast_preset_skips_url_dates() -> None:
+    html = "<link rel=canonical href=https://x.test/2021/09/14/post>"
+    assert dates(html, DateExtraction.fast()) is None
+
+
+def test_output_format_is_applied() -> None:
+    assert dates(_TWO_DATES, DateExtraction(output_format="%d.%m.%Y")) == "04.03.2022"
+
+
+def test_min_date_drops_earlier_candidates() -> None:
+    config = DateExtraction(original=True, min_date=date(2021, 1, 1))
+    assert dates(_TWO_DATES, config) == "2022-03-04"
+
+
+def test_max_date_drops_later_candidates() -> None:
+    config = DateExtraction(max_date=date(2021, 1, 1))
+    assert dates(_TWO_DATES, config) == "2020-01-01"
+
+
+def test_window_can_drop_every_candidate() -> None:
+    config = DateExtraction(min_date=date(2030, 1, 1))
+    assert dates(_TWO_DATES, config) is None
+
+
+def test_inverted_window_is_rejected() -> None:
+    with pytest.raises(ValueError, match="min_date must not be after max_date"):
+        DateExtraction(min_date=date(2022, 1, 1), max_date=date(2020, 1, 1))
+
+
+def test_equal_window_bounds_are_allowed() -> None:
+    bound = date(2020, 1, 1)
+    config = DateExtraction(min_date=bound, max_date=bound)
+    assert config.min_date == config.max_date
+
+
+def test_unpack_emits_only_overrides() -> None:
+    assert DateExtraction()._unpack() == {}
+    assert DateExtraction(original=True)._unpack() == {"original": True}

--- a/tests/features/test_extract_dates_parsing.py
+++ b/tests/features/test_extract_dates_parsing.py
@@ -1,0 +1,44 @@
+"""Date-string parsing inside :func:`turbohtml.extract.dates`, driven through a single ``<meta>`` value."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import dates
+
+
+def _page(value: str) -> str:
+    return f"<head><meta name=date content='{value}'></head>"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("2021-05-12", "2021-05-12", id="iso-date"),
+        pytest.param("2019-07-08T10:00:00Z", "2019-07-08", id="iso-datetime"),
+        pytest.param("2021-9-8", "2021-09-08", id="numeric-ymd-unpadded"),
+        pytest.param("2021/05/12", "2021-05-12", id="numeric-ymd-slash"),
+        pytest.param("13/05/2021", "2021-05-13", id="numeric-dmy-day-first"),
+        pytest.param("05/25/2021", "2021-05-25", id="numeric-mdy-fallback"),
+        pytest.param("20210512", "2021-05-12", id="compact-yyyymmdd"),
+        pytest.param("May 6, 2024", "2024-05-06", id="text-month-day-year"),
+        pytest.param("6 May 2024", "2024-05-06", id="text-day-month-year"),
+    ],
+)
+def test_parse_formats(value: str, expected: str) -> None:
+    assert dates(_page(value)) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace"),
+        pytest.param("2021-02-30", id="impossible-iso-day"),
+        pytest.param("not a date at all", id="prose"),
+        pytest.param("99999999", id="compact-out-of-range"),
+        pytest.param("32/13/2021", id="numeric-both-orders-invalid"),
+    ],
+)
+def test_unparseable_values_yield_no_date(value: str) -> None:
+    assert dates(_page(value)) is None

--- a/tools/bench/competitors/htmldate.py
+++ b/tools/bench/competitors/htmldate.py
@@ -1,0 +1,15 @@
+"""htmldate: the trafilatura-companion library whose ``find_date`` turbohtml.dates replaces."""
+
+from __future__ import annotations
+
+from htmldate import find_date
+
+REQUIREMENTS = ("htmldate>=1.9",)
+
+
+def date(text: str) -> None:
+    """Extract the publication date with htmldate, scanning the page for declared and inferred dates."""
+    find_date(text)
+
+
+OPERATIONS = {"date": (date, "htmldate")}

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -290,6 +290,11 @@ def article(text: str) -> None:
     _parsed(text).article()
 
 
+def date(text: str) -> None:
+    """Extract the publication date with turbohtml, reusing the article date-scoring path."""
+    turbohtml.dates(text)
+
+
 def text_render(text: str) -> None:
     """Render layout-aware visible text with turbohtml's to_text, walking the tree in C."""
     _parsed(text).to_text()
@@ -455,6 +460,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "markdown-google": (markdown_google, "turbohtml"),
     "tables": (tables, "turbohtml"),
     "article": (article, "turbohtml"),
+    "date": (date, "turbohtml"),
     "text-render": (text_render, "turbohtml"),
     "text-collapsed": (text_collapsed, "turbohtml"),
     "text-main": (text_main, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -109,6 +109,7 @@ OPERATIONS: dict[str, Operation] = {
     "markdown-google": Operation("Google Docs export to Markdown", "us"),
     "tables": Operation("extract table grids", "us"),
     "article": Operation("article extraction", "us"),
+    "date": Operation("publication-date extraction", "us"),
     "text-render": Operation("layout-aware text", "us"),
     "text-collapsed": Operation("collapsed word stream", "us"),
     "text-main": Operation("main-content text", "us"),
@@ -261,6 +262,26 @@ def _article_page(paragraphs: int) -> str:
     return f"{head}{nav}{article}<footer><p>Copyright notice, all rights reserved here.</p></footer></body></html>"
 
 
+_DATE_META = dedent("""\
+    <html lang=en><head><title>Comets: A Field Guide</title>
+    <meta property="article:published_time" content="2024-05-06T08:00:00Z">
+    <meta property="article:modified_time" content="2024-06-18T11:30:00Z"></head>
+    <body><article class=post><h1>Comets</h1>
+    <p>A comet is an icy small body that warms as it nears the Sun and grows a glowing coma.</p>
+    </article></body></html>""")
+
+_DATE_JSON_LD = dedent("""\
+    <html lang=en><head><title>Comets: A Field Guide</title>
+    <link rel="canonical" href="https://example.test/2024/05/06/comets">
+    <script type="application/ld+json">
+    {"@context": "https://schema.org", "@type": "NewsArticle", "headline": "Comets",
+     "datePublished": "2024-05-06T08:00:00Z", "dateModified": "2024-06-18T11:30:00Z"}
+    </script></head>
+    <body><article class=post><h1>Comets</h1>
+    <p>A comet is an icy small body that warms as it nears the Sun and grows a glowing coma.</p>
+    </article></body></html>""")
+
+
 def _xpath_cases() -> tuple[tuple[str, object], ...]:
     """Return one (label, (kind, text)) pair per XPath feature over the 9.6 kB page; the namespaced row carries SVG."""
     _name, relative, encoding = corpus.CORPUS_FILES[2]
@@ -347,6 +368,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("records (1000 rows)", ("records", _table_html(1_000))),
     ),
     "article": lambda: (("post (4 KiB)", _article_page(16)), ("longform (16 KiB)", _article_page(72))),
+    "date": lambda: (("meta tags", _DATE_META), ("json-ld + url", _DATE_JSON_LD)),
     "text-render": lambda: (("article (2 KiB)", _TEXT_ARTICLE), ("table (4 KiB)", _TEXT_TABLE)),
     "text-collapsed": lambda: (("collapsed (2 KiB)", _TEXT_ARTICLE),),
     "text-main": lambda: (("main (4 KiB)", _TEXT_MAIN),),


### PR DESCRIPTION
Scrapers and content pipelines need one fact from a news or blog page: when it was published. 📅 That job belongs to `htmldate`, a standalone `trafilatura` dependency whose only entry point is `find_date(html)`. turbohtml already harvests a publication date inside `article()`, so the scoring exists; what was missing is a direct, configurable entry point that answers the question on its own.

`turbohtml.dates()` provides it. It reuses the same declared-metadata path `Node.article()` walks (the `<time>` element, `article:published_time`, and common date `<meta>` tags) and layers JSON-LD `datePublished`/`dateModified`, last-modified metas, and a `/YYYY/MM/DD/` date in the canonical or OpenGraph URL on top, then validates the result against an optional window. ✨ The knobs ride on one frozen `DateExtraction` config mirroring `htmldate.find_date` (`original`, `output_format`, `min_date`, `max_date`, `extensive_search`), with `published()` and `fast()` presets mapping htmldate's modes; passing no config returns the most recent date as `YYYY-MM-DD`, matching htmldate's default.

The change reads only what a page declares and never infers a date from prose, so a page without a valid date yields `None`. The htmldate competitor joins the benchmark suite with a new `date` operation and turbohtml timing, alongside reference and how-to documentation. The per-library migration guide is deferred to a dedicated follow-up PR that consumes this benchmark machinery.

closes #320