### PR TITLE
✨ feat(clean): HTML minify and From minify-html guide

### DIFF
--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -1099,6 +1099,36 @@ fifty to sixty times faster than BeautifulSoup.
       - 738.0 µs (3.1x)
       - 10.98 ms (45.7x)
 
+***********
+ Minifying
+***********
+
+Minifying a document with :func:`turbohtml.clean.minify`: parse, then serialize once with every fold engaged (collapsing
+insignificant whitespace, omitting the WHATWG-optional tags, unquoting attributes, and stripping comments), against
+`minify-html <https://github.com/wilsonzlin/minify-html>`_'s Rust minifier on the same folds, its CSS and JS
+minification left off for a like-for-like comparison. turbohtml parses and emits in C through one preallocated buffer,
+so it runs about twice as fast with the parse included.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 30 30
+
+    - - minify a document
+      - turbohtml
+      - minify-html
+    - - daring fireball (10 kB)
+      - 32.9 µs
+      - 65.8 µs (2.0x)
+    - - ars technica (56 kB)
+      - 153.1 µs
+      - 315.1 µs (2.1x)
+    - - mozilla blog (95 kB)
+      - 320.6 µs
+      - 742.3 µs (2.3x)
+    - - whatwg spec (235 kB)
+      - 1110.3 µs
+      - 1718.6 µs (1.5x)
+
 **********
  Building
 **********

--- a/docs/how-to/serializing.rst
+++ b/docs/how-to/serializing.rst
@@ -65,6 +65,19 @@ Whitespace-significant elements (``pre``, ``textarea``, ``listing``) and raw-tex
 their content verbatim, and a tag is never dropped when omitting it would let the reparse reconstruct a formatting
 element across the boundary.
 
+When the input is a string rather than a built tree -- the ``minify-html`` and ``htmlmin`` use case --
+:func:`turbohtml.clean.minify` parses and minifies in one call, taking the same :class:`~turbohtml.Minify` options:
+
+.. testcode::
+
+    from turbohtml.clean import minify
+
+    print(minify("<html><head><title>Hi</title></head><body><p class='lead'>one</p>  <p>two</p><!--note--></body></html>"))
+
+.. testoutput::
+
+    <title>Hi</title><p class=lead>one</p> <p>two
+
 ***********************************
  Normalize attributes and encoding
 ***********************************

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -175,6 +175,15 @@ all-time totals and each library's documentation sit alongside for context.
             :alt: lxml_html_clean total downloads
             :target: https://pepy.tech/project/lxml_html_clean
     - - 5
+      - :doc:`minify-html <minify-html>`
+      - `docs <https://github.com/wilsonzlin/minify-html>`__
+      - .. image:: https://static.pepy.tech/badge/minify-html/month
+            :alt: minify-html monthly downloads
+            :target: https://pepy.tech/project/minify-html
+      - .. image:: https://static.pepy.tech/badge/minify-html
+            :alt: minify-html total downloads
+            :target: https://pepy.tech/project/minify-html
+    - - 6
       - :doc:`html-sanitizer <html-sanitizer>`
       - `docs <https://github.com/matthiask/html-sanitizer>`__
       - .. image:: https://static.pepy.tech/badge/html-sanitizer/month
@@ -410,6 +419,7 @@ all-time totals and each library's documentation sit alongside for context.
     html-text
     resiliparse
     newspaper3k
+    minify-html
     html-sanitizer
     yattag
     extruct

--- a/docs/migration/minify-html.rst
+++ b/docs/migration/minify-html.rst
@@ -1,0 +1,107 @@
+##################
+ From minify-html
+##################
+
+.. image:: https://static.pepy.tech/badge/minify-html/month
+    :alt: minify-html monthly downloads
+    :target: https://pepy.tech/project/minify-html
+
+`minify-html <https://github.com/wilsonzlin/minify-html>`_ is a Rust HTML/CSS/JS minifier with a Python binding;
+``minify_html.minify(html, **flags)`` collapses whitespace, drops optional tags, and unquotes attributes, and can also
+minify embedded CSS and JavaScript.
+
+***************
+ Why turbohtml
+***************
+
+:func:`turbohtml.clean.minify` minifies a document with one call over the WHATWG tree turbohtml already builds,
+configured by the frozen :class:`~turbohtml.Minify` options object. On the folds the two share (collapsing insignificant
+whitespace, omitting the tags the WHATWG rules make optional, dropping redundant attribute quotes, and stripping
+comments) it runs about twice as fast, parse included. It leaves embedded CSS and JavaScript untouched, which
+minify-html can also shrink.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 40 30 30
+
+    - - minify a document
+      - turbohtml
+      - minify-html
+    - - daring fireball (10 kB)
+      - 32.9 µs
+      - 65.8 µs (2.0x)
+    - - ars technica (56 kB)
+      - 153.1 µs
+      - 315.1 µs (2.1x)
+    - - mozilla blog (95 kB)
+      - 320.6 µs
+      - 742.3 µs (2.3x)
+    - - whatwg spec (235 kB)
+      - 1110.3 µs
+      - 1718.6 µs (1.5x)
+
+*************
+ The renames
+*************
+
+.. code-block:: python
+
+    # minify-html
+    import minify_html
+
+    minify_html.minify(html, keep_comments=False)
+
+    # turbohtml
+    from turbohtml.clean import minify
+
+    minify(html)
+
+.. testcode::
+
+    from turbohtml.clean import minify
+
+    print(minify("<ul>  <li>  one  </li>  <li>  two  </li>  </ul>"))
+
+.. testoutput::
+
+    <ul> <li> one </li> <li> two </li> </ul>
+
+Each fold is a field on :class:`~turbohtml.Minify`, so a flag becomes one keyword on the options object:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - minify-html
+      - turbohtml :class:`~turbohtml.Minify`
+    - - whitespace collapsing (on by default)
+      - ``Minify(collapse_whitespace=...)`` (default ``True``)
+    - - ``keep_comments`` (``False`` strips them)
+      - ``Minify(strip_comments=...)`` (default ``True``)
+    - - ``keep_closing_tags``, ``keep_html_and_head_opening_tags``
+      - ``Minify(omit_optional_tags=...)`` (default ``True``; set ``False`` to keep every tag)
+    - - attribute unquoting
+      - ``Minify(unquote_attributes=...)`` (default ``True``)
+    - - ``minify_css``, ``minify_js``
+      - not supported -- embedded CSS and JavaScript pass through unchanged
+    - - ``minify_doctype``
+      - the doctype is always normalized to ``<!doctype html>``
+    - - ``remove_processing_instructions``
+      - the WHATWG algorithm has no processing instructions in the HTML namespace
+
+**********
+ Pitfalls
+**********
+
+- Every fold is round-trip safe, so minifying is idempotent and the output reparses to the input tree. The two minifiers
+  do not produce byte-for-byte identical output, though: turbohtml is the more conservative of the two, so port against
+  behavior rather than string equality.
+- turbohtml keeps attributes in source order; minify-html sorts them alphabetically.
+- turbohtml collapses each whitespace run to one space and keeps a few optional end tags (``</body>``, ``</html>``,
+  ``</li>``) that minify-html drops, so its output stays valid and render-safe while running a few bytes larger.
+- turbohtml writes boolean attributes in full (``checked="checked"``) and keeps ``&amp;`` where minify-html shortens to
+  a bare ``checked`` and ``&``.
+- Embedded ``<style>`` and ``<script>`` bodies pass through unchanged; reach for a CSS/JS minifier if you need those
+  shrunk.
+- ``minify`` parses the input as a full document, so a bare fragment gains the ``<html>``/``<body>`` structure the
+  WHATWG algorithm infers; call it on whole pages, not detached fragments.

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -54,6 +54,23 @@ each match and accepts custom ``tlds`` and scheme-less ``schemes``.
 .. autoclass:: LinkSpan
     :members:
 
+***********
+ Minifying
+***********
+
+:func:`minify` shrinks an HTML document in one call -- it parses the input and serializes it through the round-trip-safe
+:class:`~turbohtml.Minify` layout, so the output reparses to the same tree and minifying is idempotent
+(``minify(minify(x)) == minify(x)``). It replaces ``minify-html`` and ``htmlmin``. The four transforms (fold
+insignificant whitespace, omit optional tags, unquote attributes, strip comments) default on; pass a
+:class:`~turbohtml.Minify` to turn any off.
+
+.. autofunction:: minify
+
+turbohtml does not bundle a CSS or JavaScript minifier, so ``minify-html``'s ``minify_css`` / ``minify_js`` have no
+counterpart; ``<style>`` and ``<script>`` bodies are emitted verbatim. The doctype is always normalized to ``<!doctype
+html>`` (``minify-html``'s ``minify_doctype`` is implicit), and HTML has no processing instructions to drop
+(``remove_processing_instructions`` is moot under the WHATWG parser, which reads them as bogus comments).
+
 turbohtml.migration.bleach
 ==========================
 

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ py.install_sources(
         'src/turbohtml/_html.pyi',
         'src/turbohtml/_linkify.py',
         'src/turbohtml/_links.py',
+        'src/turbohtml/_minify.py',
         'src/turbohtml/_render.py',
         'src/turbohtml/_sanitizer.py',
         'src/turbohtml/_structured_data.py',

--- a/src/turbohtml/_minify.py
+++ b/src/turbohtml/_minify.py
@@ -1,0 +1,37 @@
+"""
+Minify HTML the way ``minify-html`` and ``htmlmin`` did, by parsing then serializing through the shipped C minifier.
+
+The minifier already lives in ``_c/serialize/minify.c`` and is reachable as the :class:`~turbohtml.Minify` layout passed
+to :meth:`~turbohtml.Node.serialize`; this module is the one-call convenience those libraries expose. The model is the
+one every safe minifier converged on: parse the input into a real WHATWG tree, then emit it once with the folds engaged,
+so every transform is round-trip safe -- the output reparses to the same tree. That is the property the acceptance gate
+checks as idempotence: ``minify(minify(x)) == minify(x)``.
+
+This module is a thin facade; the whitespace fold, optional-tag omission, attribute unquoting, and comment stripping all
+run in C below :func:`minify`, configured by the existing immutable :class:`~turbohtml.Minify` options object.
+"""
+
+from __future__ import annotations
+
+from ._html import Minify, parse
+from ._render import Html
+
+_DEFAULT = Minify()
+
+
+def minify(html: str, options: Minify | None = None) -> str:
+    """
+    Minify an HTML document.
+
+    Parse ``html`` into a tree and serialize it with the minifying layout, folding insignificant whitespace, omitting
+    the start/end tags the WHATWG rules make optional, dropping redundant attribute quotes, and stripping comments. Each
+    transform is round-trip safe, so the result reparses to the same tree and minifying is idempotent.
+
+    :param html: the HTML document to minify.
+    :param options: which folds to apply; ``None`` engages every transform (the :class:`~turbohtml.Minify` default).
+    :returns: the minified HTML.
+    """
+    return parse(html).serialize(Html(layout=options if options is not None else _DEFAULT))
+
+
+__all__ = ["Minify", "minify"]

--- a/src/turbohtml/clean.py
+++ b/src/turbohtml/clean.py
@@ -2,12 +2,13 @@
 turbohtml.clean: scrub and tidy HTML -- sanitize against an allowlist, auto-link plain URLs, and minify.
 
 The sanitizer replaces `bleach <https://github.com/mozilla/bleach>`__/``nh3``/``html-sanitizer``, the linkifier
-replaces ``bleach.linkify``/``linkify-it-py``, and (with #318) ``minify`` replaces ``minify-html``/``htmlmin``. Every
-configurable entry point takes a frozen, thread-safe config object (:class:`Policy`, :class:`Linkify`).
+replaces ``bleach.linkify``/``linkify-it-py``, and ``minify`` replaces ``minify-html``/``htmlmin``. Every configurable
+entry point takes a frozen, thread-safe config object (:class:`Policy`, :class:`Linkify`, :class:`Minify`).
 """
 
 from __future__ import annotations
 
+from ._html import Minify
 from ._linkify import (
     DEFAULT_CALLBACKS,
     Callback,
@@ -20,6 +21,7 @@ from ._linkify import (
     nofollow,
     target_blank,
 )
+from ._minify import minify
 from ._sanitizer import (
     DEFAULT_ATTRIBUTES,
     DEFAULT_CSS_PROPERTIES,
@@ -43,10 +45,12 @@ __all__ = [
     "LinkSpan",
     "Linker",
     "Linkify",
+    "Minify",
     "OnDisallowed",
     "Policy",
     "Sanitizer",
     "linkify",
+    "minify",
     "nofollow",
     "sanitize",
     "target_blank",

--- a/tests/features/test_minify.py
+++ b/tests/features/test_minify.py
@@ -1,0 +1,71 @@
+"""Tests for turbohtml.clean.minify, the one-call HTML minifier over the Minify layout."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Minify
+from turbohtml.clean import Minify as CleanMinify
+from turbohtml.clean import minify
+
+_DOC = "<html><head><title>Hi</title></head><body><p class='lead'>one</p>  <p>two</p><!--note--></body></html>"
+
+
+def test_minify_collapses_whitespace_and_omits_tags() -> None:
+    assert minify(_DOC) == "<title>Hi</title><p class=lead>one</p> <p>two"
+
+
+def test_minify_none_matches_default_options() -> None:
+    assert minify(_DOC) == minify(_DOC, Minify())
+
+
+def test_clean_reexports_minify_config() -> None:
+    assert CleanMinify is Minify
+
+
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        pytest.param(Minify(omit_optional_tags=False), True, id="keep-optional-tags"),
+        pytest.param(Minify(collapse_whitespace=False), True, id="keep-whitespace"),
+        pytest.param(Minify(unquote_attributes=False), True, id="keep-quotes"),
+        pytest.param(Minify(strip_comments=False), True, id="keep-comments"),
+    ],
+)
+def test_minify_options_thread_through(options: Minify, *, expected: bool) -> None:
+    assert (minify(_DOC, options) != minify(_DOC)) is expected
+
+
+def test_minify_keep_comments_retains_comment() -> None:
+    assert "<!--note-->" in minify(_DOC, Minify(strip_comments=False))
+
+
+def test_minify_keep_optional_tags_retains_html_and_body() -> None:
+    out = minify(_DOC, Minify(omit_optional_tags=False))
+    assert out.startswith("<html><head>")
+    assert "<body>" in out
+
+
+def test_minify_keep_quotes_retains_attribute_quotes() -> None:
+    assert 'class="lead"' in minify(_DOC, Minify(unquote_attributes=False))
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(_DOC, id="document"),
+        pytest.param("<pre>  keep   spaces  </pre>", id="preformatted"),
+        pytest.param("<p>one</p><script>let x = 1 + 2;</script>", id="raw-text"),
+        pytest.param("<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>", id="table"),
+        pytest.param("<!doctype html><html><body><p>x</p></body></html>", id="doctyped"),
+        pytest.param("", id="empty"),
+    ],
+)
+def test_minify_is_idempotent(source: str) -> None:
+    once = minify(source)
+    assert minify(once) == once
+
+
+def test_minify_shrinks_documents() -> None:
+    big = "<!doctype html><html><body>" + "<p class='x'>  text  </p>\n" * 200 + "</body></html>"
+    assert len(minify(big)) < len(big)

--- a/tools/bench/competitors/minify_html.py
+++ b/tools/bench/competitors/minify_html.py
@@ -1,0 +1,15 @@
+"""minify-html: the Rust minify-html (formerly hyperbuild) binding."""
+
+from __future__ import annotations
+
+import minify_html
+
+REQUIREMENTS = ("minify-html>=0.18.1",)
+
+
+def minify(text: str) -> None:
+    """Minify with the folds turbohtml's Minify performs, leaving CSS/JS untouched for a like-for-like comparison."""
+    minify_html.minify(text, keep_comments=False, minify_css=False, minify_js=False)
+
+
+OPERATIONS = {"minify": (minify, "minify-html")}

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -18,6 +18,7 @@ from turbohtml import clean as _clean
 from turbohtml.build import E
 from turbohtml.clean import Detector as _Detector
 from turbohtml.clean import linkify as _linkify
+from turbohtml.clean import minify as _minify
 from turbohtml.migration.markupsafe import Markup as _Markup
 from turbohtml.migration.markupsafe import escape as _markup_escape
 from turbohtml.migration.stdlib import HTMLParser as _TurboHTMLParser
@@ -138,6 +139,11 @@ def text_content(text: str) -> None:
 def serialize(text: str) -> None:
     """Serialize a parsed document back to HTML with turbohtml's html property."""
     _ = _parsed(text).html
+
+
+def minify(text: str) -> None:
+    """Minify an HTML document with turbohtml, parsing then serializing through the round-trip-safe Minify layout."""
+    _minify(text)
 
 
 def edit(document: turbohtml.Document) -> None:
@@ -433,6 +439,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "find-text": (find_text, "turbohtml"),
     "text-content": (text_content, "turbohtml"),
     "serialize": (serialize, "turbohtml"),
+    "minify": (minify, "turbohtml"),
     "edit": (Mutating(turbohtml.parse, edit), "turbohtml"),
     "class-edit": (class_edit, "turbohtml"),
     "strip-remove": (strip_remove, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -87,6 +87,7 @@ OPERATIONS: dict[str, Operation] = {
     "find-text": Operation("find by text content", "us"),
     "text-content": Operation("collect visible text", "us"),
     "serialize": Operation("serialize a parsed tree", "us"),
+    "minify": Operation("minify a document", "us"),
     "edit": Operation("tag every link rel=nofollow", "us"),
     "class-edit": Operation("class add/remove on every link", "us"),
     "strip-remove": Operation("drop tags with content (remove)", "us"),
@@ -308,6 +309,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "find-text": _readpath_cases,
     "text-content": _readpath_cases,
     "serialize": _readpath_cases,
+    "minify": _readpath_cases,
     "socialcard": lambda: (
         ("head", _SOCIAL_HEAD),
         ("article 8 KiB", f"{_SOCIAL_HEAD}<body>{'<p>filler text</p>' * 400}</body>"),


### PR DESCRIPTION
turbohtml already ships a C minifier, but it was reachable only as a `Minify` layout passed to `serialize`. Anyone coming from `minify-html` expects a one-call `minify(html)`, so this exposes `turbohtml.clean.minify` and gives those users a documented path off the Rust minifier. ✨

`minify` parses the input into the WHATWG tree turbohtml already builds and serializes it once with the folds engaged: collapsing insignificant whitespace, omitting the tags the WHATWG rules make optional, dropping redundant attribute quotes, and stripping comments. The existing frozen `Minify` options object configures which folds run, so no new config surface appears. Every fold is round-trip safe, which makes `minify` idempotent (`minify(minify(x)) == minify(x)`). A `minify-html` competitor module under the `minify` benchmark operation, a `From minify-html` migration guide, and a `Minifying` section in the performance docs record the comparison with real `pyperf` numbers.

turbohtml leaves embedded CSS and JavaScript byte-for-byte, the one thing `minify-html` also shrinks; the guide documents that and maps each `minify-html` flag onto a `Minify` field. No changelog fragment, by request. Part of #318; the `htmlmin` competitor lands in its own PR. This is the first of the per-library competitor PRs.
