### PR TITLE
📝 docs(build): htbuilder migration coverage

### DIFF
--- a/docs/changelog/322.doc.rst
+++ b/docs/changelog/322.doc.rst
@@ -1,0 +1,3 @@
+A new "From htbuilder" migration guide maps `htbuilder <https://github.com/tvst/htbuilder>`__'s
+attributes-then-children calls onto :data:`turbohtml.build.E` and benchmarks the two builders on the same workload - by
+:user:`gaborbernat`.

--- a/docs/changelog/322.doc.rst
+++ b/docs/changelog/322.doc.rst
@@ -1,3 +1,2 @@
-A new "From htbuilder" migration guide maps `htbuilder <https://github.com/tvst/htbuilder>`__'s
-attributes-then-children calls onto :data:`turbohtml.build.E` and benchmarks the two builders on the same workload - by
-:user:`gaborbernat`.
+A new "From htbuilder" migration guide maps `htbuilder <https://github.com/tvst/htbuilder>`__'s attributes-then-children
+calls onto :data:`turbohtml.build.E` and benchmarks the two builders on the same workload - by :user:`gaborbernat`.

--- a/docs/migration/bench/htbuilder.json
+++ b/docs/migration/bench/htbuilder.json
@@ -1,0 +1,25 @@
+{
+  "label": "build a list",
+  "parties": [
+    ":data:`E <turbohtml.build.E>`",
+    "htbuilder"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "100 rows",
+      0.00014,
+      0.000227
+    ],
+    [
+      "1k rows",
+      0.001631,
+      0.002382
+    ],
+    [
+      "10k rows",
+      0.017441,
+      0.028424
+    ]
+  ]
+}

--- a/docs/migration/htbuilder.rst
+++ b/docs/migration/htbuilder.rst
@@ -1,0 +1,87 @@
+################
+ From htbuilder
+################
+
+.. package-meta:: htbuilder tvst/htbuilder
+
+`htbuilder <https://github.com/tvst/htbuilder>`_ assembles HTML in Python from the other direction than a parser: each
+element takes its attributes as keyword arguments in one call and its children in a second (``div(_class="card")(...)``,
+with ``_class`` mangled to ``class`` and ``data_i`` to ``data-i``), and stringifying the result renders it. turbohtml
+replaces it with the terse :data:`turbohtml.build.E` builder.
+
+***************
+ Why turbohtml
+***************
+
+turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
+:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
+attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
+edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
+parse it back:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
+
+``E`` assembles the fragment in turbohtml's arena and serializes it in C; htbuilder stays in Python. The same ``<ul>``
+of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
+
+.. bench-table::
+    :file: bench/htbuilder.json
+
+``E`` is about one and a half times faster than htbuilder, and the decisive difference is the result type: ``E`` hands
+back a real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can
+query, edit, and re-:meth:`~turbohtml.Node.serialize`.
+
+*************
+ The renames
+*************
+
+htbuilder splits an element across two calls, attributes first and children second; turbohtml passes both to one call:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `htbuilder <https://github.com/tvst/htbuilder>`__
+      - turbohtml
+    - - ``div(_class="card")(h1("Title"))``
+      - :data:`E.div({"class": "card"}, E.h1("Title")) <turbohtml.build.E>`; attributes are a leading mapping, children
+        follow in the same call
+    - - ``li(_class="item", data_i="1")("text")``
+      - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
+    - - ``classes("card", "lg")`` / ``styles(...)`` helpers
+      - a plain string, or a list value that joins on a space: ``{"class": ["card", "lg"]}``
+
+``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
+attribute joins on a space so a class list reads naturally:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    print(E("my-card", {"class": ["card", "lg"]}, "hi").serialize())
+
+.. testoutput::
+
+    <my-card class="card lg">hi</my-card>
+
+**********
+ Pitfalls
+**********
+
+- ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
+  Serialize the element you built, or append it under a parsed document when you need the full page shell.
+- htbuilder mangles keyword arguments (``_class`` to ``class``, ``data_i`` to ``data-i``); ``E`` takes a plain mapping,
+  so write the real attribute name as the dict key -- no underscore convention to remember.
+- htbuilder renders lazily, escaping nothing: ``str(div("<b>"))`` emits the ``<b>`` markup verbatim. ``E`` builds text
+  nodes, so the same call serializes as ``&lt;b&gt;``; markup belongs in child elements, not strings.
+- The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
+  ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -420,6 +420,15 @@ page benchmarks all of them).
             :alt: yattag total downloads
             :target: https://pepy.tech/project/yattag
     - - 3
+      - :doc:`htbuilder <htbuilder>`
+      - `docs <https://github.com/tvst/htbuilder>`__
+      - .. image:: https://static.pepy.tech/badge/htbuilder/month
+            :alt: htbuilder monthly downloads
+            :target: https://pepy.tech/project/htbuilder
+      - .. image:: https://static.pepy.tech/badge/htbuilder
+            :alt: htbuilder total downloads
+            :target: https://pepy.tech/project/htbuilder
+    - - 4
       - :doc:`htpy <htpy>`
       - `docs <https://htpy.dev/>`__
       - .. image:: https://static.pepy.tech/badge/htpy/month
@@ -428,7 +437,7 @@ page benchmarks all of them).
       - .. image:: https://static.pepy.tech/badge/htpy
             :alt: htpy total downloads
             :target: https://pepy.tech/project/htpy
-    - - 4
+    - - 5
       - :doc:`airium <airium>`
       - `docs <https://gitlab.com/kamichal/airium>`__
       - .. image:: https://static.pepy.tech/badge/airium/month
@@ -513,6 +522,7 @@ page benchmarks all of them).
     html-sanitizer
     yattag
     extruct
+    htbuilder
     htpy
     mechanicalsoup
     airium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ bench = [
   "cssselect>=1.4",
   "dominate>=2.9.1",
   "extruct>=0.18",
+  "htbuilder>=0.9",
   "html-sanitizer>=2.6",
   "html-text>=0.7.1",
   "html2text>=2025.4.15",

--- a/tools/bench/competitors/htbuilder.py
+++ b/tools/bench/competitors/htbuilder.py
@@ -1,0 +1,16 @@
+"""htbuilder: assemble a tree with one call for attributes and a second for children."""
+
+from __future__ import annotations
+
+from htbuilder import li, ul
+
+REQUIREMENTS = ("htbuilder>=0.9",)
+
+
+def build_e(count: int) -> None:
+    """Build a ``<ul>`` of rows with htbuilder's attributes-then-children calls and stringify it."""
+    rows = [li(_class="item", data_i=str(index))(f"item {index}") for index in range(count)]
+    _ = str(ul(*rows))
+
+
+OPERATIONS = {"build-e": (build_e, "htbuilder")}


### PR DESCRIPTION
The migration index covers dominate, yattag, htpy, and airium in its builders section, while htbuilder, at 224k monthly PyPI downloads the third most adopted builder in that table, had no migration path or benchmark. Part of #322.

The existing `turbohtml.build.E` builder already expresses htbuilder's idioms, so this adds no API. The guide translates the attributes-then-children call pair (`div(_class="card")(h1("Title"))`) into one `E` call with a leading attribute mapping, spells out the keyword-mangling difference (`_class`/`data_i` versus literal dict keys), and warns that htbuilder emits string children verbatim where `E` escapes them into text nodes. The bench competitor module registers the shared `build-e` operation, and the committed feed measures `E` at about 1.5x faster across 100, 1k, and 10k row builds.

First of five stacked PRs covering the remaining builders from #322 (htbuilder, simple-html, hyperpython, markyp, fast-html). Each later branch bases on the previous one because they all touch the migration index, the bench dependency group, and the shared changelog fragment.
