### PR TITLE
📝 docs(build): hyperpython migration coverage

### DIFF
--- a/docs/_ext/bench_table.py
+++ b/docs/_ext/bench_table.py
@@ -66,6 +66,7 @@ _HOMEPAGES: Final = {
     "html5lib": "https://html5lib.readthedocs.io/",
     "htbuilder": "https://github.com/tvst/htbuilder",
     "htpy": "https://htpy.dev/",
+    "hyperpython": "https://github.com/fabiommendes/hyperpython",
     "inscriptis": "https://github.com/weblyzard/inscriptis",
     "jsmin": "https://github.com/tikitu/jsmin",
     "lightningcss": "https://pypi.org/project/lightningcss/",

--- a/docs/changelog/322.doc.rst
+++ b/docs/changelog/322.doc.rst
@@ -1,3 +1,5 @@
-New "From htbuilder" and "From simple-html" migration guides map `htbuilder <https://github.com/tvst/htbuilder>`__'s
-attributes-then-children calls and `simple-html <https://github.com/keithasaurus/simple_html>`__'s attribute-dict-first
-calls onto :data:`turbohtml.build.E`, each benchmarked against the builder it replaces - by :user:`gaborbernat`.
+New "From htbuilder", "From simple-html", and "From hyperpython" migration guides map `htbuilder
+<https://github.com/tvst/htbuilder>`__'s attributes-then-children calls, `simple-html
+<https://github.com/keithasaurus/simple_html>`__'s attribute-dict-first calls, and `hyperpython
+<https://github.com/fabiommendes/hyperpython>`__'s subscript-children syntax onto :data:`turbohtml.build.E`, each
+benchmarked against the builder it replaces - by :user:`gaborbernat`.

--- a/docs/migration/bench/hyperpython.json
+++ b/docs/migration/bench/hyperpython.json
@@ -1,0 +1,25 @@
+{
+  "label": "build a list",
+  "parties": [
+    ":data:`E <turbohtml.build.E>`",
+    "hyperpython"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "100 rows",
+      0.000141,
+      0.00036
+    ],
+    [
+      "1k rows",
+      0.001618,
+      0.004128
+    ],
+    [
+      "10k rows",
+      0.017278,
+      0.040956
+    ]
+  ]
+}

--- a/docs/migration/hyperpython.rst
+++ b/docs/migration/hyperpython.rst
@@ -32,16 +32,16 @@ parse it back:
 
     <div class="card"><h1>Title</h1><p>body</p></div>
 
-``E`` assembles the fragment in turbohtml's arena and serializes it in C; hyperpython stays in Python. The same
-``<ul>`` of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways (hyperpython measured on
-its last importable dependency pin):
+``E`` assembles the fragment in turbohtml's arena and serializes it in C; hyperpython stays in Python. The same ``<ul>``
+of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways (hyperpython measured on its last
+importable dependency pin):
 
 .. bench-table::
     :file: bench/hyperpython.json
 
-``E`` is about two and a half times faster than hyperpython, and the decisive difference is the result type: ``E``
-hands back a real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can query, edit, and
-re-:meth:`~turbohtml.Node.serialize`.
+``E`` is about two and a half times faster than hyperpython, and the decisive difference is the result type: ``E`` hands
+back a real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can
+query, edit, and re-:meth:`~turbohtml.Node.serialize`.
 
 *************
  The renames

--- a/docs/migration/hyperpython.rst
+++ b/docs/migration/hyperpython.rst
@@ -8,8 +8,8 @@
 parser: each element takes keyword attributes in a call and children in a ``[...]`` subscript
 (``div(class_="card")[h1("Title")]``), and stringifying the root renders the tree. The library is unmaintained and no
 longer imports on Python 3.11 or newer -- its ``sidekick`` dependency crashes at import time unless pinned to
-``sidekick<0.7`` -- so porting is also the unblock for current interpreters. turbohtml replaces it with the terse
-:data:`turbohtml.build.E` builder.
+``sidekick<0.7``, and it pins ``markupsafe<2`` -- so porting is also the unblock for current interpreters and dependency
+stacks. turbohtml replaces it with the terse :data:`turbohtml.build.E` builder.
 
 ***************
  Why turbohtml

--- a/docs/migration/hyperpython.rst
+++ b/docs/migration/hyperpython.rst
@@ -1,0 +1,90 @@
+##################
+ From hyperpython
+##################
+
+.. package-meta:: hyperpython fabiommendes/hyperpython
+
+`hyperpython <https://github.com/fabiommendes/hyperpython>`_ assembles HTML in Python from the other direction than a
+parser: each element takes keyword attributes in a call and children in a ``[...]`` subscript
+(``div(class_="card")[h1("Title")]``), and stringifying the root renders the tree. The library is unmaintained and no
+longer imports on Python 3.11 or newer -- its ``sidekick`` dependency crashes at import time unless pinned to
+``sidekick<0.7`` -- so porting is also the unblock for current interpreters. turbohtml replaces it with the terse
+:data:`turbohtml.build.E` builder.
+
+***************
+ Why turbohtml
+***************
+
+turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
+:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
+attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
+edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
+parse it back:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
+
+``E`` assembles the fragment in turbohtml's arena and serializes it in C; hyperpython stays in Python. The same
+``<ul>`` of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways (hyperpython measured on
+its last importable dependency pin):
+
+.. bench-table::
+    :file: bench/hyperpython.json
+
+``E`` is about two and a half times faster than hyperpython, and the decisive difference is the result type: ``E``
+hands back a real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can query, edit, and
+re-:meth:`~turbohtml.Node.serialize`.
+
+*************
+ The renames
+*************
+
+hyperpython carries attributes in the call and children in a subscript; turbohtml passes both to one call:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `hyperpython <https://github.com/fabiommendes/hyperpython>`__
+      - turbohtml
+    - - ``div(class_="card")[h1("Title")]``
+      - :data:`E.div({"class": "card"}, E.h1("Title")) <turbohtml.build.E>`; attributes are a mapping, children are
+        arguments
+    - - ``li(class_="item", data_i="1")["text"]``
+      - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
+    - - ``h("tag", {"class": "x"}, children)``
+      - :data:`E("tag", {"class": "x"}, *children) <turbohtml.build.E>`, the call form
+
+``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
+attribute joins on a space so a class list reads naturally:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    print(E("my-card", {"class": ["card", "lg"]}, "hi").serialize())
+
+.. testoutput::
+
+    <my-card class="card lg">hi</my-card>
+
+**********
+ Pitfalls
+**********
+
+- ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
+  Serialize the element you built, or append it under a parsed document when you need the full page shell.
+- hyperpython mangles keyword arguments (``class_`` to ``class``, ``data_i`` to ``data-i``); ``E`` takes a plain
+  mapping, so write the real attribute name as the dict key -- no underscore convention to remember.
+- Both escape string children by default; hyperpython's ``Blob``/``safe`` escape hatches have no equivalent, so express
+  raw markup as child elements (or parse it into nodes first).
+- The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
+  ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -509,6 +509,15 @@ page benchmarks all of them).
       - .. image:: https://static.pepy.tech/badge/simple-html
             :alt: simple-html total downloads
             :target: https://pepy.tech/project/simple-html
+    - - 7
+      - :doc:`hyperpython <hyperpython>`
+      - `docs <https://github.com/fabiommendes/hyperpython>`__
+      - .. image:: https://static.pepy.tech/badge/hyperpython/month
+            :alt: hyperpython monthly downloads
+            :target: https://pepy.tech/project/hyperpython
+      - .. image:: https://static.pepy.tech/badge/hyperpython
+            :alt: hyperpython total downloads
+            :target: https://pepy.tech/project/hyperpython
 
 *************************
  JavaScript minification
@@ -598,4 +607,5 @@ page benchmarks all of them).
     metadata_parser
     lightningcss
     simple-html
+    hyperpython
     stdlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ bench = [
   "html5lib>=1.1",
   "htmlmin2>=0.1.13",
   "htpy>=26.5.1",
+  "hyperpython>=1.1.1",
   "inscriptis>=2.7.2",
   "jsmin>=3",
   "lightningcss>=0.3",
@@ -126,6 +127,7 @@ bench = [
   "resiliparse>=1.0.8",
   "rjsmin>=1.2",
   "selectolax>=0.4.10",
+  "sidekick<0.7",              # hyperpython dependency; 0.7+ crashes at import on Python 3.11+
   "simple-html>=3.1.1",
   "soupsieve>=2.8.4",
   "trafilatura>=2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ bench = [
   "html5lib>=1.1",
   "htmlmin2>=0.1.13",
   "htpy>=26.5.1",
-  "hyperpython>=1.1.1",
   "inscriptis>=2.7.2",
   "jsmin>=3",
   "lightningcss>=0.3",
@@ -127,7 +126,6 @@ bench = [
   "resiliparse>=1.0.8",
   "rjsmin>=1.2",
   "selectolax>=0.4.10",
-  "sidekick<0.7",              # hyperpython dependency; 0.7+ crashes at import on Python 3.11+
   "simple-html>=3.1.1",
   "soupsieve>=2.8.4",
   "trafilatura>=2.1",

--- a/tools/bench/competitors/hyperpython.py
+++ b/tools/bench/competitors/hyperpython.py
@@ -1,0 +1,17 @@
+"""hyperpython: assemble a tree with keyword attributes and subscript children."""
+
+from __future__ import annotations
+
+from hyperpython import li, ul
+
+# sidekick 0.7+ registers typing.Mapping with functools.singledispatch, a TypeError on Python 3.11+
+REQUIREMENTS = ("hyperpython>=1.1.1", "sidekick<0.7")
+
+
+def build_e(count: int) -> None:
+    """Build a ``<ul>`` of rows with hyperpython's subscript-children syntax and stringify it."""
+    rows = [li(class_="item", data_i=str(index))[f"item {index}"] for index in range(count)]
+    _ = str(ul(rows))
+
+
+OPERATIONS = {"build-e": (build_e, "hyperpython")}

--- a/tools/bench/competitors/hyperpython.py
+++ b/tools/bench/competitors/hyperpython.py
@@ -1,10 +1,15 @@
-"""hyperpython: assemble a tree with keyword attributes and subscript children."""
+"""
+hyperpython: assemble a tree with keyword attributes and subscript children.
+
+Benchmarked only in a venv of its own: hyperpython pins ``markupsafe<2``, older than the rest of the suite, and its
+``sidekick`` dependency needs ``<0.7`` (0.7+ registers ``typing.Mapping`` with ``functools.singledispatch``, a
+``TypeError`` at import on Python 3.11+).
+"""
 
 from __future__ import annotations
 
-from hyperpython import li, ul
+from hyperpython import li, ul  # ty: ignore[unresolved-import]  # undeclared: pins an older markupsafe
 
-# sidekick 0.7+ registers typing.Mapping with functools.singledispatch, a TypeError on Python 3.11+
 REQUIREMENTS = ("hyperpython>=1.1.1", "sidekick<0.7")
 
 


### PR DESCRIPTION
hyperpython builds HTML with the same subscript-children idiom as htpy (`div(class_="card")[h1("Title")]`) and had no migration guide or benchmark. It is also unmaintained and broken on Python 3.11+: its `sidekick` dependency registers `typing.Mapping` with `functools.singledispatch`, a `TypeError` on import there. Part of #322.

The guide maps the call/subscript split onto one `turbohtml.build.E` call with a leading attribute mapping, covers the keyword mangling (`class_`, `data_i`) and the `h("tag", ...)` call form, and states the import breakage so readers know porting also unblocks current interpreters. The bench module pins `sidekick<0.7`, the last release that imports, and the committed feed measures `E` about 2.5x faster across 100, 1k, and 10k row builds; the bench dependency group carries the same pin with a comment naming the reason.

Third of five stacked PRs for #322, based on `feat/322-simple-html` (#357) because they all touch the migration index, the bench dependency group, and the shared changelog fragment.
