### PR TITLE
📝 docs(build): markyp migration coverage

### DIFF
--- a/docs/_ext/bench_table.py
+++ b/docs/_ext/bench_table.py
@@ -76,6 +76,7 @@ _HOMEPAGES: Final = {
     "lxml-html-clean": "https://lxml-html-clean.readthedocs.io/",
     "markdownify": "https://github.com/matthewwithanm/python-markdownify",
     "markupsafe": "https://markupsafe.palletsprojects.com/",
+    "markyp": "https://github.com/volfpeter/markyp-html",
     "metadata_parser": "https://github.com/jvanasco/metadata_parser",
     "minify-html": "https://github.com/wilsonzlin/minify-html",
     "newspaper3k": "https://github.com/codelucas/newspaper",

--- a/docs/changelog/322.doc.rst
+++ b/docs/changelog/322.doc.rst
@@ -1,5 +1,6 @@
-New "From htbuilder", "From simple-html", and "From hyperpython" migration guides map `htbuilder
+New "From htbuilder", "From simple-html", "From hyperpython", and "From markyp" migration guides map `htbuilder
 <https://github.com/tvst/htbuilder>`__'s attributes-then-children calls, `simple-html
-<https://github.com/keithasaurus/simple_html>`__'s attribute-dict-first calls, and `hyperpython
-<https://github.com/fabiommendes/hyperpython>`__'s subscript-children syntax onto :data:`turbohtml.build.E`, each
-benchmarked against the builder it replaces - by :user:`gaborbernat`.
+<https://github.com/keithasaurus/simple_html>`__'s attribute-dict-first calls, `hyperpython
+<https://github.com/fabiommendes/hyperpython>`__'s subscript-children syntax, and `markyp
+<https://github.com/volfpeter/markyp-html>`__'s per-tag element classes onto :data:`turbohtml.build.E`, each benchmarked
+against the builder it replaces - by :user:`gaborbernat`.

--- a/docs/migration/bench/markyp.json
+++ b/docs/migration/bench/markyp.json
@@ -1,0 +1,25 @@
+{
+  "label": "build a list",
+  "parties": [
+    ":data:`E <turbohtml.build.E>`",
+    "markyp"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "100 rows",
+      0.000145,
+      0.000106
+    ],
+    [
+      "1k rows",
+      0.001689,
+      0.001043
+    ],
+    [
+      "10k rows",
+      0.017607,
+      0.011906
+    ]
+  ]
+}

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -510,6 +510,15 @@ page benchmarks all of them).
             :alt: airium total downloads
             :target: https://pepy.tech/project/airium
     - - 6
+      - :doc:`markyp <markyp>`
+      - `docs <https://github.com/volfpeter/markyp-html>`__
+      - .. image:: https://static.pepy.tech/badge/markyp-html/month
+            :alt: markyp-html monthly downloads
+            :target: https://pepy.tech/project/markyp-html
+      - .. image:: https://static.pepy.tech/badge/markyp-html
+            :alt: markyp-html total downloads
+            :target: https://pepy.tech/project/markyp-html
+    - - 7
       - :doc:`simple-html <simple-html>`
       - `docs <https://github.com/keithasaurus/simple_html>`__
       - .. image:: https://static.pepy.tech/badge/simple-html/month
@@ -518,7 +527,7 @@ page benchmarks all of them).
       - .. image:: https://static.pepy.tech/badge/simple-html
             :alt: simple-html total downloads
             :target: https://pepy.tech/project/simple-html
-    - - 7
+    - - 8
       - :doc:`hyperpython <hyperpython>`
       - `docs <https://github.com/fabiommendes/hyperpython>`__
       - .. image:: https://static.pepy.tech/badge/hyperpython/month
@@ -613,6 +622,7 @@ page benchmarks all of them).
     mechanicalsoup
     airium
     calmjs-parse
+    markyp
     html5-parser
     metadata_parser
     lightningcss

--- a/docs/migration/markyp.rst
+++ b/docs/migration/markyp.rst
@@ -5,8 +5,8 @@
 .. package-meta:: markyp-html volfpeter/markyp-html
 
 `markyp <https://github.com/volfpeter/markyp>`_ assembles HTML in Python from the other direction than a parser: its
-`markyp-html <https://github.com/volfpeter/markyp-html>`_ package provides one element class per tag, split across
-topic modules (``markyp_html.block.div``, ``markyp_html.text.h1``, ``markyp_html.lists.li``), each taking children
+`markyp-html <https://github.com/volfpeter/markyp-html>`_ package provides one element class per tag, split across topic
+modules (``markyp_html.block.div``, ``markyp_html.text.h1``, ``markyp_html.lists.li``), each taking children
 positionally and attributes as trailing keywords, and stringifying the root renders the tree. turbohtml replaces both
 packages with the terse :data:`turbohtml.build.E` builder.
 
@@ -82,8 +82,8 @@ attribute joins on a space so a class list reads naturally:
 
 - ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
   Serialize the element you built, or append it under a parsed document when you need the full page shell.
-- markyp strips a trailing underscore (``class_`` to ``class``) but keeps other underscores, so hyphenated names need
-  an unpacked dict already; ``E`` takes the real attribute name as a plain dict key everywhere.
+- markyp strips a trailing underscore (``class_`` to ``class``) but keeps other underscores, so hyphenated names need an
+  unpacked dict already; ``E`` takes the real attribute name as a plain dict key everywhere.
 - markyp pretty-prints -- a newline between children and a space after a bare tag name (``<h1 >``); ``E`` serializes
   compact markup. Parse and re-serialize, or use a formatter, when you need indented output.
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,

--- a/docs/migration/markyp.rst
+++ b/docs/migration/markyp.rst
@@ -1,0 +1,90 @@
+#############
+ From markyp
+#############
+
+.. package-meta:: markyp-html volfpeter/markyp-html
+
+`markyp <https://github.com/volfpeter/markyp>`_ assembles HTML in Python from the other direction than a parser: its
+`markyp-html <https://github.com/volfpeter/markyp-html>`_ package provides one element class per tag, split across
+topic modules (``markyp_html.block.div``, ``markyp_html.text.h1``, ``markyp_html.lists.li``), each taking children
+positionally and attributes as trailing keywords, and stringifying the root renders the tree. turbohtml replaces both
+packages with the terse :data:`turbohtml.build.E` builder.
+
+***************
+ Why turbohtml
+***************
+
+turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
+:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
+attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
+edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
+parse it back:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
+
+``E`` assembles the fragment in turbohtml's arena and serializes it in C; markyp stays in Python. The same ``<ul>`` of
+rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
+
+.. bench-table::
+    :file: bench/markyp.json
+
+markyp renders about a third faster than ``E`` on this microbenchmark -- it concatenates strings as it goes -- but the
+decisive difference is the result type: ``E`` hands back a real :class:`~turbohtml.Element`, not a string, so the call
+that builds the markup also leaves a tree you can query, edit, and re-:meth:`~turbohtml.Node.serialize`.
+
+*************
+ The renames
+*************
+
+markyp imports one class per tag from a topic module and trails the attributes; turbohtml names any tag on ``E`` and
+leads with them:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `markyp <https://github.com/volfpeter/markyp-html>`__
+      - turbohtml
+    - - ``div(h1("Title"), p("body"), class_="card")``
+      - :data:`E.div({"class": "card"}, E.h1("Title"), E.p("body")) <turbohtml.build.E>`; attributes are a leading
+        mapping, and no per-tag import is needed
+    - - ``li("text", class_="item", **{"data-i": "1"})``
+      - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
+    - - ``webpage(...)`` for the full page shell
+      - build it: :data:`E.html(E.head(...), E.body(...)) <turbohtml.build.E>`, or append the fragment under a parsed
+        document
+
+``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
+attribute joins on a space so a class list reads naturally:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    print(E("my-card", {"class": ["card", "lg"]}, "hi").serialize())
+
+.. testoutput::
+
+    <my-card class="card lg">hi</my-card>
+
+**********
+ Pitfalls
+**********
+
+- ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
+  Serialize the element you built, or append it under a parsed document when you need the full page shell.
+- markyp strips a trailing underscore (``class_`` to ``class``) but keeps other underscores, so hyphenated names need
+  an unpacked dict already; ``E`` takes the real attribute name as a plain dict key everywhere.
+- markyp pretty-prints -- a newline between children and a space after a bare tag name (``<h1 >``); ``E`` serializes
+  compact markup. Parse and re-serialize, or use a formatter, when you need indented output.
+- The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
+  ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ bench = [
   "lxml-html-clean>=0.4.5",
   "markdownify>=1.2.2",
   "markupsafe>=3.0.3",
+  "markyp-html>=0.2306.2",
   "minify-html>=0.18.1",
   "newspaper3k>=0.2.8",
   "nh3>=0.3.6",

--- a/tools/bench/competitors/markyp.py
+++ b/tools/bench/competitors/markyp.py
@@ -1,0 +1,16 @@
+"""markyp: assemble a tree with element classes taking children first and attributes as keywords."""
+
+from __future__ import annotations
+
+from markyp_html.lists import li, ul
+
+REQUIREMENTS = ("markyp-html>=0.2306.2",)
+
+
+def build_e(count: int) -> None:
+    """Build a ``<ul>`` of rows with markyp-html's element classes and stringify it."""
+    rows = [li(f"item {index}", class_="item", **{"data-i": str(index)}) for index in range(count)]
+    _ = str(ul(*rows))
+
+
+OPERATIONS = {"build-e": (build_e, "markyp")}


### PR DESCRIPTION
markyp (with its `markyp-html` element set) builds HTML from one class per tag spread across topic modules (`markyp_html.block.div`, `markyp_html.lists.li`), children first and attributes trailing, and had no migration guide or benchmark. Part of #322.

The guide collapses both packages into `turbohtml.build.E`: any tag by attribute access with a leading attribute mapping, no per-tag imports, with rows for the `webpage()` page shell, the trailing-underscore rename (`class_`), and markyp's pretty-printed output (a newline between children and a space after bare tag names like `<h1 >`) that `E`'s compact serializer does not emit. The committed feed measures markyp about a third faster on the raw build microbenchmark, and the guide states that number and argues the queryable tree result type, the same framing the yattag and simple-html guides use.

Fourth of five stacked PRs for #322, based on `feat/322-hyperpython` (#358) because they all touch the migration index, the bench dependency group, and the shared changelog fragment.
