### PR TITLE
📝 docs(build): fast-html migration coverage

### DIFF
--- a/docs/_ext/bench_table.py
+++ b/docs/_ext/bench_table.py
@@ -55,6 +55,7 @@ _HOMEPAGES: Final = {
     "cssmin": "https://github.com/zacharyvoase/cssmin",
     "dominate": "https://github.com/Knio/dominate",
     "extruct": "https://github.com/scrapinghub/extruct",
+    "fast-html": "https://github.com/pcarbonn/fast_html",
     "faust-cchardet": "https://github.com/faust-streaming/cChardet",
     "html-sanitizer": "https://github.com/matthiask/html-sanitizer",
     "html-text": "https://github.com/zytedata/html-text",

--- a/docs/changelog/322.doc.rst
+++ b/docs/changelog/322.doc.rst
@@ -1,6 +1,7 @@
-New "From htbuilder", "From simple-html", "From hyperpython", and "From markyp" migration guides map `htbuilder
-<https://github.com/tvst/htbuilder>`__'s attributes-then-children calls, `simple-html
+New "From htbuilder", "From simple-html", "From hyperpython", "From markyp", and "From fast-html" migration guides map
+`htbuilder <https://github.com/tvst/htbuilder>`__'s attributes-then-children calls, `simple-html
 <https://github.com/keithasaurus/simple_html>`__'s attribute-dict-first calls, `hyperpython
-<https://github.com/fabiommendes/hyperpython>`__'s subscript-children syntax, and `markyp
-<https://github.com/volfpeter/markyp-html>`__'s per-tag element classes onto :data:`turbohtml.build.E`, each benchmarked
-against the builder it replaces - by :user:`gaborbernat`.
+<https://github.com/fabiommendes/hyperpython>`__'s subscript-children syntax, `markyp
+<https://github.com/volfpeter/markyp-html>`__'s per-tag element classes, and `fast-html
+<https://github.com/pcarbonn/fast_html>`__'s generator tags onto :data:`turbohtml.build.E`, each benchmarked against the
+builder it replaces - by :user:`gaborbernat`.

--- a/docs/migration/bench/fast-html.json
+++ b/docs/migration/bench/fast-html.json
@@ -1,0 +1,25 @@
+{
+  "label": "build a list",
+  "parties": [
+    ":data:`E <turbohtml.build.E>`",
+    "fast-html"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "100 rows",
+      0.000147,
+      0.00033
+    ],
+    [
+      "1k rows",
+      0.00168,
+      0.003386
+    ],
+    [
+      "10k rows",
+      0.020189,
+      0.03536
+    ]
+  ]
+}

--- a/docs/migration/fast-html.rst
+++ b/docs/migration/fast-html.rst
@@ -1,0 +1,87 @@
+################
+ From fast-html
+################
+
+.. package-meta:: fast-html pcarbonn/fast_html
+
+`fast-html <https://github.com/pcarbonn/fast_html>`_ assembles HTML in Python from the other direction than a parser:
+each tag function takes its children first (one node or a list) and attributes as trailing keywords, yields the markup
+lazily as a generator of string fragments, and ``render`` joins them. turbohtml replaces it with the terse
+:data:`turbohtml.build.E` builder.
+
+***************
+ Why turbohtml
+***************
+
+turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
+:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
+attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
+edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
+parse it back:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
+
+``E`` assembles the fragment in turbohtml's arena and serializes it in C; fast-html stays in Python. The same ``<ul>``
+of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
+
+.. bench-table::
+    :file: bench/fast-html.json
+
+``E`` is about twice as fast as fast-html, and the decisive difference is the result type: ``E`` hands back a real
+:class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can query, edit,
+and re-:meth:`~turbohtml.Node.serialize`.
+
+*************
+ The renames
+*************
+
+fast-html takes children first and attributes last; turbohtml leads with the attributes:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `fast-html <https://github.com/pcarbonn/fast_html>`__
+      - turbohtml
+    - - ``render(div([h1("Title"), p("body")], class_="card"))``
+      - :data:`E.div({"class": "card"}, E.h1("Title"), E.p("body")) <turbohtml.build.E>` ``.serialize()``; children are
+        plain arguments, no list wrapper
+    - - ``li("text", class_="item", data_i="1")``
+      - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
+
+``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
+attribute joins on a space so a class list reads naturally:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    print(E("my-card", {"class": ["card", "lg"]}, "hi").serialize())
+
+.. testoutput::
+
+    <my-card class="card lg">hi</my-card>
+
+**********
+ Pitfalls
+**********
+
+- ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
+  Serialize the element you built, or append it under a parsed document when you need the full page shell.
+- fast-html mangles keyword arguments (``class_`` to ``class``, ``data_i`` to ``data-i``); ``E`` takes a plain mapping,
+  so write the real attribute name as the dict key -- no underscore convention to remember.
+- fast-html never escapes: ``render(div("<b>"))`` emits the markup verbatim. ``E`` builds text nodes, so the same call
+  serializes as ``&lt;b&gt;``; markup belongs in child elements, not strings.
+- A fast-html tag is a generator, consumed by the ``render`` that joins it; an :class:`~turbohtml.Element` is a tree
+  you can serialize as many times as you like.
+- The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
+  ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/fast-html.rst
+++ b/docs/migration/fast-html.rst
@@ -81,7 +81,7 @@ attribute joins on a space so a class list reads naturally:
   so write the real attribute name as the dict key -- no underscore convention to remember.
 - fast-html never escapes: ``render(div("<b>"))`` emits the markup verbatim. ``E`` builds text nodes, so the same call
   serializes as ``&lt;b&gt;``; markup belongs in child elements, not strings.
-- A fast-html tag is a generator, consumed by the ``render`` that joins it; an :class:`~turbohtml.Element` is a tree
-  you can serialize as many times as you like.
+- A fast-html tag is a generator, consumed by the ``render`` that joins it; an :class:`~turbohtml.Element` is a tree you
+  can serialize as many times as you like.
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -519,6 +519,15 @@ page benchmarks all of them).
             :alt: markyp-html total downloads
             :target: https://pepy.tech/project/markyp-html
     - - 7
+      - :doc:`fast-html <fast-html>`
+      - `docs <https://github.com/pcarbonn/fast_html>`__
+      - .. image:: https://static.pepy.tech/badge/fast-html/month
+            :alt: fast-html monthly downloads
+            :target: https://pepy.tech/project/fast-html
+      - .. image:: https://static.pepy.tech/badge/fast-html
+            :alt: fast-html total downloads
+            :target: https://pepy.tech/project/fast-html
+    - - 8
       - :doc:`simple-html <simple-html>`
       - `docs <https://github.com/keithasaurus/simple_html>`__
       - .. image:: https://static.pepy.tech/badge/simple-html/month
@@ -527,7 +536,7 @@ page benchmarks all of them).
       - .. image:: https://static.pepy.tech/badge/simple-html
             :alt: simple-html total downloads
             :target: https://pepy.tech/project/simple-html
-    - - 8
+    - - 9
       - :doc:`hyperpython <hyperpython>`
       - `docs <https://github.com/fabiommendes/hyperpython>`__
       - .. image:: https://static.pepy.tech/badge/hyperpython/month
@@ -626,6 +635,7 @@ page benchmarks all of them).
     html5-parser
     metadata_parser
     lightningcss
+    fast-html
     simple-html
     hyperpython
     stdlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ bench = [
   "cssselect>=1.4",
   "dominate>=2.9.1",
   "extruct>=0.18",
+  "fast-html>=1.0.12",
   "faust-cchardet>=2.1.19",
   "htbuilder>=0.9",
   "html-sanitizer>=2.6",

--- a/tools/bench/competitors/fast_html.py
+++ b/tools/bench/competitors/fast_html.py
@@ -1,0 +1,16 @@
+"""fast-html: assemble a generator tree with children-first tag calls and ``render``."""
+
+from __future__ import annotations
+
+from fast_html import li, render, ul
+
+REQUIREMENTS = ("fast-html>=1.0.12",)
+
+
+def build_e(count: int) -> None:
+    """Build a ``<ul>`` of rows with fast-html's generator tags and render it."""
+    rows = [li(f"item {index}", class_="item", data_i=str(index)) for index in range(count)]
+    _ = render(ul(rows))
+
+
+OPERATIONS = {"build-e": (build_e, "fast-html")}


### PR DESCRIPTION
fast-html builds HTML lazily: each tag function yields string fragments as a generator, children come first (one node or a list) and mangled keyword attributes trail, and `render` joins the stream. It was the last of the five builders from #322 without a migration guide or benchmark.

The guide maps that shape onto one `turbohtml.build.E` call with a leading attribute mapping and no list wrapper, and warns about the two behavioral gaps: fast-html never escapes string children (`render(div("<b>"))` emits the markup verbatim, `E` serializes `&lt;b&gt;`), and its generators are single-use where an `Element` serializes as many times as you like. The committed feed measures `E` about twice as fast across 100, 1k, and 10k row builds.

Fifth and last of the stacked PRs for #322 (after #356, #357, #358, #359), based on `feat/322-markyp` because they all touch the migration index, the bench dependency group, and the shared changelog fragment. With the builders section now covering all nine libraries, this closes #322.
