### PR TITLE
📝 docs(migration): boilerpy3 migration coverage

### DIFF
--- a/docs/_ext/bench_table.py
+++ b/docs/_ext/bench_table.py
@@ -47,6 +47,7 @@ _HOMEPAGES: Final = {
     "airium": "https://pypi.org/project/airium/",
     "BeautifulSoup": "https://www.crummy.com/software/BeautifulSoup/",
     "bleach": "https://bleach.readthedocs.io/",
+    "boilerpy3": "https://github.com/jmriebold/BoilerPy3",
     "calmjs.parse": "https://github.com/calmjs/calmjs.parse",
     "chardet": "https://chardet.readthedocs.io/",
     "charset-normalizer": "https://charset-normalizer.readthedocs.io/",

--- a/docs/changelog/319.doc.rst
+++ b/docs/changelog/319.doc.rst
@@ -1,0 +1,3 @@
+Migration guides with measured benchmarks for the boilerplate-removal and article-extraction libraries
+:func:`turbohtml.extract.boilerplate` and :meth:`~turbohtml.Node.article` replace: ``boilerpy3`` - by
+:user:`gaborbernat`.

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -157,10 +157,11 @@ boilerplate the heuristic discounts is part of the measured cost.
  Boilerplate classification
 ****************************
 
-:func:`turbohtml.extract.boilerplate` against `justext <https://github.com/miso-belica/jusText>`_, the per-paragraph
-boilerplate classifier. Both segment the page into paragraph units and mark each good or boilerplate; justext scores
-every paragraph in Python over an lxml tree (length, link density, stopword density), where turbohtml scores the tree
-once in C and classifies the units in a thin Python layer. The inputs are the article-extraction pages, so the
+:func:`turbohtml.extract.boilerplate` against `justext <https://github.com/miso-belica/jusText>`_ and `boilerpy3
+<https://github.com/jmriebold/BoilerPy3>`_, the per-block boilerplate classifiers. All three segment the page into units
+and mark each good or boilerplate; justext scores every paragraph in Python over an lxml tree (length, link density,
+stopword density), boilerpy3 classifies the blocks of its own SAX stream with boilerpipe's rules, and turbohtml scores
+the tree once in C and classifies the units in a thin Python layer. The inputs are the article-extraction pages, so the
 navigation and footer each classifier must reject are part of the measured cost.
 
 .. bench-table::

--- a/docs/migration/bench/boilerpy3.json
+++ b/docs/migration/bench/boilerpy3.json
@@ -2,22 +2,19 @@
   "label": "input",
   "parties": [
     "turbohtml",
-    "boilerpy3",
-    "justext"
+    "boilerpy3"
   ],
   "metrics": [],
   "rows": [
     [
       "post (4 KiB)",
       2.76e-05,
-      0.000251,
-      0.000816
+      0.000251
     ],
     [
       "longform (16 KiB)",
       0.000104,
-      0.00087,
-      0.00336
+      0.00087
     ]
   ]
 }

--- a/docs/migration/boilerpy3.rst
+++ b/docs/migration/boilerpy3.rst
@@ -1,0 +1,93 @@
+################
+ From boilerpy3
+################
+
+.. package-meta:: boilerpy3 jmriebold/BoilerPy3
+
+`boilerpy3 <https://github.com/jmriebold/BoilerPy3>`_ is the Python port of boilerpipe, the original boilerplate-removal
+library: an extractor (``ArticleExtractor``, ``CanolaExtractor``, ...) segments a page into text blocks, classifies each
+block content or boilerplate from word counts and link densities, and returns either the surviving text or the
+classified blocks.
+
+***************
+ Why turbohtml
+***************
+
+:func:`turbohtml.extract.boilerplate` answers the same per-block question over the C main-content scoring
+:meth:`~turbohtml.Node.main_content` runs: the scoring picks the content body, every paragraph unit outside it is
+boilerplate, and a unit inside it must still clear the length and link-density thresholds of an
+:class:`~turbohtml.extract.Extraction` config. Each unit comes back a :class:`~turbohtml.extract.Paragraph`, the shape
+of boilerpy3's ``text_blocks`` entries. When you only want the surviving text (boilerpy3's ``get_content``),
+:meth:`~turbohtml.Node.main_text` is the one-call form, and :meth:`~turbohtml.Node.article` adds the metadata harvest
+beside it.
+
+Classifying every block of a full page -- navigation, a scored article, and a footer. turbohtml scores the tree in one C
+pass and classifies the units in a thin Python layer; boilerpy3 parses with its own SAX handler and classifies each
+block in Python. Numbers vary with input and hardware.
+
+.. bench-table::
+    :file: bench/boilerpy3.json
+
+*************
+ The renames
+*************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `boilerpy3 <https://github.com/jmriebold/BoilerPy3>`__
+      - turbohtml
+    - - ``ArticleExtractor().get_content(html)``
+      - ``parse(html).main_text()`` (or ``article().text``)
+    - - ``ArticleExtractor().get_doc(html).text_blocks``
+      - :func:`extract.boilerplate(html) <turbohtml.extract.boilerplate>`
+    - - ``block.text``
+      - ``paragraph.text``, the same field on :class:`~turbohtml.extract.Paragraph`
+    - - ``block.is_content``
+      - ``not paragraph.is_boilerplate``
+    - - ``block.link_density`` cutoffs
+      - :class:`Extraction(max_link_density=...) <turbohtml.extract.Extraction>`
+    - - ``block.num_words`` floors (``NumWordsRulesExtractor``)
+      - :class:`Extraction(min_length=...) <turbohtml.extract.Extraction>`, a character floor
+    - - ``get_doc(html).title``
+      - ``parse(html).article().title``
+    - - ``KeepEverythingExtractor().get_content(html)``
+      - :meth:`~turbohtml.Node.to_text`, the full visible text
+    - - ``get_content_from_url(url)``
+      - fetch the page yourself (``urllib`` or ``httpx``), then parse the markup
+
+.. testcode::
+
+    from turbohtml import parse
+
+    page = (
+        "<body><nav><ul><li><a href='/'>Home</a></li><li><a href='/faq'>FAQ</a></li></ul></nav>"
+        "<article class='post'><h1>Comets</h1>"
+        "<p>A comet is an icy body that releases gas, forming a visible tail, as it nears the Sun.</p>"
+        "</article></body>"
+    )
+    print(parse(page).main_text())
+
+.. testoutput::
+
+    Comets
+
+    A comet is an icy body that releases gas, forming a visible tail, as it nears the Sun.
+
+**********
+ Pitfalls
+**********
+
+- boilerpy3 segments at inline/block transitions of its SAX stream, so a navigation list, a heading, and the first
+  paragraph can fuse into one block; turbohtml emits one :class:`~turbohtml.extract.Paragraph` per block element, so
+  expect more, smaller units at the same total text.
+- The extractor family collapses to configuration: ``ArticleExtractor`` maps to the defaults,
+  ``NumWordsRulesExtractor``-style floors to ``min_length``, and ``KeepEverythingExtractor`` to
+  :meth:`~turbohtml.Node.to_text`. There is no equivalent of ``CanolaExtractor``'s trained rule set.
+- boilerpy3 classifies each block from its neighbors, so two content islands both survive; turbohtml first picks the
+  single best-scoring content body and only units inside it can be good.
+- ``get_doc(html).title`` is usually ``None`` (it needs a marked title block); ``article().title`` harvests the first
+  ``<h1>``, ``og:title``, or ``<title>`` instead.
+- boilerpy3 raises ``HTMLExtractionError`` on markup its parser rejects unless ``raise_on_failure=False``;
+  :func:`turbohtml.parse` follows the WHATWG recovery rules and never raises on malformed input.

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -427,6 +427,15 @@ page benchmarks all of them).
       - .. image:: https://static.pepy.tech/badge/newspaper3k
             :alt: newspaper3k total downloads
             :target: https://pepy.tech/project/newspaper3k
+    - - 7
+      - :doc:`boilerpy3 <boilerpy3>`
+      - `docs <https://github.com/jmriebold/BoilerPy3>`__
+      - .. image:: https://static.pepy.tech/badge/boilerpy3/month
+            :alt: boilerpy3 monthly downloads
+            :target: https://pepy.tech/project/boilerpy3
+      - .. image:: https://static.pepy.tech/badge/boilerpy3
+            :alt: boilerpy3 total downloads
+            :target: https://pepy.tech/project/boilerpy3
 
 *****************
  Structured data
@@ -624,6 +633,7 @@ page benchmarks all of them).
     htmlmin
     csscompressor
     newspaper3k
+    boilerpy3
     html-sanitizer
     yattag
     extruct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ bench = [
   "airium>=0.2.7",
   "beautifulsoup4>=4.15",
   "bleach>=6.4",
+  "boilerpy3>=1.0.7",
   "calmjs-parse>=1.3",
   "chardet>=5.2",
   "charset-normalizer>=3.4",

--- a/tools/bench/competitors/boilerpy3.py
+++ b/tools/bench/competitors/boilerpy3.py
@@ -1,0 +1,17 @@
+"""boilerpy3: the boilerpipe-port block classifier turbohtml.extract.boilerplate succeeds."""
+
+from __future__ import annotations
+
+from boilerpy3 import extractors
+
+REQUIREMENTS = ("boilerpy3>=1.0.7",)
+
+_EXTRACTOR = extractors.ArticleExtractor(raise_on_failure=False)
+
+
+def boilerplate(text: str) -> None:
+    """Classify every text block content or boilerplate with boilerpy3's ArticleExtractor."""
+    _EXTRACTOR.get_doc(text)
+
+
+OPERATIONS = {"boilerplate": (boilerplate, "boilerpy3")}


### PR DESCRIPTION
`boilerpy3` carries boilerpipe, the original boilerplate-removal library, to Python: an extractor segments a page into text blocks and classifies each one content or boilerplate. That is the per-block question `turbohtml.extract.boilerplate()` answers since #362, so this port needs a map rather than new API.

The `From boilerpy3` guide translates the surface: `text_blocks` onto `Paragraph` records, `get_content` onto `main_text()`, `get_doc(html).title` onto `article().title`, the extractor family onto `Extraction` thresholds (`KeepEverythingExtractor` onto `to_text()`), and documents where the models part: boilerpy3 fuses inline runs into blocks and lets several content islands survive, while turbohtml emits one `Paragraph` per block element inside the single best-scoring content body. On the three mozilla/readability corpus pages the bench suite vendors, the surviving text overlaps boilerpy3's `ArticleExtractor` at 0.66-0.92 word Jaccard.

The measured `bench` feed shows turbohtml 8-9x faster on the shared article pages (28 µs vs 251 µs on the 4 KiB post, 104 µs vs 870 µs on the 16 KiB longform); the boilerpy3 competitor module joins the `boilerplate` op and the three-party feed lands in `performance.rst`. The migration index gains boilerpy3 in the extraction section by download rank.

Second of five stacked PRs for the extraction-shim campaign (justext #362 → boilerpy3 → goose3 → readabilipy → news-please); only the last closes the issue. Part of #319.
