### PR TITLE
📝 docs(migration): goose3 migration coverage

### DIFF
--- a/docs/_ext/bench_table.py
+++ b/docs/_ext/bench_table.py
@@ -58,6 +58,7 @@ _HOMEPAGES: Final = {
     "extruct": "https://github.com/scrapinghub/extruct",
     "fast-html": "https://github.com/pcarbonn/fast_html",
     "faust-cchardet": "https://github.com/faust-streaming/cChardet",
+    "goose3": "https://goose3.readthedocs.io/",
     "html-sanitizer": "https://github.com/matthiask/html-sanitizer",
     "html-text": "https://github.com/zytedata/html-text",
     "html.escape": "https://docs.python.org/3/library/html.html",

--- a/docs/changelog/319.doc.rst
+++ b/docs/changelog/319.doc.rst
@@ -1,3 +1,3 @@
 Migration guides with measured benchmarks for the boilerplate-removal and article-extraction libraries
-:func:`turbohtml.extract.boilerplate` and :meth:`~turbohtml.Node.article` replace: ``boilerpy3`` - by
+:func:`turbohtml.extract.boilerplate` and :meth:`~turbohtml.Node.article` replace: ``boilerpy3`` and ``goose3`` - by
 :user:`gaborbernat`.

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -144,11 +144,11 @@ the smallest, where pandas pays its fixed per-frame construction cost.
 ********************
 
 :meth:`turbohtml.Node.article` against `trafilatura <https://trafilatura.readthedocs.io>`_, `readability-lxml
-<https://github.com/buriy/python-readability>`_, and `newspaper3k <https://newspaper.readthedocs.io>`_, the article
-extractors it succeeds. Each scores the dominant content body and (trafilatura and newspaper3k) harvests the page
-metadata beside it; the others build an lxml tree in Python first, where turbohtml does the scoring and the harvest in
-one C pass over the parsed tree. The inputs are full pages -- navigation, a scored article, and a footer -- so the
-boilerplate the heuristic discounts is part of the measured cost.
+<https://github.com/buriy/python-readability>`_, `newspaper3k <https://newspaper.readthedocs.io>`_, and `goose3
+<https://goose3.readthedocs.io>`_, the article extractors it succeeds. Each scores the dominant content body and
+(trafilatura, newspaper3k, and goose3) harvests the page metadata beside it; the others build an lxml tree in Python
+first, where turbohtml does the scoring and the harvest in one C pass over the parsed tree. The inputs are full pages --
+navigation, a scored article, and a footer -- so the boilerplate the heuristic discounts is part of the measured cost.
 
 .. bench-table::
     :file: bench/article-extraction.json

--- a/docs/migration/bench/goose3.json
+++ b/docs/migration/bench/goose3.json
@@ -2,28 +2,19 @@
   "label": "input",
   "parties": [
     "turbohtml",
-    "goose3",
-    "newspaper3k",
-    "readability-lxml",
-    "trafilatura"
+    "goose3"
   ],
   "metrics": [],
   "rows": [
     [
       "post (4 KiB)",
       9.65e-06,
-      0.00274,
-      0.00196,
-      0.000552,
-      0.000662
+      0.00274
     ],
     [
       "longform (16 KiB)",
       3.56e-05,
-      0.00902,
-      0.00561,
-      0.00153,
-      0.00178
+      0.00902
     ]
   ]
 }

--- a/docs/migration/goose3.rst
+++ b/docs/migration/goose3.rst
@@ -1,0 +1,91 @@
+#############
+ From goose3
+#############
+
+.. package-meta:: goose3 goose3/goose3
+
+`goose3 <https://goose3.readthedocs.io>`_ is an article extractor in the newspaper mold: ``Goose().extract(url=...)``
+(or ``raw_html=...``) fetches a page, scores the content body on an lxml tree, runs its cleaners over the winner, and
+returns an ``Article`` carrying the cleaned text alongside the harvested metadata, images, and embedded media.
+
+***************
+ Why turbohtml
+***************
+
+:meth:`~turbohtml.Node.article` fills the same contract in one C pass over the parsed tree: the content-density scoring
+picks the body and the metadata harvest fills the :class:`~turbohtml.Article` record (``element``, ``text``, ``title``,
+``byline``, ``date``, ``description``, ``lang``) from the page's declared sources. turbohtml works on HTML you already
+have, so pair it with a downloader (``urllib`` or ``httpx``) where goose fetches for you.
+
+Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
+:meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; goose3 builds an lxml tree,
+scores it, and runs its cleaner chain in Python. Numbers vary with input and hardware.
+
+.. bench-table::
+    :file: bench/goose3.json
+
+*************
+ The renames
+*************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `goose3 <https://goose3.readthedocs.io/>`__
+      - turbohtml
+    - - ``Goose().extract(raw_html=html)``
+      - ``parse(html).article()``
+    - - ``article.title``
+      - ``article().title``
+    - - ``article.cleaned_text``
+      - ``article().text``
+    - - ``article.authors`` (a list)
+      - ``article().byline`` (the first author source, one string)
+    - - ``article.publish_date``
+      - ``article().date``
+    - - ``article.meta_description``
+      - ``article().description``
+    - - ``article.meta_lang``
+      - ``article().lang``
+    - - ``article.top_node``
+      - ``article().element`` (the scored element, ``None`` when nothing reads as content)
+    - - ``article.opengraph``
+      - :meth:`doc.opengraph() <turbohtml.Document.opengraph>`
+    - - ``article.links``
+      - :meth:`doc.links() <turbohtml.Node.links>`
+
+.. testcode::
+
+    from turbohtml import parse
+
+    doc = parse(
+        "<html lang=en><head><title>Comets</title>"
+        "<meta property=article:published_time content='2024-05-06'>"
+        "<meta name=description content='A short guide to comets.'></head>"
+        "<body><article class=post><h1>Comets</h1>"
+        "<p>By <a rel=author href='/u'>Ada Lovelace</a></p>"
+        "<p>A comet is an icy body that releases gas, forming a visible tail, as it nears the Sun.</p>"
+        "</article></body></html>"
+    )
+    art = doc.article()
+    print(art.title, "|", art.byline, "|", art.date, "|", art.description)
+
+.. testoutput::
+
+    Comets | Ada Lovelace | 2024-05-06 | A short guide to comets.
+
+**********
+ Pitfalls
+**********
+
+- goose3 downloads URLs (``extract(url=...)``); :meth:`~turbohtml.Node.article` takes parsed HTML. Fetch the page
+  yourself and pass the markup to :func:`turbohtml.parse`.
+- ``article().byline`` is one whitespace-folded string from the first author source; goose's ``authors`` is a list, so a
+  multi-author page keeps only the first name.
+- Both report the date the page declares, from different preferred sources (a ``<time>`` first for turbohtml,
+  ``article:published_time`` first for goose), so the same page can answer with two spellings of the same instant.
+- ``article().title`` prefers the first ``<h1>``, then ``og:title``, then ``<title>``; goose starts from ``<title>`` and
+  splits site-name suffixes off, so pages whose ``<h1>`` and ``<title>`` disagree yield different titles.
+- goose's image (``top_image``, ``infography``) and embed (``movies``, ``tweets``) extraction, its language-specific
+  stopword configuration, and video handling have no turbohtml equivalent and are out of scope.

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -436,6 +436,15 @@ page benchmarks all of them).
       - .. image:: https://static.pepy.tech/badge/boilerpy3
             :alt: boilerpy3 total downloads
             :target: https://pepy.tech/project/boilerpy3
+    - - 8
+      - :doc:`goose3 <goose3>`
+      - `docs <https://goose3.readthedocs.io/>`__
+      - .. image:: https://static.pepy.tech/badge/goose3/month
+            :alt: goose3 monthly downloads
+            :target: https://pepy.tech/project/goose3
+      - .. image:: https://static.pepy.tech/badge/goose3
+            :alt: goose3 total downloads
+            :target: https://pepy.tech/project/goose3
 
 *****************
  Structured data
@@ -643,6 +652,7 @@ page benchmarks all of them).
     csscompressor
     newspaper3k
     boilerpy3
+    goose3
     html-sanitizer
     yattag
     extruct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ bench = [
   "extruct>=0.18",
   "fast-html>=1.0.12",
   "faust-cchardet>=2.1.19",
+  "goose3>=3.1.19",
   "htbuilder>=0.9",
   "html-sanitizer>=2.6",
   "html-text>=0.7.1",

--- a/tools/bench/competitors/goose3.py
+++ b/tools/bench/competitors/goose3.py
@@ -1,0 +1,17 @@
+"""goose3: the lxml-backed article extractor turbohtml.article succeeds."""
+
+from __future__ import annotations
+
+from goose3 import Goose
+
+REQUIREMENTS = ("goose3>=3.1.19",)
+
+_GOOSE = Goose({"enable_image_fetching": False})
+
+
+def article(text: str) -> None:
+    """Extract the content body and metadata with goose3, cleaning an lxml tree."""
+    _GOOSE.extract(raw_html=text)
+
+
+OPERATIONS = {"article": (article, "goose3")}

--- a/tools/bench/competitors/newspaper3k.py
+++ b/tools/bench/competitors/newspaper3k.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from newspaper import Article
 
-REQUIREMENTS = ("newspaper3k>=0.2.8",)
+# lxml-html-clean restores the lxml.html.clean module newspaper imports, split out of lxml 5.2
+REQUIREMENTS = ("newspaper3k>=0.2.8", "lxml-html-clean>=0.4.5")
 
 
 def article(text: str) -> None:


### PR DESCRIPTION
`goose3` answers the question `article()` already answers: score the content body of a page and harvest the title, authors, date, description, and language beside it. The port therefore needs a rename map, and this PR ships it: `cleaned_text` onto `article().text`, `authors` onto the single `byline` string, `top_node` onto `element`, `opengraph`/`links` onto the document methods, with pitfalls recording where the two legitimately differ (title source preference: first `<h1>` vs a split `<title>`; both report the declared date, from different preferred sources).

The measured `bench` feed puts turbohtml 250-280x ahead of goose3 on the shared article pages (9.6 µs vs 2.7 ms on the 4 KiB post); goose3 also trails trafilatura, readability-lxml, and newspaper3k, so `performance.rst` gains the regenerated five-party `article` feed. On the three mozilla/readability corpus pages, `article().text` overlaps goose3's `cleaned_text` at 0.52-0.91 word Jaccard, with byline, date, and language agreeing on the news article.

Regenerating that feed surfaced bench bitrot: newspaper3k imports `lxml.html.clean`, which lxml 5.2 split into `lxml_html_clean`, so its isolated venv now aborts the whole `article` run. Its `REQUIREMENTS` gain the shim package.

Third of five stacked PRs for the extraction-shim campaign (justext #362 → boilerpy3 #364 → goose3 → readabilipy → news-please); only the last closes the issue. Part of #319.
