### PR TITLE
✨ feat(extract): microdata get_items shim (microdata)

### DIFF
--- a/docs/changelog/323.feature.rst
+++ b/docs/changelog/323.feature.rst
@@ -1,0 +1,5 @@
+Extract HTML Microdata items with :func:`turbohtml.extract.microdata`, the ``microdata.get_items`` call shape over the
+existing C walk. The returned :class:`~turbohtml.MicrodataItem` records gain :meth:`~turbohtml.MicrodataItem.get`,
+:meth:`~turbohtml.MicrodataItem.get_all`, and :meth:`~turbohtml.MicrodataItem.json` accessors matching the ``microdata``
+library's ``Item``, so turbohtml replaces it with a migration guide and benchmark (35-42x faster) - by
+:user:`gaborbernat`.

--- a/docs/migration/bench/microdata.json
+++ b/docs/migration/bench/microdata.json
@@ -1,0 +1,20 @@
+{
+  "label": "structured-data extraction",
+  "parties": [
+    "turbohtml",
+    "microdata"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "product",
+      7.002900061081618e-06,
+      0.00024479611016658964
+    ],
+    [
+      "catalog 8 KiB",
+      5.9403084301834495e-05,
+      0.00246606565615366
+    ]
+  ]
+}

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -504,6 +504,15 @@ page benchmarks all of them).
       - .. image:: https://static.pepy.tech/badge/metadata_parser
             :alt: metadata_parser total downloads
             :target: https://pepy.tech/project/metadata_parser
+    - - 3
+      - :doc:`microdata <microdata>`
+      - `docs <https://github.com/edsu/microdata>`__
+      - .. image:: https://static.pepy.tech/badge/microdata/month
+            :alt: microdata monthly downloads
+            :target: https://pepy.tech/project/microdata
+      - .. image:: https://static.pepy.tech/badge/microdata
+            :alt: microdata total downloads
+            :target: https://pepy.tech/project/microdata
 
 ***************
  HTML builders
@@ -694,6 +703,7 @@ page benchmarks all of them).
     markyp
     html5-parser
     metadata_parser
+    microdata
     lightningcss
     fast-html
     simple-html

--- a/docs/migration/microdata.rst
+++ b/docs/migration/microdata.rst
@@ -1,0 +1,112 @@
+################
+ From microdata
+################
+
+.. package-meta:: microdata edsu/microdata
+
+`microdata <https://github.com/edsu/microdata>`_ pulls the HTML Microdata items a page embeds: ``get_items(html)`` builds
+an html5lib tree, walks its ``itemscope`` elements, and returns ``Item`` objects you read with ``.itemtype``,
+``.get``/``.get_all``, and ``.json``. turbohtml serves that surface from :func:`turbohtml.extract.microdata` over the
+same C walk :meth:`turbohtml.Document.microdata` runs.
+
+***************
+ Why turbohtml
+***************
+
+:func:`turbohtml.extract.microdata` returns the page's top-level items as :class:`~turbohtml.MicrodataItem` records with
+the same accessors -- :meth:`~turbohtml.MicrodataItem.get`, :meth:`~turbohtml.MicrodataItem.get_all`, and
+:meth:`~turbohtml.MicrodataItem.json` -- so a nested property that is itself an ``itemscope`` comes back as a nested
+:class:`~turbohtml.MicrodataItem` rather than a flat string:
+
+.. testcode::
+
+    from turbohtml.extract import microdata
+
+    item = microdata(
+        '<div itemscope itemtype="https://schema.org/Person">'
+        '<span itemprop="name">Ada</span>'
+        '<span itemprop="name">Lovelace</span>'
+        '<div itemprop="address" itemscope><span itemprop="city">London</span></div>'
+        "</div>"
+    )[0]
+    print(item.type)
+    print(item.get("name"), item.get_all("name"))
+    print(item.get("address").get("city"))
+
+.. testoutput::
+
+    https://schema.org/Person
+    Ada ['Ada', 'Lovelace']
+    London
+
+``microdata`` starts from the raw HTML string, so it parses before it extracts: it builds an html5lib tree and walks the
+``itemscope`` elements in Python, where :func:`~turbohtml.extract.microdata` parses to the WHATWG tree and gathers the
+items in one C walk. On a product page carrying Microdata alongside JSON-LD and OpenGraph, and on an 8 KiB catalog of the
+same, the walk runs 35 to 42 times faster:
+
+.. bench-table::
+    :file: bench/microdata.json
+
+Over the fixtures in ``microdata``'s own test suite the two libraries return byte-identical ``json()`` for every page
+but one, where turbohtml follows the spec more closely (see :ref:`microdata-divergences`).
+
+*************
+ The renames
+*************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `microdata <https://github.com/edsu/microdata>`__
+      - turbohtml
+    - - ``microdata.get_items(html)``
+      - :func:`turbohtml.extract.microdata`
+    - - ``item.itemtype`` (a list of ``URI``)
+      - :attr:`item.type <turbohtml.MicrodataItem.type>` (the ``itemtype`` string verbatim)
+    - - ``item.itemid``
+      - :attr:`item.id <turbohtml.MicrodataItem.id>`
+    - - ``item.props``
+      - :attr:`item.properties <turbohtml.MicrodataItem.properties>`
+    - - ``item.get(name)`` / ``item.get_all(name)``
+      - :meth:`~turbohtml.MicrodataItem.get` / :meth:`~turbohtml.MicrodataItem.get_all`
+    - - ``item.json()``
+      - :meth:`~turbohtml.MicrodataItem.json`
+
+The items are frozen records that hold no reference back into the tree, so you can keep them after the document is gone:
+
+.. testcode::
+
+    item = microdata('<div itemscope itemid="urn:isbn:1"><span itemprop="name">B</span></div>')[0]
+    print(item.id, item.json())
+
+.. testoutput::
+
+    urn:isbn:1 {
+      "id": "urn:isbn:1",
+      "properties": {
+        "name": [
+          "B"
+        ]
+      }
+    }
+
+.. _microdata-divergences:
+
+**********
+ Pitfalls
+**********
+
+- ``item.itemtype`` is a list of ``URI`` objects (``item.itemtype[0].string``); :attr:`~turbohtml.MicrodataItem.type`
+  is the raw ``itemtype`` string, which the `WHATWG spec <https://html.spec.whatwg.org/multipage/microdata.html>`_
+  treats as a space-separated token set. Call ``.type.split()`` for the list, the form
+  :meth:`~turbohtml.MicrodataItem.json` emits.
+- A text property's value is the element's ``textContent`` per the spec, so a ``<script>`` or ``<style>`` nested inside
+  a property element contributes its text; ``microdata`` drops that text. This is the one page in ``microdata``'s
+  fixtures where the ``json()`` output differs.
+- :meth:`~turbohtml.MicrodataItem.get` returns the first value or ``None`` and :meth:`~turbohtml.MicrodataItem.get_all`
+  returns the list or ``[]``, matching ``Item.get``/``Item.get_all``; a property that is itself an ``itemscope`` comes
+  back as a nested :class:`~turbohtml.MicrodataItem`, not a string.
+- :func:`~turbohtml.extract.microdata` reparses the string on each call. Hold a :func:`turbohtml.parse` document and
+  call :meth:`~turbohtml.Document.microdata` when you also need :meth:`~turbohtml.Document.json_ld` or
+  :meth:`~turbohtml.Document.opengraph` off the same page.

--- a/docs/migration/microdata.rst
+++ b/docs/migration/microdata.rst
@@ -4,8 +4,8 @@
 
 .. package-meta:: microdata edsu/microdata
 
-`microdata <https://github.com/edsu/microdata>`_ pulls the HTML Microdata items a page embeds: ``get_items(html)`` builds
-an html5lib tree, walks its ``itemscope`` elements, and returns ``Item`` objects you read with ``.itemtype``,
+`microdata <https://github.com/edsu/microdata>`_ pulls the HTML Microdata items a page embeds: ``get_items(html)``
+builds an html5lib tree, walks its ``itemscope`` elements, and returns ``Item`` objects you read with ``.itemtype``,
 ``.get``/``.get_all``, and ``.json``. turbohtml serves that surface from :func:`turbohtml.extract.microdata` over the
 same C walk :meth:`turbohtml.Document.microdata` runs.
 
@@ -41,8 +41,8 @@ the same accessors -- :meth:`~turbohtml.MicrodataItem.get`, :meth:`~turbohtml.Mi
 
 ``microdata`` starts from the raw HTML string, so it parses before it extracts: it builds an html5lib tree and walks the
 ``itemscope`` elements in Python, where :func:`~turbohtml.extract.microdata` parses to the WHATWG tree and gathers the
-items in one C walk. On a product page carrying Microdata alongside JSON-LD and OpenGraph, and on an 8 KiB catalog of the
-same, the walk runs 35 to 42 times faster:
+items in one C walk. On a product page carrying Microdata alongside JSON-LD and OpenGraph, and on an 8 KiB catalog of
+the same, the walk runs 35 to 42 times faster:
 
 .. bench-table::
     :file: bench/microdata.json
@@ -97,10 +97,10 @@ The items are frozen records that hold no reference back into the tree, so you c
  Pitfalls
 **********
 
-- ``item.itemtype`` is a list of ``URI`` objects (``item.itemtype[0].string``); :attr:`~turbohtml.MicrodataItem.type`
-  is the raw ``itemtype`` string, which the `WHATWG spec <https://html.spec.whatwg.org/multipage/microdata.html>`_
-  treats as a space-separated token set. Call ``.type.split()`` for the list, the form
-  :meth:`~turbohtml.MicrodataItem.json` emits.
+- ``item.itemtype`` is a list of ``URI`` objects (``item.itemtype[0].string``); :attr:`~turbohtml.MicrodataItem.type` is
+  the raw ``itemtype`` string, which the `WHATWG spec <https://html.spec.whatwg.org/multipage/microdata.html>`_ treats
+  as a space-separated token set. Call ``.type.split()`` for the list, the form :meth:`~turbohtml.MicrodataItem.json`
+  emits.
 - A text property's value is the element's ``textContent`` per the spec, so a ``<script>`` or ``<style>`` nested inside
   a property element contributes its text; ``microdata`` drops that text. This is the one page in ``microdata``'s
   fixtures where the ``json()`` output differs.

--- a/docs/reference/extract.rst
+++ b/docs/reference/extract.rst
@@ -31,3 +31,11 @@ The URL helpers are successors to ``courlan`` and the ``w3lib.url`` canonicaliza
 
 .. autoclass:: UrlCleaning
     :members: w3lib
+
+:func:`microdata` extracts a page's top-level HTML Microdata items, the ``microdata.get_items`` call shape
+(:doc:`microdata guide </migration/microdata>`). It returns :class:`~turbohtml.MicrodataItem` records whose
+:meth:`~turbohtml.MicrodataItem.get`, :meth:`~turbohtml.MicrodataItem.get_all`, and
+:meth:`~turbohtml.MicrodataItem.json` accessors mirror the library's ``Item`` (documented under
+:doc:`/reference/structured-data`).
+
+.. autofunction:: microdata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ bench = [
   "markdownify>=1.2.2",
   "markupsafe>=3.0.3",
   "markyp-html>=0.2306.2",
+  "microdata>=0.8",
   "minify-html>=0.18.1",
   "newspaper3k>=0.2.8",
   "nh3>=0.3.6",

--- a/src/turbohtml/_structured_data.py
+++ b/src/turbohtml/_structured_data.py
@@ -40,6 +40,19 @@ class MicrodataItem:
     properties: dict[str, list[str | MicrodataItem]]
     """each ``itemprop`` name mapped to its values in document order."""
 
+    def get(self, name: str) -> str | MicrodataItem | None:
+        """Return the property's first value, or ``None`` when the item lacks it (``microdata.Item.get``)."""
+        values = self.properties.get(name)
+        return values[0] if values else None
+
+    def get_all(self, name: str) -> list[str | MicrodataItem]:
+        """Return the property's values in document order, an empty list when absent (``microdata.Item.get_all``)."""
+        return self.properties.get(name, [])
+
+    def json(self) -> str:
+        """Serialize as ``microdata.Item.json`` does: a two-space-indented JSON object of the tree below the item."""
+        return json.dumps(_as_dict(self), indent=2)
+
 
 @dataclass(frozen=True, slots=True)
 class StructuredData:
@@ -63,6 +76,20 @@ class StructuredData:
     """reserved for a later phase, an empty list for now."""
     rdfa: list[JSONValue]
     """reserved for a later phase, an empty list for now."""
+
+
+def _as_dict(item: MicrodataItem) -> dict[str, JSONValue]:
+    """Render the item as nested plain dicts: ``type`` (whitespace-split), ``id``, and its properties recursively."""
+    result: dict[str, JSONValue] = {}
+    if item.type is not None:
+        result["type"] = item.type.split()
+    if item.id is not None:
+        result["id"] = item.id
+    result["properties"] = {
+        name: [_as_dict(value) if isinstance(value, MicrodataItem) else value for value in values]
+        for name, values in item.properties.items()
+    }
+    return result
 
 
 def _parse_json_ld(texts: list[str]) -> list[JSONValue]:

--- a/src/turbohtml/extract.py
+++ b/src/turbohtml/extract.py
@@ -14,6 +14,10 @@ the length and link-density thresholds a frozen :class:`Extraction` config carri
 
 The URL helpers live here directly: :func:`clean_url`, :func:`normalize_url`, and :func:`extract_links`, configured
 by a frozen :class:`UrlCleaning`, replace ``courlan`` and the ``w3lib.url`` canonicalization surface.
+
+:func:`microdata` gives the ``microdata`` library's ``get_items(html)`` entry point over the same C walk
+:meth:`turbohtml.Document.microdata` runs, returning the :class:`MicrodataItem` records whose ``.get``/``.get_all``/
+``.json`` accessors mirror that library's ``Item``.
 """
 
 from __future__ import annotations
@@ -38,6 +42,7 @@ __all__ = [
     "boilerplate",
     "clean_url",
     "extract_links",
+    "microdata",
     "normalize_url",
 ]
 
@@ -95,6 +100,22 @@ class Extraction:
 
 
 _DEFAULT: Final = Extraction()
+
+
+def microdata(html: str, /) -> list[MicrodataItem]:
+    """
+    Extract a page's top-level HTML Microdata items, the successor to ``microdata.get_items(html)``.
+
+    Each returned :class:`~turbohtml.MicrodataItem` carries the ``itemtype`` as
+    :attr:`~turbohtml.MicrodataItem.type`, the ``itemid`` as :attr:`~turbohtml.MicrodataItem.id`, and the ``itemprop``
+    values under :attr:`~turbohtml.MicrodataItem.properties`, with :meth:`~turbohtml.MicrodataItem.get`,
+    :meth:`~turbohtml.MicrodataItem.get_all`, and :meth:`~turbohtml.MicrodataItem.json` matching the library's ``Item``.
+    Shorthand for :meth:`turbohtml.Document.microdata` when a page string is all you hold.
+
+    :param html: the page markup.
+    :returns: one :class:`~turbohtml.MicrodataItem` per top-level ``itemscope`` element, in document order.
+    """
+    return parse(html).microdata()
 
 
 def boilerplate(html: str, options: Extraction | None = None, /) -> list[Paragraph]:

--- a/tests/features/test_extract_microdata.py
+++ b/tests/features/test_extract_microdata.py
@@ -1,0 +1,84 @@
+"""microdata: the extract.microdata entry point and the MicrodataItem get/get_all/json accessors."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from turbohtml import MicrodataItem, parse
+from turbohtml.extract import microdata
+
+_NESTED = (
+    '<div itemscope itemtype="https://schema.org/Person">'
+    '<span itemprop="name">Ada</span>'
+    '<span itemprop="name">Lovelace</span>'
+    '<div itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">'
+    '<span itemprop="city">London</span>'
+    "</div>"
+    "</div>"
+)
+
+
+def test_microdata_returns_top_level_items() -> None:
+    items = microdata('<div itemscope><span itemprop="name">Ada</span></div>')
+    assert items == [MicrodataItem(type=None, id=None, properties={"name": ["Ada"]})]
+
+
+def test_microdata_matches_document_method() -> None:
+    assert microdata(_NESTED) == parse(_NESTED).microdata()
+
+
+def test_microdata_empty_without_items() -> None:
+    assert microdata("<p>nothing here</p>") == []
+
+
+@pytest.fixture
+def person() -> MicrodataItem:
+    return microdata(_NESTED)[0]
+
+
+def test_get_returns_first_value(person: MicrodataItem) -> None:
+    assert person.get("name") == "Ada"
+
+
+def test_get_returns_nested_item(person: MicrodataItem) -> None:
+    assert person.get("address") == MicrodataItem(
+        type="https://schema.org/PostalAddress", id=None, properties={"city": ["London"]}
+    )
+
+
+def test_get_missing_property_is_none(person: MicrodataItem) -> None:
+    assert person.get("missing") is None
+
+
+def test_get_all_returns_every_value(person: MicrodataItem) -> None:
+    assert person.get_all("name") == ["Ada", "Lovelace"]
+
+
+def test_get_all_missing_property_is_empty(person: MicrodataItem) -> None:
+    assert person.get_all("missing") == []
+
+
+def test_json_renders_type_id_and_nested_tree() -> None:
+    item = microdata(
+        '<div itemscope itemtype="https://schema.org/Book https://schema.org/Thing" itemid="urn:isbn:1">'
+        '<span itemprop="name">B</span>'
+        '<div itemprop="author" itemscope><span itemprop="name">A</span></div>'
+        "</div>"
+    )[0]
+    assert json.loads(item.json()) == {
+        "type": ["https://schema.org/Book", "https://schema.org/Thing"],
+        "id": "urn:isbn:1",
+        "properties": {"name": ["B"], "author": [{"properties": {"name": ["A"]}}]},
+    }
+
+
+def test_json_omits_absent_type_and_id() -> None:
+    item = microdata('<div itemscope><span itemprop="name">Ada</span></div>')[0]
+    assert json.loads(item.json()) == {"properties": {"name": ["Ada"]}}
+
+
+def test_json_is_two_space_indented() -> None:
+    item = microdata('<div itemscope><span itemprop="name">Ada</span></div>')[0]
+    assert item.json() == '{\n  "properties": {\n    "name": [\n      "Ada"\n    ]\n  }\n}'

--- a/tools/bench/competitors/microdata.py
+++ b/tools/bench/competitors/microdata.py
@@ -1,0 +1,15 @@
+"""microdata: html5lib-based Microdata item extraction, the competitor to turbohtml's microdata surface."""
+
+from __future__ import annotations
+
+import microdata
+
+REQUIREMENTS = ("microdata>=0.8",)
+
+
+def structured(text: str) -> None:
+    """Pull the page's Microdata items, which builds an html5lib tree and walks its itemscope elements."""
+    microdata.get_items(text)
+
+
+OPERATIONS = {"structured": (structured, "microdata")}


### PR DESCRIPTION
The C walk behind `Document.microdata` already returns every top-level HTML Microdata item, but nothing offered the shape the [`microdata`](https://github.com/edsu/microdata) library exposes: `get_items(html)` and an `Item` you read through `.get`/`.get_all`/`.json`. Anyone porting from that library had no drop-in, so `microdata` sat unmapped and unbenchmarked in the coverage plan for #313.

`turbohtml.extract.microdata(html)` reparses a page string and returns the existing `MicrodataItem` records, which now carry `get`, `get_all`, and `json` accessors matching `microdata.Item`: `get` answers the first value or `None`, `get_all` the list or `[]`, and `json` serializes the two-space-indented tree the library emits, with `itemtype` as a whitespace-split list and a nested `itemscope` property recursed as a child object. 🧩 No new engine lands here; this is the accessor layer plus a page-string entry point over the walk that already exists.

The `json()` output follows the [WHATWG microdata spec](https://html.spec.whatwg.org/multipage/microdata.html): a text property's value is the element's `textContent`, so a `<script>` nested inside a property element contributes its text where the library drops it. Over `microdata`'s own fixtures the two agree byte-for-byte on `json()` for every page but that one spec point, which the guide calls out. The existing `structured` benchmark op times the walk at 35-42x faster than `microdata` on a product page and an 8 KiB catalog.

part of #313, part of #323
