### PR TITLE
✨ feat(extract): opengraph card shim (opengraph)

### DIFF
--- a/docs/changelog/323.feature.rst
+++ b/docs/changelog/323.feature.rst
@@ -3,3 +3,8 @@ existing C walk. The returned :class:`~turbohtml.MicrodataItem` records gain :me
 :meth:`~turbohtml.MicrodataItem.get_all`, and :meth:`~turbohtml.MicrodataItem.json` accessors matching the ``microdata``
 library's ``Item``, so turbohtml replaces it with a migration guide and benchmark (35-42x faster) - by
 :user:`gaborbernat`.
+
+Extract a page's Open Graph card with :func:`turbohtml.extract.opengraph`, the ``opengraph`` library's
+``OpenGraph(html=...)`` call shape over the same walk. It returns an :class:`~turbohtml.extract.OpenGraph` mapping keyed
+by the ``og:``-stripped property names with an :meth:`~turbohtml.extract.OpenGraph.is_valid` check, so turbohtml
+replaces ``opengraph``/``opengraph_py3`` with a migration guide and benchmark (94-133x faster) - by :user:`gaborbernat`.

--- a/docs/migration/bench/opengraph.json
+++ b/docs/migration/bench/opengraph.json
@@ -1,0 +1,20 @@
+{
+  "label": "social-card extraction",
+  "parties": [
+    "turbohtml",
+    "opengraph"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "head",
+      1.8750061053118827e-06,
+      0.00017645677710333984
+    ],
+    [
+      "article 8 KiB",
+      2.7699301145389655e-05,
+      0.0036775625612790463
+    ]
+  ]
+}

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -513,6 +513,15 @@ page benchmarks all of them).
       - .. image:: https://static.pepy.tech/badge/microdata
             :alt: microdata total downloads
             :target: https://pepy.tech/project/microdata
+    - - 4
+      - :doc:`opengraph <opengraph>`
+      - `docs <https://pypi.org/project/opengraph-py3/>`__
+      - .. image:: https://static.pepy.tech/badge/opengraph-py3/month
+            :alt: opengraph-py3 monthly downloads
+            :target: https://pepy.tech/project/opengraph-py3
+      - .. image:: https://static.pepy.tech/badge/opengraph-py3
+            :alt: opengraph-py3 total downloads
+            :target: https://pepy.tech/project/opengraph-py3
 
 ***************
  HTML builders
@@ -704,6 +713,7 @@ page benchmarks all of them).
     html5-parser
     metadata_parser
     microdata
+    opengraph
     lightningcss
     fast-html
     simple-html

--- a/docs/migration/opengraph.rst
+++ b/docs/migration/opengraph.rst
@@ -1,0 +1,104 @@
+################
+ From opengraph
+################
+
+.. package-meta:: opengraph-py3 erikriver/opengraph
+
+`opengraph <https://pypi.org/project/opengraph-py3/>`_ (the ``opengraph_py3`` Python 3 fork of erikriver's
+``opengraph``) reads a page's Open Graph card: ``OpenGraph(html=...)`` builds a BeautifulSoup tree, scans the head for
+``og:``-prefixed ``<meta>`` tags, and returns a ``dict`` subclass keyed by the property name minus its ``og:`` prefix,
+with ``is_valid()`` reporting whether the required tags are present. turbohtml serves that shape from
+:func:`turbohtml.extract.opengraph` over :meth:`turbohtml.Document.opengraph`.
+
+***************
+ Why turbohtml
+***************
+
+:func:`turbohtml.extract.opengraph` returns an :class:`~turbohtml.extract.OpenGraph` mapping with the same
+prefix-stripped keys, so ``og["title"]`` reads the ``og:title`` tag, and the same
+:meth:`~turbohtml.extract.OpenGraph.is_valid` check. It is a read-only mapping, so ``in``, ``.get``, iteration, and
+equality against a plain ``dict`` all work, and it holds no reference back into the tree:
+
+.. testcode::
+
+    from turbohtml.extract import opengraph
+
+    og = opengraph(
+        "<head>"
+        '<meta property="og:title" content="The Rock">'
+        '<meta property="og:type" content="video.movie">'
+        '<meta property="og:image" content="https://x/rock.jpg">'
+        '<meta property="og:url" content="https://x/tt0117500/">'
+        '<meta name="twitter:card" content="summary">'
+        "</head>"
+    )
+    print(og["title"])
+    print(dict(og))
+    print(og.is_valid())
+
+.. testoutput::
+
+    The Rock
+    {'title': 'The Rock', 'type': 'video.movie', 'image': 'https://x/rock.jpg', 'url': 'https://x/tt0117500/'}
+    True
+
+Both libraries start from the raw HTML string, so each parses before it reads the tags: ``opengraph`` builds a
+BeautifulSoup tree (over html5lib) and scans the head in Python, where :func:`~turbohtml.extract.opengraph` parses to
+the WHATWG tree and gathers the ``og:`` tags in one C walk. On a social-card head, and on an 8 KiB article carrying that
+head, the walk runs 94 to 133 times faster:
+
+.. bench-table::
+    :file: bench/opengraph.json
+
+Across hand-built cards covering the protocol's basic, structured-image, and required-tag shapes, the two libraries
+return byte-identical mappings.
+
+*************
+ The renames
+*************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `opengraph <https://pypi.org/project/opengraph-py3/>`__
+      - turbohtml
+    - - ``OpenGraph(html=html)``
+      - :func:`turbohtml.extract.opengraph`
+    - - ``OpenGraph(url=url)``
+      - :func:`~turbohtml.extract.opengraph` on the HTML you fetch yourself
+    - - ``og["title"]`` / ``og.get("title")``
+      - the same keys on :class:`~turbohtml.extract.OpenGraph`
+    - - ``og.is_valid()``
+      - :meth:`turbohtml.extract.OpenGraph.is_valid`
+    - - ``og.to_json()`` / ``og.to_html()``
+      - build these from ``dict(og)`` yourself
+
+turbohtml does not fetch URLs; ``OpenGraph(url=...)`` becomes your HTTP client plus :func:`~turbohtml.extract.opengraph`
+on the response body:
+
+.. testcode::
+
+    og = opengraph('<head><meta property="og:title" content="Only a title"></head>')
+    print(og.get("title"), og.is_valid())
+
+.. testoutput::
+
+    Only a title False
+
+**********
+ Pitfalls
+**********
+
+- Keys drop the ``og:`` prefix (``og["title"]``, not ``og["og:title"]``), matching ``opengraph`` and diverging from the
+  prefixed keys :meth:`turbohtml.Document.opengraph` returns. Structured sub-properties keep their tail, so
+  ``og:image:width`` reads as ``og["image:width"]``.
+- :func:`~turbohtml.extract.opengraph` drops the ``twitter:`` tags that :meth:`turbohtml.Document.opengraph` also
+  returns, because ``opengraph`` only reads ``og:``-prefixed properties. Call :meth:`~turbohtml.Document.opengraph` when
+  you want the Twitter card too.
+- :meth:`~turbohtml.extract.OpenGraph.is_valid` requires the `Open Graph protocol <https://ogp.me/>`_'s four basic
+  properties (``og:title``, ``og:type``, ``og:image``, ``og:url``). The ``opengraph_py3`` fork additionally requires
+  ``og:description``, so a card with the four but no description is valid here and invalid there.
+- ``OpenGraph`` scraping mode (``scrape=True``, which falls back to ``<title>`` and body ``<img>`` when og tags are
+  missing) has no equivalent; select those elements yourself with :meth:`~turbohtml.Node.find` when the card is
+  incomplete.

--- a/docs/reference/extract.rst
+++ b/docs/reference/extract.rst
@@ -39,3 +39,11 @@ The URL helpers are successors to ``courlan`` and the ``w3lib.url`` canonicaliza
 :doc:`/reference/structured-data`).
 
 .. autofunction:: microdata
+
+:func:`opengraph` extracts a page's Open Graph card as an :class:`OpenGraph` mapping, the ``opengraph`` library's
+``OpenGraph(html=...)`` call shape (:doc:`opengraph guide </migration/opengraph>`).
+
+.. autofunction:: opengraph
+
+.. autoclass:: OpenGraph
+    :members: is_valid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ bench = [
   "minify-html>=0.18.1",
   "newspaper3k>=0.2.8",
   "nh3>=0.3.6",
+  "opengraph-py3>=0.71",
   "pandas>=3.0.3",
   "parsel>=1.11",
   "pyperf>=2.10",

--- a/src/turbohtml/extract.py
+++ b/src/turbohtml/extract.py
@@ -17,13 +17,16 @@ by a frozen :class:`UrlCleaning`, replace ``courlan`` and the ``w3lib.url`` cano
 
 :func:`microdata` gives the ``microdata`` library's ``get_items(html)`` entry point over the same C walk
 :meth:`turbohtml.Document.microdata` runs, returning the :class:`MicrodataItem` records whose ``.get``/``.get_all``/
-``.json`` accessors mirror that library's ``Item``.
+``.json`` accessors mirror that library's ``Item``. :func:`opengraph` gives the ``opengraph`` library's
+``OpenGraph(html=...)`` shape over :meth:`turbohtml.Document.opengraph`: an :class:`OpenGraph` mapping of the
+``og:``-stripped keys with an :meth:`~OpenGraph.is_valid` check.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Final, NamedTuple
+from typing import TYPE_CHECKING, Final, NamedTuple
 
 from ._article import Article
 from ._html import Element, parse
@@ -31,11 +34,15 @@ from ._links import Link
 from ._structured_data import MicrodataItem, StructuredData
 from ._urls import UrlCleaning, clean_url, extract_links, normalize_url
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
 __all__ = [
     "Article",
     "Extraction",
     "Link",
     "MicrodataItem",
+    "OpenGraph",
     "Paragraph",
     "StructuredData",
     "UrlCleaning",
@@ -44,6 +51,7 @@ __all__ = [
     "extract_links",
     "microdata",
     "normalize_url",
+    "opengraph",
 ]
 
 _HEADINGS: Final = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
@@ -116,6 +124,68 @@ def microdata(html: str, /) -> list[MicrodataItem]:
     :returns: one :class:`~turbohtml.MicrodataItem` per top-level ``itemscope`` element, in document order.
     """
     return parse(html).microdata()
+
+
+_OG_PREFIX: Final = "og:"
+_OG_REQUIRED: Final = ("title", "type", "image", "url")
+"""The Open Graph protocol's four required properties; the check behind :meth:`OpenGraph.is_valid`."""
+
+
+class OpenGraph(Mapping[str, str]):
+    """
+    A page's Open Graph metadata as a read-only mapping, the record :func:`opengraph` returns.
+
+    Keys are the ``og:`` property names with that prefix stripped (``og:title`` reads as ``og["title"]``), matching the
+    ``opengraph`` library's ``OpenGraph`` dict. The mapping supports the full read surface -- ``og["title"]``,
+    ``"title" in og``, ``og.get("title")``, iteration, and equality against a plain ``dict`` -- and adds
+    :meth:`is_valid`.
+    """
+
+    __slots__ = ("_properties",)
+
+    def __init__(self, properties: dict[str, str], /) -> None:
+        """Wrap the already prefix-stripped ``og:`` property mapping :func:`opengraph` builds."""
+        self._properties = properties
+
+    def __getitem__(self, key: str) -> str:
+        """Return the value of the ``og:<key>`` property, raising :exc:`KeyError` when the page lacks it."""
+        return self._properties[key]
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate the prefix-stripped property names in document order."""
+        return iter(self._properties)
+
+    def __len__(self) -> int:
+        """Return the number of ``og:`` properties the page carries."""
+        return len(self._properties)
+
+    def __repr__(self) -> str:
+        """Render as ``OpenGraph({...})`` around the underlying property mapping."""
+        return f"OpenGraph({self._properties!r})"
+
+    def is_valid(self) -> bool:
+        """
+        Return whether the page carries the four properties the Open Graph protocol requires, each non-empty.
+
+        Mirrors the ``opengraph`` library's ``is_valid``: every one of ``og:title``, ``og:type``, ``og:image``, and
+        ``og:url`` is present with a non-empty value. The ``opengraph_py3`` fork also demands ``og:description``; the
+        `Open Graph protocol <https://ogp.me/>`_ does not, so it is not required here.
+        """
+        return all(self._properties.get(name) for name in _OG_REQUIRED)
+
+
+def opengraph(html: str, /) -> OpenGraph:
+    """
+    Extract a page's Open Graph metadata, the successor to ``opengraph.OpenGraph(html=...)``.
+
+    Reads the ``og:`` ``<meta>`` tags :meth:`turbohtml.Document.opengraph` gathers, drops the ``twitter:`` tags that
+    method also returns, and strips the ``og:`` prefix from each key so ``og["title"]`` reads the ``og:title`` tag.
+
+    :param html: the page markup.
+    :returns: an :class:`OpenGraph` mapping of the prefix-stripped ``og:`` properties, empty when the page has none.
+    """
+    tags = parse(html).opengraph()
+    return OpenGraph({key[len(_OG_PREFIX) :]: value for key, value in tags.items() if key.startswith(_OG_PREFIX)})
 
 
 def boilerplate(html: str, options: Extraction | None = None, /) -> list[Paragraph]:

--- a/tests/features/test_extract_opengraph.py
+++ b/tests/features/test_extract_opengraph.py
@@ -1,0 +1,77 @@
+"""opengraph: the extract.opengraph entry point and the OpenGraph mapping with its is_valid check."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml.extract import OpenGraph, opengraph
+
+_FULL = (
+    '<meta property="og:title" content="The Rock">'
+    '<meta property="og:type" content="video.movie">'
+    '<meta property="og:image" content="http://x/rock.jpg">'
+    '<meta property="og:url" content="http://x/tt0117500/">'
+)
+
+
+def test_opengraph_strips_prefix() -> None:
+    assert opengraph('<meta property="og:title" content="Hello">') == {"title": "Hello"}
+
+
+def test_opengraph_drops_twitter_tags() -> None:
+    html = '<meta property="og:title" content="Hi"><meta name="twitter:card" content="summary">'
+    assert dict(opengraph(html)) == {"title": "Hi"}
+
+
+def test_opengraph_keeps_structured_subkeys() -> None:
+    html = '<meta property="og:image" content="http://x/a.png"><meta property="og:image:width" content="400">'
+    assert opengraph(html) == {"image": "http://x/a.png", "image:width": "400"}
+
+
+def test_opengraph_empty_without_tags() -> None:
+    assert dict(opengraph("<p>plain</p>")) == {}
+
+
+def test_getitem_reads_stripped_key() -> None:
+    assert opengraph('<meta property="og:title" content="Hello">')["title"] == "Hello"
+
+
+def test_missing_key_raises() -> None:
+    with pytest.raises(KeyError):
+        _ = opengraph('<meta property="og:title" content="Hello">')["type"]
+
+
+def test_membership_and_get() -> None:
+    og = opengraph('<meta property="og:title" content="Hello">')
+    assert "title" in og
+    assert og.get("missing") is None
+
+
+def test_repr_wraps_properties() -> None:
+    assert repr(opengraph('<meta property="og:title" content="Hi">')) == "OpenGraph({'title': 'Hi'})"
+
+
+def test_is_valid_with_all_four_required() -> None:
+    assert opengraph(_FULL).is_valid() is True
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        pytest.param('<meta property="og:title" content="only">', id="one-property"),
+        pytest.param("<p>no meta</p>", id="no-properties"),
+    ],
+)
+def test_is_valid_false_when_required_missing(html: str) -> None:
+    assert opengraph(html).is_valid() is False
+
+
+def test_is_valid_false_when_required_empty() -> None:
+    html = _FULL + '<meta property="og:url" content="">'
+    assert opengraph(html).is_valid() is False
+
+
+def test_direct_construction() -> None:
+    og = OpenGraph({"title": "Hi", "type": "article", "image": "i", "url": "u"})
+    assert og.is_valid() is True
+    assert len(og) == 4

--- a/tools/bench/competitors/opengraph.py
+++ b/tools/bench/competitors/opengraph.py
@@ -1,0 +1,15 @@
+"""opengraph: og: meta-tag extraction over BeautifulSoup, the competitor to turbohtml's OpenGraph surface."""
+
+from __future__ import annotations
+
+from opengraph_py3 import OpenGraph
+
+REQUIREMENTS = ("opengraph-py3>=0.71", "html5lib>=1.1")
+
+
+def socialcard(text: str) -> None:
+    """Read the og: tags with opengraph, which builds a BeautifulSoup tree and scans the head's og-prefixed meta."""
+    OpenGraph(html=text)
+
+
+OPERATIONS = {"socialcard": (socialcard, "opengraph")}


### PR DESCRIPTION
`Document.opengraph` already returns a page's `og:` and `twitter:` meta tags, but nothing offered the shape the [`opengraph`](https://pypi.org/project/opengraph-py3/) library exposes: `OpenGraph(html=...)` yielding a mapping keyed by the property name minus its `og:` prefix, with `is_valid()` reporting whether the required tags are present. Anyone porting from that library (or its `opengraph_py3` fork) had no drop-in, which was the last unmapped structured-data library in #313.

`turbohtml.extract.opengraph(html)` reads the same C walk, drops the `twitter:` tags, strips the `og:` prefix, and returns an `OpenGraph` mapping so `og["title"]` reads the `og:title` tag. 🗂️ `OpenGraph` is a read-only `Mapping`, so `in`, `.get`, iteration, and equality against a plain `dict` come for free, and `is_valid` sits on top. No new engine lands here; the shim is the prefix strip plus the wrapper over the walk that already exists.

`is_valid` follows the [Open Graph protocol](https://ogp.me/) as the authority: the four basic properties `og:title`, `og:type`, `og:image`, and `og:url`, each non-empty. The `opengraph_py3` fork additionally requires `og:description`, a divergence the guide calls out. Over hand-built cards covering the protocol's basic, structured-image, and required-tag shapes the two libraries return byte-identical mappings, and the `socialcard` benchmark op times the walk at 94-133x faster than `opengraph` on a card head and an 8 KiB article.

closes #323
