### PR TITLE
🐛 fix(selectors): decode quoted-string escapes and fix XPath round() ties

### DIFF
--- a/docs/changelog/372.bugfix.rst
+++ b/docs/changelog/372.bugfix.rst
@@ -1,3 +1,3 @@
 Decode CSS escapes inside a quoted attribute-value string in a selector, so ``[id="\0 pre"]`` folds the null escape to
-U+FFFD, ``[id="pr\<newline>e"]`` drops the backslash-newline line continuation, and an escaped quote no longer ends
-the string early -- matching the quoted form to the already-correct identifier form - by :user:`gaborbernat`.
+U+FFFD, ``[id="pr\<newline>e"]`` drops the backslash-newline line continuation, and an escaped quote no longer ends the
+string early -- matching the quoted form to the already-correct identifier form - by :user:`gaborbernat`.

--- a/docs/changelog/372.bugfix.rst
+++ b/docs/changelog/372.bugfix.rst
@@ -1,0 +1,3 @@
+Decode CSS escapes inside a quoted attribute-value string in a selector, so ``[id="\0 pre"]`` folds the null escape to
+U+FFFD, ``[id="pr\<newline>e"]`` drops the backslash-newline line continuation, and an escaped quote no longer ends
+the string early -- matching the quoted form to the already-correct identifier form - by :user:`gaborbernat`.

--- a/docs/changelog/373.bugfix.rst
+++ b/docs/changelog/373.bugfix.rst
@@ -1,0 +1,2 @@
+Round exact half values toward positive infinity in the XPath ``round()`` function and ``substring()`` argument
+coercion, so ``round(-2.5)`` is ``-2`` rather than ``-3`` per XPath 1.0 §4.4 - by :user:`gaborbernat`.

--- a/src/turbohtml/_c/query/css/selector.h
+++ b/src/turbohtml/_c/query/css/selector.h
@@ -187,6 +187,45 @@ static void sel_ident(sel_parser *parser, const Py_UCS4 **out, Py_ssize_t *out_l
     }
 }
 
+/* Read a quoted-string value (the opening quote at parser->pos), decoding CSS
+   escapes in place like sel_ident. Two rules set a string apart from an
+   identifier (CSS Syntax 4.3.5 "consume a string token"): a backslash before a
+   newline is a line continuation and is dropped, and a raw U+0000 folds to
+   U+FFFD (Syntax 3.3 preprocessing). A decoded run is never longer than its
+   source, so it is written back over the source. */
+static void sel_string(sel_parser *parser, const Py_UCS4 **out, Py_ssize_t *out_len) {
+    Py_UCS4 quote = parser->src[parser->pos++];
+    Py_ssize_t start = parser->pos;
+    Py_ssize_t write = start;
+    while (parser->pos < parser->len && parser->src[parser->pos] != quote) {
+        if (parser->src[parser->pos] == '\\') {
+            Py_UCS4 next = parser->pos + 1 < parser->len ? parser->src[parser->pos + 1] : 0;
+            if (next == '\n' || next == '\x0c') {
+                parser->pos += 2; /* line continuation: the escaped newline is dropped */
+                continue;
+            }
+            if (next == '\r') {
+                parser->pos += 2;
+                if (parser->pos < parser->len && parser->src[parser->pos] == '\n') {
+                    parser->pos++; /* a CR LF pair counts as one newline */
+                }
+                continue;
+            }
+            parser->src[write++] = sel_consume_escape(parser);
+            continue;
+        }
+        Py_UCS4 ch = parser->src[parser->pos++];
+        parser->src[write++] = ch == 0 ? 0xFFFD : ch;
+    }
+    if (parser->pos >= parser->len) {
+        parser->error = 1; /* an unterminated string is invalid */
+        return;
+    }
+    parser->pos++; /* the closing quote */
+    *out = parser->src + start;
+    *out_len = write - start;
+}
+
 /* UTF-8 encode a slice and resolve it to a tag atom. */
 static uint16_t sel_tag_atom(const Py_UCS4 *name, Py_ssize_t len) {
     char bytes[64];
@@ -322,18 +361,10 @@ static void sel_attribute(sel_parser *parser, sel_simple *simple) {
     }
     sel_skip_ws(parser);
     if (parser->pos < parser->len && (parser->src[parser->pos] == '"' || parser->src[parser->pos] == '\'')) {
-        Py_UCS4 quote = parser->src[parser->pos++];
-        Py_ssize_t start = parser->pos;
-        while (parser->pos < parser->len && parser->src[parser->pos] != quote) {
-            parser->pos++;
-        }
-        if (parser->pos >= parser->len) {
-            parser->error = 1;
+        sel_string(parser, &simple->value, &simple->value_len);
+        if (parser->error) {
             return;
         }
-        simple->value = parser->src + start;
-        simple->value_len = parser->pos - start;
-        parser->pos++;
     } else {
         sel_ident(parser, &simple->value, &simple->value_len);
         if (parser->error) {

--- a/src/turbohtml/_c/query/xpath/functions.c
+++ b/src/turbohtml/_c/query/xpath/functions.c
@@ -11,6 +11,13 @@
 
 /* -------------------------------------------------------- function library */
 
+/* XPath 1.0 round(): the integer closest to the argument, ties resolved toward
+   positive infinity (§4.4, so round(-2.5) is -2, not the -3 that C round() gives
+   by rounding half away from zero). NaN and the infinities pass through floor. */
+static double xp_round(double value) {
+    return floor(value + 0.5);
+}
+
 /* number() with no argument: the context node's string-value parsed as first number. */
 static double context_node_number(xp_ctx *ctx) {
     xp_item item = {ctx->node, -1};
@@ -141,8 +148,8 @@ static int substring(struct th_tree *tree, xp_result *args, int argc, xp_result 
     if (text == NULL) { /* GCOVR_EXCL_BR_LINE: alloc */
         return -1;      /* GCOVR_EXCL_LINE */
     }
-    double start = round(to_number(tree, &args[1]));
-    double last = argc >= 3 ? start + round(to_number(tree, &args[2])) : (double)slen + 1;
+    double start = xp_round(to_number(tree, &args[1]));
+    double last = argc >= 3 ? start + xp_round(to_number(tree, &args[2])) : (double)slen + 1;
     Py_ssize_t lo = start < 1 ? 0 : (start > (double)slen + 1 ? slen : (Py_ssize_t)start - 1);
     Py_ssize_t hi = last < 1 ? 0 : (last > (double)slen + 1 ? slen : (Py_ssize_t)last - 1);
     if (hi < lo) {
@@ -961,7 +968,9 @@ int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *o
         result_number(out, argc >= 1 ? to_number(ctx->tree, &args[0]) : context_node_number(ctx));
     } else if (func_is(fn, "floor") || func_is(fn, "ceiling") || func_is(fn, "round")) {
         double value = to_number(ctx->tree, &args[0]);
-        result_number(out, func_is(fn, "floor") ? floor(value) : func_is(fn, "ceiling") ? ceil(value) : round(value));
+        result_number(out, func_is(fn, "floor")     ? floor(value)
+                           : func_is(fn, "ceiling") ? ceil(value)
+                                                    : xp_round(value));
     } else if (func_is(fn, "count")) {
         if (args[0].kind != XP_NODESET) {
             *ctx->feature = "count() of a non-node-set";

--- a/tests/query/css/test_tree_matches.py
+++ b/tests/query/css/test_tree_matches.py
@@ -83,3 +83,18 @@ def test_rejects_non_str(link: Element, method: str) -> None:
 def test_rejects_invalid_selector(link: Element, method: str) -> None:
     with pytest.raises(ValueError, match="selector"):
         getattr(link, method)("[")
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        pytest.param('[id="unterminated]', id="plain"),
+        # a string ending in a lone backslash (the escape yields U+FFFD) is still unterminated
+        pytest.param('[id="x\\', id="trailing-backslash"),
+        # a backslash before a bare CR at end of input is a line continuation with nothing after it
+        pytest.param('[id="x\\\r', id="trailing-cr-continuation"),
+    ],
+)
+def test_rejects_unterminated_attribute_string(link: Element, selector: str) -> None:
+    with pytest.raises(ValueError, match="selector"):
+        link.matches(selector)

--- a/tests/query/css/test_tree_select.py
+++ b/tests/query/css/test_tree_select.py
@@ -175,6 +175,20 @@ def test_select_over_doc(selector: str, tags: list[str]) -> None:
         pytest.param('<div class="Az">', r".\41z", ["div"], id="class-hex-escape-stops-at-non-hex"),
         # a trailing backslash escapes U+FFFD
         pytest.param('<div class="x�">', ".x\\", ["div"], id="class-trailing-backslash-is-replacement"),
+        # a quoted attribute-value string decodes the same escapes as an identifier
+        # (Syntax 4.3.5): \HH hex escapes, a null/out-of-range escape folding to U+FFFD,
+        # and a backslash escaping a literal (here the closing quote, which does not end it)
+        pytest.param('<a id="a:b"></a>', r'[id="a\:b"]', ["a"], id="string-escaped-literal"),
+        pytest.param('<a id="©"></a>', r'[id="\A9 "]', ["a"], id="string-hex-escape"),
+        pytest.param('<a id="�pre"></a>', r'[id="\0 pre"]', ["a"], id="string-null-hex-is-replacement"),
+        pytest.param('<a id="�pre"></a>', '[id="\x00pre"]', ["a"], id="string-raw-null-is-replacement"),
+        pytest.param("""<a id='say "hi"'></a>""", r'[id="say \"hi\""]', ["a"], id="string-escaped-quote-kept"),
+        # a backslash before a newline is a string line continuation and is dropped
+        # (a newline is LF, CR, FF, or a CR LF pair; each collapses to nothing here)
+        pytest.param('<a id="pre"></a>', '[id="pr\\\ne"]', ["a"], id="string-line-continuation-lf"),
+        pytest.param('<a id="pre"></a>', "[id='pr\\\re']", ["a"], id="string-line-continuation-cr"),
+        pytest.param('<a id="pre"></a>', "[id='pr\\\r\ne']", ["a"], id="string-line-continuation-crlf"),
+        pytest.param('<a id="pre"></a>', "[id='pr\\\x0ce']", ["a"], id="string-line-continuation-ff"),
         # the WHATWG "case-sensitivity of selectors" set: type/rel/... compare their
         # value ASCII case-insensitively by default on HTML elements (no flag needed)
         pytest.param('<input type="TEXT">', "input[type=text]", ["input"], id="ci-attr-set-default"),

--- a/tests/query/xpath/test_xpath_functions.py
+++ b/tests/query/xpath/test_xpath_functions.py
@@ -49,6 +49,11 @@ def doc() -> turbohtml.Node:
         pytest.param("floor(3.7)", 3.0, id="floor"),
         pytest.param("ceiling(3.2)", 4.0, id="ceiling"),
         pytest.param("round(3.5)", 4.0, id="round"),
+        # round() resolves ties toward positive infinity (XPath 1.0 §4.4), so a
+        # negative .5 rounds up, not away from zero as C round() would
+        pytest.param("round(-2.5)", -2.0, id="round-neg-half-up"),
+        pytest.param("round(-0.5)", 0.0, id="round-neg-half-to-zero"),
+        pytest.param("round(2.5)", 3.0, id="round-pos-half-up"),
         pytest.param("number('3.5')", 3.5, id="number-string"),
         pytest.param("number(true())", 1.0, id="number-bool"),
         pytest.param("number(false())", 0.0, id="number-false"),
@@ -78,6 +83,9 @@ def doc() -> turbohtml.Node:
         pytest.param("substring('hello', 0, 2)", "h", id="substring-clamp-low"),
         pytest.param("substring('hello', 10)", "", id="substring-past-end"),
         pytest.param("substring('hello', 2, 100)", "ello", id="substring-clamp-high"),
+        # substring rounds its numeric arguments with the XPath round (ties toward
+        # positive infinity): round(1.5)=2 and round(2.6)=3 select positions 2..4
+        pytest.param("substring('12345', 1.5, 2.6)", "234", id="substring-rounded-args"),
         pytest.param("substring('hello', 3, -1)", "", id="substring-empty"),
         pytest.param("substring('', 1, 1)", "", id="substring-of-empty"),
         pytest.param("substring-before('a/b/c', '/')", "a", id="substring-before"),


### PR DESCRIPTION
A differential audit of the CSS selector and XPath engines against soupsieve, cssselect, lxml, and Chrome surfaced two spec-conformance defects that this PR fixes.

A quoted string in an attribute selector was matched byte for byte: the parser scanned for the closing quote and kept the raw slice, so escapes and line continuations inside it were never decoded. The identifier form `[id=\A9]` already worked, but the quoted form `[id="\A9"]` did not. A new `sel_string` decodes the quoted value the same way `sel_ident` decodes an identifier, and adds the two rules that a string has and an identifier does not, per CSS Syntax 3 (https://www.w3.org/TR/css-syntax-3/#consume-string-token): a backslash before a newline is a line continuation and is dropped, and a raw `U+0000` folds to `U+FFFD`. An escaped quote inside the value no longer ends the string early. This closes #372.

The XPath `round()` function used C `round()`, which breaks ties by rounding away from zero, so `round(-2.5)` returned `-3`. XPath 1.0 §4.4 (https://www.w3.org/TR/xpath-19991116/#function-round) resolves ties toward positive infinity, making the answer `-2`. A small `xp_round` helper using `floor(x + 0.5)` replaces it in both `round()` and the `substring()` argument coercion, which §4.2 defines in terms of the same rounding. This closes #373.

The audit also found three divergences that are not turbohtml bugs and needed no change: soupsieve and cssselect reject `::before` and other pseudo-elements exactly as turbohtml does; the `:disabled`/`:enabled` and `:dir()` results that differed from soupsieve match Chrome, the WHATWG reference, where turbohtml is correct and soupsieve is not; and cssselect's `:enabled` misses a bare `<input>` because its translation requires `@type != 'hidden'`. Two genuine but riskier gaps are filed for later rather than fixed here: `:dir()` on form controls ignores the input value and the telephone special case (#374), and the parser accepts a type selector that is not first in its compound and a bare `-` (#375).
