### PR TITLE
fix(extract): clean_url returns None on lone surrogate

### DIFF
--- a/docs/changelog/377.bugfix.rst
+++ b/docs/changelog/377.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`turbohtml.extract.clean_url` now returns ``None`` for a URL carrying a lone surrogate instead of raising
+``UnicodeEncodeError``, honoring its documented ``str | None`` contract as ``courlan.clean_url`` does.

--- a/src/turbohtml/_urls.py
+++ b/src/turbohtml/_urls.py
@@ -189,7 +189,10 @@ def clean_url(url: str, options: UrlCleaning | None = None, /) -> str | None:
         return None
     if active.language is not None and not _language_matches(parts, active.language, strict=active.strict):
         return None
-    return _normalize(parts, active)
+    try:
+        return _normalize(parts, active)
+    except UnicodeEncodeError:  # a lone surrogate the percent-encoder cannot UTF-8 encode: not a fetchable web URL
+        return None
 
 
 def normalize_url(url: str, options: UrlCleaning | None = None, /) -> str:

--- a/tests/features/test_extract_urls_clean.py
+++ b/tests/features/test_extract_urls_clean.py
@@ -47,6 +47,7 @@ def test_clean_scrubs_markup_damage(url: str, expected: str) -> None:
         pytest.param("http://", id="empty-host"),
         pytest.param("http://localhost/x", id="dotless-host"),
         pytest.param("http://[::1/x", id="unsplittable"),
+        pytest.param("http://a.com/\udce9", id="lone-surrogate-unencodable"),
         pytest.param("", id="empty-string"),
     ],
 )


### PR DESCRIPTION
## Summary

`turbohtml.extract.clean_url` documents a total `str | None` contract -- "the cleaned, normalized URL, or `None` for anything that is not a fetchable web URL" -- and already swallows `ValueError` from `urlsplit` for that purpose. It still raised `UnicodeEncodeError` when a path/query/fragment carried a lone (unpaired) surrogate, which `urllib.parse.quote` cannot UTF-8 encode.

```python
clean_url("http://a.com/\udce9")   # was: UnicodeEncodeError; now: None
```

`courlan.clean_url`, the library this surface replaces, returns `None` on the same input; a migrant passing a `surrogateescape`-decoded href gets a graceful `None` from courlan but a crash here.

## Fix

Guard the final `_normalize` call in `clean_url` and return `None` on `UnicodeEncodeError`. `normalize_url` is left raising: its contract is a non-total `str` with `:raises ValueError:`, so failing loud on genuinely un-encodable input is defensible there.

## Scope

Not reachable through turbohtml's own pipeline: the tree builder maps surrogate numeric character references (`&#xDCE9;`) to U+FFFD per the WHATWG rules, so `extract_links` never feeds a lone surrogate to `clean_url`. This only affects a direct caller passing an invalid-Unicode string.

## Verification

- Added the surrogate case to `test_clean_rejects_non_web_urls`.
- 100% line + branch coverage on `turbohtml._urls` (the new branch included); full `tests/features` suite green (1300 passed).

closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)
