### PR TITLE
👷 ci: add CodSpeed continuous benchmarking

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -1,0 +1,40 @@
+name: 👷 benchmark
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    tags-ignore: ["**"]
+  pull_request:
+concurrency:
+  group: codspeed-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  codspeed:
+    name: 🚀 CodSpeed
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write # OIDC lets the CodSpeed GitHub App authenticate this public repo without a token secret
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # meson project() derives the version from git history
+          submodules: true # the benchmarks read the vendored html5lib-python and War-and-Peace corpora
+          persist-credentials: false
+      - name: 🔄 Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      # build the optimized extension and install the benchmark deps outside the runner, so
+      # only the pytest process below is measured under instrumentation, never the uv/meson build
+      - name: 🏗️ Build the extension and install benchmark deps
+        run: uvx --with tox-uv tox run -e codspeed --notest
+        env:
+          UV_PYTHON_PREFERENCE: only-managed
+      - name: 🚀 Run benchmarks
+        uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
+        with:
+          mode: simulation
+          run: .tox/codspeed/bin/python -m pytest tests/benchmarks --codspeed

--- a/docs/changelog/380.misc.rst
+++ b/docs/changelog/380.misc.rst
@@ -1,0 +1,6 @@
+Gate performance on every pull request with `CodSpeed <https://codspeed.io>`_: a ``👷 benchmark`` workflow runs one
+pytest-codspeed benchmark per operation under instrumentation and reports the per-benchmark delta against the base
+branch. The cases are generated from the same ``bench.core.OPERATIONS`` registry the ``pyperf`` suite in ``tools/bench``
+times, over the same real corpora, so every tracked operation gets a gate and adding one adds a benchmark. The
+benchmarks live in ``tests/benchmarks`` and run only under ``--codspeed`` (the benchmark job passes it; locally they are
+opt-in), so the regular test run skips them. The ``pyperf`` competitor comparison is unchanged.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -33,7 +33,18 @@ submodule update --init --depth 1 tools/bench-data/whatwg-html tools/bench-data/
 (line and branch). Other environments: ``type`` (`ty <https://github.com/astral-sh/ty>`_), ``docs`` (Sphinx), ``fix``
 (`pre-commit <https://pre-commit.com>`_), ``pkg_meta`` (wheel/sdist metadata), ``bench`` (`pyperf
 <https://pyperf.readthedocs.io>`_ comparison against each competitor library, each in its own isolated ``uv`` venv; see
-the :doc:`performance` page), and ``regen`` (regenerate the entity tables).
+the :doc:`performance` page), ``codspeed`` (the pytest-codspeed hot-path benchmarks behind the CI regression gate,
+below), and ``regen`` (regenerate the entity tables).
+
+Every pull request runs the ``codspeed`` benchmarks under `CodSpeed <https://codspeed.io>`_ in the ``👷 benchmark``
+workflow. It counts the CPU instructions of one benchmark per operation under Valgrind and comments the per-benchmark
+delta against the base branch, so a regression shows up before merge instead of in a later profiling session. The
+benchmarks in ``tests/benchmarks/`` are generated from the same ``bench.core.OPERATIONS`` registry the ``pyperf`` suite
+times, over the same real corpora (``tools/bench/ci.py`` pairs each operation with a lazy loader for one of them -- the
+vendored html5lib-python and War-and-Peace documents, the pinned upstream stylesheet and JS library, or the bench's own
+inline case), so every operation the project tracks gets a gate and adding an operation adds a benchmark. The benchmarks
+run only under ``--codspeed``: the ``codspeed`` environment passes it, and locally they are opt-in (``tox r -e
+codspeed`` or ``pytest tests/benchmarks --codspeed``), so the ordinary test run skips them and stays fast.
 
 *******************************
  Before opening a pull request

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ test = [
   "meson-python>=0.20",
   "ninja>=1.13",
   "pytest>=9.1.1",
+  "pytest-codspeed>=5.0.3",     # the benchmark fixture powers the CodSpeed CI gate; a no-op timer without --codspeed
   "pytest-cov>=7.1",
   "pytest-mock>=3.15.1",
   "pytest-run-parallel>=0.9.1", # runs each test in many threads to surface free-threaded data races
@@ -244,6 +245,7 @@ max_supported_python = "3.15"
 
 [tool.ty]
 src.exclude = [ "tests/html5lib-tests", "tools/html5lib-python" ]  # vendored suites, not our code
+environment.extra-paths = [ "tools" ]  # the CodSpeed benchmarks import the bench registry from tools/bench
 environment.python-version = "3.15"
 
 [tool.pytest]
@@ -264,6 +266,7 @@ ini_options.filterwarnings = [
 # module importorskips itself where its oracle is absent; measuring them would make the gate
 # environment-dependent. They still run and validate wherever the oracle installs (the dev env).
 run.omit = [
+  "tests/benchmarks/*",                                # run only under --codspeed (the CI benchmark job), never in the coverage run
   "tests/match/test_soupsieve_differential.py",
   "tests/query/css/test_css_to_xpath_differential.py",
   "tests/query/xpath/test_xpath_differential.py",

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,26 @@
+"""Put ``tools`` on the path for the ``bench`` registry, and run the benchmarks only under ``--codspeed``.
+
+The benchmarks exist for the CodSpeed CI job, which passes ``--codspeed`` (or sets ``CODSPEED_ENV``); the ordinary test
+run skips them so it stays fast, and locally they are opt-in behind the same flag.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parents[1] / "tools"))
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip the benchmarks in this directory unless CodSpeed is driving the run."""
+    if config.getoption("--codspeed") or os.environ.get("CODSPEED_ENV") is not None:
+        return
+    skip = pytest.mark.skip(reason="benchmark: pass --codspeed to run (the CI benchmark job does)")
+    for item in items:
+        if _HERE in item.path.parents:
+            item.add_marker(skip)

--- a/tests/benchmarks/test_operations.py
+++ b/tests/benchmarks/test_operations.py
@@ -1,0 +1,37 @@
+"""One CodSpeed benchmark per turbohtml operation, driven off the shared ``bench`` registry.
+
+The cases come from :func:`bench.ci.benchmarks`, which walks the same :data:`bench.core.OPERATIONS` the pyperf suite
+times over the same real corpora, so every operation the project tracks gets an instruction-count regression gate in CI
+and adding an operation adds a benchmark. The benchmarks run only under ``--codspeed`` (see ``conftest.py``): the CI
+benchmark job passes it, and locally it is opt-in. Mutating operations rebuild their tree through the pedantic ``setup``
+hook, which runs untimed before each measured call, so the number is the mutation and not the parse. A case whose corpus
+is not checked out (or cannot be fetched) skips rather than fails.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from bench.ci import benchmarks
+from bench.timing import Mutating
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pytest_codspeed import BenchmarkFixture
+
+
+@pytest.mark.parametrize(
+    ("operation", "load"),
+    [pytest.param(run, load, id=name) for name, run, load in benchmarks()],
+)
+def test_feature(benchmark: BenchmarkFixture, operation: object, load: Callable[[], object]) -> None:
+    try:
+        case = load()
+    except OSError as exc:  # corpus submodule not checked out, or the pinned upstream file could not be fetched
+        pytest.skip(f"corpus unavailable: {exc}")
+    if isinstance(operation, Mutating):
+        benchmark.pedantic(operation.run, setup=lambda: ((operation.setup(case),), {}))
+    else:
+        benchmark(cast("Callable[[object], object]", operation), case)

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -1,0 +1,100 @@
+"""
+Real, offline benchmark cases for the CodSpeed CI regression gate.
+
+The pyperf suite times every operation in :data:`bench.core.OPERATIONS` over real corpora (see :mod:`bench.corpus`).
+:func:`benchmarks` walks that same registry and pairs each turbohtml operation with a lazy loader for one of those real
+inputs -- the vendored html5lib-python and War-and-Peace corpora for the markup and text operations, the pinned upstream
+stylesheet and JS library for the minifiers, and the bench's own inline cases for the rest. Both suites therefore share
+the operation list and the corpus, so a new operation added to ``OPERATIONS`` is benchmarked here automatically. The
+loaders are lazy so the corpus is read only when a benchmark runs (under ``--codspeed``); a case whose corpus is missing
+raises, and the test skips it.
+"""
+
+from __future__ import annotations
+
+from functools import cache, partial
+from typing import TYPE_CHECKING
+
+from bench import corpus
+from bench.core import OPERATIONS
+from bench.operations import INPUTS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+_TEXT_BYTES = 1 << 16  # a 64 kB slice of the book: representative work without a multi-megabyte parse under Valgrind
+
+
+@cache
+def _spec() -> str:
+    """Return the vendored whatwg HTML spec (235 kB): the read-path operations' shared real document."""
+    _name, relative, encoding = corpus.CORPUS_FILES[5]
+    return corpus.corpus_text(relative, encoding)
+
+
+def _xpath_case() -> tuple[str, str]:
+    """Return the ``(kind, document)`` pair the xpath operation expects, over the spec."""
+    return "//a[@href]", _spec()
+
+
+# read-path, parse and tokenize all run over one shared real document (bench.core caches the parse), so they measure the
+# query, not a re-parse; xpath, the text corpora and the minifier corpora load their own real inputs.
+_DOCUMENT_OPS = (
+    "parse",
+    "tokenize",
+    "find",
+    "select",
+    "select-has",
+    "match",
+    "find-text",
+    "text-content",
+    "serialize",
+    "minify",
+    "edit",
+    "class-edit",
+    "strip-remove",
+    "strip-tags",
+    "set-html",
+    "set-text",
+    "navigate",
+    "chain",
+    "links-extract",
+    "links-absolutize",
+    "links-rewrite",
+    "extract-attr",
+    "extract-text",
+    "htmlparser",
+    "path",
+    "path-xpath",
+    "links-filter",
+)
+
+_LOADERS: dict[str, Callable[[], object]] = dict.fromkeys(_DOCUMENT_OPS, _spec)
+_LOADERS["xpath"] = _xpath_case
+_LOADERS["escape"] = partial(corpus.corpus, "war-and-peace/2600.txt", _TEXT_BYTES)
+_LOADERS["unescape"] = partial(corpus.corpus, "war-and-peace/2600-h/2600-h.htm", _TEXT_BYTES)
+_LOADERS["encoding"] = lambda: corpus.corpus("war-and-peace/2600.txt", _TEXT_BYTES).encode("cp1252")
+_LOADERS["minify-css"] = partial(corpus.large_text, *corpus.STYLESHEETS[1][1:])  # pico.css (90 kB)
+_LOADERS["minify-js"] = partial(corpus.large_text, *corpus.JS_FILES[0][1:])  # underscore (67 kB)
+
+
+def _inline(operation: str) -> object:
+    """Return the first case the bench already defines inline for ``operation`` (no corpus needed)."""
+    return INPUTS[operation]()[0][1]
+
+
+def loader_for(operation: str) -> Callable[[], object]:
+    """Return the lazy loader for ``operation``: a real corpus reader, or the bench's own inline case."""
+    return _LOADERS.get(operation, partial(_inline, operation))
+
+
+def benchmarks() -> Iterator[tuple[str, object, Callable[[], object]]]:
+    """Yield ``(name, callable, load)`` for every turbohtml operation, in registry order."""
+    for name, (run, _owner) in OPERATIONS.items():
+        yield name, run, loader_for(name)
+
+
+__all__ = [
+    "benchmarks",
+    "loader_for",
+]

--- a/tox.toml
+++ b/tox.toml
@@ -210,6 +210,17 @@ package = "skip"
 set_env = { PYTHONPATH = "{tox_root}{/}tools" }
 commands = [ [ "python", "-m", "bench", { replace = "posargs", extend = true } ] ]
 
+[env.codspeed]
+description = "run the pytest-codspeed hot-path benchmarks (the CodSpeed CI regression gate)"
+base_python = [ "3.14" ]
+package = "editable"  # an optimized build, not the coverage-instrumented one env_run_base installs
+deps = []  # drop the gcovr the coverage gate pulls in; the benchmarks never measure coverage
+dependency_groups = [ "test" ]  # carries pytest-codspeed and the benchmark fixture
+commands_pre = []  # no instrumented reinstall; the editable package above is the build we benchmark
+commands = [
+  [ "pytest", "{tox_root}{/}tests{/}benchmarks", "--codspeed", { replace = "posargs", extend = true } ],
+]
+
 [env.dev]
 description = "dev environment with all dependencies at {envdir}"
 package = "editable"


### PR DESCRIPTION
turbohtml's `pyperf` suite in `tools/bench` compares every operation against competitor libraries, but it runs nowhere in CI, so a change that quietly slows a hot path only surfaces when someone reruns the benchmarks by hand. 🚀 This wires up [CodSpeed](https://codspeed.io) so every pull request counts the CPU instructions of each operation under Valgrind and comments the per-benchmark delta against the base branch, turning a regression into a review signal instead of a later surprise.

The benchmark set is generated from the same `bench.core.OPERATIONS` registry the `pyperf` suite times, one benchmark per operation (58 today), rather than a hand-picked few. A shared `tools/bench/ci.py` walks that registry and pairs each operation with one small fixed input: it reuses the `pyperf` case where that case is already inline, and substitutes an offline stand-in of the same shape where the `pyperf` input is a downloaded or submodule corpus the CI gate cannot reproduce (the read-path family, `minify-css`, `minify-js`, `parse`, `tokenize`, `escape`, `unescape`, `encoding`, `xpath`). Because both suites share one operation list, adding an operation to `OPERATIONS` gives it a gate automatically; offline cases flow straight through and a new network-backed one only needs a `_SUBSTITUTE` entry. Only turbohtml's own implementations are measured, so the job imports no competitor library.

The benchmarks in `tests/benchmarks/` stay ordinary test modules: pytest-codspeed's `benchmark` fixture is a plain no-op timer without `--codspeed`, so the regular suite exercises each operation once as a smoke test and stays green offline. ⚙️ Mutating operations (`edit`, `set-html`, `set-text`, `links-absolutize`) rebuild their tree through the pedantic `setup` hook, which runs untimed before the single measured call, so the number is the mutation and not the parse.

The `👷 benchmark` workflow builds the optimized extension and installs the deps through a dedicated `codspeed` tox environment outside the runner, then hands only the `pytest` process to `CodSpeedHQ/action` in `simulation` mode, so the instruction count measures the library and never the `meson` build. Auth uses the CodSpeed GitHub App plus OIDC (`id-token: write`), so no `CODSPEED_TOKEN` secret is required for this public repo. The CodSpeed status check appears on this PR once the App finishes indexing the repository; until then the workflow still runs and uploads, and the check reconciles when the App is active.
