### PR TITLE
🐛 fix(selectors): four Selectors-4 conformance gaps

### DIFF
--- a/docs/changelog/349.bugfix.rst
+++ b/docs/changelog/349.bugfix.rst
@@ -1,0 +1,3 @@
+``:link`` and ``:any-link`` now match in :meth:`~turbohtml.Node.select` and the rest of the selector API instead of
+selecting nothing. A parsed tree has no visit history, so both reduce to ``:is(a, area)[href]`` per HTML, letting a
+scraping selector like ``a:any-link`` find the links it names.

--- a/docs/changelog/350.bugfix.rst
+++ b/docs/changelog/350.bugfix.rst
@@ -1,0 +1,3 @@
+``:lang()`` now honours wildcard language ranges. A ``*`` subtag matches by RFC 4647 §3.3.2 extended filtering, so a
+leading ``*`` (as in ``:lang('*')``) matches any element with a determined language and ``:lang('*-US')`` matches any
+region-US tag, where before every wildcard range selected nothing.

--- a/docs/changelog/350.bugfix.rst
+++ b/docs/changelog/350.bugfix.rst
@@ -1,3 +1,3 @@
-``:lang()`` now honours wildcard language ranges. A ``*`` subtag matches by RFC 4647 §3.3.2 extended filtering, so a
+``:lang()`` now honors wildcard language ranges. A ``*`` subtag matches by RFC 4647 §3.3.2 extended filtering, so a
 leading ``*`` (as in ``:lang('*')``) matches any element with a determined language and ``:lang('*-US')`` matches any
 region-US tag, where before every wildcard range selected nothing.

--- a/docs/changelog/351.bugfix.rst
+++ b/docs/changelog/351.bugfix.rst
@@ -1,0 +1,3 @@
+``:scope`` now matches the document element when a query is rooted at the document, mirroring ``:root``, so
+``Document.select(':scope')`` and compounds like ``:scope > body > div`` resolve instead of matching nothing.
+Element-rooted queries still scope ``:scope`` to the element the query ran on.

--- a/docs/changelog/352.bugfix.rst
+++ b/docs/changelog/352.bugfix.rst
@@ -1,0 +1,4 @@
+The selector tokenizer now accepts two CSS Syntax §4.3.2/§4.3.5 forms it used to reject: a ``/* ... */`` comment
+anywhere whitespace is allowed (such as ``div /* pick */ span``), and a backslash-newline line continuation inside a
+quoted attribute value (``[id="pr\`` + newline + ``e"]`` meaning ``[id="pre"]``). Attribute-value strings now also
+decode the other CSS escapes.

--- a/docs/migration/soupsieve.rst
+++ b/docs/migration/soupsieve.rst
@@ -99,11 +99,6 @@ The matcher methods and module helpers keep soupsieve's names; only the trees an
   :meth:`~turbohtml.Node.find_all` with ``text=`` instead).
 - ``namespaces`` and ``flags`` are carried for parity but never change which elements match: turbohtml selects by local
   name, so ``svg|rect`` matches every ``rect`` whatever the mapping says, and ``DEBUG`` prints nothing.
-- Three engine gaps silently match nothing for now: ``:link``/``:any-link`` (`#349
-  <https://github.com/tox-dev/turbohtml/issues/349>`__), wildcard ``:lang()`` ranges such as ``:lang('*-US')`` (`#350
-  <https://github.com/tox-dev/turbohtml/issues/350>`__), and ``:scope`` queried from a document (`#351
-  <https://github.com/tox-dev/turbohtml/issues/351>`__); ``/* comments */`` inside a selector are rejected (`#352
-  <https://github.com/tox-dev/turbohtml/issues/352>`__).
 - Two soupsieve 2.8 behaviors are off spec and not reproduced: an only child never matches a functional
   ``:nth-child(An+B)`` (an only child sits at position 1, so ``:nth-child(-n+3)`` must match it), and
   ``input[type=hidden]`` is excluded from ``:enabled`` (the current HTML spec no longer carves out hidden inputs).

--- a/src/turbohtml/_c/query/css/selector.h
+++ b/src/turbohtml/_c/query/css/selector.h
@@ -52,6 +52,9 @@ enum sel_pseudo {
     PSEUDO_DEFAULT,
     PSEUDO_LANG, /* §11.1, the comma list of ranges is stored as the value slice */
     PSEUDO_DIR,  /* §11.2, the direction (1 ltr, 2 rtl, 0 other) is stored in nth_a */
+    /* :link/:any-link: an unvisited or any hyperlink. A parsed tree has no visit
+       history, so both reduce to :is(a, area)[href] (HTML "the :link/:any-link") */
+    PSEUDO_ANY_LINK,
     /* live UA/interaction or navigation state a static tree cannot express: these
        parse as valid selectors but match nothing (so :is()/:not() still compose) */
     PSEUDO_NEVER,
@@ -497,8 +500,7 @@ static void sel_free_alts(sel_complex *alts, int count);
    parsed tree cannot express. They parse as valid selectors but match nothing,
    so :is()/:not() compositions stay usable instead of failing to compile. */
 static const char *const SEL_NEVER_PSEUDOS[] = {
-    "hover",  "focus",         "focus-within", "focus-visible", "active",
-    "target", "target-within", "visited",      "link",          "any-link",
+    "hover", "focus", "focus-within", "focus-visible", "active", "target", "target-within", "visited",
 };
 
 /* Parse the :dir() argument (pos just after '('): an identifier, mapped to the
@@ -603,6 +605,8 @@ static void sel_pseudo(sel_parser *parser, sel_simple *simple) {
         langdir = PSEUDO_LANG;
     } else if (sel_kw(name, name_len, "dir")) {
         langdir = PSEUDO_DIR;
+    } else if (sel_kw(name, name_len, "link") || sel_kw(name, name_len, "any-link")) {
+        simple->pseudo = PSEUDO_ANY_LINK;
     } else {
         for (size_t index = 0; index < sizeof(SEL_NEVER_PSEUDOS) / sizeof(SEL_NEVER_PSEUDOS[0]); index++) {
             if (sel_kw(name, name_len, SEL_NEVER_PSEUDOS[index])) {
@@ -1558,6 +1562,9 @@ static int sel_match_pseudo(th_node *node, const sel_simple *simple, const sel_c
         return sel_matches_lang(node, simple);
     case PSEUDO_DIR:
         return sel_direction(ctx->tree, node) == simple->nth_a;
+    /* :link/:any-link: an a or area carrying an href (HTML "the :link/:any-link") */
+    case PSEUDO_ANY_LINK:
+        return (node->atom == TH_TAG_A || node->atom == TH_TAG_AREA) && sel_has_attr(node, TH_ATTR_HREF);
     /* live UA/interaction or navigation state a static tree cannot express */
     case PSEUDO_NEVER:
         return 0;

--- a/src/turbohtml/_c/query/css/selector.h
+++ b/src/turbohtml/_c/query/css/selector.h
@@ -124,9 +124,24 @@ static int sel_is_hex(Py_UCS4 ch) {
     return (ch >= '0' && ch <= '9') || ((ch | 32) >= 'a' && (ch | 32) <= 'f');
 }
 
+/* Skip whitespace and CSS comments (CSS Syntax §4.3.2: a comment is valid anywhere
+   whitespace is). An unterminated comment runs to end of input rather than erroring,
+   as the spec's consume-comments step treats a file-ending comment as complete. */
 static void sel_skip_ws(sel_parser *parser) {
-    while (parser->pos < parser->len && is_space(parser->src[parser->pos])) {
-        parser->pos++;
+    while (parser->pos < parser->len) {
+        if (is_space(parser->src[parser->pos])) {
+            parser->pos++;
+        } else if (parser->src[parser->pos] == '/' && parser->pos + 1 < parser->len &&
+                   parser->src[parser->pos + 1] == '*') {
+            parser->pos += 2;
+            while (parser->pos + 1 < parser->len &&
+                   !(parser->src[parser->pos] == '*' && parser->src[parser->pos + 1] == '/')) {
+                parser->pos++;
+            }
+            parser->pos = parser->pos + 1 < parser->len ? parser->pos + 2 : parser->len;
+        } else {
+            break;
+        }
     }
 }
 

--- a/src/turbohtml/_c/query/css/selector.h
+++ b/src/turbohtml/_c/query/css/selector.h
@@ -1581,9 +1581,13 @@ static int sel_match_pseudo(th_node *node, const sel_simple *simple, const sel_c
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 0, 1));
     case PSEUDO_NTH_LAST_OF_TYPE:
         return sel_nth_matches(simple->nth_a, simple->nth_b, sel_sibling_index(node, 1, 1));
-    /* §6.6 the scoping root: the element the query was rooted at */
+    /* §6.6 the scoping root: the element the query was rooted at, or, when the root is
+       the document (or a fragment), the document element, as :root resolves to */
     case PSEUDO_SCOPE:
-        return node == ctx->scope;
+        if (ctx->scope->type == TH_NODE_ELEMENT) {
+            return node == ctx->scope;
+        }
+        return node->parent->type != TH_NODE_ELEMENT;
     /* §12 the input pseudo-classes determinable from the static tree */
     case PSEUDO_CHECKED:
         return sel_is_checked(node);

--- a/src/turbohtml/_c/query/css/selector.h
+++ b/src/turbohtml/_c/query/css/selector.h
@@ -519,15 +519,20 @@ static void sel_parse_dir(sel_parser *parser, sel_simple *simple) {
 }
 
 /* Parse the :lang() argument (pos just after '('): a non-empty comma-separated
-   list of language ranges, captured verbatim as the value slice and split at
-   match time. */
+   list of language ranges. Escapes are decoded in place (so an escaped wildcard
+   like \2a or \* becomes '*'); the decoded slice is the value, split at match time. */
 static void sel_parse_lang(sel_parser *parser, sel_simple *simple) {
     sel_skip_ws(parser);
     Py_ssize_t start = parser->pos;
+    Py_ssize_t write = parser->pos;
     while (parser->pos < parser->len && parser->src[parser->pos] != ')') {
-        parser->pos++;
+        if (parser->src[parser->pos] == '\\') {
+            parser->src[write++] = sel_consume_escape(parser);
+            continue;
+        }
+        parser->src[write++] = parser->src[parser->pos++];
     }
-    Py_ssize_t end = parser->pos;
+    Py_ssize_t end = write;
     while (end > start && is_space(parser->src[end - 1])) {
         end--;
     }
@@ -1388,16 +1393,54 @@ static int sel_is_default(th_node *node) {
     return 0;
 }
 
-/* Whether a language tag matches a range: equal, or the tag begins with the
-   range followed by '-' (BCP47 basic filtering, ASCII case-insensitive). */
+/* The end (exclusive) of the '-'-delimited subtag of s beginning at start. */
+static Py_ssize_t sel_subtag_end(const Py_UCS4 *s, Py_ssize_t len, Py_ssize_t start) {
+    Py_ssize_t end = start;
+    while (end < len && s[end] != '-') {
+        end++;
+    }
+    return end;
+}
+
+/* Whether a language tag matches a range by RFC 4647 §3.3.2 extended filtering
+   (ASCII case-insensitive): a '*' subtag is a wildcard (a leading '*' matches any
+   primary tag, an interior '*' is skipped), and a non-matching, non-singleton tag
+   subtag is skipped, so a range's subtags need only appear in order. */
 static int sel_lang_range_matches(const Py_UCS4 *tag, Py_ssize_t tag_len, const Py_UCS4 *range, Py_ssize_t range_len) {
-    if (range_len == 0 || range_len > tag_len) {
+    if (range_len == 0) {
         return 0;
     }
-    if (!sel_eq(tag, range_len, range, range_len, 1)) {
-        return 0;
+    Py_ssize_t rend = sel_subtag_end(range, range_len, 0);
+    Py_ssize_t tend = sel_subtag_end(tag, tag_len, 0);
+    if ((rend != 1 || range[0] != '*') && !sel_eq(tag, tend, range, rend, 1)) {
+        return 0; /* the primary subtag must match unless the range's is the wildcard */
     }
-    return tag_len == range_len || tag[range_len] == '-';
+    Py_ssize_t rstart = rend + 1;
+    Py_ssize_t tstart = tend + 1;
+    while (rstart < range_len) {
+        rend = sel_subtag_end(range, range_len, rstart);
+        Py_ssize_t rlen = rend - rstart;
+        if (rlen == 1 && range[rstart] == '*') {
+            rstart = rend + 1;
+            continue;
+        }
+        while (1) {
+            if (tstart >= tag_len) {
+                return 0; /* the range has subtags left but the tag has none */
+            }
+            tend = sel_subtag_end(tag, tag_len, tstart);
+            if (sel_eq(tag + tstart, tend - tstart, range + rstart, rlen, 1)) {
+                tstart = tend + 1;
+                break;
+            }
+            if (tend - tstart == 1) {
+                return 0; /* a singleton tag subtag cannot be skipped by the implicit wildcard */
+            }
+            tstart = tend + 1;
+        }
+        rstart = rend + 1;
+    }
+    return 1;
 }
 
 /* :lang(): the element's language is the nearest lang attribute on it or an

--- a/src/turbohtml/_c/query/css/to_xpath.h
+++ b/src/turbohtml/_c/query/css/to_xpath.h
@@ -588,6 +588,9 @@ static int xt_pseudo_cond(xt_ctx *ctx, const sel_simple *simple, const sel_compo
            XPath 1.0 string functions cannot inspect */
         ctx->error = ":dir() cannot be expressed in XPath 1.0";
         return 1;
+    case PSEUDO_ANY_LINK:
+        xt_text(&ctx->out, "((self::a or self::area) and @href)");
+        return 1;
     case PSEUDO_NEVER:
         xt_text(&ctx->out, "false()");
         return 1;

--- a/tests/match/test_soupsieve_differential.py
+++ b/tests/match/test_soupsieve_differential.py
@@ -11,8 +11,6 @@ Excluded from the corpus, with the reasons on record:
 - soupsieve's proprietary extensions (``[attr!=value]``, ``:-soup-contains``, ``:-soup-contains-own``) and the
   pseudo-classes turbohtml rejects as unknown (``:current``, ``:host``, ``:open``, ...) -- both engines fail loudly,
   one at compile and one at zero matches, so there is nothing to diff.
-- ``:link``/``:any-link``, wildcard ``:lang()`` ranges, and document-scoped ``:scope``, which turbohtml parses but
-  never matches (tracked engine gaps, see the migration guide's pitfalls).
 - ``:nth-child(An+B)`` on an element with no sibling nodes at all and ``input[type=hidden]`` under ``:enabled``, where
   soupsieve 2.8 disagrees with Selectors-4/HTML (an only child sits at position 1, and the current HTML spec no longer
   excludes hidden inputs), so the oracle is the one off spec.
@@ -234,6 +232,21 @@ SELECTORS = (
     "article:not(:target-within)",
     ":where(span, a)",
     ":where(span, a:where(#\\32))",
+    # :link/:any-link reduce to :is(a, area)[href] on a parsed tree (issue #349)
+    ":any-link",
+    ":link",
+    "a:any-link",
+    ":not(a:any-link)",
+    # wildcard :lang() ranges by RFC 4647 extended filtering (issue #350)
+    ":lang('*')",
+    ":lang('*-US')",
+    "p:lang('*-US')",
+    ":lang(\\*-DE)",
+    # document-scoped :scope resolves to the document element (issue #351)
+    ":scope",
+    ":scope > body",
+    ":scope > body > div",
+    ":scope a",
 )
 
 

--- a/tests/query/css/test_tree_select.py
+++ b/tests/query/css/test_tree_select.py
@@ -101,6 +101,24 @@ def test_select_over_doc(selector: str, tags: list[str]) -> None:
 
 
 @pytest.mark.parametrize(
+    ("selector", "tags"),
+    [
+        # CSS Syntax §4.3.2: a comment is valid anywhere whitespace is (issue #352)
+        pytest.param("section /* the link */ a", ["a"], id="comment-as-descendant-ws"),
+        pytest.param("p.lead /* c */ a", ["a"], id="comment-around-child-context"),
+        pytest.param("section /* a*b keeps scanning */ a", ["a"], id="comment-with-inner-asterisk"),
+        pytest.param("section a /* trailing", ["a"], id="unterminated-comment-runs-to-end"),
+        pytest.param('[href /* c */ = "/x"]', ["a"], id="comment-inside-attribute"),
+        # CSS Syntax §4.3.5 string escapes in an attribute value (issue #352)
+        pytest.param('[href="/\\\nx"]', ["a"], id="attr-value-line-continuation"),
+        pytest.param(r'[href="\2f x"]', ["a"], id="attr-value-hex-escape"),
+    ],
+)
+def test_comments_and_string_escapes(selector: str, tags: list[str]) -> None:
+    assert _sel(_DOC, selector) == tags
+
+
+@pytest.mark.parametrize(
     ("html", "selector", "tags"),
     [
         pytest.param("<div></div>text<p>x</p>", "div + p", ["p"], id="adjacent-skips-text-node"),
@@ -588,6 +606,12 @@ def test_has_skips_non_element_following_sibling() -> None:
         pytest.param(":nth-child(of .x)", id="nth-of-without-anb"),
         pytest.param(":nth-of-type(2n of .x)", id="nth-of-type-rejects-of"),
         pytest.param(":nth-last-of-type(1 of p)", id="nth-last-of-type-rejects-of"),
+        # a comment separates tokens but is not itself a combinator, so an adjacent
+        # comment with no surrounding whitespace leaves the compounds unjoined (#352)
+        pytest.param("h2/* c */p", id="comment-without-combinator-whitespace"),
+        # a lone '/' is not a comment: at end of input, or before a non-'*' character
+        pytest.param("h2 /", id="slash-at-end-of-input"),
+        pytest.param("h2 /x", id="slash-not-opening-a-comment"),
     ],
 )
 def test_invalid_selectors_raise(selector: str) -> None:

--- a/tests/query/css/test_tree_select.py
+++ b/tests/query/css/test_tree_select.py
@@ -78,6 +78,15 @@ def _sel(html: str, selector: str) -> list[str]:
         pytest.param("h2 ~ ul", ["ul"], id="general-sibling-scans-past-non-matches"),
         pytest.param("div > ul > li", [], id="child-chain-breaks-above-match"),
         pytest.param("h2 + ul", [], id="adjacent-compound-miss"),
+        # :link/:any-link reduce to :is(a, area)[href] on a parsed tree (issue #349)
+        pytest.param(":any-link", ["a"], id="any-link"),
+        pytest.param(":link", ["a"], id="link"),
+        pytest.param("a:any-link", ["a"], id="any-link-compound"),
+        pytest.param(
+            ":not(a:any-link)",
+            ["html", "head", "body", "section", "h2", "p", "p", "ul", "li", "li", "my-widget"],
+            id="not-any-link",
+        ),
         # grouping
         pytest.param("h2, a", ["h2", "a"], id="comma-group-in-document-order"),
         pytest.param("#nope", [], id="id-present-but-mismatched"),

--- a/tests/query/css/test_tree_select_ui.py
+++ b/tests/query/css/test_tree_select_ui.py
@@ -398,6 +398,15 @@ def test_scope_is_the_query_root() -> None:
     assert _scope_ids(p1.select(":scope > a")) == ["link"]
 
 
+def test_document_scope_falls_back_to_the_document_element() -> None:
+    # rooted at the document, :scope resolves to the document element like :root does
+    # (issue #351): the html element and every compound built on it now match
+    doc = parse("<!doctype html><html><body><div id=d><p id=p>x</p></div></body></html>")
+    assert [e.tag for e in doc.select(":scope")] == ["html"]
+    assert [e.tag for e in doc.select(":scope > body > div")] == ["div"]
+    assert [e.attrs.get("id") for e in doc.select(":scope div > p")] == ["p"]
+
+
 @pytest.mark.parametrize(
     "selector",
     [

--- a/tests/query/css/test_tree_select_ui.py
+++ b/tests/query/css/test_tree_select_ui.py
@@ -344,8 +344,6 @@ def test_detached_element_resolves_lang_and_dir_to_no_ancestor() -> None:
             ":target",
             ":target-within",
             ":visited",
-            ":link",
-            ":any-link",
         )
     ],
 )

--- a/tests/query/css/test_tree_select_ui.py
+++ b/tests/query/css/test_tree_select_ui.py
@@ -177,6 +177,21 @@ def test_ui_pseudo_cases(html: str, selector: str, ids: list[str]) -> None:
         pytest.param('<span id=a lang="english">x</span>', ":lang(en)", [], id="no-hyphen-boundary"),
         pytest.param("<span id=a>x</span>", ":lang(en)", [], id="no-lang-attribute"),
         pytest.param('<span id=a lang="">x</span>', ":lang(en)", [], id="empty-lang-attribute"),
+        # RFC 4647 §3.3.2 extended filtering: a non-matching, non-singleton subtag is
+        # skipped, so a range's subtags need only appear in the tag in order
+        pytest.param('<span id=a lang="en-Latn-GB">x</span>', ":lang(en-GB)", ["a"], id="extended-skip-script"),
+        pytest.param('<span id=a lang="en-a-bbb">x</span>', ":lang(en-bbb)", [], id="extended-singleton-blocks"),
+        # a '*' wildcard subtag: leading '*' matches any determined language, and an
+        # interior/quoted or escaped '*' passes through per Selectors-4 §14
+        pytest.param('<span id=a lang="de-DE">x</span>', ":lang('*')", ["a"], id="wildcard-any-language"),
+        pytest.param("<span id=a>x</span>", ":lang('*')", [], id="wildcard-needs-a-language"),
+        pytest.param('<span id=a lang="en-US">x</span>', ":lang('*-US')", ["a"], id="wildcard-primary-region"),
+        pytest.param('<span id=a lang="en-GB">x</span>', ":lang('*-US')", [], id="wildcard-primary-region-miss"),
+        pytest.param('<span id=a lang="de-DE">x</span>', r":lang(\*-DE)", ["a"], id="wildcard-escaped-asterisk"),
+        pytest.param('<span id=a lang="en-Latn-US">x</span>', ":lang('*-US')", ["a"], id="wildcard-skips-script"),
+        # an interior '*' subtag passes through; a non-wildcard single-char subtag matches literally
+        pytest.param('<span id=a lang="de-Latn-DE">x</span>', ":lang('de-*-DE')", ["a"], id="wildcard-interior"),
+        pytest.param('<span id=a lang="en-a-bbb">x</span>', ":lang('en-a')", ["a"], id="single-char-subtag"),
     ],
 )
 def test_lang_pseudo(html: str, selector: str, ids: list[str]) -> None:


### PR DESCRIPTION
The #317 soupsieve differential surfaced four selectors the engine parsed but then matched nothing on, so a scraping selector like `a:any-link` silently returned an empty set instead of the anchors it names. 🔍 Each is a Selectors-4 conformance gap rather than a soupsieve-parity choice.

`:link` and `:any-link` now reduce to `:is(a, area)[href]`: a parsed tree carries no visit history, so per HTML every hyperlink counts as unvisited and both pseudo-classes match it. `:lang()` applies RFC 4647 §3.3.2 extended filtering, so a wildcard range like `:lang('*-US')` matches any region-US element instead of nothing. `:scope` matches the document element when the query is rooted at the document, mirroring `:root`, while element-rooted queries still scope it to the element the query ran on. The tokenizer accepts a `/* ... */` comment anywhere whitespace is allowed and a backslash-newline continuation inside a quoted attribute value, both per CSS Syntax §4.3, and attribute-value strings now decode the remaining CSS escapes.

The soupsieve migration guide drops its "these silently match nothing" caveat now that the engine covers all four.

closes #349
closes #350
closes #351
closes #352