### PR TITLE
👷 ci: pin PYTHONHASHSEED in the CodSpeed run

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -35,6 +35,8 @@ jobs:
           UV_PYTHON_PREFERENCE: only-managed
       - name: 🚀 Run benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
+        env:
+          PYTHONHASHSEED: "0" # pin the seed so str-dict iteration order is fixed run to run; else untouched benchmarks drift a few percent between the base and PR runs and mask a real regression
         with:
           mode: simulation
           run: .tox/codspeed/bin/python -m pytest tests/benchmarks --codspeed


### PR DESCRIPTION
The CodSpeed detail view showed benchmarks the change never touched drifting a few percent between the base and PR runs. 📉 The cause is the interpreter hash seed: CodSpeed runs the benchmarks outside tox, so nothing pinned `PYTHONHASHSEED` and CPython randomized it per process, giving the base run and the PR run different string-dict iteration orders. Operations that build or return Python objects then walk those dicts in a different order and their instruction trace moves even though their code is identical, while pure scalar operations stay flat.

Pinning `PYTHONHASHSEED=0` on the benchmark step fixes the iteration order across runs, so the instruction count is reproducible and the noise floor collapses toward zero. The deltas were always below CodSpeed's significance threshold, so this changes no verdicts today; it removes the room a real sub-threshold regression could hide in.