### PR TITLE
👷 ci: stabilize CodSpeed noise floor via glibc hwcaps

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -35,8 +35,6 @@ jobs:
           UV_PYTHON_PREFERENCE: only-managed
       - name: 🚀 Run benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
-        env:
-          PYTHONHASHSEED: "0" # pin the seed so str-dict iteration order is fixed run to run; else untouched benchmarks drift a few percent between the base and PR runs and mask a real regression
         with:
           mode: simulation
           run: .tox/codspeed/bin/python -m pytest tests/benchmarks --codspeed

--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -35,6 +35,11 @@ jobs:
           UV_PYTHON_PREFERENCE: only-managed
       - name: 🚀 Run benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
+        env:
+          # GitHub hands each run a different physical CPU (Intel Xeon with AVX-512, or AMD EPYC without), and glibc
+          # dispatches a different SIMD memcpy/memmove per CPU, so Callgrind counts different instructions for the same
+          # code and untouched benchmarks drift a few percent run to run. Force one baseline path on every CPU.
+          GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW,-AVX512DQ,-AVX512CD,-AVX2,-AVX,-ERMS,-FSRM"
         with:
           mode: simulation
           run: .tox/codspeed/bin/python -m pytest tests/benchmarks --codspeed

--- a/docs/changelog/383.misc.rst
+++ b/docs/changelog/383.misc.rst
@@ -1,0 +1,3 @@
+Stabilize the CodSpeed benchmark gate against GitHub's heterogeneous runners by pinning ``GLIBC_TUNABLES`` so glibc
+selects one baseline ``memcpy``/``memmove`` path on every CPU. Without it a different physical CPU per run made
+allocation-heavy benchmarks drift a few percent, wide enough to mask a real small regression.


### PR DESCRIPTION
The CodSpeed detail view showed benchmarks a change never touched drifting a few percent between the base and PR runs, wide enough that a real 3% regression could hide under the 10% alert threshold. 📉 The first attempt (#382) pinned `PYTHONHASHSEED`, but its own report disproved that theory: the drift was unchanged and `minify-js` (pure C, no Python dict iteration in the measured region) still swung +6%, which a hash seed cannot cause.

The real cause is documented by CodSpeed: GitHub assigns a different physical CPU per run (Intel Xeon with AVX-512, or AMD EPYC without), and glibc dispatches a different SIMD `memcpy`/`memmove` per CPU, so Callgrind counts different instructions for identical code — "the majority of performance differences are within glibc's implementation of malloc." Their preferred fixes (GitHub larger runners, CodSpeed Macro runners) need a plan tox-dev does not have; the org cannot provision hosted larger runners at all.

This reverts the hash-seed pin and instead pins `GLIBC_TUNABLES=glibc.cpu.hwcaps=-AVX512F,...,-AVX,-ERMS,-FSRM`, disabling the SIMD paths that differ across those CPUs so glibc uses one baseline implementation everywhere. The instruction count then reproduces run to run and the noise floor collapses toward zero. 🎯 Because the gate measures instruction counts rather than wall time, the slower baseline path costs nothing.

One-time effect: this PR's own report will show large deltas on allocation-heavy benchmarks, since its base ran on the AVX path and its head runs on the baseline path. That is the expected step change, not a regression; determinism holds once `main` also carries the pin. A follow-up will lower the regression threshold once the flat floor is confirmed.