### PR TITLE
🐛 fix(query): XPath memory-safety and conformance

### DIFF
--- a/docs/changelog/398.bugfix.rst
+++ b/docs/changelog/398.bugfix.rst
@@ -1,0 +1,3 @@
+:meth:`~turbohtml.Node.xpath` now renders a number as the shortest decimal that round-trips the IEEE-754 double (XPath
+1.0 §4.2), so ``string(1 div 3)`` is ``0.3333333333333333`` and ``number(string(x)) == x``, rather than truncating to 12
+significant digits.

--- a/docs/changelog/401.bugfix.rst
+++ b/docs/changelog/401.bugfix.rst
@@ -1,0 +1,3 @@
+:meth:`~turbohtml.Node.xpath` no longer crashes when the attribute axis or ``lang()`` reaches a non-element context node
+(a text, comment, or document node); every reader of a node's attribute storage now gates on the element type, so
+``//@id``, ``//@*``, and ``lang()`` return the spec-correct empty result on non-elements instead of faulting.

--- a/docs/changelog/420.bugfix.rst
+++ b/docs/changelog/420.bugfix.rst
@@ -1,0 +1,3 @@
+:meth:`~turbohtml.Node.xpath` now enforces each core and EXSLT function's fixed arity (XPath 1.0 §4): a call with too
+few or too many arguments raises :exc:`ValueError` naming the function and its expected count, rather than reading an
+uninitialized argument slot (a crash) or, for ``count()``, returning uninitialized memory.

--- a/docs/changelog/421.bugfix.rst
+++ b/docs/changelog/421.bugfix.rst
@@ -1,0 +1,3 @@
+:meth:`~turbohtml.Node.xpath` now caps expression nesting and operator-chain depth in both the parser and the evaluator,
+raising :exc:`ValueError` on a pathological expression (deeply nested groups or a long ``or``/``+`` spine) instead of
+overflowing the C stack.

--- a/docs/changelog/434.bugfix.rst
+++ b/docs/changelog/434.bugfix.rst
@@ -1,0 +1,3 @@
+:meth:`~turbohtml.Node.xpath` now raises a :exc:`ValueError` naming an unknown function, a :exc:`TypeError` when a query
+puts a value where the grammar requires a node-set, and a parse error that carries the offending token and its source
+offset, in place of the previous ``NotImplementedError``.

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1459,13 +1459,16 @@ static PyObject *xpath_item_to_py(module_state *state, PyObject *handle, th_tree
     return node_wrap(state, handle, item.node);
 }
 
-/* Translate an xp_eval status (-2 unsupported, -1 OOM) into a Python error. */
+/* Translate an xp_eval status into a Python error: -4 a TypeError (a value where a
+   node-set is required), -3 a ValueError (an unbound variable, an unbound prefix, or an
+   over-deep expression), -1 an allocation failure or an already-set exception (an unknown
+   function, a wrong-arity call, a malformed regex, or an extension failure). */
 static void *xpath_raise_status(int status, const char *feature) {
-    if (PyErr_Occurred()) { /* a borrowed Python call (e.g. a malformed regex) already set the exception */
+    if (PyErr_Occurred()) { /* a borrowed Python call already set the exception (regex, unknown function, ...) */
         return NULL;
     }
-    if (status == -2) {
-        PyErr_Format(PyExc_NotImplementedError, "xpath: %s are not implemented yet", feature);
+    if (status == -4) {
+        PyErr_Format(PyExc_TypeError, "xpath: %s", feature);
         return NULL;
     }
     if (status == -3) { /* GCOVR_EXCL_BR_LINE: the remaining status -1 is an allocation failure */
@@ -2186,7 +2189,12 @@ PyDoc_STRVAR(xpath_compiled_doc, "XPath(expression, *, smart_strings=False, exte
                                  "variables: XPath(\"//td[@class=$cls]\")(row, cls=\"num\"). It returns the same\n"
                                  "results as Node.xpath. smart_strings and the extensions dict are bound here\n"
                                  "at construction. The object is immutable and re-entrant, so one instance can\n"
-                                 "be shared across threads.");
+                                 "be shared across threads.\n\n"
+                                 ":raises TypeError: expression is not a str, a variable binding is of an\n"
+                                 "    unsupported type, or a value is used where a node-set is required.\n"
+                                 ":raises ValueError: the expression is not valid XPath (with the offending\n"
+                                 "    token and its offset), nests past the depth limit, calls an unknown or\n"
+                                 "    wrong-arity function, or references an unbound variable or prefix.");
 
 static PyType_Slot xpath_compiled_slots[] = {
     {Py_tp_doc, (void *)xpath_compiled_doc},

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -1176,7 +1176,13 @@ PyDoc_STRVAR(xpath_doc, "xpath(expression, /, *, smart_strings=False, extensions
                         ":param variables: values bound to the $name variables used in the expression; a\n"
                         "    str, int, float, or bool binds a scalar, and an Element or an iterable of\n"
                         "    Elements binds a node-set. A node from a different document raises ValueError.\n"
-                        ":returns: the result list, of Elements and str values in document order.");
+                        ":returns: the result list, of Elements and str values in document order.\n"
+                        ":raises TypeError: expression is not a str, a variable binding is of an\n"
+                        "    unsupported type, or a value is used where the grammar requires a node-set.\n"
+                        ":raises ValueError: the expression is not valid XPath (with the offending token\n"
+                        "    and its offset), nests past the depth limit, calls an unknown function or one\n"
+                        "    with the wrong number of arguments, references an unbound variable or prefix,\n"
+                        "    or binds a node from a different document.");
 
 PyDoc_STRVAR(xpath_iter_doc, "xpath_iter(expression, /, *, smart_strings=False, extensions=None, **variables)\n--\n\n"
                              "Like xpath(), but stream the results instead of building a list.\n\n"
@@ -1185,7 +1191,11 @@ PyDoc_STRVAR(xpath_iter_doc, "xpath_iter(expression, /, *, smart_strings=False, 
                              "    the Element it came from.\n"
                              ":param extensions: maps an (namespace, name) pair to a custom XPath function.\n"
                              ":param variables: values bound to the $name variables in the expression.\n"
-                             ":returns: an iterator over the results in document order.");
+                             ":returns: an iterator over the results in document order.\n"
+                             ":raises TypeError: expression is not a str, a variable binding is of an\n"
+                             "    unsupported type, or a value is used where a node-set is required.\n"
+                             ":raises ValueError: the expression is invalid XPath, nests too deeply, calls an\n"
+                             "    unknown or wrong-arity function, or references an unbound variable or prefix.");
 
 PyDoc_STRVAR(xpath_one_doc, "xpath_one(expression, /, *, smart_strings=False, extensions=None, **variables)\n--\n\n"
                             "Like xpath(), but return only the first result.\n\n"
@@ -1194,7 +1204,11 @@ PyDoc_STRVAR(xpath_one_doc, "xpath_one(expression, /, *, smart_strings=False, ex
                             "    Element it came from.\n"
                             ":param extensions: maps an (namespace, name) pair to a custom XPath function.\n"
                             ":param variables: values bound to the $name variables in the expression.\n"
-                            ":returns: the first result in document order, or None when there is none.");
+                            ":returns: the first result in document order, or None when there is none.\n"
+                            ":raises TypeError: expression is not a str, a variable binding is of an\n"
+                            "    unsupported type, or a value is used where a node-set is required.\n"
+                            ":raises ValueError: the expression is invalid XPath, nests too deeply, calls an\n"
+                            "    unknown or wrong-arity function, or references an unbound variable or prefix.");
 
 PyDoc_STRVAR(matches_doc, "matches(selector, /)\n--\n\n"
                           "Test this node against a CSS selector, evaluated with its own ancestors and\n"

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -117,6 +117,20 @@ int th_tree_set_attr(th_tree *tree, th_node *node, Py_ssize_t index, const char 
 int th_node_attr_set(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len, const Py_UCS4 *value,
                      Py_ssize_t value_len, int has_value);
 
+/* An element's attribute array and count; (NULL, 0) for every non-element node. Only
+   an element carries attribute storage: a text-node span reuses attr_count to hold a
+   source offset with attrs == NULL, so a reader that walks arbitrary nodes (the XPath
+   attribute axis, lang()) must gate on the element type -- which it does by reaching
+   the storage only through this accessor (issues #401, #422). */
+static inline Py_ssize_t th_node_attributes(const th_node *node, th_node_attr **attrs) {
+    if (node->type == TH_NODE_ELEMENT) {
+        *attrs = node->attrs;
+        return node->attr_count;
+    }
+    *attrs = NULL;
+    return 0;
+}
+
 /* The index of node's attribute named `name` (UTF-8, caller-lowercased), or -1.
    Foreign elements can store a case-adjusted name (e.g. MathML definitionURL), so
    a missed atom match falls back to a case-insensitive scan for non-HTML nodes. */

--- a/src/turbohtml/_c/query/xpath/eval.c
+++ b/src/turbohtml/_c/query/xpath/eval.c
@@ -176,18 +176,22 @@ static int emit_if_match(xp_nodeset *out, struct th_node *node, const xn *step, 
 
 static int apply_step(xp_nodeset *out, struct th_node *ctx, const xn *step, const step_match *match) {
     switch (step->axis) {
-    case AX_ATTRIBUTE:
+    case AX_ATTRIBUTE: {
         /* node() and * both match every attribute; a name test matches by atom; a
            prefixed name test matches none (HTML attributes carry no namespace);
-           text()/comment()/processing-instruction() match no attribute. */
-        for (Py_ssize_t index = 0; index < ctx->attr_count; index++) {
+           text()/comment()/processing-instruction() match no attribute. A non-element
+           context node carries no attribute storage, so the axis yields nothing. */
+        th_node_attr *attrs;
+        Py_ssize_t attr_count = th_node_attributes(ctx, &attrs);
+        for (Py_ssize_t index = 0; index < attr_count; index++) {
             int hit = step->test == NT_STAR || step->test == NT_NODE ||
-                      (step->test == NT_NAME && !match->has_ns && ctx->attrs[index].name_atom == match->attr_atom);
+                      (step->test == NT_NAME && !match->has_ns && attrs[index].name_atom == match->attr_atom);
             if (hit && ns_push(out, ctx, index) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced */
                 return -1;                             /* GCOVR_EXCL_LINE */
             }
         }
         return 0;
+    }
     case AX_SELF:
         return emit_if_match(out, ctx, step, match);
     case AX_CHILD:
@@ -470,18 +474,82 @@ double parse_number(const Py_UCS4 *text, Py_ssize_t len) {
     return seen_digit ? sign * (value + frac) : (double)NAN;
 }
 
-static int format_number(double value, Py_UCS4 **out, Py_ssize_t *out_len) {
-    char buf[64];
-    if (isnan(value)) { /* GCOVR_EXCL_BR_LINE: dead type-dispatch arm of the isnan macro */
-        memcpy(buf, "NaN", 4);
-    } else if (isinf(value)) { /* GCOVR_EXCL_BR_LINE: dead type-dispatch arm of the isinf macro */
-        memcpy(buf, value < 0 ? "-Infinity" : "Infinity", value < 0 ? 10 : 9);
-    } else if (value == (double)(long long)value && fabs(value) < 1e15) {
-        snprintf(buf, sizeof(buf), "%lld", (long long)value);
-    } else {
-        snprintf(buf, sizeof(buf), "%.12g", value);
+/* Render a finite non-integer (or a large integer past the %lld fast path) as the plain
+   decimal XPath 1.0 §4.2 requires: the fewest significant digits that round-trip the
+   double, never an exponent. PyOS_double_to_string with the 'r' code gives the shortest
+   round-tripping digits (the same repr Python's float uses); this expands its mantissa
+   and decimal exponent into positional notation. Returns the written length, or -1 with
+   a Python exception set on allocation failure. */
+static Py_ssize_t decimal_expand(double value, char *out) {
+    char *repr = PyOS_double_to_string(value, 'r', 0, 0, NULL);
+    if (repr == NULL) { /* GCOVR_EXCL_BR_LINE: the repr allocation cannot be forced to fail */
+        return -1;      /* GCOVR_EXCL_LINE */
     }
-    Py_ssize_t len = (Py_ssize_t)strlen(buf);
+    char digits[32];
+    Py_ssize_t written = 0;
+    const char *cursor = repr;
+    if (*cursor == '-') {
+        out[written++] = '-';
+        cursor++;
+    }
+    Py_ssize_t digit_count = 0;
+    Py_ssize_t point = -1; /* index in digits of the decimal point, or the end when absent */
+    for (; *cursor != '\0' && *cursor != 'e'; cursor++) { /* the 'r' code always spells the exponent lowercase */
+        if (*cursor == '.') {
+            point = digit_count;
+        } else {
+            digits[digit_count++] = *cursor;
+        }
+    }
+    if (point < 0) {
+        point = digit_count;
+    }
+    Py_ssize_t exponent = *cursor == '\0' ? 0 : (Py_ssize_t)strtol(cursor + 1, NULL, 10);
+    PyMem_Free(repr);
+    Py_ssize_t split = point + exponent; /* digits left of the point after applying the exponent */
+    if (split <= 0) {
+        out[written++] = '0';
+        out[written++] = '.';
+        for (Py_ssize_t index = 0; index < -split; index++) {
+            out[written++] = '0';
+        }
+        for (Py_ssize_t index = 0; index < digit_count; index++) {
+            out[written++] = digits[index];
+        }
+    } else if (split >= digit_count) {
+        for (Py_ssize_t index = 0; index < digit_count; index++) {
+            out[written++] = digits[index];
+        }
+        for (Py_ssize_t index = 0; index < split - digit_count; index++) {
+            out[written++] = '0';
+        }
+    } else {
+        for (Py_ssize_t index = 0; index < split; index++) {
+            out[written++] = digits[index];
+        }
+        out[written++] = '.';
+        for (Py_ssize_t index = split; index < digit_count; index++) {
+            out[written++] = digits[index];
+        }
+    }
+    return written;
+}
+
+static int format_number(double value, Py_UCS4 **out, Py_ssize_t *out_len) {
+    char buf[512]; /* the widest finite double expands to ~325 decimal digits */
+    Py_ssize_t len;
+    if (isnan(value)) { /* GCOVR_EXCL_BR_LINE: dead type-dispatch arm of the isnan macro */
+        len = snprintf(buf, sizeof(buf), "NaN");
+    } else if (isinf(value)) { /* GCOVR_EXCL_BR_LINE: dead type-dispatch arm of the isinf macro */
+        len = snprintf(buf, sizeof(buf), "%s", value < 0 ? "-Infinity" : "Infinity");
+    } else if (value == (double)(long long)value && fabs(value) < 1e15) {
+        len = snprintf(buf, sizeof(buf), "%lld", (long long)value);
+    } else {
+        len = decimal_expand(value, buf);
+        if (len < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+            return -1; /* GCOVR_EXCL_LINE */
+        }
+    }
     Py_UCS4 *buffer = PyMem_Malloc((size_t)len * sizeof(Py_UCS4));
     if (buffer == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced */
         return -1;        /* GCOVR_EXCL_LINE */
@@ -568,8 +636,9 @@ static int apply_predicates(const xp_program *prog, int32_t pred_head, xp_ctx *c
         Py_ssize_t size = set->len;
         Py_ssize_t write_pos = 0;
         for (Py_ssize_t index = 0; index < set->len; index++) {
-            xp_ctx pctx = {ctx->tree,       set->items[index].node, index + 1,         size, ctx->feature, ctx->vars,
-                           ctx->namespaces, ctx->extension,         ctx->extension_ctx};
+            xp_ctx pctx = {
+                ctx->tree,       set->items[index].node, index + 1,          size,      ctx->feature, ctx->vars,
+                ctx->namespaces, ctx->extension,         ctx->extension_ctx, ctx->depth};
             xp_result value;
             int rc = eval_expr(prog, expr, &pctx, &value);
             if (rc < 0) {
@@ -667,7 +736,7 @@ static int eval_path(const xp_program *prog, int32_t path_idx, xp_ctx *ctx, xp_n
         if (base.kind != XP_NODESET) {
             xp_result_free(&base);
             *ctx->feature = "a path step on a non-node-set";
-            return -2;
+            return -4;
         }
         cur = base.nodes; /* take ownership */
     } else {
@@ -858,7 +927,7 @@ static int copy_result(const xp_result *src, xp_result *dst) {
     return 0;
 }
 
-int eval_expr(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *out) {
+static int eval_expr_inner(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *out) {
     const xn *expr = &prog->nodes[idx];
     switch (expr->kind) {
     case XN_NUM:
@@ -903,7 +972,7 @@ int eval_expr(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *out) 
         if (primary.kind != XP_NODESET) {
             xp_result_free(&primary);
             *ctx->feature = "a predicate on a non-node-set";
-            return -2;
+            return -4;
         }
         sort_unique(&primary.nodes);
         rc = apply_predicates(prog, expr->second, ctx, &primary.nodes);
@@ -930,7 +999,7 @@ int eval_expr(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *out) 
             xp_result_free(&left);
             xp_result_free(&right);
             *ctx->feature = "a union of non-node-sets";
-            return -2;
+            return -4;
         }
         if (nodeset_union(&left.nodes, &right.nodes) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
             xp_result_free(&left);                          /* GCOVR_EXCL_LINE */
@@ -1008,9 +1077,22 @@ int eval_expr(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *out) 
     }
 }
 
+/* Guard every recursive descent with a depth cap so a long operator spine or a deeply
+   nested group raises past the bound instead of overflowing the C stack (issue #421). */
+int eval_expr(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *out) {
+    if (ctx->depth >= XP_MAX_DEPTH) {
+        *ctx->feature = "an expression nested too deeply";
+        return -3;
+    }
+    ctx->depth++;
+    int rc = eval_expr_inner(prog, idx, ctx, out);
+    ctx->depth--;
+    return rc;
+}
+
 int xp_eval(const xp_program *prog, struct th_tree *tree, struct th_node *context, const xp_bindings *vars,
             const xp_namespaces *namespaces, xp_extension_fn extension, void *extension_ctx, xp_result *out,
             const char **feature) {
-    xp_ctx ctx = {tree, context, 1, 1, feature, vars, namespaces, extension, extension_ctx};
+    xp_ctx ctx = {tree, context, 1, 1, feature, vars, namespaces, extension, extension_ctx, 0};
     return eval_expr(prog, prog->root, &ctx, out);
 }

--- a/src/turbohtml/_c/query/xpath/functions.c
+++ b/src/turbohtml/_c/query/xpath/functions.c
@@ -164,6 +164,46 @@ static int substring(struct th_tree *tree, xp_result *args, int argc, xp_result 
     return 0;
 }
 
+/* concat(s, s, s*): the string-values of every argument joined. Variadic (two or more
+   arguments), so the per-argument strings are held in a heap array sized to the call. */
+static int concat(struct th_tree *tree, xp_result *args, int argc, xp_result *out) {
+    Py_UCS4 **parts = PyMem_Calloc((size_t)argc, sizeof(Py_UCS4 *));
+    Py_ssize_t *lens = PyMem_Calloc((size_t)argc, sizeof(Py_ssize_t));
+    if (parts == NULL || lens == NULL) { /* GCOVR_EXCL_BR_LINE: alloc */
+        PyMem_Free(parts);               /* GCOVR_EXCL_LINE */
+        PyMem_Free(lens);                /* GCOVR_EXCL_LINE */
+        return -1;                       /* GCOVR_EXCL_LINE */
+    }
+    int rc = 0;
+    Py_ssize_t total = 0;
+    for (int index = 0; index < argc; index++) {
+        parts[index] = to_string(tree, &args[index], &lens[index]);
+        if (parts[index] == NULL) { /* GCOVR_EXCL_BR_LINE: alloc */
+            rc = -1;                /* GCOVR_EXCL_LINE */
+        } /* GCOVR_EXCL_LINE */
+        total += lens[index];
+    }
+    if (rc == 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+        Py_UCS4 *buf = PyMem_Malloc((size_t)total * sizeof(Py_UCS4));
+        if (buf == NULL) { /* GCOVR_EXCL_BR_LINE: alloc */
+            rc = -1;       /* GCOVR_EXCL_LINE */
+        } else {           /* GCOVR_EXCL_LINE: brace of the never-taken alloc-failure branch */
+            Py_ssize_t write_pos = 0;
+            for (int index = 0; index < argc; index++) {
+                memcpy(buf + write_pos, parts[index], (size_t)lens[index] * sizeof(Py_UCS4));
+                write_pos += lens[index];
+            }
+            result_string(out, buf, total);
+        }
+    }
+    for (int index = 0; index < argc; index++) {
+        PyMem_Free(parts[index]);
+    }
+    PyMem_Free(parts);
+    PyMem_Free(lens);
+    return rc;
+}
+
 /* namespace-uri(): empty for HTML elements, attributes, namespace nodes, and
    non-elements; the foreign-content URI for an SVG or MathML element. */
 static Py_UCS4 *node_namespace_uri(xp_ctx *ctx, xp_result *args, int argc, Py_ssize_t *len) {
@@ -217,10 +257,12 @@ static int node_lang(xp_ctx *ctx, xp_result *arg) {
     }
     int result = 0;
     for (struct th_node *node = ctx->node; node != NULL; node = node->parent) {
+        th_node_attr *attrs;
+        Py_ssize_t attr_count = th_node_attributes(node, &attrs);
         const th_node_attr *lang_attr = NULL;
-        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-            if (node->attrs[index].name_atom == TH_ATTR_LANG) {
-                lang_attr = &node->attrs[index];
+        for (Py_ssize_t index = 0; index < attr_count; index++) {
+            if (attrs[index].name_atom == TH_ATTR_LANG) {
+                lang_attr = &attrs[index];
                 break;
             }
         }
@@ -932,26 +974,142 @@ static int date_leap_year(struct th_tree *tree, const xp_result *arg, xp_result 
     return 0;
 }
 
+/* Every core and EXSLT function's fixed arity (XPath 1.0 §4): the least and most
+   arguments it accepts, with max_args -1 for the one variadic function, concat. A call
+   whose count falls outside this range is a static error rejected before the body runs,
+   so no branch ever reads an argument the caller did not supply (issue #420). */
+typedef struct {
+    const char *name;
+    int8_t min_args;
+    int8_t max_args;
+} xp_func_sig;
+
+static const xp_func_sig FUNC_SIGS[] = {
+    {"last", 0, 0},
+    {"position", 0, 0},
+    {"count", 1, 1},
+    {"id", 1, 1},
+    {"local-name", 0, 1},
+    {"namespace-uri", 0, 1},
+    {"name", 0, 1},
+    {"string", 0, 1},
+    {"concat", 2, -1},
+    {"starts-with", 2, 2},
+    {"contains", 2, 2},
+    {"substring-before", 2, 2},
+    {"substring-after", 2, 2},
+    {"substring", 2, 3},
+    {"string-length", 0, 1},
+    {"normalize-space", 0, 1},
+    {"translate", 3, 3},
+    {"boolean", 1, 1},
+    {"not", 1, 1},
+    {"true", 0, 0},
+    {"false", 0, 0},
+    {"lang", 1, 1},
+    {"number", 0, 1},
+    {"sum", 1, 1},
+    {"floor", 1, 1},
+    {"ceiling", 1, 1},
+    {"round", 1, 1},
+    {"re:test", 2, 3},
+    {"re:replace", 4, 4},
+    {"set:difference", 2, 2},
+    {"set:intersection", 2, 2},
+    {"set:has-same-node", 2, 2},
+    {"set:leading", 2, 2},
+    {"set:trailing", 2, 2},
+    {"set:distinct", 1, 1},
+    {"str:concat", 1, 1},
+    {"str:replace", 3, 3},
+    {"str:padding", 1, 2},
+    {"str:align", 2, 3},
+    {"math:min", 1, 1},
+    {"math:max", 1, 1},
+    {"math:highest", 1, 1},
+    {"math:lowest", 1, 1},
+    {"math:abs", 1, 1},
+    {"math:power", 2, 2},
+    {"date:year", 1, 1},
+    {"date:month-in-year", 1, 1},
+    {"date:day-in-month", 1, 1},
+    {"date:day-in-week", 1, 1},
+    {"date:leap-year", 1, 1},
+};
+
+static const xp_func_sig *func_signature(const xn *fn) {
+    for (size_t index = 0; index < sizeof(FUNC_SIGS) / sizeof(FUNC_SIGS[0]); index++) {
+        if (func_is(fn, FUNC_SIGS[index].name)) {
+            return &FUNC_SIGS[index];
+        }
+    }
+    return NULL;
+}
+
+/* A fresh Python str of the called function's name, for an error message. */
+static PyObject *function_name(const xn *fn) {
+    return PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, fn->str, fn->str_len);
+}
+
+/* Report a call to a name that is neither a core function nor a registered extension.
+   Returns -1 with a ValueError set, which xpath_raise_status then surfaces unchanged. */
+static int raise_unknown_function(const xn *fn) {
+    PyObject *name = function_name(fn);
+    if (name != NULL) { /* GCOVR_EXCL_BR_LINE: the name allocation cannot be forced to fail */
+        PyErr_Format(PyExc_ValueError, "xpath: unknown function '%U'", name);
+        Py_DECREF(name);
+    }
+    return -1;
+}
+
+/* Report a call whose argument count is outside the function's fixed arity. */
+static int raise_arity(const xn *fn, const xp_func_sig *sig, int argc) {
+    PyObject *name = function_name(fn);
+    if (name == NULL) { /* GCOVR_EXCL_BR_LINE: the name allocation cannot be forced to fail */
+        return -1;      /* GCOVR_EXCL_LINE */
+    }
+    if (sig->max_args < 0) {
+        PyErr_Format(PyExc_ValueError, "xpath: %U() takes at least %d arguments, got %d", name, sig->min_args, argc);
+    } else if (sig->min_args == sig->max_args) {
+        PyErr_Format(PyExc_ValueError, "xpath: %U() takes %d argument%s, got %d", name, sig->min_args,
+                     sig->min_args == 1 ? "" : "s", argc);
+    } else {
+        PyErr_Format(PyExc_ValueError, "xpath: %U() takes %d to %d arguments, got %d", name, sig->min_args,
+                     sig->max_args, argc);
+    }
+    Py_DECREF(name);
+    return -1;
+}
+
 int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *out) {
     const xn *fn = &prog->nodes[idx];
-    xp_result args[8];
     int argc = 0;
     for (int32_t arg_node = fn->first; arg_node >= 0; arg_node = prog->nodes[arg_node].next) {
-        if (argc == 8) { /* GCOVR_EXCL_BR_LINE: no supported function takes 8 args */
-            *ctx->feature = "a function with too many arguments";                /* GCOVR_EXCL_LINE */
-            for (int cleanup_index = 0; cleanup_index < argc; cleanup_index++) { /* GCOVR_EXCL_LINE */
-                xp_result_free(&args[cleanup_index]);                            /* GCOVR_EXCL_LINE */
-            } /* GCOVR_EXCL_LINE */
-            return -2; /* GCOVR_EXCL_LINE */
+        argc++;
+    }
+    const xp_func_sig *sig = func_signature(fn);
+    if (sig != NULL && (argc < sig->min_args || (sig->max_args >= 0 && argc > sig->max_args))) {
+        return raise_arity(fn, sig, argc);
+    }
+    xp_result *args = NULL;
+    if (argc > 0) {
+        args = PyMem_Calloc((size_t)argc, sizeof(xp_result));
+        if (args == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced */
+            PyErr_NoMemory(); /* GCOVR_EXCL_LINE */
+            return -1;        /* GCOVR_EXCL_LINE */
         }
-        int rc = eval_expr(prog, arg_node, ctx, &args[argc]);
-        if (rc < 0) {
-            for (int cleanup_index = 0; cleanup_index < argc; cleanup_index++) {
+    }
+    int filled = 0;
+    for (int32_t arg_node = fn->first; arg_node >= 0; arg_node = prog->nodes[arg_node].next) {
+        int arg_rc = eval_expr(prog, arg_node, ctx, &args[filled]);
+        if (arg_rc < 0) {
+            for (int cleanup_index = 0; cleanup_index < filled; cleanup_index++) {
                 xp_result_free(&args[cleanup_index]);
             }
-            return rc;
+            PyMem_Free(args);
+            return arg_rc;
         }
-        argc++;
+        filled++;
     }
     int rc = 0;
     if (func_is(fn, "true") || func_is(fn, "false")) {
@@ -974,14 +1132,14 @@ int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *o
     } else if (func_is(fn, "count")) {
         if (args[0].kind != XP_NODESET) {
             *ctx->feature = "count() of a non-node-set";
-            rc = -2;
+            rc = -4;
         } else {
             result_number(out, (double)args[0].nodes.len);
         }
     } else if (func_is(fn, "sum")) {
         if (args[0].kind != XP_NODESET) {
             *ctx->feature = "sum() of a non-node-set";
-            rc = -2;
+            rc = -4;
         } else {
             double total = 0;
             for (Py_ssize_t index = 0; index < args[0].nodes.len; index++) {
@@ -1048,7 +1206,7 @@ int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *o
                func_is(fn, "set:leading") || func_is(fn, "set:trailing")) {
         if (args[0].kind != XP_NODESET || args[1].kind != XP_NODESET) {
             *ctx->feature = "a set: function on a non-node-set";
-            rc = -2;
+            rc = -4;
         } else if (func_is(fn, "set:difference")) {
             rc = set_filter(args, 0, out);
         } else if (func_is(fn, "set:intersection")) {
@@ -1061,14 +1219,14 @@ int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *o
     } else if (func_is(fn, "set:distinct")) {
         if (args[0].kind != XP_NODESET) {
             *ctx->feature = "set:distinct on a non-node-set";
-            rc = -2;
+            rc = -4;
         } else {
             rc = set_distinct(ctx->tree, &args[0], out);
         }
     } else if (func_is(fn, "str:concat")) {
         if (args[0].kind != XP_NODESET) {
             *ctx->feature = "str:concat on a non-node-set";
-            rc = -2;
+            rc = -4;
         } else {
             rc = str_concat(ctx->tree, &args[0], out);
         }
@@ -1082,7 +1240,7 @@ int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *o
                func_is(fn, "math:lowest")) {
         if (args[0].kind != XP_NODESET) {
             *ctx->feature = "a math: function on a non-node-set";
-            rc = -2;
+            rc = -4;
         } else if (func_is(fn, "math:min") || func_is(fn, "math:max")) {
             rc = math_extreme(ctx->tree, &args[0], func_is(fn, "math:max"), out);
         } else {
@@ -1103,32 +1261,7 @@ int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *o
     } else if (func_is(fn, "date:leap-year")) {
         rc = date_leap_year(ctx->tree, &args[0], out);
     } else if (func_is(fn, "concat")) {
-        Py_ssize_t total = 0;
-        Py_UCS4 *parts[8];
-        Py_ssize_t lens[8];
-        for (int index = 0; index < argc; index++) {
-            parts[index] = to_string(ctx->tree, &args[index], &lens[index]);
-            if (parts[index] == NULL) { /* GCOVR_EXCL_BR_LINE: alloc */
-                rc = -1;                /* GCOVR_EXCL_LINE */
-            } /* GCOVR_EXCL_LINE */
-            total += lens[index];
-        }
-        if (rc == 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-            Py_UCS4 *buf = PyMem_Malloc((size_t)total * sizeof(Py_UCS4));
-            if (buf == NULL) { /* GCOVR_EXCL_BR_LINE: alloc */
-                rc = -1;       /* GCOVR_EXCL_LINE */
-            } else {           /* GCOVR_EXCL_LINE: brace of the never-taken alloc-failure branch */
-                Py_ssize_t write_pos = 0;
-                for (int index = 0; index < argc; index++) {
-                    memcpy(buf + write_pos, parts[index], (size_t)lens[index] * sizeof(Py_UCS4));
-                    write_pos += lens[index];
-                }
-                result_string(out, buf, total);
-            }
-        }
-        for (int index = 0; index < argc; index++) {
-            PyMem_Free(parts[index]);
-        }
+        rc = concat(ctx->tree, args, argc, out);
     } else if (func_is(fn, "starts-with") || func_is(fn, "contains")) {
         Py_ssize_t hl;
         Py_ssize_t nl;
@@ -1183,12 +1316,12 @@ int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *o
                (rc = ctx->extension(ctx->extension_ctx, ctx->node, fn->str, fn->str_len, args, argc, out)) != -2) {
         /* a registered extension handled it (rc is 0 or a propagated error) */
     } else {
-        *ctx->feature = "this function";
-        rc = -2;
+        rc = raise_unknown_function(fn);
     }
     for (int cleanup_index = 0; cleanup_index < argc; cleanup_index++) {
         xp_result_free(&args[cleanup_index]);
     }
+    PyMem_Free(args);
     return rc;
 }
 

--- a/src/turbohtml/_c/query/xpath/internal.h
+++ b/src/turbohtml/_c/query/xpath/internal.h
@@ -128,6 +128,7 @@ typedef struct {
     const Py_UCS4 *src;
     Py_ssize_t len;
     Py_ssize_t pos;
+    Py_ssize_t tokpos; /* start of the current token in src, for error positions */
     tok_kind kind;
     const Py_UCS4 *tstart; /* NAME / LITERAL text (into src) */
     Py_ssize_t tlen;
@@ -159,6 +160,12 @@ int xp_name_eq(const lexer *lx, const char *kw);
 #define XP_SVG_NS_URI "http://www.w3.org/2000/svg"
 #define XP_MATHML_NS_URI "http://www.w3.org/1998/Math/MathML"
 
+/* An upper bound on parser nesting and evaluator recursion. A single group or
+   operator level costs a bounded number of C stack frames, so this caps the stack a
+   pathological expression -- deeply nested groups, or a long left-associative operator
+   spine -- can consume before it faults (issue #421). */
+#define XP_MAX_DEPTH 1024
+
 /* The evaluation context: the tree, the current node, its 1-based proximity
    position and the context size, plus where to report an unimplemented feature. */
 typedef struct {
@@ -171,6 +178,7 @@ typedef struct {
     const xp_namespaces *namespaces;
     xp_extension_fn extension;
     void *extension_ctx;
+    int depth; /* current eval_expr recursion depth, capped at XP_MAX_DEPTH */
 } xp_ctx;
 
 /* Pre-order successor, shared by the evaluator and id(). ns_push is declared in the

--- a/src/turbohtml/_c/query/xpath/lexer.c
+++ b/src/turbohtml/_c/query/xpath/lexer.c
@@ -60,6 +60,7 @@ void lex_next(lexer *lx) {
         lx->pos++;
     }
     int prev_op = lx->op_context;
+    lx->tokpos = lx->pos;
     if (lx->pos >= lx->len) {
         lx->kind = TK_EOF;
         return;

--- a/src/turbohtml/_c/query/xpath/parser.c
+++ b/src/turbohtml/_c/query/xpath/parser.c
@@ -11,13 +11,20 @@ typedef struct {
     lexer lx;
     xp_program *prog;
     int failed;
+    int depth; /* current parse recursion depth, capped at XP_MAX_DEPTH */
     const char *msg;
+    Py_ssize_t err_pos;     /* offset of the offending token when failed */
+    const Py_UCS4 *err_tok; /* the offending token text (into the source) */
+    Py_ssize_t err_tok_len;
 } parser;
 
 static void fail(parser *ps, const char *msg) {
     if (!ps->failed) {
         ps->failed = 1;
         ps->msg = msg;
+        ps->err_pos = ps->lx.tokpos;
+        ps->err_tok = ps->lx.src + ps->lx.tokpos;
+        ps->err_tok_len = ps->lx.pos - ps->lx.tokpos;
     }
 }
 
@@ -427,18 +434,31 @@ static int32_t parse_union(parser *ps) {
     return left;
 }
 
+/* Every recursion cycle -- a nested group, a predicate, a function argument, or a chain
+   of unary minus -- descends through here, so a single depth cap bounds the whole
+   parser's stack use and raises past the bound instead of overflowing (issue #421). */
 static int32_t parse_unary(parser *ps) {
+    if (ps->depth >= XP_MAX_DEPTH) {
+        fail(ps, "expression nested too deeply");
+        return -1;
+    }
+    ps->depth++;
+    int32_t result;
     if (ps->lx.kind == TK_MINUS) {
         lex_next(&ps->lx);
         int32_t operand = parse_unary(ps);
         int32_t neg = xn_new(ps->prog, XN_NEG);
-        if (neg < 0) { /* GCOVR_EXCL_BR_LINE: arena allocation failure cannot be forced */
-            return -1; /* GCOVR_EXCL_LINE */
+        if (neg < 0) {   /* GCOVR_EXCL_BR_LINE: arena allocation failure cannot be forced */
+            ps->depth--; /* GCOVR_EXCL_LINE */
+            return -1;   /* GCOVR_EXCL_LINE */
         }
         ps->prog->nodes[neg].first = operand;
-        return neg;
+        result = neg;
+    } else {
+        result = parse_union(ps);
     }
-    return parse_union(ps);
+    ps->depth--;
+    return result;
 }
 
 static int32_t parse_multiplicative(parser *ps) {
@@ -674,6 +694,28 @@ static void optimize_descendant_steps(xp_program *prog) {
     }
 }
 
+/* Write the parse error into errbuf: the reason, the source offset, and a short ASCII
+   slice of the offending token (non-ASCII code points shown as '?'), or a note that the
+   expression ended early when the failure is at end of input. */
+static void format_error(char *errbuf, size_t errlen, const parser *ps) {
+    /* ps->msg is NULL only when an arena OOM failed the parse without a message, which
+       cannot be forced from a test */
+    const char *reason = ps->msg != NULL ? ps->msg : "invalid XPath expression"; /* GCOVR_EXCL_BR_LINE */
+    char token[32];
+    Py_ssize_t span = ps->err_tok_len > 0 ? ps->err_tok_len : (ps->err_pos < ps->lx.len ? 1 : 0);
+    Py_ssize_t count = span < (Py_ssize_t)sizeof(token) - 1 ? span : (Py_ssize_t)sizeof(token) - 1;
+    for (Py_ssize_t index = 0; index < count; index++) {
+        Py_UCS4 ch = ps->err_tok[index];
+        token[index] = ch < 0x80 ? (char)ch : '?';
+    }
+    token[count] = '\0';
+    if (count > 0) {
+        snprintf(errbuf, errlen, "%s at offset %zd near '%s'", reason, ps->err_pos, token);
+    } else {
+        snprintf(errbuf, errlen, "%s at the end of the expression", reason);
+    }
+}
+
 xp_program *xp_compile(const Py_UCS4 *src, Py_ssize_t len, char *errbuf, size_t errlen) {
     xp_program *prog = PyMem_Malloc(sizeof(*prog));
     if (prog == NULL) {                            /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced */
@@ -704,8 +746,8 @@ xp_program *xp_compile(const Py_UCS4 *src, Py_ssize_t len, char *errbuf, size_t 
     }
     /* root < 0 and a NULL message only arise from an arena allocation failure that
        did not record a message, so those branches cannot be forced from a test */
-    if (ps.failed || prog->root < 0) {                                                /* GCOVR_EXCL_BR_LINE */
-        snprintf(errbuf, errlen, "%s", ps.msg ? ps.msg : "invalid XPath expression"); /* GCOVR_EXCL_BR_LINE */
+    if (ps.failed || prog->root < 0) { /* GCOVR_EXCL_BR_LINE: root < 0 is an unforced arena OOM */
+        format_error(errbuf, errlen, &ps);
         xp_free(prog);
         return NULL;
     }

--- a/src/turbohtml/_c/query/xpath/xpath.h
+++ b/src/turbohtml/_c/query/xpath/xpath.h
@@ -107,10 +107,12 @@ typedef int (*xp_extension_fn)(void *ctx, struct th_node *context_node, const Py
    (NULL when none); namespaces supplies prefix-to-URI bindings for prefixed name tests
    (NULL when none); extension/extension_ctx supply user functions (extension NULL when
    none). Returns 0 with *out filled (the caller frees it with xp_result_free). Returns
-   -2 for a construct not yet implemented, or -3 for an evaluation error (a reference to
-   an unbound variable, or a name test whose prefix is not bound), with *feature set to a
-   short name for the message. Returns -1 on allocation failure (or a Python error from
-   an extension). */
+   -3 for an evaluation error that maps to ValueError (a reference to an unbound variable,
+   a name test whose prefix is not bound, or an expression nested past XP_MAX_DEPTH), or
+   -4 for a type error that maps to TypeError (a value used where a node-set is required),
+   with *feature set to a short name for the message. Returns -1 on allocation failure or
+   when a Python error is already set (a malformed regex, an extension failure, or an
+   unknown-function/wrong-arity call reported with the function name). */
 struct th_tree;
 int xp_eval(const xp_program *prog, struct th_tree *tree, struct th_node *context, const xp_bindings *vars,
             const xp_namespaces *namespaces, xp_extension_fn extension, void *extension_ctx, xp_result *out,

--- a/tests/query/xpath/test_xpath_eval.py
+++ b/tests/query/xpath/test_xpath_eval.py
@@ -213,7 +213,7 @@ def test_xpath_iter_supports_partial_consumption(doc: turbohtml.Node) -> None:
 
 
 def test_xpath_iter_propagates_errors(doc: turbohtml.Node) -> None:
-    with pytest.raises(NotImplementedError, match="this function"):
+    with pytest.raises(ValueError, match="unknown function 'bogus-fn'"):
         doc.xpath_iter("bogus-fn(1)")
     with pytest.raises(TypeError, match="must be a str"):
         doc.xpath_iter(123)  # ty: ignore[invalid-argument-type]  # non-str exercises the TypeError path
@@ -225,8 +225,8 @@ def test_namespace_axis(doc: turbohtml.Node) -> None:
     assert doc.xpath("//p/namespace::*") == ["http://www.w3.org/XML/1998/namespace"] * 2
 
 
-def test_xpath_one_unsupported_raises(doc: turbohtml.Node) -> None:
-    with pytest.raises(NotImplementedError, match="this function"):
+def test_xpath_one_unknown_function_raises(doc: turbohtml.Node) -> None:
+    with pytest.raises(ValueError, match="unknown function 'bogus-fn'"):
         doc.xpath_one("bogus-fn(1)")
 
 
@@ -650,3 +650,43 @@ def _every_element(document: Document) -> list[Element]:
 @pytest.mark.parametrize("element", _every_element(_PATH_DOCUMENT), ids=lambda element: element.xpath_path())
 def test_xpath_path_reselects_only_this_element(element: Element) -> None:
     assert _PATH_DOCUMENT.xpath(element.xpath_path()) == [element]
+
+
+# //@id expands to descendant-or-self::node()/@id, so the attribute axis visits the text
+# nodes in the tree. A text-node span reuses attr_count as a source offset with
+# attrs == NULL, so an axis that read attribute storage without an element-type gate
+# dereferenced a null pointer (issue #401).
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        pytest.param("//@id", ["x"], id="named"),
+        pytest.param("//@*", ["x", "en"], id="wildcard"),
+        pytest.param("//node()/@id", ["x"], id="via-node-test"),
+        pytest.param("string(//@id)", "x", id="string-of-attribute"),
+    ],
+)
+def test_attribute_axis_survives_text_nodes(expr: str, expected: object) -> None:
+    doc = turbohtml.parse("<a id=x lang=en>hi<b>x</b></a>")
+    assert doc.xpath(expr) == expected
+
+
+def test_attribute_axis_of_a_text_node_is_empty() -> None:
+    assert turbohtml.parse("<a>t</a>").xpath("//text()/@id") == []
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pytest.param(" or ".join(["1=1"] * 5000), id="or-spine"),
+        pytest.param("+".join(["1"] * 5000), id="additive-spine"),
+    ],
+)
+def test_deep_operator_spine_raises_instead_of_overflowing(doc: turbohtml.Node, expr: str) -> None:
+    # a long left-associative chain parses iteratively but the evaluator descends its
+    # spine; the depth cap raises before the C stack overflows (issue #421)
+    with pytest.raises(ValueError, match="nested too deeply"):
+        doc.xpath(expr)
+
+
+def test_moderately_nested_expression_still_evaluates(doc: turbohtml.Node) -> None:
+    assert doc.xpath("(" * 100 + "1 + 1" + ")" * 100) == pytest.approx(2.0)

--- a/tests/query/xpath/test_xpath_exslt.py
+++ b/tests/query/xpath/test_xpath_exslt.py
@@ -150,7 +150,7 @@ def test_set_has_same_node(doc: turbohtml.Node, expr: str, *, expected: bool) ->
     ],
 )
 def test_set_non_nodeset_argument_raises(doc: turbohtml.Node, expr: str) -> None:
-    with pytest.raises(NotImplementedError, match="non-node-set"):
+    with pytest.raises(TypeError, match="non-node-set"):
         doc.xpath(expr)
 
 
@@ -224,7 +224,7 @@ def test_str_functions(doc: turbohtml.Node, expr: str, expected: str) -> None:
 
 
 def test_str_concat_non_nodeset_argument_raises(doc: turbohtml.Node) -> None:
-    with pytest.raises(NotImplementedError, match="non-node-set"):
+    with pytest.raises(TypeError, match="non-node-set"):
         doc.xpath("str:concat('x')")
 
 
@@ -281,7 +281,7 @@ def test_math_select(doc: turbohtml.Node, expr: str, expected: list[str]) -> Non
     ],
 )
 def test_math_non_nodeset_argument_raises(doc: turbohtml.Node, expr: str) -> None:
-    with pytest.raises(NotImplementedError, match="non-node-set"):
+    with pytest.raises(TypeError, match="non-node-set"):
         doc.xpath(expr)
 
 

--- a/tests/query/xpath/test_xpath_extensions.py
+++ b/tests/query/xpath/test_xpath_extensions.py
@@ -88,18 +88,18 @@ def test_extension_through_xpath_one(doc: turbohtml.Node) -> None:
     assert doc.xpath_one("count_nodes(//a)", extensions=EXTENSIONS) == pytest.approx(2.0)
 
 
-def test_unknown_function_with_extensions_is_unimplemented(doc: turbohtml.Node) -> None:
-    with pytest.raises(NotImplementedError):
+def test_unknown_function_with_extensions_raises(doc: turbohtml.Node) -> None:
+    with pytest.raises(ValueError, match="unknown function 'nope'"):
         doc.xpath("nope()", extensions=EXTENSIONS)
 
 
-def test_unknown_function_without_extensions_is_unimplemented(doc: turbohtml.Node) -> None:
-    with pytest.raises(NotImplementedError):
+def test_unknown_function_without_extensions_raises(doc: turbohtml.Node) -> None:
+    with pytest.raises(ValueError, match="unknown function 'count_nodes'"):
         doc.xpath("count_nodes(//a)")
 
 
 def test_empty_extensions_dict_registers_nothing(doc: turbohtml.Node) -> None:
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError, match="unknown function 'count_nodes'"):
         doc.xpath("count_nodes(//a)", extensions={})
 
 

--- a/tests/query/xpath/test_xpath_functions.py
+++ b/tests/query/xpath/test_xpath_functions.py
@@ -7,6 +7,7 @@ matching ``float`` / ``str`` / ``bool``, the same as lxml.
 from __future__ import annotations
 
 import math
+import re
 
 import pytest
 
@@ -71,7 +72,7 @@ def doc() -> turbohtml.Node:
         pytest.param("string(1 div 0)", "Infinity", id="string-infinity"),
         pytest.param("string(-1 div 0)", "-Infinity", id="string-neg-infinity"),
         pytest.param("string(0 div 0)", "NaN", id="string-nan"),
-        pytest.param("string(1000000000000000)", "1e+15", id="string-huge"),
+        pytest.param("string(1000000000000000)", "1000000000000000", id="string-huge"),
         pytest.param("string(//input/@disabled)", "", id="string-valueless-attr"),
         pytest.param("string(//comment())", "note", id="string-comment"),
         pytest.param("concat('a', 'b', 'c')", "abc", id="concat"),
@@ -181,36 +182,49 @@ def test_filter_base_node_set_continues_as_path(doc: turbohtml.Node) -> None:
     assert [node.tag for node in result if isinstance(node, Element)] == ["p", "p", "p"]
 
 
+# An unknown function name is a static error (XPath 1.0 §3.2); nested inside any
+# expression form the ValueError still propagates out, naming the offending function.
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pytest.param("bogus-fn(1)", id="unknown-function"),
+        pytest.param("count(bogus-fn(1))", id="in-function-arg"),
+        pytest.param("concat('x', bogus-fn(1))", id="in-later-function-arg"),
+        pytest.param("//p[bogus-fn(1)]", id="in-predicate"),
+        pytest.param("(bogus-fn(1))[1]", id="in-filter-primary"),
+        pytest.param("(//p)[bogus-fn(1)]", id="in-filter-predicate"),
+        pytest.param("(bogus-fn(1))/p", id="in-filter-base"),
+        pytest.param("bogus-fn(1) | //p", id="in-union-left"),
+        pytest.param("//p | bogus-fn(1)", id="in-union-right"),
+        pytest.param("bogus-fn(1) or 1", id="in-or-left"),
+        pytest.param("false() or bogus-fn(1)", id="in-or-right"),
+        pytest.param("bogus-fn(1) and 1", id="in-and-left"),
+        pytest.param("true() and bogus-fn(1)", id="in-and-right"),
+        pytest.param("- bogus-fn(1)", id="in-negation"),
+        pytest.param("bogus-fn(1) = 1", id="in-compare-left"),
+        pytest.param("1 = bogus-fn(1)", id="in-compare-right"),
+    ],
+)
+def test_unknown_function_raises(doc: turbohtml.Node, expr: str) -> None:
+    with pytest.raises(ValueError, match=r"xpath: unknown function 'bogus-fn'"):
+        doc.xpath(expr)
+
+
+# A scalar where the grammar requires a node-set is a type error, not an unimplemented
+# feature: the function arguments, the path base, a predicate base, and a union operand.
 @pytest.mark.parametrize(
     ("expr", "message"),
     [
-        pytest.param("bogus-fn(1)", "this function", id="unknown-function"),
         pytest.param("count('x')", "count.. of a non-node-set", id="count-non-nodeset"),
         pytest.param("sum('x')", "sum.. of a non-node-set", id="sum-non-nodeset"),
-        pytest.param("(1)/p", "non-node-set", id="path-on-non-nodeset"),
-        pytest.param("(1)[1]", "non-node-set", id="predicate-on-non-nodeset"),
-        pytest.param("//a | 1", "non-node-set", id="union-of-non-nodesets"),
-        pytest.param("1 | //a", "non-node-set", id="union-non-nodeset-left"),
-        # an unknown function nested in each expression form propagates the error out
-        pytest.param("count(bogus-fn(1))", "this function", id="in-function-arg"),
-        pytest.param("concat('x', bogus-fn(1))", "this function", id="in-later-function-arg"),
-        pytest.param("//p[bogus-fn(1)]", "this function", id="in-predicate"),
-        pytest.param("(bogus-fn(1))[1]", "this function", id="in-filter-primary"),
-        pytest.param("(//p)[bogus-fn(1)]", "this function", id="in-filter-predicate"),
-        pytest.param("(bogus-fn(1))/p", "this function", id="in-filter-base"),
-        pytest.param("bogus-fn(1) | //p", "this function", id="in-union-left"),
-        pytest.param("//p | bogus-fn(1)", "this function", id="in-union-right"),
-        pytest.param("bogus-fn(1) or 1", "this function", id="in-or-left"),
-        pytest.param("false() or bogus-fn(1)", "this function", id="in-or-right"),
-        pytest.param("bogus-fn(1) and 1", "this function", id="in-and-left"),
-        pytest.param("true() and bogus-fn(1)", "this function", id="in-and-right"),
-        pytest.param("- bogus-fn(1)", "this function", id="in-negation"),
-        pytest.param("bogus-fn(1) = 1", "this function", id="in-compare-left"),
-        pytest.param("1 = bogus-fn(1)", "this function", id="in-compare-right"),
+        pytest.param("(1)/p", "path step on a non-node-set", id="path-on-non-nodeset"),
+        pytest.param("(1)[1]", "predicate on a non-node-set", id="predicate-on-non-nodeset"),
+        pytest.param("//a | 1", "union of non-node-sets", id="union-of-non-nodesets"),
+        pytest.param("1 | //a", "union of non-node-sets", id="union-non-nodeset-left"),
     ],
 )
-def test_unsupported_constructs_raise(doc: turbohtml.Node, expr: str, message: str) -> None:
-    with pytest.raises(NotImplementedError, match=message):
+def test_non_nodeset_raises_type_error(doc: turbohtml.Node, expr: str, message: str) -> None:
+    with pytest.raises(TypeError, match=message):
         doc.xpath(expr)
 
 
@@ -229,3 +243,82 @@ def test_namespace_axis(doc: turbohtml.Node) -> None:
     assert doc.xpath("//p/namespace::*/a") == []  # a namespace node has no axes
     # an attribute and the namespace node of the same element sort node-then-namespace
     assert doc.xpath("count(//p/@class | //p/namespace::*)") == pytest.approx(4.0)
+
+
+# A core function has a fixed arity (XPath 1.0 §4). Too few arguments used to read an
+# uninitialized args[] slot and fault; too many were silently ignored. Both now raise.
+@pytest.mark.parametrize(
+    ("expr", "message"),
+    [
+        pytest.param("count()", "count() takes 1 argument, got 0", id="count-too-few"),
+        pytest.param("count(//a, //a)", "count() takes 1 argument, got 2", id="count-too-many"),
+        pytest.param("true(1)", "true() takes 0 arguments, got 1", id="niladic-too-many"),
+        pytest.param("starts-with()", "starts-with() takes 2 arguments, got 0", id="starts-with-too-few"),
+        pytest.param("sum()", "sum() takes 1 argument, got 0", id="sum-too-few"),
+        pytest.param("floor()", "floor() takes 1 argument, got 0", id="floor-too-few"),
+        pytest.param("id()", "id() takes 1 argument, got 0", id="id-too-few"),
+        pytest.param("translate('a')", "translate() takes 3 arguments, got 1", id="fixed-three-too-few"),
+        pytest.param("substring('a')", "substring() takes 2 to 3 arguments, got 1", id="range-too-few"),
+        pytest.param("substring('a', 1, 2, 3)", "substring() takes 2 to 3 arguments, got 4", id="range-too-many"),
+        pytest.param("concat('a')", "concat() takes at least 2 arguments, got 1", id="variadic-too-few"),
+    ],
+)
+def test_wrong_arity_raises_value_error(doc: turbohtml.Node, expr: str, message: str) -> None:
+    with pytest.raises(ValueError, match=re.escape(message)):
+        doc.xpath(expr)
+
+
+def test_count_of_a_nodeset_is_the_length_not_uninitialized_memory(doc: turbohtml.Node) -> None:
+    # count() with no argument used to return an uninitialized stack double
+    assert doc.xpath("count(//zzz)") == pytest.approx(0.0)
+    assert doc.xpath("count(//p)") == pytest.approx(3.0)
+
+
+def test_concat_grows_past_the_old_eight_argument_buffer(doc: turbohtml.Node) -> None:
+    assert doc.xpath("concat(1,2,3,4,5,6,7,8,9,0)") == "1234567890"
+
+
+# XPath 1.0 §4.2: a number stringifies to the fewest digits that round-trip the double,
+# always in positional notation (no exponent).
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(1 / 3, "0.3333333333333333", id="one-third"),
+        pytest.param(0.1, "0.1", id="tenth"),
+        pytest.param(0.2, "0.2", id="fifth"),
+        pytest.param(2 / 3, "0.6666666666666666", id="two-thirds"),
+        pytest.param(1e-7, "0.0000001", id="small-decimal"),
+        pytest.param(1.5e-7, "0.00000015", id="small-decimal-mantissa"),
+        pytest.param(1e21, "1000000000000000000000", id="large-integer"),
+        pytest.param(1.25e21, "1250000000000000000000", id="large-integer-mantissa"),
+        pytest.param(42.0, "42", id="integer-fast-path"),
+        pytest.param(-0.5, "-0.5", id="negative-fraction"),
+        pytest.param(1234567890123456.7, "1234567890123456.8", id="seventeen-significant-digits"),
+    ],
+)
+def test_number_to_string_is_shortest_decimal(value: float, expected: str) -> None:
+    doc = turbohtml.parse("<r/>")
+    assert doc.xpath("string($v)", v=value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(1 / 3, id="one-third"),
+        pytest.param(0.1, id="tenth"),
+        pytest.param(2 / 3, id="two-thirds"),
+        pytest.param(math.pi, id="pi"),
+        pytest.param(math.e, id="e"),
+        pytest.param(1e-7, id="small"),
+        pytest.param(1e21, id="large"),
+        pytest.param(123.456, id="mixed"),
+        pytest.param(9.999999999999999e-5, id="seventeen-digits"),
+        pytest.param(5e-324, id="smallest-subnormal"),
+    ],
+)
+def test_number_to_string_round_trips(value: float) -> None:
+    doc = turbohtml.parse("<r/>")
+    rendered = doc.xpath("string($v)", v=value)
+    assert isinstance(rendered, str)
+    # the rendered decimal parses back to the bit-identical double it came from
+    assert float(rendered).hex() == float(value).hex()

--- a/tests/query/xpath/test_xpath_node_functions.py
+++ b/tests/query/xpath/test_xpath_node_functions.py
@@ -122,3 +122,16 @@ def test_lang_reads_html_lang_attribute_where_lxml_reads_xml_lang(langs: turboht
     # lxml's lang() returns nothing here (no xml:lang); turbohtml matches the
     # 'inherit' (lang='en-US') and 'outer' (lang='en') paragraphs.
     assert len(langs.xpath("//p[lang('en')]")) == 2
+
+
+def test_lang_on_a_text_node_context_reads_ancestor_lang() -> None:
+    # lang() walks self-or-ancestor elements from the context node; on a text-node
+    # context it used to loop over a text-node span's attr_count with attrs == NULL and
+    # dereference a null pointer (issue #422)
+    doc = turbohtml.parse("<p lang=en>hi<b>x</b></p>")
+    assert doc.xpath('//text()[lang("en")]') == ["hi", "x"]
+
+
+def test_lang_is_false_with_no_lang_bearing_ancestor() -> None:
+    doc = turbohtml.parse("<div><p>hi</p></div>")
+    assert doc.xpath("//text()[lang('en')]") == []

--- a/tests/query/xpath/test_xpath_parse.py
+++ b/tests/query/xpath/test_xpath_parse.py
@@ -6,6 +6,8 @@ these assert the parse shape without an evaluator. Evaluation lands in a later p
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from turbohtml import _html
@@ -296,3 +298,38 @@ def test_rejects(expr: str, message: str) -> None:
 def test_non_string_argument() -> None:
     with pytest.raises(TypeError, match="must be a str"):
         parse(123)  # ty: ignore[invalid-argument-type]  # non-str exercises the TypeError path
+
+
+@pytest.mark.parametrize(
+    ("expr", "fragment"),
+    [
+        pytest.param("a~b", "invalid character in expression at offset 1 near '~'", id="stray-char"),
+        pytest.param("1 2", "trailing tokens at offset 2 near '2'", id="trailing-token"),
+        pytest.param("(1", "expected ')' at the end of the expression", id="early-end"),
+        pytest.param("1 δ", "trailing tokens at offset 2 near '?'", id="non-ascii-token"),
+    ],
+)
+def test_parse_error_names_position_and_token(expr: str, fragment: str) -> None:
+    with pytest.raises(ValueError, match=re.escape(fragment)):
+        parse(expr)
+
+
+def test_parse_error_clamps_a_long_offending_token() -> None:
+    with pytest.raises(ValueError, match="offset") as excinfo:
+        parse("1 " + "z" * 60)
+    assert "z" * 31 in str(excinfo.value)
+    assert "z" * 32 not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        pytest.param("(" * 5000 + "1" + ")" * 5000, id="nested-groups"),
+        pytest.param("-" * 5000 + "1", id="unary-minus-chain"),
+    ],
+)
+def test_deeply_nested_expression_is_rejected(expr: str) -> None:
+    # nested groups and a chain of unary minus both recurse in the parser; the depth cap
+    # raises before the C stack overflows (issue #421)
+    with pytest.raises(ValueError, match="nested too deeply"):
+        parse(expr)


### PR DESCRIPTION
A differential audit of the XPath engine turned up four ways a valid, idiomatic query could fault the interpreter or leak stack memory. `//@id` on any document containing a text node segfaulted, because `//` visits text nodes and the attribute axis then walked element attribute storage on one; a text-node span reuses `attr_count` as a source offset with `attrs == NULL`, so the loop dereferenced a null pointer. 💥 `lang()` hit the same null through a different reader. A core function called with too few arguments read an uninitialized `args[]` slot as an `xp_result` and faulted, and `count()` with no argument returned an uninitialized stack double. A deeply nested group or a long left-associative operator spine overflowed the C stack at parse or eval time. And `string(1 div 3)` truncated to 12 significant digits, so the value no longer round-tripped.

The root of the two crash classes is that several readers touched a node's attribute storage without checking the node is an element. This routes every one of them through a single `th_node_attributes` accessor that returns an empty span for non-elements, so the attribute axis, `lang()`, and the namespace axis all yield the spec-correct empty result instead of a fault. Function calls now carry a fixed-arity table (XPath 1.0 §4): the engine rejects a call outside a function's argument range before its body runs, and sizes the argument buffer to the call, which also lifts the old eight-argument cap on `concat`. The parser and evaluator share a depth bound that raises past pathological nesting rather than recursing into the stack guard. Number-to-string uses `PyOS_double_to_string` for the shortest round-tripping digits, expanded to the positional notation XPath requires (no exponent), so `string(1 div 3)` is `0.3333333333333333` and `number(string(x))` equals `x`.

The error surface is now spec-shaped: an unknown function raises `ValueError` naming it, a value used where the grammar requires a node-set raises `TypeError`, and a parse error carries the offending token and its source offset. This replaces the previous `NotImplementedError: xpath: ... are not implemented yet`, so callers catching that class for these cases need to catch `ValueError` or `TypeError` instead. The touched xpath docstrings gained `:raises:` blocks.

closes #401
closes #422
closes #420
closes #398
part of #421
part of #434
