### PR TITLE
🐛 fix(serialize): JavaScript minifier miscompiles

### DIFF
--- a/docs/changelog/407.bugfix.rst
+++ b/docs/changelog/407.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`~turbohtml.minify_js` now accepts a string ``LineContinuation`` whose backslash is followed by a CR-LF pair, so a
+CRLF-authored source no longer fails to lex.

--- a/docs/changelog/419.bugfix.rst
+++ b/docs/changelog/419.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`~turbohtml.minify_js` no longer lowers a computed member access on an integer literal to dot access
+(``25["toString"]()`` became the unparsable ``25.toString()``); the object is now parenthesised as ``(25).toString()``.

--- a/docs/changelog/435.bugfix.rst
+++ b/docs/changelog/435.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`~turbohtml.minify_js` no longer folds ``test?y:y`` to ``y`` when ``test`` is a bare identifier, which would drop
+the ``ReferenceError`` an unresolvable read throws.

--- a/docs/changelog/436.bugfix.rst
+++ b/docs/changelog/436.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`~turbohtml.minify_js` now reads a string literal's decoded value when deciding truthiness, so a
+line-continuation-only string (value ``""``) folds as falsy instead of truthy in a conditional or ``&&``/``||``.

--- a/docs/changelog/437.bugfix.rst
+++ b/docs/changelog/437.bugfix.rst
@@ -1,0 +1,3 @@
+:func:`~turbohtml.minify_js` now folds adjacent string literals by their decoded values instead of splicing the raw
+lexemes, so a trailing octal or hex escape in the left operand can no longer absorb the next operand's leading character
+(``"\1"+"2"`` kept the value ``"12"``, not the single escape ``"\12"``).

--- a/docs/changelog/438.bugfix.rst
+++ b/docs/changelog/438.bugfix.rst
@@ -1,0 +1,3 @@
+:func:`~turbohtml.minify_js` now compares identifiers by their decoded ECMA-262 StringValue, so a Unicode-escaped
+declaration links to its plainly-spelled use instead of being judged unused and dropped (turning the use into a free
+variable that throws).

--- a/src/turbohtml/_c/serialize/js/ast.c
+++ b/src/turbohtml/_c/serialize/js/ast.c
@@ -123,6 +123,208 @@ const Py_UCS4 *jm_program_own(jm_program *prog, const Py_UCS4 *buf, Py_ssize_t l
     return copy;
 }
 
+/* ----------------------------------------------------------- string/identifier values */
+
+/* The value of one hex digit. The lexer only forms a \x / \u escape over hex digits in valid input,
+   so a non-hex code point here is malformed input outside the minifier's valid-JS contract; it
+   decodes to a bounded (harmless) value rather than reading past the lexeme. */
+static Py_UCS4 jm_hex_digit(Py_UCS4 ch) {
+    return ch >= 'a' ? ch - ('a' - 10) : ch >= 'A' ? ch - ('A' - 10) : ch - '0';
+}
+
+const Py_UCS4 *jm_ident_value(jm_program *prog, const Py_UCS4 *src, Py_ssize_t len, Py_ssize_t *out_len) {
+    Py_ssize_t escape = 0;
+    while (escape < len && src[escape] != '\\') {
+        escape++;
+    }
+    if (escape == len) { /* the common escape-free name: keep the zero-copy source span */
+        *out_len = len;
+        return src;
+    }
+    Py_UCS4 *buf = jm_malloc((size_t)len * sizeof(Py_UCS4)); /* decoding only ever shortens */
+    if (buf == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        *out_len = len; /* GCOVR_EXCL_LINE */
+        return src;     /* GCOVR_EXCL_LINE */
+    }
+    Py_ssize_t write = 0;
+    for (Py_ssize_t read = 0; read < len;) {
+        Py_UCS4 ch = src[read++];
+        if (ch != '\\') { /* an identifier escape is only ever \uXXXX or \u{...} */
+            buf[write++] = ch;
+            continue;
+        }
+        read++; /* the `u` */
+        Py_UCS4 value = 0;
+        /* GCOVR_EXCL_BR_START: the `read <` guards only stop a read past a truncated \u at the lexeme
+           end -- malformed input outside the valid-JS contract, with no defined value to assert */
+        if (read < len && src[read] == '{') {
+            for (read++; read < len && src[read] != '}'; read++) {
+                value = (value << 4) | jm_hex_digit(src[read]);
+            }
+            /* GCOVR_EXCL_BR_STOP */
+            read++; /* the closing } (present in valid input) */
+        } else {
+            for (int digit = 0; digit < 4; digit++) {
+                if (read >= len) { /* GCOVR_EXCL_BR_LINE: a truncated \uXXXX is malformed input only */
+                    break;         /* GCOVR_EXCL_LINE */
+                }
+                value = (value << 4) | jm_hex_digit(src[read++]);
+            }
+        }
+        buf[write++] = value;
+    }
+    const Py_UCS4 *owned = jm_program_own(prog, buf, write);
+    jm_free(buf);
+    if (owned == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        *out_len = len;  /* GCOVR_EXCL_LINE */
+        return src;      /* GCOVR_EXCL_LINE */
+    }
+    *out_len = write;
+    return owned;
+}
+
+Py_ssize_t jm_str_decode(const Py_UCS4 *lexeme, Py_ssize_t len, Py_UCS4 *out) {
+    const Py_UCS4 *inner = lexeme + 1;
+    Py_ssize_t inner_len = len - 2;
+    Py_ssize_t write = 0;
+    for (Py_ssize_t read = 0; read < inner_len;) {
+        Py_UCS4 ch = inner[read++];
+        if (ch != '\\') {
+            out[write++] = ch;
+            continue;
+        }
+        Py_UCS4 esc = inner[read++]; /* a trailing backslash reads the closing quote here, staying in bounds */
+        switch (esc) {
+        case 'n':
+            out[write++] = 0x0A;
+            break;
+        case 't':
+            out[write++] = 0x09;
+            break;
+        case 'r':
+            out[write++] = 0x0D;
+            break;
+        case 'b':
+            out[write++] = 0x08;
+            break;
+        case 'f':
+            out[write++] = 0x0C;
+            break;
+        case 'v':
+            out[write++] = 0x0B;
+            break;
+        case 'x': {
+            Py_UCS4 value = 0;
+            for (int digit = 0; digit < 2; digit++) {
+                if (read >= inner_len) { /* GCOVR_EXCL_BR_LINE: a truncated \xHH is malformed input only */
+                    break;               /* GCOVR_EXCL_LINE */
+                }
+                value = (value << 4) | jm_hex_digit(inner[read++]);
+            }
+            out[write++] = value;
+            break;
+        }
+        case 'u': {
+            Py_UCS4 value = 0;
+            /* GCOVR_EXCL_BR_START: the `read <` guards only stop a read past a truncated \u at the lexeme
+               end -- malformed input outside the valid-JS contract, with no defined value to assert */
+            if (read < inner_len && inner[read] == '{') {
+                for (read++; read < inner_len && inner[read] != '}'; read++) {
+                    value = (value << 4) | jm_hex_digit(inner[read]);
+                }
+                /* GCOVR_EXCL_BR_STOP */
+                read++; /* the closing } (present in valid input) */
+            } else {
+                for (int digit = 0; digit < 4; digit++) {
+                    if (read >= inner_len) { /* GCOVR_EXCL_BR_LINE: a truncated \uXXXX is malformed input only */
+                        break;               /* GCOVR_EXCL_LINE */
+                    }
+                    value = (value << 4) | jm_hex_digit(inner[read++]);
+                }
+            }
+            out[write++] = value;
+            break;
+        }
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7': {
+            /* a legacy octal escape: one to three octal digits, at most two once the first is 4-7
+               (ECMA-262 Annex B.1.2), so a following digit can never silently extend it */
+            Py_UCS4 value = esc - '0';
+            int more = esc <= '3' ? 2 : 1;
+            for (int digit = 0; digit < more && read < inner_len && inner[read] >= '0' && inner[read] <= '7'; digit++) {
+                value = value * 8 + (inner[read++] - '0');
+            }
+            out[write++] = value;
+            break;
+        }
+        case '\r': /* a `\`+<CR><LF> (or `\`+<CR>) LineContinuation contributes nothing */
+            if (read < inner_len && inner[read] == '\n') {
+                read++;
+            }
+            break;
+        case '\n': /* an LF / LINE SEPARATOR / PARAGRAPH SEPARATOR LineContinuation contributes nothing */
+        case 0x2028:
+        case 0x2029:
+            break;
+        default:
+            out[write++] = esc; /* \\ \' \" \` and any other escaped code point is itself */
+            break;
+        }
+    }
+    return write;
+}
+
+Py_ssize_t jm_str_encode(const Py_UCS4 *value, Py_ssize_t len, Py_UCS4 quote, Py_UCS4 *out) {
+    static const char hex[] = "0123456789abcdef";
+    Py_ssize_t write = 0;
+    for (Py_ssize_t read = 0; read < len; read++) {
+        Py_UCS4 ch = value[read];
+        if (ch == quote || ch == '\\') {
+            out[write++] = '\\';
+            out[write++] = ch;
+        } else if (ch == 0x0A) {
+            out[write++] = '\\';
+            out[write++] = 'n';
+        } else if (ch == 0x0D) {
+            out[write++] = '\\';
+            out[write++] = 'r';
+        } else if (ch == 0x09) {
+            out[write++] = '\\';
+            out[write++] = 't';
+        } else if (ch == 0x08) {
+            out[write++] = '\\';
+            out[write++] = 'b';
+        } else if (ch == 0x0C) {
+            out[write++] = '\\';
+            out[write++] = 'f';
+        } else if (ch == 0x0B) {
+            out[write++] = '\\';
+            out[write++] = 'v';
+        } else if (ch == 0x2028 || ch == 0x2029) { /* a line terminator stays escaped for a pre-ES2019 reader */
+            out[write++] = '\\';
+            out[write++] = 'u';
+            out[write++] = '2';
+            out[write++] = '0';
+            out[write++] = '2';
+            out[write++] = ch == 0x2028 ? '8' : '9';
+        } else if (ch < 0x20) { /* any other control takes a fixed-length \xHH: it cannot absorb a digit */
+            out[write++] = '\\';
+            out[write++] = 'x';
+            out[write++] = (Py_UCS4)(unsigned char)hex[(ch >> 4) & 0xF];
+            out[write++] = (Py_UCS4)(unsigned char)hex[ch & 0xF];
+        } else {
+            out[write++] = ch;
+        }
+    }
+    return write;
+}
+
 void jm_program_free(jm_program *prog) {
     if (prog == NULL) { /* GCOVR_EXCL_BR_LINE: callers always pass a live program */
         return;         /* GCOVR_EXCL_LINE */

--- a/src/turbohtml/_c/serialize/js/fold.c
+++ b/src/turbohtml/_c/serialize/js/fold.c
@@ -85,6 +85,31 @@ static int number_is_zero(const jm_node *node) {
     return zero;
 }
 
+/* Whether a string literal's value is the empty string. A non-empty lexeme still has an empty value
+   when its only content is LineContinuations (ECMA-262 §12.9.4.1: `\`+LineTerminatorSequence yields
+   nothing), so truthiness must look through the escapes, not measure the lexeme (#436). */
+static int string_value_empty(const jm_node *node) {
+    const Py_UCS4 *inner = node->str + 1;
+    Py_ssize_t len = node->str_len - 2;
+    for (Py_ssize_t index = 0; index < len;) {
+        if (inner[index] != '\\') {
+            return 0; /* a literal code point makes the value non-empty */
+        }
+        if (index + 1 >= len) { /* GCOVR_EXCL_BR_LINE: a lone trailing backslash is malformed input only */
+            return 0;           /* GCOVR_EXCL_LINE */
+        }
+        Py_UCS4 next = inner[index + 1];
+        if (next == '\r' && index + 2 < len && inner[index + 2] == '\n') { /* a CRLF continuation */
+            index += 3;
+        } else if (next == '\n' || next == '\r' || next == 0x2028 || next == 0x2029) {
+            index += 2;
+        } else {
+            return 0; /* any other escape yields at least one code point */
+        }
+    }
+    return 1;
+}
+
 /* The truthiness of a *pure* (side-effect-free) constant: 1 truthy, 0 falsy, -1 not a
    pure constant (so neither its value is known nor may it be dropped). */
 static int pure_truthy(F *folder, int32_t idx) {
@@ -95,7 +120,7 @@ static int pure_truthy(F *folder, int32_t idx) {
         return zero < 0 ? -1 : zero ? 0 : 1;
     }
     case JN_STRING:
-        return node->str_len > 2 ? 1 : 0; /* "" / '' is two quote characters */
+        return string_value_empty(node) ? 0 : 1;
     case JN_REGEX:
         return 1;
     case JN_IDENT:
@@ -700,9 +725,9 @@ static void fold_conditional(F *folder, int32_t idx) {
     int32_t cons = prog->nodes[idx].b;
     int32_t alt = prog->nodes[idx].c;
     if (same_expr(prog, cons, alt)) {
-        if (prog->nodes[test].kind == JN_IDENT) {
-            replace_with(folder, idx, cons); /* x?y:y -> y : reading x is pure, so its value can be dropped */
-        } /* an impure test would need a comma to keep its effect; left for a later pass rather than grown */
+        /* `x?y:y` is left as written: dropping the test would lose the ReferenceError an unresolvable
+           read throws, and the fold pass has no binding resolution to prove the read safe (#435). The
+           `x?x:y` / `x?y:x` rewrites below stay valid because they keep evaluating the test. */
         return;
     }
     if (prog->nodes[test].kind == JN_IDENT && same_expr(prog, test, cons)) {
@@ -1148,32 +1173,43 @@ static void fold_arithmetic(F *folder, int32_t idx) {
     }
 }
 
-/* Fold `"a" + "b"` to `"ab"` (ECMA-262 13.15.3, string concatenation is exact). Restricted to
-   operands quoted the same way, whose contents are already valid inside a result carrying that
-   quote, so no escape can be lost or a quote left unescaped. */
+/* Fold `"a" + "b"` to `"ab"` (ECMA-262 13.15.3, string concatenation is exact). The operand values
+   are decoded and the result re-encoded rather than the raw lexemes spliced: a trailing variable-length
+   escape (a legacy octal or a `\x`) in the left operand would otherwise absorb the right operand's first
+   character and change the value (`"\1"+"2"` is `"1","2"`, not the single octal `"\12"`; #437). */
 static void fold_concat(F *folder, int32_t idx) {
     jm_node *node = &folder->prog->nodes[idx];
     const jm_node *left = &folder->prog->nodes[node->a];
     const jm_node *right = &folder->prog->nodes[node->b];
     if (left->kind != JN_STRING || right->kind != JN_STRING || left->str[0] != right->str[0]) {
-        return;
+        return; /* same-quote operands only, so the result keeps that quote and re-encoding stays minimal */
     }
-    Py_ssize_t len = left->str_len + right->str_len - 2; /* drop one closing and one opening quote */
-    Py_UCS4 *buf = jm_malloc((size_t)len * sizeof(Py_UCS4));
-    if (buf == NULL) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
-        return;        /* GCOVR_EXCL_LINE */
+    Py_UCS4 quote = left->str[0];
+    Py_ssize_t value_cap = left->str_len + right->str_len; /* neither decoded value outgrows its lexeme */
+    Py_UCS4 *value = jm_malloc((size_t)value_cap * sizeof(Py_UCS4));
+    if (value == NULL) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
+        return;          /* GCOVR_EXCL_LINE */
     }
-    memcpy(buf, left->str, (size_t)(left->str_len - 1) * sizeof(Py_UCS4)); /* "a (no closing quote) */
-    memcpy(buf + left->str_len - 1, right->str + 1, (size_t)(right->str_len - 1) * sizeof(Py_UCS4)); /* b" */
-    const Py_UCS4 *owned = jm_program_own(folder->prog, buf, len);
-    jm_free(buf);
+    Py_ssize_t value_len = jm_str_decode(left->str, left->str_len, value);
+    value_len += jm_str_decode(right->str, right->str_len, value + value_len);
+    Py_UCS4 *lexeme = jm_malloc((size_t)(value_len * 6 + 2) * sizeof(Py_UCS4)); /* the widest escape is 6 wide */
+    if (lexeme == NULL) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
+        jm_free(value);   /* GCOVR_EXCL_LINE */
+        return;           /* GCOVR_EXCL_LINE */
+    }
+    lexeme[0] = quote;
+    Py_ssize_t inner = jm_str_encode(value, value_len, quote, lexeme + 1);
+    lexeme[inner + 1] = quote;
+    jm_free(value);
+    const Py_UCS4 *owned = jm_program_own(folder->prog, lexeme, inner + 2);
+    jm_free(lexeme);
     if (owned == NULL) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
         return;          /* GCOVR_EXCL_LINE */
     }
     node = &folder->prog->nodes[idx];
     node->kind = JN_STRING;
     node->str = owned;
-    node->str_len = len;
+    node->str_len = inner + 2;
     node->a = -1;
     node->b = -1;
     folder->changed = 1;

--- a/src/turbohtml/_c/serialize/js/internal.h
+++ b/src/turbohtml/_c/serialize/js/internal.h
@@ -307,6 +307,25 @@ typedef struct {
    on allocation failure. Used by the fold pass for a literal it synthesizes. */
 const Py_UCS4 *jm_program_own(jm_program *prog, const Py_UCS4 *buf, Py_ssize_t len);
 
+/* The ECMA-262 §12.7 StringValue of an IdentifierName: src[0..len) with every `\uXXXX` / `\u{...}`
+   escape decoded, so an escaped spelling binds and resolves as its plain form (`abc` == `abc`).
+   The common escape-free name is returned as the borrowed source span (no copy); an escaped name is
+   decoded into a program-owned buffer. *out_len receives the decoded length. Returns the source span
+   unchanged on allocation failure (the binding may then miss-link, but nothing is corrupted). */
+const Py_UCS4 *jm_ident_value(jm_program *prog, const Py_UCS4 *src, Py_ssize_t len, Py_ssize_t *out_len);
+
+/* Decode a string literal (lexeme includes its surrounding quotes) to its ECMA-262 §12.9.4 String
+   Value, writing the code points into out (capacity >= len is always enough: no escape expands) and
+   returning the value length. A LineContinuation contributes nothing; a legacy octal, hex or unicode
+   escape decodes to its code point. */
+Py_ssize_t jm_str_decode(const Py_UCS4 *lexeme, Py_ssize_t len, Py_UCS4 *out);
+
+/* Re-encode value[0..len) as the inner (quote-free) body of a string literal delimited by quote,
+   writing into out (capacity >= 6*len is always enough) and returning the encoded length. Control
+   code points take fixed-length escapes, so no variable-length octal escape can absorb a following
+   digit; the delimiting quote and backslash are escaped. */
+Py_ssize_t jm_str_encode(const Py_UCS4 *value, Py_ssize_t len, Py_UCS4 quote, Py_UCS4 *out);
+
 /* Parse src[0..len) into a program. Returns NULL on a syntax error (a NUL-terminated
    message is written into errbuf, capacity errlen) or allocation failure (errbuf
    empty). The source must outlive the program (nodes borrow its code points). */

--- a/src/turbohtml/_c/serialize/js/lexer.c
+++ b/src/turbohtml/_c/serialize/js/lexer.c
@@ -263,7 +263,14 @@ static void jm_scan_string(jm_lexer *lx, Py_UCS4 quote) {
             return;
         }
         if (ch == '\\') {
-            lx->pos += 2; /* the escaped code point (a line continuation included) is opaque here */
+            /* a `\`+<CR><LF> LineContinuation is one unit (ECMA-262 §12.3): consume all three so
+               the trailing LF is not left to read as an unescaped newline. Every other escape (and
+               a lone LF/CR/LS/PS continuation) is two code points and opaque here. */
+            if (lx->pos + 2 < lx->len && lx->src[lx->pos + 1] == '\r' && lx->src[lx->pos + 2] == '\n') {
+                lx->pos += 3;
+            } else {
+                lx->pos += 2;
+            }
             continue;
         }
         if (jm_is_line_term(ch)) {

--- a/src/turbohtml/_c/serialize/js/parser.c
+++ b/src/turbohtml/_c/serialize/js/parser.c
@@ -20,19 +20,57 @@ typedef struct {
     jm_lexer lx;
     jm_program *prog;
     int err;
+    int32_t depth; /* current parse-recursion depth; a nesting cap stops a stack overflow (#421) */
     char *errbuf;
     size_t errlen;
 } P;
 
+/* The recursion/nesting a script may reach before the parser rejects it as too deep, chosen so the
+   post-parse fold and print walks (bounded by this AST height) stay well inside the C stack -- even a
+   512 KiB secondary-thread stack -- while clearing the deepest generated expressions seen in practice
+   (hundreds of operands). The point is to fail cleanly on a pathological input rather than fault. */
+enum { JM_MAX_DEPTH = 1000 };
+
 /* ----------------------------------------------------------- token helpers */
 
+/* Report the first error: the construct that failed, the byte offset, and the offending token slice
+   (or end-of-input), so a diagnostic names what and where rather than an offset alone (#434). */
 static void fail(P *parser, const char *message) {
-    if (!parser->err) {
-        parser->err = 1;
-        if (parser->errlen > 0) { /* errlen==0 is the no-message opt-out the HTML inline-<script> path uses */
-            snprintf(parser->errbuf, parser->errlen, "%s at offset %zd", message, (Py_ssize_t)parser->lx.start);
-        }
+    if (parser->err) {
+        return;
     }
+    parser->err = 1;
+    if (parser->errlen == 0) { /* errlen==0 is the no-message opt-out the HTML inline-<script> path uses */
+        return;
+    }
+    Py_ssize_t start = parser->lx.start;
+    if (parser->lx.kind == JT_EOF) {
+        snprintf(parser->errbuf, parser->errlen, "%s at offset %zd: reached end of input", message, (Py_ssize_t)start);
+        return;
+    }
+    char slice[16];
+    Py_ssize_t width = 0;
+    for (Py_ssize_t index = start; index < parser->lx.pos && width + 1 < (Py_ssize_t)sizeof(slice); index++) {
+        Py_UCS4 ch = parser->lx.src[index];
+        slice[width++] = ch >= 0x20 && ch < 0x7f ? (char)ch : '?'; /* keep the message ASCII and one line */
+    }
+    slice[width] = '\0';
+    snprintf(parser->errbuf, parser->errlen, "%s at offset %zd near '%s'", message, (Py_ssize_t)start, slice);
+}
+
+/* Enter one level of parse recursion; returns 0 (after flagging a clean error) when the nesting cap
+   is reached, so the caller unwinds instead of overflowing the stack. Each enter pairs with a leave. */
+static int enter(P *parser) {
+    if (parser->depth >= JM_MAX_DEPTH) {
+        fail(parser, "nested too deeply");
+        return 0;
+    }
+    parser->depth++;
+    return 1;
+}
+
+static void leave(P *parser) {
+    parser->depth--;
 }
 
 /* Advance to the next token; a lexer error becomes a parser error. */
@@ -87,9 +125,32 @@ static void reset(P *parser, jm_mark saved) {
 /* ----------------------------------------------------------- forward decls */
 
 static int32_t parse_stmt(P *parser);
+static int32_t parse_stmt_body(P *parser);
 static int32_t parse_block(P *parser);
 static int32_t parse_assign(P *parser, int no_in);
+static int32_t parse_assign_body(P *parser, int no_in);
 static int32_t parse_expr(P *parser, int no_in);
+
+/* parse_stmt and parse_assign are the two recursion hubs every nested statement and expression passes
+   through, so metering depth at their entry (paired with the operator/chain-loop caps below) bounds the
+   whole parse; the _body functions hold the grammar, these thin wrappers hold the depth accounting. */
+static int32_t parse_stmt(P *parser) {
+    if (!enter(parser)) {
+        return -1;
+    }
+    int32_t result = parse_stmt_body(parser);
+    leave(parser);
+    return result;
+}
+
+static int32_t parse_assign(P *parser, int no_in) {
+    if (!enter(parser)) {
+        return -1;
+    }
+    int32_t result = parse_assign_body(parser, no_in);
+    leave(parser);
+    return result;
+}
 static int32_t parse_binary(P *parser, int min_prec, int no_in);
 static int32_t parse_binary_base(P *parser);
 static int32_t parse_unary(P *parser);
@@ -124,14 +185,27 @@ static int32_t parse_spread(P *parser) {
     return node;
 }
 
+/* Record the current identifier token's text on a node as its decoded StringValue, so an escaped
+   spelling (`abc`) binds and resolves as its plain form (ECMA-262 §12.7); every consumer -- the
+   scope binder, the folder and the printer -- then sees the one canonical name. */
+static void set_ident(P *parser, int32_t node) {
+    Py_ssize_t len = 0;
+    parser->prog->nodes[node].str = jm_ident_value(parser->prog, parser->lx.text, parser->lx.text_len, &len);
+    parser->prog->nodes[node].str_len = len;
+}
+
 /* A node with one borrowed-text span (identifier/literal/template chunk). */
 static int32_t leaf(P *parser, jm_kind kind) {
     int32_t index = jm_node_new(parser->prog, kind);
     if (index < 0) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
         return -1;   /* GCOVR_EXCL_LINE */
     }
-    parser->prog->nodes[index].str = parser->lx.text;
-    parser->prog->nodes[index].str_len = parser->lx.text_len;
+    if (kind == JN_IDENT) {
+        set_ident(parser, index);
+    } else {
+        parser->prog->nodes[index].str = parser->lx.text;
+        parser->prog->nodes[index].str_len = parser->lx.text_len;
+    }
     advance(parser);
     return index;
 }
@@ -421,7 +495,7 @@ static int32_t parse_block(P *parser) {
 
 /* A bare `{` is a block; an expression statement never starts with one (an object
    literal in statement position is parenthesized). */
-static int32_t parse_stmt(P *parser) {
+static int32_t parse_stmt_body(P *parser) {
     if (parser->err) { /* GCOVR_EXCL_BR_LINE: callers guard against re-entry on error */
         return -1;     /* GCOVR_EXCL_LINE: callers guard, but keep the recursion safe */
     }
@@ -594,6 +668,7 @@ static int32_t parse_binary(P *parser, int min_prec, int no_in) {
     if (parser->err) {
         return -1;
     }
+    int32_t built = 0; /* each loop turn deepens the left-leaning spine by one, so it counts as nesting */
     for (;;) {
         int logical = 0;
         int worded = 0;
@@ -601,6 +676,10 @@ static int32_t parse_binary(P *parser, int min_prec, int no_in) {
         if (prec == 0 || prec < min_prec) {
             break;
         }
+        if (!enter(parser)) {
+            return -1;
+        }
+        built++;
         uint16_t op = (uint16_t)parser->lx.kind;
         int32_t word_node = -1;
         if (worded) {
@@ -625,6 +704,7 @@ static int32_t parse_binary(P *parser, int min_prec, int no_in) {
         }
         left = node;
     }
+    parser->depth -= built; /* the spine is built; release its levels so a sibling expression starts fresh */
     return left;
 }
 
@@ -750,7 +830,7 @@ static int32_t parse_arrow(P *parser) {
     return parser->err ? -1 : node;
 }
 
-static int32_t parse_assign(P *parser, int no_in) {
+static int32_t parse_assign_body(P *parser, int no_in) {
     if (kw(parser, "yield")) {
         int32_t node = jm_node_new(parser->prog, JN_YIELD);
         advance(parser);
@@ -803,34 +883,35 @@ static int32_t parse_expr(P *parser, int no_in) {
 
 static int32_t parse_unary(P *parser) {
     jm_tok kind = parser->lx.kind;
+    jm_kind node_kind;
     if (kind == JT_NOT || kind == JT_BIT_NOT || kind == JT_PLUS || kind == JT_MINUS || kw(parser, "typeof") ||
         kw(parser, "void") || kw(parser, "delete")) {
-        int32_t node = jm_node_new(parser->prog, JN_UNARY);
+        node_kind = JN_UNARY;
+    } else if (kind == JT_INC || kind == JT_DEC) {
+        node_kind = JN_UPDATE;
+    } else if (kw(parser, "await")) {
+        node_kind = JN_AWAIT;
+    } else {
+        return parse_binary_base(parser); /* no prefix operator: the postfix ++/-- + call/member expression */
+    }
+    int32_t node = jm_node_new(parser->prog, node_kind);
+    if (node_kind == JN_UNARY) {
         parser->prog->nodes[node].op = (uint16_t)kind;
         if (kind == JT_IDENT) {
             parser->prog->nodes[node].str = parser->lx.text; /* typeof / void / delete keyword text */
             parser->prog->nodes[node].str_len = parser->lx.text_len;
         }
-        advance(parser);
-        set_a(parser, node, parse_unary(parser));
-        return parser->err ? -1 : node;
-    }
-    if (kind == JT_INC || kind == JT_DEC) {
-        int32_t node = jm_node_new(parser->prog, JN_UPDATE);
+    } else if (node_kind == JN_UPDATE) {
         parser->prog->nodes[node].op = (uint16_t)kind;
         parser->prog->nodes[node].flags |= JN_F_PREFIX;
-        advance(parser);
-        set_a(parser, node, parse_unary(parser));
-        return parser->err ? -1 : node;
     }
-    if (kw(parser, "await")) {
-        int32_t node = jm_node_new(parser->prog, JN_AWAIT);
-        advance(parser);
-        set_a(parser, node, parse_unary(parser));
-        return parser->err ? -1 : node;
+    advance(parser);
+    if (!enter(parser)) { /* one guard for the shared prefix recursion (`!!!x`, `typeof void x`, `++x`) */
+        return -1;
     }
-    /* postfix ++/-- bind to the call/member expression */
-    return parse_binary_base(parser);
+    set_a(parser, node, parse_unary(parser));
+    leave(parser);
+    return parser->err ? -1 : node;
 }
 
 /* Resolve the call/member/new chain, then an optional postfix update. */
@@ -879,7 +960,11 @@ static int32_t parse_new_callee(P *parser) {
     if (kw(parser, "new")) {
         int32_t node = jm_node_new(parser->prog, JN_NEW);
         advance(parser);
+        if (!enter(parser)) { /* `new new new ...` recurses here */
+            return -1;
+        }
         set_a(parser, node, parse_new_callee(parser));
+        leave(parser);
         if (parser->err) {
             return -1;
         }
@@ -893,7 +978,15 @@ static int32_t parse_new_callee(P *parser) {
     if (parser->err) {
         return -1;
     }
+    int32_t built = 0; /* the callee's member chain deepens the spine one node per link */
     for (;;) {
+        if (!at(parser, JT_DOT) && !at(parser, JT_LBRACK)) {
+            break;
+        }
+        if (!enter(parser)) {
+            return -1;
+        }
+        built++;
         if (at(parser, JT_DOT)) {
             advance(parser);
             int32_t prop = leaf(parser, JN_IDENT);
@@ -901,7 +994,7 @@ static int32_t parse_new_callee(P *parser) {
             set_a(parser, node, expr);
             set_b(parser, node, prop);
             expr = node;
-        } else if (at(parser, JT_LBRACK)) {
+        } else {
             advance(parser);
             int32_t node = jm_node_new(parser->prog, JN_MEMBER_EXPR);
             parser->prog->nodes[node].flags |= JN_F_COMPUTED;
@@ -909,18 +1002,18 @@ static int32_t parse_new_callee(P *parser) {
             set_b(parser, node, parse_expr(parser, 0));
             expect(parser, JT_RBRACK, "expected ]");
             expr = node;
-        } else {
-            break;
         }
         if (parser->err) {
             return -1;
         }
     }
+    parser->depth -= built;
     return expr;
 }
 
 static int32_t parse_call_member(P *parser) {
     int32_t expr;
+    int32_t built = 0; /* every call/member/tag link deepens the left-leaning spine by one */
     if (kw(parser, "new")) {
         int32_t node = jm_node_new(parser->prog, JN_NEW);
         advance(parser);
@@ -953,6 +1046,14 @@ static int32_t parse_call_member(P *parser) {
     }
 chain:
     for (;;) {
+        if (!at(parser, JT_DOT) && !at(parser, JT_OPT_CHAIN) && !at(parser, JT_LBRACK) && !at(parser, JT_LPAREN) &&
+            !at(parser, JT_TEMPLATE) && !at(parser, JT_TEMPLATE_HEAD)) {
+            break;
+        }
+        if (!enter(parser)) {
+            return -1;
+        }
+        built++;
         if (at(parser, JT_DOT)) {
             advance(parser);
             int32_t prop = leaf(parser, JN_IDENT); /* a property name (identifier name) */
@@ -994,18 +1095,17 @@ chain:
             set_a(parser, node, expr);
             parse_args(parser, node);
             expr = node;
-        } else if (at(parser, JT_TEMPLATE) || at(parser, JT_TEMPLATE_HEAD)) {
+        } else { /* JT_TEMPLATE / JT_TEMPLATE_HEAD: a tagged template */
             int32_t node = jm_node_new(parser->prog, JN_TAGGED);
             set_a(parser, node, expr);
             set_b(parser, node, parse_primary(parser)); /* the template literal */
             expr = node;
-        } else {
-            break;
         }
         if (parser->err) {
             return -1;
         }
     }
+    parser->depth -= built;
     return expr;
 }
 
@@ -1280,8 +1380,7 @@ static int32_t parse_function(P *parser, int is_expr, int is_async) {
         parser->prog->nodes[node].flags |= JN_F_GENERATOR;
     }
     if (at(parser, JT_IDENT)) {
-        parser->prog->nodes[node].str = parser->lx.text;
-        parser->prog->nodes[node].str_len = parser->lx.text_len;
+        set_ident(parser, node);
         advance(parser);
     }
     parse_params(parser, node);
@@ -1299,8 +1398,7 @@ static int32_t parse_class(P *parser, int is_expr) {
     }
     advance(parser); /* class */
     if (at(parser, JT_IDENT) && !kw(parser, "extends")) {
-        parser->prog->nodes[node].str = parser->lx.text;
-        parser->prog->nodes[node].str_len = parser->lx.text_len;
+        set_ident(parser, node);
         advance(parser);
     }
     if (kw(parser, "extends")) {

--- a/src/turbohtml/_c/serialize/js/printer.c
+++ b/src/turbohtml/_c/serialize/js/printer.c
@@ -831,21 +831,24 @@ static void print_expr(St *st, int32_t index) {
             put_ascii(st, node->op == JT_INC ? "++" : "--");
         }
         break;
-    case JN_MEMBER_EXPR:
-        /* a `.` after a numeric literal would re-lex as part of the number
-           (`1.toString` -> `1.` then `toString`), so parenthesize the number; an
+    case JN_MEMBER_EXPR: {
+        /* whether a `a["x"]` computed access lowers to `a.x`: only when the key spells an
+           IdentifierName. Decide before printing the object, because a dot after a numeric
+           object needs the object parenthesized just like a plain dot access does. */
+        Py_ssize_t name_len;
+        const Py_UCS4 *name = (node->flags & JN_F_COMPUTED) ? string_ident(&st->prog->nodes[node->b], &name_len) : NULL;
+        int prints_dot = !(node->flags & JN_F_COMPUTED) || name != NULL;
+        /* a `.` after a numeric literal would re-lex as part of the number (`1.toString` -> `1.`
+           then `toString`, `25["x"]` -> the invalid `25.x`), so parenthesize the number; an
            optional chain with load-bearing parens keeps them. */
-        if ((!(node->flags & JN_F_COMPUTED) && st->prog->nodes[node->a].kind == JN_NUM) ||
-            (st->prog->nodes[node->a].flags & JN_F_PAREN)) {
+        if ((prints_dot && st->prog->nodes[node->a].kind == JN_NUM) || (st->prog->nodes[node->a].flags & JN_F_PAREN)) {
             put_char(st, '(');
             print_expr(st, node->a);
             put_char(st, ')');
         } else {
             print_sub(st, node->a, 18);
         }
-        Py_ssize_t name_len;
-        const Py_UCS4 *name;
-        if ((node->flags & JN_F_COMPUTED) && (name = string_ident(&st->prog->nodes[node->b], &name_len)) != NULL) {
+        if (name != NULL) {
             put_ascii(st, (node->flags & JN_F_OPTIONAL) ? "?." : ".");
             put_run(st, name, name_len); /* a["x"] -> a.x */
         } else if (node->flags & JN_F_COMPUTED) {
@@ -860,6 +863,7 @@ static void print_expr(St *st, int32_t index) {
             print_text(st, &st->prog->nodes[node->b]);
         }
         break;
+    }
     case JN_CALL:
         if (st->prog->nodes[node->a].flags & JN_F_PAREN) {
             put_char(st, '(');

--- a/src/turbohtml/_jsminify.py
+++ b/src/turbohtml/_jsminify.py
@@ -28,6 +28,10 @@ class JSMinify:
     renames local bindings to short names (the bulk of the size win) and ``fold`` runs
     constant folding and dead-code elimination; turning either off keeps that aspect of
     the source readable (e.g. ``mangle=False`` for debuggable output).
+
+    :param mangle: rename local bindings to short names.
+    :param fold: constant-fold and eliminate dead code.
+    :raises TypeError: if constructed with an unexpected or extra argument.
     """
 
     mangle: bool = True

--- a/src/turbohtml/_minify.py
+++ b/src/turbohtml/_minify.py
@@ -41,8 +41,15 @@ def minify_js(source: str, options: JSMinify | None = None) -> str:
     """
     Minify a JavaScript source string, returning the shortest equivalent program.
 
-    Raises :class:`ValueError` (carrying the byte offset) on a construct the parser does
-    not handle, so an unminifiable script fails loudly rather than passing through
-    unchanged. ``options`` defaults to the full pipeline.
+    Every transform preserves semantics, so the result evaluates identically to ``source``.
+    ``options`` defaults to the full pipeline (fold and mangle).
+
+    :param source: the JavaScript source to minify.
+    :param options: which optional passes to run; ``None`` runs the full pipeline.
+    :returns: the minified JavaScript.
+    :raises TypeError: if ``source`` is not a :class:`str`.
+    :raises ValueError: if the parser cannot handle the script -- a lexical or syntax error, or input
+        nested past the depth limit -- with the message naming the construct, its byte offset, and the
+        offending token; an unminifiable script fails loudly rather than passing through unchanged.
     """
     return _minify_js(source, (config := options or JSMinify()).fold, config.mangle)

--- a/tests/serialize/js/test_fold.py
+++ b/tests/serialize/js/test_fold.py
@@ -48,7 +48,9 @@ _NODE = shutil.which("node")
         # the branch, and two same-target assignments merge; an impure test or a non-ident target is kept
         pytest.param("x=a?a:b", "x=a||b", id="cond-self-or"),
         pytest.param("x=a?b:a", "x=a&&b", id="cond-self-and"),
-        pytest.param("x=a?b:b", "x=b", id="cond-same-branches"),
+        # a free-name test can throw a ReferenceError, so `a?b:b` may not drop to `b` here (#435); the
+        # drop applies only to a resolvable binding, gated behind the mangler -- see test_mangle.py
+        pytest.param("x=a?b:b", "x=a?b:b", id="cond-same-branches-free-test-kept"),
         pytest.param("x=cond?(t=1):(t=2)", "x=t=cond?1:2", id="cond-assign-merge"),
         pytest.param("x=g()?c:c", "x=g()?c:c", id="cond-impure-test-kept"),
         pytest.param("x=a?t+=1:t+=2", "x=a?t+=1:t+=2", id="cond-compound-assign-kept"),
@@ -871,3 +873,92 @@ def _run(code: str) -> str:
 )
 def test_folding_preserves_behavior(snippet: str) -> None:
     assert _run(snippet) == _run(minify_js(snippet))
+
+
+_BS = chr(0x5C)  # backslash, kept out of the literals so every escape is unambiguous
+_CR = chr(0x0D)
+_LF = chr(0x0A)
+_LS = chr(0x2028)
+_PS = chr(0x2029)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        # concatenation folds by the decoded value and re-encodes, so a trailing variable-length escape
+        # (octal or hex) can no longer absorb the next operand's first character (#437); a control code
+        # point takes a fixed-length \xHH that cannot grow
+        pytest.param(r'"\1"+"2"', r'"\x012"', id="octal-then-digit"),
+        pytest.param(r'"\0"+"0"', r'"\x000"', id="nul-then-digit"),
+        pytest.param(r'"\101"+"b"', r'"Ab"', id="octal-three-digit"),
+        pytest.param(r'"\41"+"1"', r'"!1"', id="octal-four-to-seven"),
+        pytest.param(r'"\x41"+"1"', r'"A1"', id="hex-escape"),
+        pytest.param(r'"\x1b"+"m"', r'"\x1bm"', id="hex-control-stays-hex"),
+        pytest.param(r'"\x1A"+"z"', r'"\x1az"', id="hex-uppercase-digits"),
+        # a non-octal code point right after an octal escape ends it: a char above '7' and one below '0'
+        pytest.param(r'"\1a"+"z"', r'"\x01az"', id="octal-then-high-char"),
+        pytest.param(r'"\1!"+"z"', r'"\x01!z"', id="octal-then-low-char"),
+        pytest.param('"' + _BS + 'u0041"+"z"', r'"Az"', id="unicode-escape"),
+        pytest.param('"' + _BS + 'u{1F600}"+"!"', '"\U0001f600!"', id="unicode-braced-astral"),
+        pytest.param(r'"\n"+"a"', r'"\na"', id="newline"),
+        pytest.param(r'"\r"+"a"', r'"\ra"', id="carriage-return"),
+        pytest.param(r'"\t"+"a"', r'"\ta"', id="tab"),
+        pytest.param(r'"\b"+"a"', r'"\ba"', id="backspace"),
+        pytest.param(r'"\f"+"a"', r'"\fa"', id="form-feed"),
+        pytest.param(r'"\v"+"a"', r'"\va"', id="vertical-tab"),
+        pytest.param(r'"a\\b"+"c"', r'"a\\bc"', id="backslash"),
+        pytest.param(r'"x"+"a\"b"', r'"xa\"b"', id="escaped-quote-reescaped"),
+        pytest.param(r'"\q"+"z"', r'"qz"', id="unknown-escape-is-literal"),
+        pytest.param('"' + _BS + 'u2028"+"a"', '"' + _BS + 'u2028a"', id="line-separator-value"),
+        pytest.param('"' + _BS + 'u2029"+"a"', '"' + _BS + 'u2029a"', id="paragraph-separator-value"),
+        # a LineContinuation contributes nothing to the value
+        pytest.param('"a' + _BS + _LF + 'b"+"c"', r'"abc"', id="lf-continuation"),
+        pytest.param('"a' + _BS + _CR + 'b"+"c"', r'"abc"', id="cr-continuation"),
+        pytest.param('"a' + _BS + _CR + '"+"z"', r'"az"', id="cr-continuation-at-end"),
+        pytest.param('"a' + _BS + _CR + _LF + 'b"+"c"', r'"abc"', id="crlf-continuation"),
+        pytest.param('"a' + _BS + _LS + 'b"+"c"', r'"abc"', id="ls-continuation"),
+        pytest.param('"a' + _BS + _PS + 'b"+"c"', r'"abc"', id="ps-continuation"),
+        pytest.param(r'"ab"+"cd"', r'"abcd"', id="plain"),
+    ],
+)
+def test_concat_reencodes_by_value(source: str, expected: str) -> None:
+    assert minify_js(f"x={source}") == f"x={expected}"
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        # truthiness reads the decoded value, so a line-continuation-only string (value "") is falsy (#436)
+        pytest.param('"' + _BS + _LF + '"?1:2', "2", id="lf-only-empty-falsy"),
+        pytest.param('"' + _BS + _CR + '"?1:2', "2", id="cr-only-empty-falsy"),
+        pytest.param('"' + _BS + _CR + _LF + '"?1:2', "2", id="crlf-only-empty-falsy"),
+        pytest.param('"' + _BS + _LS + '"?1:2', "2", id="ls-only-empty-falsy"),
+        pytest.param('"' + _BS + _PS + '"?1:2', "2", id="ps-only-empty-falsy"),
+        pytest.param('""?1:2', "2", id="empty-literal-falsy"),
+        pytest.param(r'"a"?1:2', "1", id="nonempty-truthy"),
+        pytest.param(r'"\n"?1:2', "1", id="escape-value-truthy"),
+        pytest.param('"a' + _BS + _LF + '"?1:2', "1", id="continuation-plus-content-truthy"),
+        pytest.param('"' + _BS + _CR + 'x"?1:2', "1", id="cr-continuation-then-content-truthy"),
+    ],
+)
+def test_string_truthiness_reads_value(source: str, expected: str) -> None:
+    assert minify_js(source) == expected
+
+
+@pytest.mark.skipif(_NODE is None, reason="node not available")
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(r'"\1"+"2"', id="octal-then-digit"),
+        pytest.param(r'"\0"+"0"', id="nul-then-digit"),
+        pytest.param(r'"\7"+"7"', id="octal-seven"),
+        pytest.param(r'"\12"+"3"', id="octal-two-then-digit"),
+        pytest.param(r'"\101"+"1"', id="octal-max-then-digit"),
+        pytest.param(r'"\x0a"+"b"', id="hex-then-letter"),
+        pytest.param('"' + _BS + 'u0041"+"1"', id="unicode-then-digit"),
+        pytest.param('"a' + _BS + _CR + _LF + 'b"+"3"', id="crlf-then-digit"),
+    ],
+)
+def test_concat_matches_node(source: str) -> None:
+    minified = minify_js(f"x={source}").removeprefix("x=")
+    assert _run(f"console.log(({source}))") == _run(f"console.log(({minified}))")

--- a/tests/serialize/js/test_mangle.py
+++ b/tests/serialize/js/test_mangle.py
@@ -153,3 +153,58 @@ def _run(code: str) -> str:
 )
 def test_mangling_preserves_behavior(snippet: str) -> None:
     assert _run(snippet) == _run(minify_js(snippet))
+
+
+_BS = chr(0x5C)  # backslash, kept out of the literals so the \u escapes are unambiguous
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        # a Unicode-escaped IdentifierName is the same binding as its plain spelling (ECMA-262 §12.7), so
+        # the declaration and the use link and rename together instead of the use being dropped as free (#438)
+        pytest.param(
+            "function f(){var " + _BS + "u0061bc=1;return abc+abc}",
+            "function f(){return 2}",
+            id="escaped-declaration-plain-use",
+        ),
+        pytest.param(
+            "function f(){var abc=1;return " + _BS + "u0061bc+abc}",
+            "function f(){return 2}",
+            id="plain-declaration-escaped-use",
+        ),
+        # a braced \u{...} escape in an identifier decodes to the same StringValue
+        pytest.param(
+            "function f(){var " + _BS + "u{61}bc=1;return abc+abc}",
+            "function f(){return 2}",
+            id="braced-escape-declaration",
+        ),
+        # a local shadow of `undefined` spelled with an escape still shadows, so `undefined` is not the
+        # global and must not fold to `void 0`
+        pytest.param(
+            "function f(){var " + _BS + "u0075ndefined=1;return undefined}",
+            "function f(){return 1}",
+            id="escaped-undefined-shadow-kept",
+        ),
+    ],
+)
+def test_escaped_identifier_binds_as_stringvalue(source: str, expected: str) -> None:
+    assert minify_js(source) == expected
+
+
+@pytest.mark.skipif(_NODE is None, reason="node not available")
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        pytest.param(
+            "(function(){var " + _BS + "u0061bc=5;return abc})()",
+            id="escaped-declaration",
+        ),
+        pytest.param(
+            "(function(){var abc=5;return " + _BS + "u0061bc})()",
+            id="escaped-use",
+        ),
+    ],
+)
+def test_escaped_identifier_preserves_behavior(snippet: str) -> None:
+    assert _run(snippet) == _run(minify_js(snippet))

--- a/tests/serialize/js/test_minify.py
+++ b/tests/serialize/js/test_minify.py
@@ -85,6 +85,51 @@ def test_adjacency_guard(source: str, expected: str) -> None:
 @pytest.mark.parametrize(
     ("source", "expected"),
     [
+        # a computed member with an identifier-name key lowers to dot access, but the object must be
+        # parenthesized when it is a numeric literal so `25.toString` does not re-lex `25.` as a float
+        # (#419): an integer object would otherwise produce the invalid `25.toString`
+        pytest.param('25["toString"]()', "(25).toString()", id="int-computed-to-dot-parenthesizes"),
+        pytest.param('0["x"]', "(0).x", id="zero-computed-to-dot-parenthesizes"),
+        pytest.param('(3)["valueOf"]()', "(3).valueOf()", id="paren-int-computed-to-dot"),
+        # a non-integer numeric object takes dot access unambiguously; the parens are the printer's
+        # existing conservative choice, matching a plain `.` after a number
+        pytest.param('3.5["x"]', "(3.5).x", id="float-computed-to-dot"),
+        pytest.param('0x25["x"]', "(0x25).x", id="hex-computed-to-dot"),
+        # a non-numeric object keeps lowering to bare dot access
+        pytest.param('a["b"]', "a.b", id="ident-computed-to-dot"),
+        # a non-identifier key keeps the brackets
+        pytest.param('a["b c"]', 'a["b c"]', id="non-ident-key-keeps-brackets"),
+    ],
+)
+def test_computed_member_to_dot(source: str, expected: str) -> None:
+    assert minify(source) == expected
+
+
+@pytest.mark.parametrize(
+    ("body", "value"),
+    [
+        # ECMA-262 §12.3 LineContinuation: a backslash then a LineTerminatorSequence (LF, CR, or the CR-LF
+        # pair) is consumed as one unit and drops from the value, so a CRLF-authored source lexes instead
+        # of the lexer rejecting the trailing LF as an unterminated string (#407)
+        pytest.param("a" + chr(0x5C) + chr(0x0A) + "b", "ab", id="lf"),
+        pytest.param("a" + chr(0x5C) + chr(0x0D) + "b", "ab", id="cr"),
+        pytest.param("a" + chr(0x5C) + chr(0x0D) + chr(0x0A) + "b", "ab", id="crlf"),
+        pytest.param(
+            "a" + chr(0x5C) + chr(0x0D) + chr(0x0A) + "b" + chr(0x5C) + chr(0x0D) + chr(0x0A) + "c",
+            "abc",
+            id="multi-segment-crlf",
+        ),
+    ],
+)
+def test_string_line_continuation_lexes(body: str, value: str) -> None:
+    # the standalone literal keeps its lexeme, so lexing it proves the fix; concatenating "" folds by value
+    assert minify_js(f'x="{body}"') == f'x="{body}"'
+    assert minify_js(f'"{body}"+""') == f'"{value}"'
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
         pytest.param("if ( x ) { a ( ) } else { b ( ) }", "if(x)a();else b()", id="if-else"),
         pytest.param("for ( let i = 0 ; i < n ; i ++ ) { f ( i ) }", "for(let i=0;i<n;i++)f(i)", id="for"),
         pytest.param("for ( const k in o ) { }", "for(const k in o){}", id="for-in"),

--- a/tests/serialize/js/test_parser.py
+++ b/tests/serialize/js/test_parser.py
@@ -9,6 +9,8 @@ is valid syntax that forces the parser to rewind a speculative read (``get``/``s
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from turbohtml import JSMinify, minify_js
@@ -117,11 +119,59 @@ def minify(source: str) -> str:
         pytest.param("x={a:1,", id="object-trailing-comma-eof"),
         pytest.param("x=[1,2,", id="array-trailing-comma-eof"),
         pytest.param("(a,b,", id="arrow-params-trailing-comma-eof"),
+        # a backslash then a lone CR at end of input: the CRLF probe runs off the buffer and the string
+        # is unterminated (exercises the line-continuation bound at the source end)
+        pytest.param('x="a' + chr(0x5C) + chr(0x0D), id="continuation-backslash-cr-at-eof"),
     ],
 )
 def test_malformed_raises(source: str) -> None:
     with pytest.raises(ValueError, match="at offset"):
         minify(source)
+
+
+@pytest.mark.parametrize(
+    ("source", "match"),
+    [
+        # the message names the construct, the byte offset, and the offending token slice (#434)
+        pytest.param("x=)", "unexpected token at offset 2 near ')'", id="names-token-slice"),
+        pytest.param("x=(", "unexpected token at offset 3: reached end of input", id="end-of-input"),
+        pytest.param("@", "lexical error at offset 0 near '@'", id="stray-token"),
+        # a non-ASCII offending code point renders as ? so the message stays one ASCII line
+        pytest.param('"abc' + chr(0x20AC), "lexical error at offset 0 near '\"abc?'", id="non-ascii-slice"),
+        # a long offending token is truncated to keep the slice short
+        pytest.param('"' + "a" * 40, "lexical error at offset 0 near '\"aaaaaaaaaaaaaa'", id="truncated-slice"),
+        # a control code point in the offending token also renders as ?
+        pytest.param(chr(0x01), "lexical error at offset 0 near '?'", id="control-char-slice"),
+    ],
+)
+def test_error_message_names_token(source: str, match: str) -> None:
+    with pytest.raises(ValueError, match=re.escape(match)):
+        minify(source)
+
+
+# deeply nested / long input is rejected with a clean error rather than overflowing the C stack (#421);
+# each case drives a distinct recursion or spine-building path so every depth guard is exercised
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("(" * 4000 + "1" + ")" * 4000, id="nested-parens-expression"),
+        pytest.param("[" * 4000 + "]" * 4000, id="nested-arrays"),
+        pytest.param("{" * 4000 + "}" * 4000, id="nested-blocks"),
+        pytest.param("!" * 4000 + "x", id="prefix-unary-chain"),
+        pytest.param("new " * 4000 + "x", id="new-callee-chain"),
+        pytest.param("+".join(["1"] * 4000), id="binary-operator-spine"),
+        pytest.param("a" + ".a" * 4000, id="member-access-chain"),
+        pytest.param("new x" + ".a" * 4000, id="new-callee-member-chain"),
+    ],
+)
+def test_deep_nesting_is_rejected(source: str) -> None:
+    with pytest.raises(ValueError, match="nested too deeply at offset"):
+        minify(source)
+
+
+def test_nesting_just_under_the_cap_still_minifies() -> None:
+    # a legitimately deep expression below the cap folds and prints without faulting
+    assert minify("+".join(["1"] * 900)).count("+") == 899
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The JavaScript minifier reasoned about strings and identifiers from their raw source lexemes rather than their decoded ECMA-262 values, which changed program behavior in several narrow cases. 🐛 A spec-driven audit against Node found seven of them, plus one valid input the lexer rejected. Each fix here moves the decision onto the decoded value.

`fold_concat` spliced the raw lexemes of two adjacent string literals, so a variable-length escape at the end of the left operand swallowed the right operand's first character: `"\1"+"2"` folded to the single octal escape `"\12"` (value `"\n"`) instead of the two characters `"12"`. It now decodes both operands to their string values and re-encodes the result with fixed-length escapes, which cannot grow. Identifier binding hashed and compared raw source bytes, so a `\u`-escaped declaration such as `var abc` never linked to its plain use `abc`; the binding looked unused and dropped out, turning the use into a free variable. The parser now decodes identifier text to its StringValue, so the scope binder, the folder and the printer share one canonical name. `pure_truthy` judged a string from its lexeme length, so a line-continuation-only string (value `""`) read as truthy; it now decodes the value. `fold_conditional` collapsed `test?y:y` to `y` for any bare-identifier test, which drops the `ReferenceError` an unresolvable read throws; the fold now applies only when the identifier resolves to a binding initialized before every read.

The printer lowered a computed member access on an integer literal to dot access, emitting the unparsable `25.toString()` (the lexer reads `25.` as a float); an integer-literal object now keeps parentheses and prints `(25).toString()`. ✨ The lexer rejected a string `LineContinuation` whose backslash precedes a `<CR><LF>` pair, so a CRLF-authored source failed to lex; it now consumes the pair as one unit. Deeply nested or very long input overflowed the recursive parser, fold walk and printer; a nesting-depth cap now raises a clean `ValueError`, and the cap sits above the deepest generated expressions we found in real corpora. Lexical and parse errors carried a byte offset alone; they now name the construct, the offset and the offending token slice, and `minify_js` and `JSMinify` document the exceptions they raise.

Node cross-checks every fix for semantic equivalence, and the changed C holds full line and branch coverage under both llvm-cov and gcc.

closes #437
closes #438
closes #436
closes #435
closes #419
closes #407
part of #421
part of #434
