### PR TITLE
🐛 fix(parser): tree-construction whitespace handling

### DIFF
--- a/docs/changelog/402.bugfix.rst
+++ b/docs/changelog/402.bugfix.rst
@@ -1,0 +1,4 @@
+Keep a leading newline in ``<pre>``, ``<listing>``, and ``<textarea>`` when a comment or element comes between the
+start tag and the newline. The tree builder dropped the newline whenever one appeared, but HTML ignores it only when it
+is the token immediately following the start tag, so ``<pre><!--c-->\nX`` now keeps the ``\n`` while ``<pre>\nX`` still
+drops it.

--- a/docs/changelog/402.bugfix.rst
+++ b/docs/changelog/402.bugfix.rst
@@ -1,4 +1,4 @@
-Keep a leading newline in ``<pre>``, ``<listing>``, and ``<textarea>`` when a comment or element comes between the
-start tag and the newline. The tree builder dropped the newline whenever one appeared, but HTML ignores it only when it
-is the token immediately following the start tag, so ``<pre><!--c-->\nX`` now keeps the ``\n`` while ``<pre>\nX`` still
-drops it.
+Keep a leading newline in ``<pre>``, ``<listing>``, and ``<textarea>`` when a comment or element comes between the start
+tag and the newline. The tree builder dropped the newline whenever one appeared, but HTML ignores it only when it is the
+token immediately following the start tag, so ``<pre><!--c-->\nX`` now keeps the ``\n`` while ``<pre>\nX`` still drops
+it.

--- a/docs/changelog/439.bugfix.rst
+++ b/docs/changelog/439.bugfix.rst
@@ -1,0 +1,4 @@
+Treat a carriage return from a character reference (``&#13;`` or ``&#xD;``) as tree-construction whitespace. Input
+preprocessing folds a literal CR to LF, but a CR decoded from a reference reaches tree construction as a real U+000D,
+which is whitespace in every insertion mode. A leading ``&#13;`` is now ignored instead of leaking a stray text node,
+and it no longer flips frameset-ok, so ``&#13;<frameset>`` keeps the frameset.

--- a/src/turbohtml/_c/core/ascii.h
+++ b/src/turbohtml/_c/core/ascii.h
@@ -31,10 +31,12 @@ static inline int is_ascii_alpha(Py_UCS4 ch) {
     return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
 }
 
-/* The HTML "ASCII whitespace" set. The tokenizer normalizes CR to LF during
-   input preprocessing, so neither it nor the tree builder ever sees a CR. */
+/* The HTML "ASCII whitespace" set. Input preprocessing folds a literal CR to LF,
+   so the tokenizer's raw scan never sees U+000D; a CR decoded from a character
+   reference (&#13;) bypasses preprocessing and reaches tree construction, where
+   U+000D is whitespace in every insertion mode. */
 static inline int is_space(Py_UCS4 ch) {
-    return ch == '\t' || ch == '\n' || ch == '\x0c' || ch == ' ';
+    return ch == '\t' || ch == '\n' || ch == '\x0c' || ch == '\r' || ch == ' ';
 }
 
 #endif /* TURBOHTML_ASCII_H */

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -1720,6 +1720,13 @@ static void run_drain(th_tree *tree, th_tokenizer *sm, th_run_state *run_state) 
         }
         table_origin = M_IN_TABLE;
         tree->text_offset = 0; /* a fresh token: any consumed-prefix offset is stale */
+        /* the pre/listing/textarea leading-LF skip applies only to the token
+           immediately following the start tag: a text token consumes it in its
+           own branch, so any other intervening token (a comment or element) must
+           clear the flag here or a later newline would be dropped too */
+        if (tree->drop_newline && tok->kind != TH_TEXT) {
+            tree->drop_newline = 0;
+        }
     reprocess:;
         /* Intern the tag name once; every comparison and insert below reads
            tok->atom / tok->tag_flags instead of re-interning the same name. */

--- a/tests/dom/test_treebuilder_internals.py
+++ b/tests/dom/test_treebuilder_internals.py
@@ -412,6 +412,42 @@ def test_document_paths(html: str, needle: str) -> None:
     assert needle in _doc(html)
 
 
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        # the LF is dropped only when it is the token immediately following the start tag
+        pytest.param("<pre>\nX</pre>", "<pre>X</pre>", id="pre-immediate-lf-dropped"),
+        # an interposed comment or element means the LF is not immediately following, so it is kept
+        pytest.param("<pre><!--c-->\nX</pre>", "<pre><!--c-->\nX</pre>", id="pre-comment-before-lf-kept"),
+        pytest.param("<pre><span></span>\nX</pre>", "<pre><span></span>\nX</pre>", id="pre-element-before-lf-kept"),
+        pytest.param("<listing><!--c-->\nX</listing>", "<listing><!--c-->\nX</listing>", id="listing-comment-lf-kept"),
+        # RCDATA leaves no room for an intervening token, so a leading textarea LF is still dropped
+        pytest.param("<textarea>\nX</textarea>", "<textarea>X</textarea>", id="textarea-immediate-lf-dropped"),
+    ],
+)
+def test_leading_newline_skip_only_immediately_after_start_tag(html: str, expected: str) -> None:
+    # WHATWG "in body" ignores a leading U+000A only for the token directly following a
+    # pre/listing/textarea start tag; a comment or element between them keeps the newline (issue #402)
+    assert parse(html).serialize() == f"<html><head></head><body>{expected}</body></html>"
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        # a CR from a character reference is decoded after preprocessing, so it reaches tree
+        # construction as a real U+000D that the early modes must treat as ignorable whitespace
+        pytest.param("&#13;a", "<body>a</body>", id="decimal-cr-leading-ignored"),
+        pytest.param("&#xD;a", "<body>a</body>", id="hex-cr-leading-ignored"),
+        # a leading CR must not flip frameset-ok, so the frameset still replaces the empty body
+        pytest.param("&#13;<frameset></frameset>", "<frameset></frameset>", id="cr-keeps-frameset-ok"),
+    ],
+)
+def test_cr_character_reference_is_tree_whitespace(html: str, expected: str) -> None:
+    # U+000D is whitespace in every insertion mode, so a leading &#13; is ignored and does not
+    # set frameset-ok to "not ok"; only a literal CR is folded to LF by preprocessing (issue #439)
+    assert parse(html).serialize() == f"<html><head></head>{expected}</html>"
+
+
 @pytest.mark.parametrize("tag", ["caption", "table", "tbody", "tfoot", "thead", "tr", "td", "th"])
 def test_table_family_start_tag_pops_select_in_table(tag: str) -> None:
     # "in select in table": a table-family start tag pops the open select and reprocesses,


### PR DESCRIPTION
Two WHATWG §13 tree-construction whitespace rules produced wrong trees, and both cost content or structure in ordinary documents.

The parser dropped a leading newline in `<pre>`, `<listing>`, and `<textarea>` whenever a newline reached the first text child, even when a comment or element sat between the start tag and that newline. HTML ignores the newline only when it is the token immediately following the start tag, so an interposed token has to cancel the skip. 📄 The parser now clears the drop flag on any token other than the text that directly follows the start tag: `<pre>\nX` still drops the newline, while `<pre><!--c-->\nX` and `<pre><span></span>\nX` keep it, matching what issue #402 reported against html5lib and Lexbor.

A carriage return decoded from a character reference (`&#13;` or `&#xD;`) reached tree construction as a real U+000D that the parser never counted as whitespace. Input preprocessing folds a literal CR to LF, so the tokenizer's raw scan never sees one, but the reference decodes after preprocessing and slips past that fold. U+000D is whitespace in every insertion mode, so the early modes should ignore a leading `&#13;`, and it must not set frameset-ok to "not ok". 🔧 Adding U+000D to the shared whitespace set fixes both symptoms from issue #439: `&#13;a` no longer leaks a stray text node, and `&#13;<frameset>` keeps the frameset instead of dropping it. The tokenizer only classifies preprocessed input, so its tag and attribute delimiting stays the same.

closes #402
closes #439
