### PR TITLE
🐛 fix(clean): CSS minifier value-safety

### DIFF
--- a/docs/changelog/415.bugfix.rst
+++ b/docs/changelog/415.bugfix.rst
@@ -1,0 +1,4 @@
+:func:`turbohtml.clean.minify_css` now keeps a duplicate declaration of the same property when its value differs from a
+later one, preserving the progressive-enhancement fallback pattern (``background:url(a.png);background:url(a.svg)``). A
+browser that cannot parse the later value falls back to the earlier one, so per CSS Cascade only an identical duplicate
+-- or a longhand a later shorthand fully covers -- is dropped.

--- a/docs/changelog/416.bugfix.rst
+++ b/docs/changelog/416.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`turbohtml.clean.minify_css` now replaces a comment in an at-rule prelude with a space instead of deleting it, so
+``@media screen and/*x*/(min-width:0)`` no longer glues into the invalid function-token ``and(`` that browsers reject.

--- a/docs/changelog/417.bugfix.rst
+++ b/docs/changelog/417.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`turbohtml.clean.minify_css` now keeps the body of a ``/*! ... */`` bang comment byte-exact instead of collapsing
+its whitespace and newlines, preserving the SPDX/copyright banner the comment exists to protect.

--- a/docs/changelog/418.bugfix.rst
+++ b/docs/changelog/418.bugfix.rst
@@ -1,0 +1,3 @@
+:func:`turbohtml.clean.minify_css` no longer folds away a unitless ``0`` summed with a dimensioned term inside
+``calc()`` (``calc(100% - 30px - 0)``). Mixing a ``<number>`` with a ``<length>`` under ``+``/``-`` is a type error, so
+folding it would turn an ignored declaration into an applied one.

--- a/docs/changelog/425.bugfix.rst
+++ b/docs/changelog/425.bugfix.rst
@@ -1,0 +1,3 @@
+:func:`turbohtml.clean.minify_css` now keeps ``currentcolor`` as one component of a multi-value ``border-color``
+(``border-color:currentColor red``) rather than rewriting it to the CSS-wide keyword ``initial``, which is valid only as
+a property's sole value and would otherwise make browsers drop the whole declaration.

--- a/docs/changelog/426.bugfix.rst
+++ b/docs/changelog/426.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`turbohtml.clean.minify_css` no longer drops a ``row-gap``/``column-gap``/``gap`` declaration next to a ``grid``
+shorthand. The ``grid`` shorthand does not reset the gutter properties, so they are removed from its longhand list.

--- a/docs/changelog/427.bugfix.rst
+++ b/docs/changelog/427.bugfix.rst
@@ -1,0 +1,2 @@
+:func:`turbohtml.clean.minify_css` now keeps a full-range ``unicode-range:U+0-10FFFF`` descriptor verbatim instead of
+rewriting it to ``initial``, which is invalid for a descriptor.

--- a/src/turbohtml/_c/serialize/css_calc.h
+++ b/src/turbohtml/_c/serialize/css_calc.h
@@ -454,6 +454,20 @@ static int css_try_calc(css_buf *pool, token_vec *vec, Py_ssize_t start, Py_ssiz
     if (!sum.ok || parser.pos != end) {
         return 0;
     }
+    /* a unitless <number> summed with a dimensioned term (e.g. calc(100% - 30px - 0)) is a type error the whole
+       declaration is dropped for; folding away its zero would turn invalid input into a valid value, so bail */
+    int has_unitless = 0;
+    int has_dimension = 0;
+    for (int index = 0; index < sum.count; index++) {
+        if (sum.terms[index].unit_len == 0) {
+            has_unitless = 1;
+        } else {
+            has_dimension = 1;
+        }
+    }
+    if (has_unitless && has_dimension) {
+        return 0;
+    }
     /* the sum keeps canceled (zero) terms to preserve units; drop them now unless every term is zero */
     cterm nonzero[CALC_MAX_TERMS];
     int nonzero_count = 0;

--- a/src/turbohtml/_c/serialize/css_grammar.h
+++ b/src/turbohtml/_c/serialize/css_grammar.h
@@ -1,11 +1,6 @@
 #ifndef TURBOHTML_CSS_GRAMMAR_H
 #define TURBOHTML_CSS_GRAMMAR_H
 
-static int css_decl_value_eq(const css_buf *pool, const css_decl *left, const css_decl *right) {
-    return left->val_len == right->val_len && memcmp(pool->data + left->val_off, pool->data + right->val_off,
-                                                     (size_t)left->val_len * sizeof(css_char)) == 0;
-}
-
 static int css_decl_is_wide_keyword(const css_buf *pool, const css_decl *decl) {
     const css_char *value = pool->data + decl->val_off;
     Py_ssize_t len = decl->val_len;
@@ -354,6 +349,9 @@ static void css_at_prelude(css_buf *pool, token_vec *vec, Py_ssize_t start, Py_s
             continue;
         }
         if (token->kind == CSS_COMMENT) {
+            /* a comment separates tokens: dropping it must leave a space so a commented-out `and (` does not glue
+               into the function-token `and(` (an invalid media query), matching the declaration-value path */
+            pending_ws = 1;
             continue;
         }
         if (token->kind == CSS_URL) {
@@ -864,27 +862,12 @@ static void css_parse_rules(css_buf *pool, cursor *cur, int top, int keyframe, c
         if (token->kind == CSS_WS || token->kind == CSS_COMMENT) {
             /* a comment token's text always starts with the slash-star the tokenizer matched */
             if (token->kind == CSS_COMMENT && token->text_len >= 3 && token->text[2] == '!') {
-                /* a bang comment is preserved (whitespace-collapsed) as an opaque node */
-                css_buf text = {NULL, 0, 0, 0};
-                cbuf_puts(&text, "/*!");
-                int pending = 0;
-                for (Py_ssize_t pos = 3; pos < token->text_len - 2; pos++) {
-                    if (css_is_ws(token->text[pos])) {
-                        pending = 1;
-                    } else {
-                        if (pending && text.len > 3) {
-                            cbuf_putc(&text, ' ');
-                        }
-                        pending = 0;
-                        cbuf_putc(&text, token->text[pos]);
-                    }
-                }
-                cbuf_puts(&text, "*/");
+                /* a bang comment is a license/copyright banner kept byte-exact: its body (SPDX text, newlines,
+                   alignment) must survive verbatim, so copy the whole token unchanged */
                 rule_item item = {0};
-                item.text_off = pool_run(pool, text.data, text.len);
-                item.text_len = text.len;
+                item.text_off = pool_run(pool, token->text, token->text_len);
+                item.text_len = token->text_len;
                 rule_vec_push(&items, item);
-                cbuf_free(&text);
             }
             cur->index++;
             continue;

--- a/src/turbohtml/_c/serialize/css_render.h
+++ b/src/turbohtml/_c/serialize/css_render.h
@@ -338,6 +338,12 @@ static void css_handle_color_drop(css_buf *pool, comp_vec *comps, const css_char
 }
 
 static void css_handle_border_color(css_buf *pool, comp_vec *comps) {
+    Py_ssize_t value_count = 0;
+    for (Py_ssize_t index = 0; index < comps->len; index++) {
+        if (comps->items[index].kind != CK_SEP) {
+            value_count++;
+        }
+    }
     Py_ssize_t write = 0;
     for (Py_ssize_t index = 0; index < comps->len; index++) {
         css_comp comp = comps->items[index];
@@ -345,7 +351,9 @@ static void css_handle_border_color(css_buf *pool, comp_vec *comps) {
             continue;
         }
         if (css_comp_kw(pool, &comp, "currentcolor")) {
-            css_set_comp(pool, &comp, "initial", CK_IDENT);
+            /* a CSS-wide keyword is valid only as the sole value; in a multi-value list keep the color keyword
+               (lowercased), since border-color:initial red would drop the whole declaration */
+            css_set_comp(pool, &comp, value_count == 1 ? "initial" : "currentcolor", CK_IDENT);
         } else {
             css_minify_color_comp(pool, &comp);
         }
@@ -362,6 +370,10 @@ static void css_handle_border_color(css_buf *pool, comp_vec *comps) {
         }
         if (all_equal) {
             comps->len = 1;
+            /* the list collapsed to a single value, so a lone currentcolor is now safe to shorten to initial */
+            if (css_comp_kw(pool, &comps->items[0], "currentcolor")) {
+                css_set_comp(pool, &comps->items[0], "initial", CK_IDENT);
+            }
         }
     }
 }
@@ -623,9 +635,8 @@ static int css_handle_unicode_range(token_vec *vec, Py_ssize_t start, Py_ssize_t
             for (int pos = 0; pos < written; pos++) {
                 cbuf_putc(out, (css_char)(unsigned char)buffer[pos]);
             }
-        } else if (low == 0 && high == 0x10FFFF) {
-            cbuf_puts(out, "initial");
         } else {
+            /* a descriptor takes no CSS-wide keyword, so a full U+0-10FFFF range is never rewritten to initial */
             int nibble = 0;
             while (nibble < 6 && ((low >> (nibble * 4)) & 0xF) == 0 && ((high >> (nibble * 4)) & 0xF) == 0xF) {
                 nibble++;

--- a/src/turbohtml/_c/serialize/css_selector.h
+++ b/src/turbohtml/_c/serialize/css_selector.h
@@ -263,7 +263,7 @@ static const char *css_longhand_list(const css_char *prop, Py_ssize_t prop_len) 
         "flex flex-basis flex-grow flex-shrink",
         "flex-flow flex-direction flex-wrap",
         "grid grid-template-rows grid-template-columns grid-template-areas grid-auto-rows grid-auto-columns "
-        "grid-auto-flow grid-column-gap grid-row-gap column-gap row-gap",
+        "grid-auto-flow",
         "grid-area grid-row-start grid-column-start grid-row-end grid-column-end",
         "grid-row grid-row-start grid-row-end",
         "grid-column grid-column-start grid-column-end",
@@ -315,7 +315,15 @@ static int css_prop_in_list(const css_char *prop, Py_ssize_t prop_len, const cha
     return 0;
 }
 
-/* The pairwise dedup, fine for the typical small rule. */
+static int css_decl_value_eq(const css_buf *pool, const css_decl *left, const css_decl *right) {
+    return left->val_len == right->val_len && memcmp(pool->data + left->val_off, pool->data + right->val_off,
+                                                     (size_t)left->val_len * sizeof(css_char)) == 0;
+}
+
+/* The pairwise dedup, fine for the typical small rule. Per CSS Cascade last-wins only among declarations that parse:
+   a later same-name declaration with a *different* value may be a progressive-enhancement fallback a browser keeps
+   when it cannot parse the later value, so only an identical same-name duplicate is dropped. A longhand covered by a
+   later shorthand (a different name in its longhand list) is a strict subset and stays droppable. */
 static void css_dedup_pairwise(css_buf *pool, decl_vec *decls) {
     for (Py_ssize_t index = 0; index < decls->len; index++) {
         css_decl *later = &decls->items[index];
@@ -331,13 +339,12 @@ static void css_dedup_pairwise(css_buf *pool, decl_vec *decls) {
                 continue;
             }
             const css_char *prior = pool->data + prev->prop_off;
-            int overrides = prev->prop_len == prop_len;
-            for (Py_ssize_t pos = 0; overrides && pos < prop_len; pos++) {
-                overrides = prop[pos] == prior[pos];
+            int same_name = prev->prop_len == prop_len;
+            for (Py_ssize_t pos = 0; same_name && pos < prop_len; pos++) {
+                same_name = prop[pos] == prior[pos];
             }
-            if (!overrides && list != NULL) {
-                overrides = css_prop_in_list(prior, prev->prop_len, list);
-            }
+            int overrides = same_name ? css_decl_value_eq(pool, prev, later)
+                                      : (list != NULL && css_prop_in_list(prior, prev->prop_len, list));
             if (overrides) {
                 prev->dropped = 1;
             }
@@ -443,23 +450,30 @@ static void css_dedup(css_buf *pool, decl_vec *decls) {
         const char *list = css_longhand_list(prop, prop_len);
         if (list == NULL) {
             Py_ssize_t slot = dedup_slot_run(table, mask, pool, prop, prop_len, important);
-            if (table[slot].used && !decls->items[table[slot].index].dropped) {
+            /* a same-name duplicate is dropped only when its value is identical (see css_dedup_pairwise) */
+            if (table[slot].used && !decls->items[table[slot].index].dropped &&
+                css_decl_value_eq(pool, &decls->items[table[slot].index], later)) {
                 decls->items[table[slot].index].dropped = 1;
             }
         } else {
+            /* every longhand list begins with the shorthand's own name; that first word is a same-name duplicate
+               (value-equality gated), the rest are strict-subset longhands the shorthand always resets */
             const char *cursor = list;
+            int own_name = 1;
             while (*cursor) {
                 const char *word = cursor;
                 while (*cursor && *cursor != ' ') {
                     cursor++;
                 }
                 Py_ssize_t slot = dedup_slot_cstr(table, mask, pool, word, cursor - word, important);
-                if (table[slot].used && !decls->items[table[slot].index].dropped) {
+                if (table[slot].used && !decls->items[table[slot].index].dropped &&
+                    (!own_name || css_decl_value_eq(pool, &decls->items[table[slot].index], later))) {
                     decls->items[table[slot].index].dropped = 1;
                 }
                 while (*cursor == ' ') {
                     cursor++;
                 }
+                own_name = 0;
             }
         }
         Py_ssize_t home = dedup_slot_run(table, mask, pool, prop, prop_len, important);

--- a/tests/serialize/data/css_minify_golden.json
+++ b/tests/serialize/data/css_minify_golden.json
@@ -6,7 +6,7 @@
 ],
 [
 "/*! bang  comment */",
-"/*!bang comment*/",
+"/*! bang  comment */",
 ""
 ],
 [
@@ -21,7 +21,7 @@
 ],
 [
 "i{a:b;}/*! bang  comment */",
-"i{a:b}/*!bang comment*/",
+"i{a:b}/*! bang  comment */",
 "i{a:b}"
 ],
 [
@@ -907,7 +907,7 @@
 [
 "border-color: currentcolor red currentcolor;",
 "border-color: currentcolor red currentcolor",
-"border-color:initial red initial"
+"border-color:currentcolor red currentcolor"
 ],
 [
 "border-color: currentcolor currentcolor currentcolor;",
@@ -1372,7 +1372,7 @@
 [
 "unicode-range:U+0-10FFFF",
 "unicode-range:U+0-10FFFF",
-"unicode-range:initial"
+"unicode-range:U+0-10FFFF"
 ],
 [
 "MARGIN:1EM",
@@ -2031,8 +2031,8 @@
 ],
 [
 "a{p0:0px;p1:1px;p2:2px;p3:3px;p4:4px;p5:5px;p6:6px;p7:7px;p8:8px;p9:9px;p10:10px;p11:11px;p12:12px;p13:13px;p14:14px;p15:15px;p16:16px;p17:17px;p18:18px;p19:19px;p20:20px;p21:21px;p22:22px;p23:23px;p24:24px;p25:25px;p26:26px;p27:27px;p28:28px;p29:29px;p30:30px;p31:31px;p32:32px;color:red;color:blue}",
-"a{p0:0;p1:1px;p2:2px;p3:3px;p4:4px;p5:5px;p6:6px;p7:7px;p8:8px;p9:9px;p10:10px;p11:11px;p12:12px;p13:13px;p14:14px;p15:15px;p16:16px;p17:17px;p18:18px;p19:19px;p20:20px;p21:21px;p22:22px;p23:23px;p24:24px;p25:25px;p26:26px;p27:27px;p28:28px;p29:29px;p30:30px;p31:31px;p32:32px;color:blue}",
-"a{p0:0;p1:1px;p2:2px;p3:3px;p4:4px;p5:5px;p6:6px;p7:7px;p8:8px;p9:9px;p10:10px;p11:11px;p12:12px;p13:13px;p14:14px;p15:15px;p16:16px;p17:17px;p18:18px;p19:19px;p20:20px;p21:21px;p22:22px;p23:23px;p24:24px;p25:25px;p26:26px;p27:27px;p28:28px;p29:29px;p30:30px;p31:31px;p32:32px;color:blue}"
+"a{p0:0;p1:1px;p2:2px;p3:3px;p4:4px;p5:5px;p6:6px;p7:7px;p8:8px;p9:9px;p10:10px;p11:11px;p12:12px;p13:13px;p14:14px;p15:15px;p16:16px;p17:17px;p18:18px;p19:19px;p20:20px;p21:21px;p22:22px;p23:23px;p24:24px;p25:25px;p26:26px;p27:27px;p28:28px;p29:29px;p30:30px;p31:31px;p32:32px;color:red;color:blue}",
+"a{p0:0;p1:1px;p2:2px;p3:3px;p4:4px;p5:5px;p6:6px;p7:7px;p8:8px;p9:9px;p10:10px;p11:11px;p12:12px;p13:13px;p14:14px;p15:15px;p16:16px;p17:17px;p18:18px;p19:19px;p20:20px;p21:21px;p22:22px;p23:23px;p24:24px;p25:25px;p26:26px;p27:27px;p28:28px;p29:29px;p30:30px;p31:31px;p32:32px;color:red;color:blue}"
 ],
 [
 "a{q0:0px;q1:1px;q2:2px;q3:3px;q4:4px;q5:5px;q6:6px;q7:7px;q8:8px;q9:9px;q10:10px;q11:11px;q12:12px;q13:13px;q14:14px;q15:15px;q16:16px;q17:17px;q18:18px;q19:19px;q20:20px;q21:21px;q22:22px;q23:23px;q24:24px;q25:25px;q26:26px;q27:27px;q28:28px;q29:29px;q30:30px;q31:31px;q32:32px;margin-top:1px;margin:2px}",
@@ -2141,8 +2141,8 @@
 ],
 [
 "a{z0:0px;z1:1px;z2:2px;z3:3px;z4:4px;z5:5px;z6:6px;z7:7px;z8:8px;z9:9px;z10:10px;z11:11px;z12:12px;z13:13px;z14:14px;z15:15px;z16:16px;z17:17px;z18:18px;z19:19px;z20:20px;z21:21px;z22:22px;z23:23px;z24:24px;z25:25px;z26:26px;z27:27px;z28:28px;z29:29px;z30:30px;z31:31px;z32:32px;z33:33px;z34:34px;z35:35px;z36:36px;z37:37px;z38:38px;z39:39px;z40:40px;z41:41px;z42:42px;z43:43px;z44:44px;z45:45px;z46:46px;z47:47px;z48:48px;z49:49px;z50:50px;z51:51px;z52:52px;z53:53px;z54:54px;z55:55px;z56:56px;z57:57px;z58:58px;z59:59px;z60:60px;z61:61px;z62:62px;z63:63px;z64:64px;z65:65px;z66:66px;z67:67px;z68:68px;z69:69px;z70:70px;z71:71px;z72:72px;z73:73px;z74:74px;z75:75px;z76:76px;z77:77px;z78:78px;z79:79px;z80:80px;z81:81px;z82:82px;z83:83px;z84:84px;z85:85px;z86:86px;z87:87px;z88:88px;z89:89px;z90:90px;z91:91px;z92:92px;z93:93px;z94:94px;z95:95px;z96:96px;z97:97px;z98:98px;z99:99px;z100:100px;z101:101px;z102:102px;z103:103px;z104:104px;z105:105px;z106:106px;z107:107px;z108:108px;z109:109px;z110:110px;z111:111px;z112:112px;z113:113px;z114:114px;z115:115px;z116:116px;z117:117px;z118:118px;z119:119px;z120:120px;z121:121px;z122:122px;z123:123px;z124:124px;z125:125px;z126:126px;z127:127px;z128:128px;z129:129px;z130:130px;z131:131px;z132:132px;z133:133px;z134:134px;z135:135px;z136:136px;z137:137px;z138:138px;z139:139px;z140:140px;z141:141px;z142:142px;z143:143px;z144:144px;z145:145px;z146:146px;z147:147px;z148:148px;z149:149px;z150:150px;z151:151px;z152:152px;z153:153px;z154:154px;z155:155px;z156:156px;z157:157px;z158:158px;z159:159px;z160:160px;z161:161px;z162:162px;z163:163px;z164:164px;z165:165px;z166:166px;z167:167px;z168:168px;z169:169px;z170:170px;z171:171px;z172:172px;z173:173px;z174:174px;z175:175px;z176:176px;z177:177px;z178:178px;z179:179px;z180:180px;z181:181px;z182:182px;z183:183px;z184:184px;z185:185px;z186:186px;z187:187px;z188:188px;z189:189px;z190:190px;z191:191px;z192:192px;z193:193px;z194:194px;z195:195px;z196:196px;z197:197px;z198:198px;z199:199px;z200:200px;z201:201px;z202:202px;z203:203px;z204:204px;z205:205px;z206:206px;z207:207px;z208:208px;z209:209px;z210:210px;z211:211px;z212:212px;z213:213px;z214:214px;z215:215px;z216:216px;z217:217px;z218:218px;z219:219px;z220:220px;z221:221px;z222:222px;z223:223px;z224:224px;z225:225px;z226:226px;z227:227px;z228:228px;z229:229px;z230:230px;z231:231px;z232:232px;z233:233px;z234:234px;z235:235px;z236:236px;z237:237px;z238:238px;z239:239px;z240:240px;z241:241px;z242:242px;z243:243px;z244:244px;z245:245px;z246:246px;z247:247px;z248:248px;z249:249px;z250:250px;z251:251px;z252:252px;z253:253px;z254:254px;z255:255px;z256:256px;z257:257px;z258:258px;z259:259px;z260:260px;z261:261px;z262:262px;z263:263px;z264:264px;z265:265px;z266:266px;z267:267px;z268:268px;z269:269px;z270:270px;z271:271px;z272:272px;z273:273px;z274:274px;z275:275px;z276:276px;z277:277px;z278:278px;z279:279px;z280:280px;z281:281px;z282:282px;z283:283px;z284:284px;z285:285px;z286:286px;z287:287px;z288:288px;z289:289px;z290:290px;z291:291px;z292:292px;z293:293px;z294:294px;z295:295px;z296:296px;z297:297px;z298:298px;z299:299px;color:red;color:blue}",
-"a{z0:0;z1:1px;z2:2px;z3:3px;z4:4px;z5:5px;z6:6px;z7:7px;z8:8px;z9:9px;z10:10px;z11:11px;z12:12px;z13:13px;z14:14px;z15:15px;z16:16px;z17:17px;z18:18px;z19:19px;z20:20px;z21:21px;z22:22px;z23:23px;z24:24px;z25:25px;z26:26px;z27:27px;z28:28px;z29:29px;z30:30px;z31:31px;z32:32px;z33:33px;z34:34px;z35:35px;z36:36px;z37:37px;z38:38px;z39:39px;z40:40px;z41:41px;z42:42px;z43:43px;z44:44px;z45:45px;z46:46px;z47:47px;z48:48px;z49:49px;z50:50px;z51:51px;z52:52px;z53:53px;z54:54px;z55:55px;z56:56px;z57:57px;z58:58px;z59:59px;z60:60px;z61:61px;z62:62px;z63:63px;z64:64px;z65:65px;z66:66px;z67:67px;z68:68px;z69:69px;z70:70px;z71:71px;z72:72px;z73:73px;z74:74px;z75:75px;z76:76px;z77:77px;z78:78px;z79:79px;z80:80px;z81:81px;z82:82px;z83:83px;z84:84px;z85:85px;z86:86px;z87:87px;z88:88px;z89:89px;z90:90px;z91:91px;z92:92px;z93:93px;z94:94px;z95:95px;z96:96px;z97:97px;z98:98px;z99:99px;z100:100px;z101:101px;z102:102px;z103:103px;z104:104px;z105:105px;z106:106px;z107:107px;z108:108px;z109:109px;z110:110px;z111:111px;z112:112px;z113:113px;z114:114px;z115:115px;z116:116px;z117:117px;z118:118px;z119:119px;z120:120px;z121:121px;z122:122px;z123:123px;z124:124px;z125:125px;z126:126px;z127:127px;z128:128px;z129:129px;z130:130px;z131:131px;z132:132px;z133:133px;z134:134px;z135:135px;z136:136px;z137:137px;z138:138px;z139:139px;z140:140px;z141:141px;z142:142px;z143:143px;z144:144px;z145:145px;z146:146px;z147:147px;z148:148px;z149:149px;z150:150px;z151:151px;z152:152px;z153:153px;z154:154px;z155:155px;z156:156px;z157:157px;z158:158px;z159:159px;z160:160px;z161:161px;z162:162px;z163:163px;z164:164px;z165:165px;z166:166px;z167:167px;z168:168px;z169:169px;z170:170px;z171:171px;z172:172px;z173:173px;z174:174px;z175:175px;z176:176px;z177:177px;z178:178px;z179:179px;z180:180px;z181:181px;z182:182px;z183:183px;z184:184px;z185:185px;z186:186px;z187:187px;z188:188px;z189:189px;z190:190px;z191:191px;z192:192px;z193:193px;z194:194px;z195:195px;z196:196px;z197:197px;z198:198px;z199:199px;z200:200px;z201:201px;z202:202px;z203:203px;z204:204px;z205:205px;z206:206px;z207:207px;z208:208px;z209:209px;z210:210px;z211:211px;z212:212px;z213:213px;z214:214px;z215:215px;z216:216px;z217:217px;z218:218px;z219:219px;z220:220px;z221:221px;z222:222px;z223:223px;z224:224px;z225:225px;z226:226px;z227:227px;z228:228px;z229:229px;z230:230px;z231:231px;z232:232px;z233:233px;z234:234px;z235:235px;z236:236px;z237:237px;z238:238px;z239:239px;z240:240px;z241:241px;z242:242px;z243:243px;z244:244px;z245:245px;z246:246px;z247:247px;z248:248px;z249:249px;z250:250px;z251:251px;z252:252px;z253:253px;z254:254px;z255:255px;z256:256px;z257:257px;z258:258px;z259:259px;z260:260px;z261:261px;z262:262px;z263:263px;z264:264px;z265:265px;z266:266px;z267:267px;z268:268px;z269:269px;z270:270px;z271:271px;z272:272px;z273:273px;z274:274px;z275:275px;z276:276px;z277:277px;z278:278px;z279:279px;z280:280px;z281:281px;z282:282px;z283:283px;z284:284px;z285:285px;z286:286px;z287:287px;z288:288px;z289:289px;z290:290px;z291:291px;z292:292px;z293:293px;z294:294px;z295:295px;z296:296px;z297:297px;z298:298px;z299:299px;color:blue}",
-"a{z0:0;z1:1px;z2:2px;z3:3px;z4:4px;z5:5px;z6:6px;z7:7px;z8:8px;z9:9px;z10:10px;z11:11px;z12:12px;z13:13px;z14:14px;z15:15px;z16:16px;z17:17px;z18:18px;z19:19px;z20:20px;z21:21px;z22:22px;z23:23px;z24:24px;z25:25px;z26:26px;z27:27px;z28:28px;z29:29px;z30:30px;z31:31px;z32:32px;z33:33px;z34:34px;z35:35px;z36:36px;z37:37px;z38:38px;z39:39px;z40:40px;z41:41px;z42:42px;z43:43px;z44:44px;z45:45px;z46:46px;z47:47px;z48:48px;z49:49px;z50:50px;z51:51px;z52:52px;z53:53px;z54:54px;z55:55px;z56:56px;z57:57px;z58:58px;z59:59px;z60:60px;z61:61px;z62:62px;z63:63px;z64:64px;z65:65px;z66:66px;z67:67px;z68:68px;z69:69px;z70:70px;z71:71px;z72:72px;z73:73px;z74:74px;z75:75px;z76:76px;z77:77px;z78:78px;z79:79px;z80:80px;z81:81px;z82:82px;z83:83px;z84:84px;z85:85px;z86:86px;z87:87px;z88:88px;z89:89px;z90:90px;z91:91px;z92:92px;z93:93px;z94:94px;z95:95px;z96:96px;z97:97px;z98:98px;z99:99px;z100:100px;z101:101px;z102:102px;z103:103px;z104:104px;z105:105px;z106:106px;z107:107px;z108:108px;z109:109px;z110:110px;z111:111px;z112:112px;z113:113px;z114:114px;z115:115px;z116:116px;z117:117px;z118:118px;z119:119px;z120:120px;z121:121px;z122:122px;z123:123px;z124:124px;z125:125px;z126:126px;z127:127px;z128:128px;z129:129px;z130:130px;z131:131px;z132:132px;z133:133px;z134:134px;z135:135px;z136:136px;z137:137px;z138:138px;z139:139px;z140:140px;z141:141px;z142:142px;z143:143px;z144:144px;z145:145px;z146:146px;z147:147px;z148:148px;z149:149px;z150:150px;z151:151px;z152:152px;z153:153px;z154:154px;z155:155px;z156:156px;z157:157px;z158:158px;z159:159px;z160:160px;z161:161px;z162:162px;z163:163px;z164:164px;z165:165px;z166:166px;z167:167px;z168:168px;z169:169px;z170:170px;z171:171px;z172:172px;z173:173px;z174:174px;z175:175px;z176:176px;z177:177px;z178:178px;z179:179px;z180:180px;z181:181px;z182:182px;z183:183px;z184:184px;z185:185px;z186:186px;z187:187px;z188:188px;z189:189px;z190:190px;z191:191px;z192:192px;z193:193px;z194:194px;z195:195px;z196:196px;z197:197px;z198:198px;z199:199px;z200:200px;z201:201px;z202:202px;z203:203px;z204:204px;z205:205px;z206:206px;z207:207px;z208:208px;z209:209px;z210:210px;z211:211px;z212:212px;z213:213px;z214:214px;z215:215px;z216:216px;z217:217px;z218:218px;z219:219px;z220:220px;z221:221px;z222:222px;z223:223px;z224:224px;z225:225px;z226:226px;z227:227px;z228:228px;z229:229px;z230:230px;z231:231px;z232:232px;z233:233px;z234:234px;z235:235px;z236:236px;z237:237px;z238:238px;z239:239px;z240:240px;z241:241px;z242:242px;z243:243px;z244:244px;z245:245px;z246:246px;z247:247px;z248:248px;z249:249px;z250:250px;z251:251px;z252:252px;z253:253px;z254:254px;z255:255px;z256:256px;z257:257px;z258:258px;z259:259px;z260:260px;z261:261px;z262:262px;z263:263px;z264:264px;z265:265px;z266:266px;z267:267px;z268:268px;z269:269px;z270:270px;z271:271px;z272:272px;z273:273px;z274:274px;z275:275px;z276:276px;z277:277px;z278:278px;z279:279px;z280:280px;z281:281px;z282:282px;z283:283px;z284:284px;z285:285px;z286:286px;z287:287px;z288:288px;z289:289px;z290:290px;z291:291px;z292:292px;z293:293px;z294:294px;z295:295px;z296:296px;z297:297px;z298:298px;z299:299px;color:blue}"
+"a{z0:0;z1:1px;z2:2px;z3:3px;z4:4px;z5:5px;z6:6px;z7:7px;z8:8px;z9:9px;z10:10px;z11:11px;z12:12px;z13:13px;z14:14px;z15:15px;z16:16px;z17:17px;z18:18px;z19:19px;z20:20px;z21:21px;z22:22px;z23:23px;z24:24px;z25:25px;z26:26px;z27:27px;z28:28px;z29:29px;z30:30px;z31:31px;z32:32px;z33:33px;z34:34px;z35:35px;z36:36px;z37:37px;z38:38px;z39:39px;z40:40px;z41:41px;z42:42px;z43:43px;z44:44px;z45:45px;z46:46px;z47:47px;z48:48px;z49:49px;z50:50px;z51:51px;z52:52px;z53:53px;z54:54px;z55:55px;z56:56px;z57:57px;z58:58px;z59:59px;z60:60px;z61:61px;z62:62px;z63:63px;z64:64px;z65:65px;z66:66px;z67:67px;z68:68px;z69:69px;z70:70px;z71:71px;z72:72px;z73:73px;z74:74px;z75:75px;z76:76px;z77:77px;z78:78px;z79:79px;z80:80px;z81:81px;z82:82px;z83:83px;z84:84px;z85:85px;z86:86px;z87:87px;z88:88px;z89:89px;z90:90px;z91:91px;z92:92px;z93:93px;z94:94px;z95:95px;z96:96px;z97:97px;z98:98px;z99:99px;z100:100px;z101:101px;z102:102px;z103:103px;z104:104px;z105:105px;z106:106px;z107:107px;z108:108px;z109:109px;z110:110px;z111:111px;z112:112px;z113:113px;z114:114px;z115:115px;z116:116px;z117:117px;z118:118px;z119:119px;z120:120px;z121:121px;z122:122px;z123:123px;z124:124px;z125:125px;z126:126px;z127:127px;z128:128px;z129:129px;z130:130px;z131:131px;z132:132px;z133:133px;z134:134px;z135:135px;z136:136px;z137:137px;z138:138px;z139:139px;z140:140px;z141:141px;z142:142px;z143:143px;z144:144px;z145:145px;z146:146px;z147:147px;z148:148px;z149:149px;z150:150px;z151:151px;z152:152px;z153:153px;z154:154px;z155:155px;z156:156px;z157:157px;z158:158px;z159:159px;z160:160px;z161:161px;z162:162px;z163:163px;z164:164px;z165:165px;z166:166px;z167:167px;z168:168px;z169:169px;z170:170px;z171:171px;z172:172px;z173:173px;z174:174px;z175:175px;z176:176px;z177:177px;z178:178px;z179:179px;z180:180px;z181:181px;z182:182px;z183:183px;z184:184px;z185:185px;z186:186px;z187:187px;z188:188px;z189:189px;z190:190px;z191:191px;z192:192px;z193:193px;z194:194px;z195:195px;z196:196px;z197:197px;z198:198px;z199:199px;z200:200px;z201:201px;z202:202px;z203:203px;z204:204px;z205:205px;z206:206px;z207:207px;z208:208px;z209:209px;z210:210px;z211:211px;z212:212px;z213:213px;z214:214px;z215:215px;z216:216px;z217:217px;z218:218px;z219:219px;z220:220px;z221:221px;z222:222px;z223:223px;z224:224px;z225:225px;z226:226px;z227:227px;z228:228px;z229:229px;z230:230px;z231:231px;z232:232px;z233:233px;z234:234px;z235:235px;z236:236px;z237:237px;z238:238px;z239:239px;z240:240px;z241:241px;z242:242px;z243:243px;z244:244px;z245:245px;z246:246px;z247:247px;z248:248px;z249:249px;z250:250px;z251:251px;z252:252px;z253:253px;z254:254px;z255:255px;z256:256px;z257:257px;z258:258px;z259:259px;z260:260px;z261:261px;z262:262px;z263:263px;z264:264px;z265:265px;z266:266px;z267:267px;z268:268px;z269:269px;z270:270px;z271:271px;z272:272px;z273:273px;z274:274px;z275:275px;z276:276px;z277:277px;z278:278px;z279:279px;z280:280px;z281:281px;z282:282px;z283:283px;z284:284px;z285:285px;z286:286px;z287:287px;z288:288px;z289:289px;z290:290px;z291:291px;z292:292px;z293:293px;z294:294px;z295:295px;z296:296px;z297:297px;z298:298px;z299:299px;color:red;color:blue}",
+"a{z0:0;z1:1px;z2:2px;z3:3px;z4:4px;z5:5px;z6:6px;z7:7px;z8:8px;z9:9px;z10:10px;z11:11px;z12:12px;z13:13px;z14:14px;z15:15px;z16:16px;z17:17px;z18:18px;z19:19px;z20:20px;z21:21px;z22:22px;z23:23px;z24:24px;z25:25px;z26:26px;z27:27px;z28:28px;z29:29px;z30:30px;z31:31px;z32:32px;z33:33px;z34:34px;z35:35px;z36:36px;z37:37px;z38:38px;z39:39px;z40:40px;z41:41px;z42:42px;z43:43px;z44:44px;z45:45px;z46:46px;z47:47px;z48:48px;z49:49px;z50:50px;z51:51px;z52:52px;z53:53px;z54:54px;z55:55px;z56:56px;z57:57px;z58:58px;z59:59px;z60:60px;z61:61px;z62:62px;z63:63px;z64:64px;z65:65px;z66:66px;z67:67px;z68:68px;z69:69px;z70:70px;z71:71px;z72:72px;z73:73px;z74:74px;z75:75px;z76:76px;z77:77px;z78:78px;z79:79px;z80:80px;z81:81px;z82:82px;z83:83px;z84:84px;z85:85px;z86:86px;z87:87px;z88:88px;z89:89px;z90:90px;z91:91px;z92:92px;z93:93px;z94:94px;z95:95px;z96:96px;z97:97px;z98:98px;z99:99px;z100:100px;z101:101px;z102:102px;z103:103px;z104:104px;z105:105px;z106:106px;z107:107px;z108:108px;z109:109px;z110:110px;z111:111px;z112:112px;z113:113px;z114:114px;z115:115px;z116:116px;z117:117px;z118:118px;z119:119px;z120:120px;z121:121px;z122:122px;z123:123px;z124:124px;z125:125px;z126:126px;z127:127px;z128:128px;z129:129px;z130:130px;z131:131px;z132:132px;z133:133px;z134:134px;z135:135px;z136:136px;z137:137px;z138:138px;z139:139px;z140:140px;z141:141px;z142:142px;z143:143px;z144:144px;z145:145px;z146:146px;z147:147px;z148:148px;z149:149px;z150:150px;z151:151px;z152:152px;z153:153px;z154:154px;z155:155px;z156:156px;z157:157px;z158:158px;z159:159px;z160:160px;z161:161px;z162:162px;z163:163px;z164:164px;z165:165px;z166:166px;z167:167px;z168:168px;z169:169px;z170:170px;z171:171px;z172:172px;z173:173px;z174:174px;z175:175px;z176:176px;z177:177px;z178:178px;z179:179px;z180:180px;z181:181px;z182:182px;z183:183px;z184:184px;z185:185px;z186:186px;z187:187px;z188:188px;z189:189px;z190:190px;z191:191px;z192:192px;z193:193px;z194:194px;z195:195px;z196:196px;z197:197px;z198:198px;z199:199px;z200:200px;z201:201px;z202:202px;z203:203px;z204:204px;z205:205px;z206:206px;z207:207px;z208:208px;z209:209px;z210:210px;z211:211px;z212:212px;z213:213px;z214:214px;z215:215px;z216:216px;z217:217px;z218:218px;z219:219px;z220:220px;z221:221px;z222:222px;z223:223px;z224:224px;z225:225px;z226:226px;z227:227px;z228:228px;z229:229px;z230:230px;z231:231px;z232:232px;z233:233px;z234:234px;z235:235px;z236:236px;z237:237px;z238:238px;z239:239px;z240:240px;z241:241px;z242:242px;z243:243px;z244:244px;z245:245px;z246:246px;z247:247px;z248:248px;z249:249px;z250:250px;z251:251px;z252:252px;z253:253px;z254:254px;z255:255px;z256:256px;z257:257px;z258:258px;z259:259px;z260:260px;z261:261px;z262:262px;z263:263px;z264:264px;z265:265px;z266:266px;z267:267px;z268:268px;z269:269px;z270:270px;z271:271px;z272:272px;z273:273px;z274:274px;z275:275px;z276:276px;z277:277px;z278:278px;z279:279px;z280:280px;z281:281px;z282:282px;z283:283px;z284:284px;z285:285px;z286:286px;z287:287px;z288:288px;z289:289px;z290:290px;z291:291px;z292:292px;z293:293px;z294:294px;z295:295px;z296:296px;z297:297px;z298:298px;z299:299px;color:red;color:blue}"
 ],
 [
 "a{margin-left:1px;margin:2px}",
@@ -2261,8 +2261,8 @@
 ],
 [
 "a{margin:0;margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:4px}",
-"a{margin:1px 2px 3px 4px}",
-"a{margin:1px 2px 3px 4px}"
+"a{margin:0;margin:1px 2px 3px 4px}",
+"a{margin:0;margin:1px 2px 3px 4px}"
 ],
 [
 "a{n0:0px;n1:1px;n2:2px;n3:3px;n4:4px;n5:5px;n6:6px;n7:7px;n8:8px;n9:9px;n10:10px;n11:11px;n12:12px;n13:13px;n14:14px;n15:15px;n16:16px;n17:17px;n18:18px;n19:19px;n20:20px;n21:21px;n22:22px;n23:23px;n24:24px;n25:25px;n26:26px;n27:27px;n28:28px;n29:29px;n30:30px;n31:31px;n32:32px;& b{color:red}}",
@@ -3146,8 +3146,8 @@
 ],
 [
 "@font-face{unicode-range:U+0-10FFFF}",
-"@font-face{unicode-range:initial}",
-"@font-face{unicode-range:initial}"
+"@font-face{unicode-range:U+0-10FFFF}",
+"@font-face{unicode-range:U+0-10FFFF}"
 ],
 [
 "@font-face{unicode-range:U+a}",
@@ -4076,13 +4076,13 @@
 ],
 [
 "a{@media x{b:1}color:red;color:blue}",
-"a{@media x{b:1};color:blue}",
-"a{@media x{b:1};color:blue}"
+"a{@media x{b:1};color:red;color:blue}",
+"a{@media x{b:1};color:red;color:blue}"
 ],
 [
 "a{x:1;x:2;x:3}",
-"a{x:3}",
-"a{x:3}"
+"a{x:1;x:2;x:3}",
+"a{x:1;x:2;x:3}"
 ],
 [
 "a{margin-top:unset;margin-right:unset;margin-bottom:unset;margin-left:unset}",
@@ -4156,8 +4156,8 @@
 ],
 [
 "a{margin-top:1px;margin-top:2px;margin-right:2px;margin-bottom:3px;margin-left:4px}",
-"a{margin:2px 2px 3px 4px}",
-"a{margin:2px 2px 3px 4px}"
+"a{margin-top:1px;margin-top:2px;margin-right:2px;margin-bottom:3px;margin-left:4px}",
+"a{margin-top:1px;margin-top:2px;margin-right:2px;margin-bottom:3px;margin-left:4px}"
 ],
 [
 "a{margin-top:vate;margin-right:vave;margin-bottom:enre;margin-left:ente}",
@@ -4176,13 +4176,13 @@
 ],
 [
 "a{p0:0;p1:1;p2:2;p3:3;p4:4;p5:5;p6:6;p7:7;p8:8;p9:9;p10:10;p11:11;p12:12;p13:13;p14:14;p15:15;p16:16;p17:17;p18:18;p19:19;p20:20;p21:21;p22:22;p23:23;p24:24;p25:25;p26:26;p27:27;p28:28;p29:29;p30:30;p31:31;p32:32;p33:33;p34:34;p35:35;p36:36;p37:37;p38:38;p39:39;p0:100;p1:101;p2:102;p3:103;p4:104}",
-"a{p5:5;p6:6;p7:7;p8:8;p9:9;p10:10;p11:11;p12:12;p13:13;p14:14;p15:15;p16:16;p17:17;p18:18;p19:19;p20:20;p21:21;p22:22;p23:23;p24:24;p25:25;p26:26;p27:27;p28:28;p29:29;p30:30;p31:31;p32:32;p33:33;p34:34;p35:35;p36:36;p37:37;p38:38;p39:39;p0:100;p1:101;p2:102;p3:103;p4:104}",
-"a{p5:5;p6:6;p7:7;p8:8;p9:9;p10:10;p11:11;p12:12;p13:13;p14:14;p15:15;p16:16;p17:17;p18:18;p19:19;p20:20;p21:21;p22:22;p23:23;p24:24;p25:25;p26:26;p27:27;p28:28;p29:29;p30:30;p31:31;p32:32;p33:33;p34:34;p35:35;p36:36;p37:37;p38:38;p39:39;p0:100;p1:101;p2:102;p3:103;p4:104}"
+"a{p0:0;p1:1;p2:2;p3:3;p4:4;p5:5;p6:6;p7:7;p8:8;p9:9;p10:10;p11:11;p12:12;p13:13;p14:14;p15:15;p16:16;p17:17;p18:18;p19:19;p20:20;p21:21;p22:22;p23:23;p24:24;p25:25;p26:26;p27:27;p28:28;p29:29;p30:30;p31:31;p32:32;p33:33;p34:34;p35:35;p36:36;p37:37;p38:38;p39:39;p0:100;p1:101;p2:102;p3:103;p4:104}",
+"a{p0:0;p1:1;p2:2;p3:3;p4:4;p5:5;p6:6;p7:7;p8:8;p9:9;p10:10;p11:11;p12:12;p13:13;p14:14;p15:15;p16:16;p17:17;p18:18;p19:19;p20:20;p21:21;p22:22;p23:23;p24:24;p25:25;p26:26;p27:27;p28:28;p29:29;p30:30;p31:31;p32:32;p33:33;p34:34;p35:35;p36:36;p37:37;p38:38;p39:39;p0:100;p1:101;p2:102;p3:103;p4:104}"
 ],
 [
 "b{q0:0;q1:1;q2:2;q3:3;q4:4;q5:5;q6:6;q7:7;q8:8;q9:9;q10:10;q11:11;q12:12;q13:13;q14:14;q15:15;q16:16;q17:17;q18:18;q19:19;q20:20;q21:21;q22:22;q23:23;q24:24;q25:25;q26:26;q27:27;q28:28;q29:29;q30:30;q31:31;q32:32;q33:33;q34:34;margin:1px;margin-top:2px;margin:3px}",
-"b{q0:0;q1:1;q2:2;q3:3;q4:4;q5:5;q6:6;q7:7;q8:8;q9:9;q10:10;q11:11;q12:12;q13:13;q14:14;q15:15;q16:16;q17:17;q18:18;q19:19;q20:20;q21:21;q22:22;q23:23;q24:24;q25:25;q26:26;q27:27;q28:28;q29:29;q30:30;q31:31;q32:32;q33:33;q34:34;margin:3px}",
-"b{q0:0;q1:1;q2:2;q3:3;q4:4;q5:5;q6:6;q7:7;q8:8;q9:9;q10:10;q11:11;q12:12;q13:13;q14:14;q15:15;q16:16;q17:17;q18:18;q19:19;q20:20;q21:21;q22:22;q23:23;q24:24;q25:25;q26:26;q27:27;q28:28;q29:29;q30:30;q31:31;q32:32;q33:33;q34:34;margin:3px}"
+"b{q0:0;q1:1;q2:2;q3:3;q4:4;q5:5;q6:6;q7:7;q8:8;q9:9;q10:10;q11:11;q12:12;q13:13;q14:14;q15:15;q16:16;q17:17;q18:18;q19:19;q20:20;q21:21;q22:22;q23:23;q24:24;q25:25;q26:26;q27:27;q28:28;q29:29;q30:30;q31:31;q32:32;q33:33;q34:34;margin:1px;margin:3px}",
+"b{q0:0;q1:1;q2:2;q3:3;q4:4;q5:5;q6:6;q7:7;q8:8;q9:9;q10:10;q11:11;q12:12;q13:13;q14:14;q15:15;q16:16;q17:17;q18:18;q19:19;q20:20;q21:21;q22:22;q23:23;q24:24;q25:25;q26:26;q27:27;q28:28;q29:29;q30:30;q31:31;q32:32;q33:33;q34:34;margin:1px;margin:3px}"
 ],
 [
 "a{x:1}a{y:2}",
@@ -4211,13 +4211,13 @@
 ],
 [
 "c{p0:0;p1:1!important;p2:2;p3:3!important;p4:4;p5:5!important;p6:6;p7:7!important;p8:8;p9:9!important;p10:10;p11:11!important;p12:12;p13:13!important;p14:14;p15:15!important;p16:16;p17:17!important;p18:18;p19:19!important;p20:20;p21:21!important;p22:22;p23:23!important;p24:24;p25:25!important;p26:26;p27:27!important;p28:28;p29:29!important;p30:30;p31:31!important;p32:32;p33:33!important;p34:34;p35:35!important;p36:36;p37:37!important;p38:38;p39:39!important;p40:40;p41:41!important;p42:42;p43:43!important;p44:44;p45:45!important;p46:46;p47:47!important;p48:48;p49:49!important;p0:9;p1:9!important}",
-"c{p2:2;p3:3!important;p4:4;p5:5!important;p6:6;p7:7!important;p8:8;p9:9!important;p10:10;p11:11!important;p12:12;p13:13!important;p14:14;p15:15!important;p16:16;p17:17!important;p18:18;p19:19!important;p20:20;p21:21!important;p22:22;p23:23!important;p24:24;p25:25!important;p26:26;p27:27!important;p28:28;p29:29!important;p30:30;p31:31!important;p32:32;p33:33!important;p34:34;p35:35!important;p36:36;p37:37!important;p38:38;p39:39!important;p40:40;p41:41!important;p42:42;p43:43!important;p44:44;p45:45!important;p46:46;p47:47!important;p48:48;p49:49!important;p0:9;p1:9!important}",
-"c{p2:2;p3:3!important;p4:4;p5:5!important;p6:6;p7:7!important;p8:8;p9:9!important;p10:10;p11:11!important;p12:12;p13:13!important;p14:14;p15:15!important;p16:16;p17:17!important;p18:18;p19:19!important;p20:20;p21:21!important;p22:22;p23:23!important;p24:24;p25:25!important;p26:26;p27:27!important;p28:28;p29:29!important;p30:30;p31:31!important;p32:32;p33:33!important;p34:34;p35:35!important;p36:36;p37:37!important;p38:38;p39:39!important;p40:40;p41:41!important;p42:42;p43:43!important;p44:44;p45:45!important;p46:46;p47:47!important;p48:48;p49:49!important;p0:9;p1:9!important}"
+"c{p0:0;p1:1!important;p2:2;p3:3!important;p4:4;p5:5!important;p6:6;p7:7!important;p8:8;p9:9!important;p10:10;p11:11!important;p12:12;p13:13!important;p14:14;p15:15!important;p16:16;p17:17!important;p18:18;p19:19!important;p20:20;p21:21!important;p22:22;p23:23!important;p24:24;p25:25!important;p26:26;p27:27!important;p28:28;p29:29!important;p30:30;p31:31!important;p32:32;p33:33!important;p34:34;p35:35!important;p36:36;p37:37!important;p38:38;p39:39!important;p40:40;p41:41!important;p42:42;p43:43!important;p44:44;p45:45!important;p46:46;p47:47!important;p48:48;p49:49!important;p0:9;p1:9!important}",
+"c{p0:0;p1:1!important;p2:2;p3:3!important;p4:4;p5:5!important;p6:6;p7:7!important;p8:8;p9:9!important;p10:10;p11:11!important;p12:12;p13:13!important;p14:14;p15:15!important;p16:16;p17:17!important;p18:18;p19:19!important;p20:20;p21:21!important;p22:22;p23:23!important;p24:24;p25:25!important;p26:26;p27:27!important;p28:28;p29:29!important;p30:30;p31:31!important;p32:32;p33:33!important;p34:34;p35:35!important;p36:36;p37:37!important;p38:38;p39:39!important;p40:40;p41:41!important;p42:42;p43:43!important;p44:44;p45:45!important;p46:46;p47:47!important;p48:48;p49:49!important;p0:9;p1:9!important}"
 ],
 [
 "d{r0:0;r1:1;r2:2;r3:3;r4:4;r5:5;r6:6;r7:7;r8:8;r9:9;r10:10;r11:11;r12:12;r13:13;r14:14;r15:15;r16:16;r17:17;r18:18;r19:19;r20:20;r21:21;r22:22;r23:23;r24:24;r25:25;r26:26;r27:27;r28:28;r29:29;r30:30;r31:31;r32:32;r33:33;r34:34;r35:35;r36:36;r37:37;r38:38;r39:39;border:1px;border-top:2px;border:3px;border-color:red;border-color:blue}",
-"d{r0:0;r1:1;r2:2;r3:3;r4:4;r5:5;r6:6;r7:7;r8:8;r9:9;r10:10;r11:11;r12:12;r13:13;r14:14;r15:15;r16:16;r17:17;r18:18;r19:19;r20:20;r21:21;r22:22;r23:23;r24:24;r25:25;r26:26;r27:27;r28:28;r29:29;r30:30;r31:31;r32:32;r33:33;r34:34;r35:35;r36:36;r37:37;r38:38;r39:39;border-top:2px;border:3px;border-color:blue}",
-"d{r0:0;r1:1;r2:2;r3:3;r4:4;r5:5;r6:6;r7:7;r8:8;r9:9;r10:10;r11:11;r12:12;r13:13;r14:14;r15:15;r16:16;r17:17;r18:18;r19:19;r20:20;r21:21;r22:22;r23:23;r24:24;r25:25;r26:26;r27:27;r28:28;r29:29;r30:30;r31:31;r32:32;r33:33;r34:34;r35:35;r36:36;r37:37;r38:38;r39:39;border-top:2px;border:3px;border-color:blue}"
+"d{r0:0;r1:1;r2:2;r3:3;r4:4;r5:5;r6:6;r7:7;r8:8;r9:9;r10:10;r11:11;r12:12;r13:13;r14:14;r15:15;r16:16;r17:17;r18:18;r19:19;r20:20;r21:21;r22:22;r23:23;r24:24;r25:25;r26:26;r27:27;r28:28;r29:29;r30:30;r31:31;r32:32;r33:33;r34:34;r35:35;r36:36;r37:37;r38:38;r39:39;border:1px;border-top:2px;border:3px;border-color:red;border-color:blue}",
+"d{r0:0;r1:1;r2:2;r3:3;r4:4;r5:5;r6:6;r7:7;r8:8;r9:9;r10:10;r11:11;r12:12;r13:13;r14:14;r15:15;r16:16;r17:17;r18:18;r19:19;r20:20;r21:21;r22:22;r23:23;r24:24;r25:25;r26:26;r27:27;r28:28;r29:29;r30:30;r31:31;r32:32;r33:33;r34:34;r35:35;r36:36;r37:37;r38:38;r39:39;border:1px;border-top:2px;border:3px;border-color:red;border-color:blue}"
 ],
 [
 "e{s0:0;s1:1;s2:2;s3:3;s4:4;s5:5;s6:6;s7:7;s8:8;s9:9;s10:10;s11:11;s12:12;s13:13;s14:14;s15:15;s16:16;s17:17;s18:18;s19:19;s20:20;s21:21;s22:22;s23:23;s24:24;s25:25;s26:26;s27:27;s28:28;s29:29;s30:30;s31:31;s32:32;s33:33;border-top-width:1px;border:0;border-top-width:2px}",
@@ -4226,18 +4226,18 @@
 ],
 [
 "f{t0:0;t1:1;t2:2;t3:3;t4:4;t5:5;t6:6;t7:7;t8:8;t9:9;t10:10;t11:11;t12:12;t13:13;t14:14;t15:15;t16:16;t17:17;t18:18;t19:19;t20:20;t21:21;t22:22;t23:23;t24:24;t25:25;t26:26;t27:27;t28:28;t29:29;t30:30;t31:31;t32:32;t33:33;border-color:red;border:1px;border-color:blue;border:2px}",
-"f{t0:0;t1:1;t2:2;t3:3;t4:4;t5:5;t6:6;t7:7;t8:8;t9:9;t10:10;t11:11;t12:12;t13:13;t14:14;t15:15;t16:16;t17:17;t18:18;t19:19;t20:20;t21:21;t22:22;t23:23;t24:24;t25:25;t26:26;t27:27;t28:28;t29:29;t30:30;t31:31;t32:32;t33:33;border:2px}",
-"f{t0:0;t1:1;t2:2;t3:3;t4:4;t5:5;t6:6;t7:7;t8:8;t9:9;t10:10;t11:11;t12:12;t13:13;t14:14;t15:15;t16:16;t17:17;t18:18;t19:19;t20:20;t21:21;t22:22;t23:23;t24:24;t25:25;t26:26;t27:27;t28:28;t29:29;t30:30;t31:31;t32:32;t33:33;border:2px}"
+"f{t0:0;t1:1;t2:2;t3:3;t4:4;t5:5;t6:6;t7:7;t8:8;t9:9;t10:10;t11:11;t12:12;t13:13;t14:14;t15:15;t16:16;t17:17;t18:18;t19:19;t20:20;t21:21;t22:22;t23:23;t24:24;t25:25;t26:26;t27:27;t28:28;t29:29;t30:30;t31:31;t32:32;t33:33;border:1px;border:2px}",
+"f{t0:0;t1:1;t2:2;t3:3;t4:4;t5:5;t6:6;t7:7;t8:8;t9:9;t10:10;t11:11;t12:12;t13:13;t14:14;t15:15;t16:16;t17:17;t18:18;t19:19;t20:20;t21:21;t22:22;t23:23;t24:24;t25:25;t26:26;t27:27;t28:28;t29:29;t30:30;t31:31;t32:32;t33:33;border:1px;border:2px}"
 ],
 [
 "g{u0:0;u1:1;u2:2;u3:3;u4:4;u5:5;u6:6;u7:7;u8:8;u9:9;u10:10;u11:11;u12:12;u13:13;u14:14;u15:15;u16:16;u17:17;u18:18;u19:19;u20:20;u21:21;u22:22;u23:23;u24:24;u25:25;u26:26;u27:27;u28:28;u29:29;u30:30;u31:31;u32:32;u33:33;margin:1px;margin-top:2px;padding:3px;padding-top:4px;margin:5px;padding:6px}",
-"g{u0:0;u1:1;u2:2;u3:3;u4:4;u5:5;u6:6;u7:7;u8:8;u9:9;u10:10;u11:11;u12:12;u13:13;u14:14;u15:15;u16:16;u17:17;u18:18;u19:19;u20:20;u21:21;u22:22;u23:23;u24:24;u25:25;u26:26;u27:27;u28:28;u29:29;u30:30;u31:31;u32:32;u33:33;margin:5px;padding:6px}",
-"g{u0:0;u1:1;u2:2;u3:3;u4:4;u5:5;u6:6;u7:7;u8:8;u9:9;u10:10;u11:11;u12:12;u13:13;u14:14;u15:15;u16:16;u17:17;u18:18;u19:19;u20:20;u21:21;u22:22;u23:23;u24:24;u25:25;u26:26;u27:27;u28:28;u29:29;u30:30;u31:31;u32:32;u33:33;margin:5px;padding:6px}"
+"g{u0:0;u1:1;u2:2;u3:3;u4:4;u5:5;u6:6;u7:7;u8:8;u9:9;u10:10;u11:11;u12:12;u13:13;u14:14;u15:15;u16:16;u17:17;u18:18;u19:19;u20:20;u21:21;u22:22;u23:23;u24:24;u25:25;u26:26;u27:27;u28:28;u29:29;u30:30;u31:31;u32:32;u33:33;margin:1px;padding:3px;margin:5px;padding:6px}",
+"g{u0:0;u1:1;u2:2;u3:3;u4:4;u5:5;u6:6;u7:7;u8:8;u9:9;u10:10;u11:11;u12:12;u13:13;u14:14;u15:15;u16:16;u17:17;u18:18;u19:19;u20:20;u21:21;u22:22;u23:23;u24:24;u25:25;u26:26;u27:27;u28:28;u29:29;u30:30;u31:31;u32:32;u33:33;margin:1px;padding:3px;margin:5px;padding:6px}"
 ],
 [
 "h{v0:0;v1:1;v2:2;v3:3;v4:4;v5:5;v6:6;v7:7;v8:8;v9:9;v10:10;v11:11;v12:12;v13:13;v14:14;v15:15;v16:16;v17:17;v18:18;v19:19;v20:20;v21:21;v22:22;v23:23;v24:24;v25:25;v26:26;v27:27;v28:28;v29:29;v30:30;v31:31;v32:32;v33:33;margin-top:1px!important;margin:2px;margin-top:3px!important;margin:4px}",
-"h{v0:0;v1:1;v2:2;v3:3;v4:4;v5:5;v6:6;v7:7;v8:8;v9:9;v10:10;v11:11;v12:12;v13:13;v14:14;v15:15;v16:16;v17:17;v18:18;v19:19;v20:20;v21:21;v22:22;v23:23;v24:24;v25:25;v26:26;v27:27;v28:28;v29:29;v30:30;v31:31;v32:32;v33:33;margin-top:3px!important;margin:4px}",
-"h{v0:0;v1:1;v2:2;v3:3;v4:4;v5:5;v6:6;v7:7;v8:8;v9:9;v10:10;v11:11;v12:12;v13:13;v14:14;v15:15;v16:16;v17:17;v18:18;v19:19;v20:20;v21:21;v22:22;v23:23;v24:24;v25:25;v26:26;v27:27;v28:28;v29:29;v30:30;v31:31;v32:32;v33:33;margin-top:3px!important;margin:4px}"
+"h{v0:0;v1:1;v2:2;v3:3;v4:4;v5:5;v6:6;v7:7;v8:8;v9:9;v10:10;v11:11;v12:12;v13:13;v14:14;v15:15;v16:16;v17:17;v18:18;v19:19;v20:20;v21:21;v22:22;v23:23;v24:24;v25:25;v26:26;v27:27;v28:28;v29:29;v30:30;v31:31;v32:32;v33:33;margin-top:1px!important;margin:2px;margin-top:3px!important;margin:4px}",
+"h{v0:0;v1:1;v2:2;v3:3;v4:4;v5:5;v6:6;v7:7;v8:8;v9:9;v10:10;v11:11;v12:12;v13:13;v14:14;v15:15;v16:16;v17:17;v18:18;v19:19;v20:20;v21:21;v22:22;v23:23;v24:24;v25:25;v26:26;v27:27;v28:28;v29:29;v30:30;v31:31;v32:32;v33:33;margin-top:1px!important;margin:2px;margin-top:3px!important;margin:4px}"
 ],
 [
 "@import url(x.css)",

--- a/tests/serialize/test_css_minify.py
+++ b/tests/serialize/test_css_minify.py
@@ -120,7 +120,7 @@ _NEWLY = CSSMinify(baseline=2021)
             "border-bottom-left-radius:1px;border-start-start-radius:9px}",
             id="no-merge-border-radius-with-logical-corner",
         ),
-        pytest.param("a{color:red;color:blue}", "a{color:blue}", id="dedup-later-wins"),
+        pytest.param("a{color:red;color:red}", "a{color:red}", id="dedup-identical-collapses"),
         pytest.param("a{width:calc(1px + 2px)}", "a{width:3px}", id="calc-add"),
         pytest.param("a{width:calc(10px / 2)}", "a{width:5px}", id="calc-divide"),
         pytest.param("a{width:calc(100% / 3)}", "a{width:calc(100% / 3)}", id="calc-non-terminating-kept"),
@@ -135,7 +135,7 @@ _NEWLY = CSSMinify(baseline=2021)
         pytest.param("a{--custom:  1px  }", "a{--custom:1px}", id="custom-property-trimmed-not-rewritten"),
         pytest.param("a{color:red!important}", "a{color:red!important}", id="important-kept"),
         pytest.param("/* drop me */a{color:red}", "a{color:red}", id="strip-normal-comment"),
-        pytest.param("/*! keep me */a{color:red}", "/*!keep me*/a{color:red}", id="keep-bang-comment"),
+        pytest.param("/*! keep me */a{color:red}", "/*! keep me */a{color:red}", id="keep-bang-comment"),
         pytest.param(".x{color:red}.y{color:red}", ".x,.y{color:red}", id="merge-identical-bodies-to-selector-list"),
         pytest.param("a{color:red}a{background:blue}", "a{color:red;background:blue}", id="merge-same-selector-bodies"),
         pytest.param(
@@ -411,10 +411,110 @@ def test_minify_css(source: str, expected: str) -> None:
         pytest.param(r"@-webkit-keyframes k{from{x:1}}", r"@-webkit-keyframes k{0%{x:1}}", id="webkit-keyframes-from"),
         pytest.param(r"@-moz-keyframes k{0%{x:1}}", r"@-moz-keyframes k{0%{x:1}}", id="moz-keyframes"),
         pytest.param(r"@-o-keyframes k{to{x:1}}", r"@-o-keyframes k{to{x:1}}", id="o-keyframes"),
+        pytest.param(
+            "a{background:url(a.png);background:url(a.svg)}",
+            "a{background:url(a.png);background:url(a.svg)}",
+            id="dedup-keeps-different-value-fallback",
+        ),
+        pytest.param(
+            "a{display:-webkit-box;display:flex}",
+            "a{display:-webkit-box;display:flex}",
+            id="dedup-keeps-prefixed-fallback",
+        ),
+        pytest.param("a{x:1;x:2;x:3}", "a{x:1;x:2;x:3}", id="dedup-keeps-every-differing-value"),
+        pytest.param(
+            "a{background:red;background:linear-gradient(red,blue)}",
+            "a{background:red;background:linear-gradient(red,blue)}",
+            id="dedup-keeps-shorthand-fallback",
+        ),
+        pytest.param("a{background:red;background:red}", "a{background:red}", id="dedup-drops-identical-shorthand"),
+        pytest.param(
+            "a{background-color:red;background:url(a.svg)}",
+            "a{background:url(a.svg)}",
+            id="dedup-drops-covered-longhand",
+        ),
+        pytest.param(
+            "@media screen and/*x*/(min-width:0){a{b:1}}",
+            "@media screen and (min-width:0){a{b:1}}",
+            id="at-prelude-comment-becomes-space",
+        ),
+        pytest.param("@media not/*x*/all{a{b:1}}", "@media not all{a{b:1}}", id="at-prelude-comment-keeps-negation"),
+        pytest.param(
+            "/*! Copyright 2024   Foo    Bar\n * All rights reserved.\n */a{color:red}",
+            "/*! Copyright 2024   Foo    Bar\n * All rights reserved.\n */a{color:red}",
+            id="bang-comment-body-kept-verbatim",
+        ),
+        pytest.param(
+            "a{width:calc(100% - 30px - 0)}", "a{width:calc(100% - 30px - 0)}", id="calc-keeps-unitless-zero-type-error"
+        ),
+        pytest.param("a{width:calc(100% - 0px)}", "a{width:100%}", id="calc-folds-zero-length"),
+        pytest.param(
+            "a{border-color:currentColor red}",
+            "a{border-color:currentcolor red}",
+            id="border-color-currentcolor-list-kept",
+        ),
+        pytest.param(
+            "a{border-color:red currentColor}",
+            "a{border-color:red currentcolor}",
+            id="border-color-currentcolor-list-kept-trailing",
+        ),
+        pytest.param(
+            "a{border-color:currentColor}", "a{border-color:initial}", id="border-color-currentcolor-sole-to-initial"
+        ),
+        pytest.param(
+            "@font-face{unicode-range:U+0-10FFFF}", "@font-face{unicode-range:U+0-10FFFF}", id="unicode-range-full-kept"
+        ),
+        pytest.param(
+            "a{row-gap:20px;grid:auto/auto}", "a{row-gap:20px;grid:auto/auto}", id="grid-does-not-reset-row-gap"
+        ),
+        pytest.param(
+            "a{column-gap:20px;grid:auto/auto}",
+            "a{column-gap:20px;grid:auto/auto}",
+            id="grid-does-not-reset-column-gap",
+        ),
+        pytest.param(
+            "a{grid-row-gap:20px;grid:auto/auto}",
+            "a{grid-row-gap:20px;grid:auto/auto}",
+            id="grid-does-not-reset-grid-row-gap",
+        ),
+        pytest.param(
+            "a{grid-template-rows:1px;grid:auto/auto}", "a{grid:auto/auto}", id="grid-resets-grid-template-rows"
+        ),
+        pytest.param(
+            "a{margin-top:1px;margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:4px}",
+            "a{margin:1px 2px 3px 4px}",
+            id="identical-longhand-duplicate-dropped-then-box-merges",
+        ),
     ],
 )
 def test_minify_css_spec_fixes(source: str, expected: str) -> None:
     assert minify_css(source) == expected
+
+
+_HASH_FILLER = "".join(f"--v{index}:{index};" for index in range(40))
+
+
+@pytest.mark.parametrize(
+    ("tail", "kept"),
+    [
+        pytest.param(
+            "background:url(a.png);background:url(a.svg)",
+            "background:url(a.png);background:url(a.svg)",
+            id="same-name-fallback-kept",
+        ),
+        pytest.param("color:red;color:red", "color:red", id="same-name-identical-dropped"),
+        pytest.param(
+            "background:red;background:url(a.svg)", "background:red;background:url(a.svg)", id="shorthand-fallback-kept"
+        ),
+        pytest.param("background:red;background:red", "background:red", id="shorthand-identical-dropped"),
+        pytest.param(
+            "background-color:red;background:url(a.svg)", "background:url(a.svg)", id="covered-longhand-dropped"
+        ),
+    ],
+)
+def test_minify_css_hash_dedup_is_value_safe(tail: str, kept: str) -> None:
+    # more than 32 declarations force the hash-based dedup path, which must apply the same value-safety rule.
+    assert minify_css(f"a{{{_HASH_FILLER}{tail}}}") == f"a{{{_HASH_FILLER}{kept}}}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Seven value-safety miscompiles in `minify_css`, each a transform that changes what the stylesheet means in a browser. All fixes live in the C engine; the Python shim is unchanged.

**Duplicate-property fallbacks (#415).** The within-rule dedup collapsed several declarations of the same property down to the last one, dropping the progressive-enhancement fallback pattern (`background:url(a.png);background:url(a.svg)` kept only the SVG; `display:-webkit-box;display:flex` kept only flex). A browser that cannot parse the later value falls back to the earlier one, so per CSS Cascade last-wins applies only among declarations that parse. Dedup now drops an earlier declaration only when the later value is identical, or when the earlier is a longhand a later shorthand fully covers (a strict subset). This applies on both the pairwise path and the hash path used for large rules.

**At-rule prelude comments (#416).** Removing a comment from a `@media`/`@supports` prelude glued the adjacent tokens: `@media screen and/*x*/(min-width:0)` became `and(`, an invalid function-token that browsers reject, and `@media not/*x*/all` became the media type `notall`. A comment separates tokens, so the prelude path now replaces it with a space, matching the declaration-value path.

**Bang comments (#417).** The body of a `/*! ... */` license comment was whitespace-collapsed, corrupting the multi-line SPDX/copyright text the comment exists to preserve. The token is now copied byte-exact.

**calc() unitless zero (#418).** `calc(100% - 30px - 0)` folded away the unitless `0` and produced a valid `calc(100% - 30px)`. Inside `calc()` a unitless `0` is a `<number>`, and `<length> - <number>` is a type error, so the declaration is invalid and browsers ignore it. Folding turned ignored into applied; the fold now bails when a unitless term is summed with a dimensioned one.

**currentColor in a color list (#425).** The minifier rewrote `border-color:currentColor red` to `border-color:initial red`. A CSS-wide keyword is valid only as a property's sole value, so browsers drop the declaration. `currentcolor` now survives (lowercased) when it is one of several values; the single-value case still shortens to `initial`.

**grid shorthand and gutters (#426).** The `grid` shorthand's longhand list wrongly included `grid-column-gap`/`grid-row-gap`/`column-gap`/`row-gap`, so `row-gap:20px;grid:auto/auto` dropped the gap. The `grid` shorthand does not reset the gutter properties, so they are removed from the list (`grid-template` already omits them).

**Full-range unicode-range (#427).** The minifier turned `unicode-range:U+0-10FFFF` into `initial`, invalid for a descriptor. It now keeps the range.

Eighteen rows of the reviewed corpus golden in `tests/serialize/data/css_minify_golden.json` shift to the safe output, mostly rules where a fallback duplicate now survives; every shifted row still holds under the round-trip fixed-point check. 🎨

closes #415
closes #416
closes #417
closes #418
closes #425
closes #426
closes #427
