### PR TITLE
🐛 fix(build): form-associated element conformance

### DIFF
--- a/docs/changelog/409.bugfix.rst
+++ b/docs/changelog/409.bugfix.rst
@@ -1,0 +1,3 @@
+:meth:`~turbohtml.Element.form_data` no longer submits form controls that live inside a ``<template>``. A template's
+contents are an inert fragment whose controls have no form owner (WHATWG §4.10.3), so the walk now skips the template
+subtree instead of descending into it.

--- a/docs/changelog/410.bugfix.rst
+++ b/docs/changelog/410.bugfix.rst
@@ -1,0 +1,4 @@
+:meth:`~turbohtml.Element.form_data` and :attr:`~turbohtml.Element.field_value` now treat an ``<option>`` inside a
+disabled ``<optgroup>`` as disabled, following the WHATWG rule that an option is disabled when it carries ``disabled``
+or its parent ``<optgroup>`` does. Such an option no longer becomes a single select's default, and a disabled selected
+option no longer submits.

--- a/docs/changelog/428.bugfix.rst
+++ b/docs/changelog/428.bugfix.rst
@@ -1,0 +1,4 @@
+A ``<select>`` whose display size is greater than 1 no longer defaults to its first option in
+:meth:`~turbohtml.Element.form_data` or :attr:`~turbohtml.Element.field_value`. The default-selectedness rule applies
+only to a single-line select (display size 1, not ``multiple``, per WHATWG §4.10.7), so with ``size=4`` and nothing
+selected the control now contributes nothing.

--- a/docs/changelog/429.bugfix.rst
+++ b/docs/changelog/429.bugfix.rst
@@ -1,0 +1,3 @@
+A ``<select>`` whose only ``selected`` option is disabled now submits nothing from :meth:`~turbohtml.Element.form_data`
+instead of falling back to the first enabled option. A disabled option keeps its selectedness, so it still wins the
+default reset, but the spec bars it from submission (WHATWG §4.10.7 / §4.10.22.4).

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -334,10 +334,11 @@ static int element_set_checked(PyObject *self, PyObject *value, void *closure);
 PyDoc_STRVAR(field_value_doc, "the form control's value, with form semantics. Reading returns the value\n"
                               "attribute (defaulting to \"on\" for a checkbox/radio), a textarea's text, an\n"
                               "option's value (its stripped text when it has no value attribute), or the\n"
-                              "selected option value(s) of a select (a list[str] when it is multiple);\n"
-                              "non-controls read None. Assigning a str writes the value (selecting the\n"
-                              "matching option of a select), a list[str] selects a multiple select, and None\n"
-                              "clears it. The checked state lives in Element.checked, not here.");
+                              "selected option value(s) of a select (a list[str] when it is multiple, None\n"
+                              "when nothing is selected); non-controls read None. Assigning a str writes the\n"
+                              "value (selecting the matching option of a select), a list[str] selects a\n"
+                              "multiple select, and None clears it. The checked state lives in\n"
+                              "Element.checked, not here.");
 
 PyDoc_STRVAR(checked_doc, "whether a checkbox or radio input is checked. Assigning requires a checkbox or\n"
                           "radio; setting a radio to True clears the other same-name radios in the owning\n"
@@ -462,9 +463,73 @@ static th_node *next_option(th_node *current, th_node *root) {
     return NULL;
 }
 
+/* WHATWG: an option is disabled if its own disabled attribute is present or it is a
+   child of an optgroup whose disabled attribute is present. */
+static int option_disabled(th_node *option) {
+    if (find_node_attr(option, TH_ATTR_DISABLED) != NULL) {
+        return 1;
+    }
+    /* an option enumerated within a select always has a parent; only optgroup elements
+       carry this atom (text and content nodes are TH_TAG_UNKNOWN) */
+    th_node *group = option->parent;
+    return group->atom == TH_TAG_OPTGROUP && find_node_attr(group, TH_ATTR_DISABLED) != NULL;
+}
+
+/* WHATWG display size of a single (non-multiple) select: the parsed non-negative
+   integer of its size attribute when that parses to at least one digit, else 1. The
+   default-first-option reset fires only when the display size is 1. */
+static Py_ssize_t single_select_display_size(th_tree *tree, th_node *select) {
+    Py_ssize_t index = find_attr_index(tree, select, "size", 4);
+    if (index >= 0) {
+        const th_node_attr *size = &select->attrs[index];
+        if (size->value != NULL) {
+            Py_ssize_t cursor = 0;
+            while (cursor < size->value_len && is_space(size->value[cursor])) {
+                cursor++;
+            }
+            Py_ssize_t number = 0;
+            int digits = 0;
+            while (cursor < size->value_len && size->value[cursor] >= '0' && size->value[cursor] <= '9') {
+                number = number * 10 + (size->value[cursor] - '0');
+                if (number > 0xffff) { /* a display size past this is meaningless and guards overflow */
+                    number = 0xffff;
+                }
+                cursor++;
+                digits = 1;
+            }
+            if (digits) {
+                return number;
+            }
+        }
+    }
+    return 1;
+}
+
+/* The option a single (non-multiple) select resolves to: the last-marked selection
+   (a disabled option still wins, keeping its selectedness), else the default first
+   non-disabled option when the display size is 1, else NULL. Callers decide whether a
+   disabled result is submittable. */
+static th_node *single_select_selection(th_tree *tree, th_node *select) {
+    th_node *selected = NULL;
+    th_node *first_enabled = NULL;
+    for (th_node *option = next_option(select, select); option != NULL; option = next_option(option, select)) {
+        if (find_node_attr(option, TH_ATTR_SELECTED) != NULL) {
+            selected = option;
+        }
+        if (first_enabled == NULL && !option_disabled(option)) {
+            first_enabled = option;
+        }
+    }
+    if (selected != NULL) {
+        return selected;
+    }
+    /* parse the size attribute only when an enabled option could actually be the
+       default, so an empty or all-disabled select skips the scan */
+    return first_enabled != NULL && single_select_display_size(tree, select) == 1 ? first_enabled : NULL;
+}
+
 /* The value(s) of a select: a list[str] of the selected options for a multiple
-   select, else the selected option's value (the last marked selected, or the first
-   option as the default), or None when it has no options. */
+   select, else the resolved option's value, or None when no option is selected. */
 static PyObject *select_value(th_tree *tree, th_node *select) {
     if (find_node_attr(select, TH_ATTR_MULTIPLE) != NULL) {
         PyObject *values = PyList_New(0);
@@ -485,17 +550,7 @@ static PyObject *select_value(th_tree *tree, th_node *select) {
         }
         return values;
     }
-    th_node *chosen = NULL;
-    th_node *first = NULL;
-    for (th_node *option = next_option(select, select); option != NULL; option = next_option(option, select)) {
-        if (first == NULL) {
-            first = option;
-        }
-        if (find_node_attr(option, TH_ATTR_SELECTED) != NULL) {
-            chosen = option;
-        }
-    }
-    th_node *use = chosen != NULL ? chosen : first;
+    th_node *use = single_select_selection(tree, select);
     if (use == NULL) {
         Py_RETURN_NONE;
     }
@@ -795,13 +850,12 @@ static int emit_pair(PyObject *pairs, const th_node_attr *name, PyObject *value)
     return rc; /* GCOVR_EXCL_BR_LINE: PyList_Append only fails on OOM */
 }
 
-/* Append each selected option of a select as a (name, value) pair: every selected
-   one for a multiple select, the selected (or default first) one otherwise,
-   skipping disabled options. */
+/* Append the submitted option(s) of a select as (name, value) pairs: every selected
+   non-disabled option for a multiple select, else the resolved single selection. */
 static int collect_select(th_tree *tree, th_node *select, const th_node_attr *name, PyObject *pairs) {
     if (find_node_attr(select, TH_ATTR_MULTIPLE) != NULL) {
         for (th_node *option = next_option(select, select); option != NULL; option = next_option(option, select)) {
-            if (find_node_attr(option, TH_ATTR_DISABLED) != NULL || find_node_attr(option, TH_ATTR_SELECTED) == NULL) {
+            if (option_disabled(option) || find_node_attr(option, TH_ATTR_SELECTED) == NULL) {
                 continue;
             }
             if (emit_pair(pairs, name, option_value_str(tree, option)) < 0) { /* GCOVR_EXCL_BR_LINE: OOM only */
@@ -810,21 +864,8 @@ static int collect_select(th_tree *tree, th_node *select, const th_node_attr *na
         }
         return 0;
     }
-    th_node *chosen = NULL;
-    th_node *first = NULL;
-    for (th_node *option = next_option(select, select); option != NULL; option = next_option(option, select)) {
-        if (find_node_attr(option, TH_ATTR_DISABLED) != NULL) {
-            continue;
-        }
-        if (first == NULL) {
-            first = option;
-        }
-        if (find_node_attr(option, TH_ATTR_SELECTED) != NULL) {
-            chosen = option;
-        }
-    }
-    th_node *use = chosen != NULL ? chosen : first;
-    if (use == NULL) {
+    th_node *use = single_select_selection(tree, select);
+    if (use == NULL || option_disabled(use)) { /* a disabled resolved option is not submittable */
         return 0;
     }
     return emit_pair(pairs, name, option_value_str(tree, use));
@@ -868,9 +909,23 @@ PyDoc_STRVAR(form_data_doc, "form_data()\n--\n\n"
                             "entry-list rules. Controls without a non-empty name, disabled controls (their\n"
                             "own disabled or a disabled ancestor fieldset), buttons, and\n"
                             "file/submit/reset/image inputs are skipped; a checkbox or radio contributes\n"
-                            "only when checked, a select one pair per selected option. Controls are matched\n"
+                            "only when checked, a select one pair per selected non-disabled option (the\n"
+                            "default first option only when its display size is 1). Controls inside a\n"
+                            "template's contents have no form owner and are excluded. Controls are matched\n"
                             "by containment in the form.\n\n"
                             ":returns: the (name, value) pairs in document order.");
+
+/* The next node after current's whole subtree within root, skipping its descendants;
+   current is always a descendant of root, so the climb reaches root before NULL. */
+static th_node *after_subtree_within(th_node *current, th_node *root) {
+    while (current != root) {
+        if (current->next_sibling != NULL) {
+            return current->next_sibling;
+        }
+        current = current->parent;
+    }
+    return NULL;
+}
 
 static PyObject *element_form_data(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     th_node *node = ((NodeObject *)self)->node;
@@ -885,11 +940,15 @@ static PyObject *element_form_data(PyObject *self, PyObject *Py_UNUSED(ignored))
     }
     int error = 0;
     Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
-    for (th_node *control = preorder_next(node, node); control != NULL; control = preorder_next(control, node)) {
+    th_node *control = preorder_next(node, node);
+    while (control != NULL) {
         if (collect_control(tree, node, control, pairs) < 0) { /* GCOVR_EXCL_BR_LINE: fails only on OOM */
             error = 1;                                         /* GCOVR_EXCL_LINE: allocation-failure path */
             break;                                             /* GCOVR_EXCL_LINE: allocation-failure path */
         }
+        /* A template's contents live in a separate inert fragment; those controls have
+           no form owner, so skip the subtree instead of descending (WHATWG §4.10.3). */
+        control = control->atom == TH_TAG_TEMPLATE ? after_subtree_within(control, node) : preorder_next(control, node);
     }
     Py_END_CRITICAL_SECTION();
     if (error) {          /* GCOVR_EXCL_BR_LINE: error is set only on an allocation failure */

--- a/tests/dom/test_tree_field_value.py
+++ b/tests/dom/test_tree_field_value.py
@@ -75,6 +75,28 @@ def test_empty_single_select_is_none() -> None:
     assert _control("<select></select>", "select").field_value is None
 
 
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        pytest.param("1", "a", id="display-size-1-defaults-to-first"),
+        pytest.param("4", None, id="display-size-4-has-no-default"),
+    ],
+)
+def test_single_select_default_only_when_display_size_is_one(size: str, expected: str | None) -> None:
+    select = _control(f"<select size={size}><option value=a><option value=b></select>", "select")
+    assert select.field_value == expected
+
+
+def test_single_select_default_skips_an_optgroup_disabled_option() -> None:
+    select = _control("<select><optgroup disabled><option value=a>A</optgroup><option value=b>B</select>", "select")
+    assert select.field_value == "b"
+
+
+def test_single_select_keeps_a_disabled_selected_option() -> None:
+    select = _control("<select><option value=a disabled selected><option value=b></select>", "select")
+    assert select.field_value == "a"
+
+
 def test_multiple_select_returns_the_selected_list() -> None:
     select = _control(
         "<select multiple><option value=a selected>A<option value=b><option value=c selected>C</select>", "select"

--- a/tests/dom/test_tree_form_data.py
+++ b/tests/dom/test_tree_form_data.py
@@ -116,6 +116,59 @@ def test_multiple_select_skips_disabled_options() -> None:
     assert form.form_data() == [("t", "b")]
 
 
+def test_single_select_default_skips_an_optgroup_disabled_option() -> None:
+    form = _form(
+        "<form><select name=s><optgroup disabled><option value=a>A</optgroup><option value=b>B</select></form>"
+    )
+    assert form.form_data() == [("s", "b")]
+
+
+def test_multiple_select_skips_optgroup_disabled_options() -> None:
+    form = _form(
+        "<form><select name=t multiple><optgroup disabled><option value=a selected>A</optgroup>"
+        "<option value=b selected>B</select></form>"
+    )
+    assert form.form_data() == [("t", "b")]
+
+
+@pytest.mark.parametrize(
+    ("attr", "expected"),
+    [
+        pytest.param("size=1", [("s", "a")], id="display-size-1"),
+        pytest.param("size=4", [], id="display-size-4"),
+        pytest.param('size=" 4"', [], id="leading-whitespace-parsed"),
+        pytest.param('size="  "', [("s", "a")], id="all-whitespace-falls-to-default"),
+        pytest.param('size="x"', [("s", "a")], id="non-numeric-falls-to-default"),
+        pytest.param('size="-1"', [("s", "a")], id="leading-non-digit-falls-to-default"),
+        pytest.param('size="99999"', [], id="huge-size-clamped-not-one"),
+        pytest.param("size", [("s", "a")], id="valueless-falls-to-default"),
+    ],
+)
+def test_select_default_first_only_when_display_size_is_one(attr: str, expected: list[tuple[str, str]]) -> None:
+    form = _form(f"<form><select name=s {attr}><option value=a><option value=b></select></form>")
+    assert form.form_data() == expected
+
+
+def test_select_with_only_a_disabled_selected_option_submits_nothing() -> None:
+    form = _form("<form><select name=s><option value=a disabled selected><option value=b></select></form>")
+    assert form.form_data() == []
+
+
+def test_form_data_ignores_controls_inside_a_template() -> None:
+    form = _form("<form><template><input name=t value=1></template><input name=a value=2></form>")
+    assert form.form_data() == [("a", "2")]
+
+
+def test_form_data_ignores_controls_nested_deep_inside_a_template() -> None:
+    form = _form("<form><template><div><input name=t value=1></div></template><input name=a value=2></form>")
+    assert form.form_data() == [("a", "2")]
+
+
+def test_form_data_skips_a_trailing_template() -> None:
+    form = _form("<form><input name=a value=2><template><input name=t value=1></template></form>")
+    assert form.form_data() == [("a", "2")]
+
+
 def test_option_value_falls_back_to_text() -> None:
     form = _form("<form><select name=c><option selected> Green </select></form>")
     assert form.form_data() == [("c", "Green")]


### PR DESCRIPTION
A spec-driven audit of form submission surfaced four cases where `Element.form_data()` and `Element.field_value` disagree with WHATWG §4.10, so turbohtml invents controls a browser never submits and misreads a select's value. All four live in the C extension's form-associated element logic.

`form_data()` walked the whole form subtree, so it collected controls sitting inside a `<template>`. A template's contents are an inert fragment whose controls have no form owner, so the collection walk now skips a template's subtree instead of descending into it. This resolves closes #409.

A single `<option>` gained a shared disabled predicate. An option is disabled when it carries `disabled` or its parent is an `<optgroup>` carrying `disabled`; the old code honored only the former. Both the form-data and `field_value` paths now route through that predicate, so an option disabled through its group drops out of a select's default and never submits. This resolves closes #410.

The default-first-option reset now fires only for a single-line select. WHATWG scopes it to a select whose display size is 1 and which is not `multiple`, so a `size=4` list with nothing selected contributes nothing rather than defaulting to its first option; a shared helper parses the display size from the `size` attribute. This resolves closes #428.

A disabled `selected` option keeps its selectedness, so it still wins the default reset, but the spec bars a disabled option from submission. The single-select resolver now returns that option and the form-data path drops it as non-submittable, instead of falling back to the first enabled option and inventing a value. This resolves closes #429.

`field_value` follows the same resolution: it reports the resolved option's value, including a disabled `selected` one to match the IDL `value` getter, and returns `None` when a multi-line select has no selection.
