### PR TITLE
🐛 fix(extract): content-extraction scorer correctness

### DIFF
--- a/docs/changelog/385.bugfix.rst
+++ b/docs/changelog/385.bugfix.rst
@@ -1,0 +1,4 @@
+:meth:`~turbohtml.Node.main_content`, :meth:`~turbohtml.Node.main_text`, and :meth:`~turbohtml.Node.article` no longer
+extract to empty when an ``<article>`` or ``<main>`` carries its body in ``<div>``/``<ul>``/``<li>`` with no scoring
+``<p>``. When nothing scores, a fallback surfaces the explicit ``<article>`` (else ``<main>``) that holds substantial
+text, so a list-structured article keeps its content instead of vanishing.

--- a/docs/changelog/399.bugfix.rst
+++ b/docs/changelog/399.bugfix.rst
@@ -1,0 +1,4 @@
+A ``<body>`` or ``<html>`` class carrying an unlikely-candidate substring -- ``has-localnav``, ``nav-open``,
+``comments-open`` -- no longer discards the whole page in :meth:`~turbohtml.Node.main_content` and
+:meth:`~turbohtml.Node.article`. The unlikely-candidate pruning treated a site-wide state class on the document root as
+a content verdict; it now never prunes ``<html>``/``<body>``, so a clear multi-paragraph body still extracts.

--- a/docs/changelog/411.bugfix.rst
+++ b/docs/changelog/411.bugfix.rst
@@ -1,0 +1,4 @@
+An article whose only substantial content sits inside a landmark element -- ``<footer>``, ``<header>``, ``<aside>``,
+``<nav>`` -- is no longer discarded by :meth:`~turbohtml.Node.main_content` and :meth:`~turbohtml.Node.article`.
+Landmark stripping had no fallback, so a landmark-wrapped body extracted to empty; the scorer now retries with landmarks
+kept when the first pass finds nothing.

--- a/src/turbohtml/_c/serialize/readability.c
+++ b/src/turbohtml/_c/serialize/readability.c
@@ -22,14 +22,23 @@
 #define READ_CHAR_SCORE_CAP 3
 /* Candidate array growth: small initial block, doubled when full. */
 #define READ_INITIAL_CANDIDATES 8
+/* The visible-text floor for the semantic-container fallback: an <article>/<main>
+   with at least this many code points reads as a real body, not a caption or lede.
+   Well above a headline yet below any genuine article, so the fallback surfaces a
+   div/list-structured body without resurrecting empty landmarks. */
+#define READ_FALLBACK_MIN_CHARS 200
 
-/* Boilerplate tags whose subtree never holds main content; their text is excluded
-   from the density counts too. <form> is deliberately absent: it stays in the walk
-   so its negative tag weight applies when it parents a paragraph. */
-static const uint16_t read_skip_tags[] = {
-    TH_TAG_SCRIPT, TH_TAG_STYLE,  TH_TAG_NOSCRIPT, TH_TAG_NAV,  TH_TAG_ASIDE,  TH_TAG_FOOTER,   TH_TAG_HEADER,
-    TH_TAG_BUTTON, TH_TAG_SELECT, TH_TAG_TEXTAREA, TH_TAG_MENU, TH_TAG_DIALOG, TH_TAG_TEMPLATE,
+/* Boilerplate tags whose subtree never holds main content and whose text is excluded
+   from the density counts too, in two groups. The hard group is markup that is never
+   prose (scripts, form controls). The landmark group is page furniture stripped on
+   the first pass but kept on the retry, since a landmark is sometimes the only place
+   the body lives. <form> is deliberately in neither: it stays in the walk so its
+   negative tag weight applies when it parents a paragraph. */
+static const uint16_t read_hard_skip_tags[] = {
+    TH_TAG_SCRIPT,   TH_TAG_STYLE, TH_TAG_NOSCRIPT, TH_TAG_BUTTON,   TH_TAG_SELECT,
+    TH_TAG_TEXTAREA, TH_TAG_MENU,  TH_TAG_DIALOG,   TH_TAG_TEMPLATE,
 };
+static const uint16_t read_landmark_tags[] = {TH_TAG_NAV, TH_TAG_ASIDE, TH_TAG_FOOTER, TH_TAG_HEADER};
 
 /* The text containers that earn a content score from their own text. */
 static const uint16_t read_paragraph_tags[] = {TH_TAG_P, TH_TAG_TD, TH_TAG_PRE};
@@ -72,6 +81,9 @@ typedef struct {
     read_candidate *candidates;
     Py_ssize_t count;
     Py_ssize_t cap;
+    /* Whether the landmark tags are pruned this pass; cleared for the retry that
+       rescues a body living inside a <footer>/<header>/<aside>/<nav>. */
+    int strip_landmarks;
 } read_scorer;
 
 /* The text statistics gathered over a subtree: total code points, comma count
@@ -172,15 +184,29 @@ static double read_tag_base(uint16_t atom) {
     return 0;
 }
 
+/* Whether a tag names a boilerplate subtree to prune: always the hard-skip tags,
+   and the landmark tags only while `strip_landmarks` is set. */
+static int read_is_skip_tag(uint16_t atom, int strip_landmarks) {
+    if (read_atom_in(atom, read_hard_skip_tags, sizeof(read_hard_skip_tags) / sizeof(uint16_t))) {
+        return 1;
+    }
+    return strip_landmarks && read_atom_in(atom, read_landmark_tags, sizeof(read_landmark_tags) / sizeof(uint16_t));
+}
+
 /* Whether an element starts a boilerplate subtree the walk should not enter: a
    foreign-namespace root, a boilerplate tag, or an unlikely class/id not rescued
-   by a "maybe" hint. */
-static int read_should_skip(th_tree *tree, th_node *node) {
+   by a "maybe" hint. The document roots <html>/<body> are never pruned: their
+   class is a site-wide state flag (has-localnav, nav-open), not a content verdict,
+   so an unlikely substring there must not zero the whole page. */
+static int read_should_skip(th_tree *tree, th_node *node, int strip_landmarks) {
     if (node->ns != TH_NS_HTML) {
         return 1;
     }
-    if (read_atom_in(node->atom, read_skip_tags, sizeof(read_skip_tags) / sizeof(uint16_t))) {
+    if (read_is_skip_tag(node->atom, strip_landmarks)) {
         return 1;
+    }
+    if (node->atom == TH_TAG_HTML || node->atom == TH_TAG_BODY) {
+        return 0;
     }
     if (read_match_keywords(tree, node, read_unlikely_words, sizeof(read_unlikely_words) / sizeof(char *)) &&
         !read_match_keywords(tree, node, read_maybe_words, sizeof(read_maybe_words) / sizeof(char *))) {
@@ -190,8 +216,9 @@ static int read_should_skip(th_tree *tree, th_node *node) {
 }
 
 /* Accumulate the text statistics over node's subtree, excluding boilerplate
-   subtrees; text inside an <a> also counts toward link_chars. */
-static void read_text_stats(th_tree *tree, th_node *node, int in_anchor, read_stats *stats) {
+   subtrees; text inside an <a> also counts toward link_chars. `strip_landmarks`
+   mirrors the walk so a retry that keeps landmarks also counts their text. */
+static void read_text_stats(th_tree *tree, th_node *node, int in_anchor, int strip_landmarks, read_stats *stats) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
         if (child->type == TH_NODE_TEXT) {
             stats->chars += child->text_len;
@@ -207,20 +234,19 @@ static void read_text_stats(th_tree *tree, th_node *node, int in_anchor, read_st
                 }
             }
         } else if (child->type == TH_NODE_ELEMENT) {
-            if (child->ns != TH_NS_HTML ||
-                read_atom_in(child->atom, read_skip_tags, sizeof(read_skip_tags) / sizeof(uint16_t))) {
+            if (child->ns != TH_NS_HTML || read_is_skip_tag(child->atom, strip_landmarks)) {
                 continue;
             }
-            read_text_stats(tree, child, in_anchor || child->atom == TH_TAG_A, stats);
+            read_text_stats(tree, child, in_anchor || child->atom == TH_TAG_A, strip_landmarks, stats);
         }
     }
 }
 
 /* The fraction of a candidate's text that lives inside links; prose scores high
    when little of it is link text. */
-static double read_link_density(th_tree *tree, th_node *node) {
+static double read_link_density(th_tree *tree, th_node *node, int strip_landmarks) {
     read_stats stats = {0, 0, 0};
-    read_text_stats(tree, node, 0, &stats);
+    read_text_stats(tree, node, 0, strip_landmarks, &stats);
     if (stats.chars == 0) { /* GCOVR_EXCL_BR_LINE: a scored candidate always holds a >=25-char paragraph */
         return 0;           /* GCOVR_EXCL_LINE: the guard only prevents a division by zero that cannot occur */
     }
@@ -254,7 +280,7 @@ static void read_add(read_scorer *scorer, th_node *node, double delta) {
    grandparent (half), the candidates that compete to be the content root. */
 static void read_score_paragraph(read_scorer *scorer, th_node *paragraph, th_node *parent, th_node *grandparent) {
     read_stats stats = {0, 0, 0};
-    read_text_stats(scorer->tree, paragraph, 0, &stats);
+    read_text_stats(scorer->tree, paragraph, 0, scorer->strip_landmarks, &stats);
     if (stats.chars < READ_MIN_PARAGRAPH_CHARS) {
         return;
     }
@@ -274,7 +300,7 @@ static void read_score_paragraph(read_scorer *scorer, th_node *paragraph, th_nod
 static void read_walk(read_scorer *scorer, th_node *node, th_node *grandparent) {
     int node_is_element = node->type == TH_NODE_ELEMENT;
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type != TH_NODE_ELEMENT || read_should_skip(scorer->tree, child)) {
+        if (child->type != TH_NODE_ELEMENT || read_should_skip(scorer->tree, child, scorer->strip_landmarks)) {
             continue;
         }
         if (node_is_element &&
@@ -291,7 +317,7 @@ static th_node *read_best(read_scorer *scorer) {
     th_node *best = NULL;
     double best_score = 0;
     for (Py_ssize_t index = 0; index < scorer->count; index++) {
-        double density = read_link_density(scorer->tree, scorer->candidates[index].node);
+        double density = read_link_density(scorer->tree, scorer->candidates[index].node, scorer->strip_landmarks);
         double score = scorer->candidates[index].score * (1.0 - density);
         if (score > best_score) {
             best_score = score;
@@ -301,13 +327,69 @@ static th_node *read_best(read_scorer *scorer) {
     return best;
 }
 
+/* The <article>/<main> element under root that holds the most visible text, tracked
+   into `pick`. Reuses read_text_stats and discounts by link density so a link farm
+   dressed as an <article> stays out. Landmark subtrees stay pruned even here, so the
+   fallback never surfaces a <footer>/<nav> body. */
+typedef struct {
+    th_node *node;
+    double effective;
+} read_pick;
+
+static void read_scan_containers(read_scorer *scorer, th_node *node, uint16_t wanted, read_pick *pick) {
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type != TH_NODE_ELEMENT || read_should_skip(scorer->tree, child, 1)) {
+            continue;
+        }
+        if (child->atom == wanted) {
+            read_stats stats = {0, 0, 0};
+            read_text_stats(scorer->tree, child, 0, 1, &stats);
+            if (stats.chars >= READ_FALLBACK_MIN_CHARS) {
+                double effective = (double)stats.chars - (double)stats.link_chars;
+                if (effective > pick->effective) {
+                    pick->effective = effective;
+                    pick->node = child;
+                }
+            }
+        }
+        read_scan_containers(scorer, child, wanted, pick);
+    }
+}
+
+/* The explicit content landmark to fall back on when nothing scored: the richest
+   <article>, else the richest <main>. HTML semantics make these the body by
+   definition, so a div/list-structured article with no scoring <p> still resolves
+   instead of extracting to empty. <article> wins ties with <main> as the more
+   specific content unit. */
+static th_node *read_semantic_fallback(read_scorer *scorer, th_node *root) {
+    read_pick pick = {NULL, 0};
+    read_scan_containers(scorer, root, TH_TAG_ARTICLE, &pick);
+    if (pick.node != NULL) {
+        return pick.node;
+    }
+    read_scan_containers(scorer, root, TH_TAG_MAIN, &pick);
+    return pick.node;
+}
+
 /* The dominant content element under root by the readability content-density
    heuristic, or NULL when no element scores as content. Pure C; the caller holds
-   the per-tree critical section and wraps (or renders) the result afterwards. */
+   the per-tree critical section and wraps (or renders) the result afterwards.
+   Three passes, each a fallback for a total-loss case: score paragraphs with
+   landmarks pruned; retry with landmarks kept when that found nothing; and finally
+   surface an explicit <article>/<main> body that carries no scoring paragraph. */
 th_node *th_node_main_content(th_tree *tree, th_node *root) {
-    read_scorer scorer = {tree, NULL, 0, 0};
+    read_scorer scorer = {tree, NULL, 0, 0, 1};
     read_walk(&scorer, root, NULL);
     th_node *best = read_best(&scorer);
+    if (best == NULL) {
+        scorer.count = 0;
+        scorer.strip_landmarks = 0;
+        read_walk(&scorer, root, NULL);
+        best = read_best(&scorer);
+    }
+    if (best == NULL) {
+        best = read_semantic_fallback(&scorer, root);
+    }
     PyMem_Free(scorer.candidates);
     return best;
 }

--- a/tests/serialize/test_tree_main_content.py
+++ b/tests/serialize/test_tree_main_content.py
@@ -28,6 +28,10 @@ SHORT_PROSE = "The tail points away from the Sun."
 # A very long paragraph (>300 chars) so the length bonus saturates at the cap.
 LONG_PROSE = PROSE + " " + PROSE + " " + PROSE
 
+# A div/list-structured body that holds no <p>/<td>/<pre> to score: the visible text
+# lives in <li>, the shape the semantic-container fallback has to rescue.
+LIST_ITEM = "<li><strong>Elf Modelle sind empfehlenswert in punkto Sicherheit.</strong></li>"
+
 # The minimal content body the article() metadata cases hang their head/body fixtures off.
 BODY = f"<article class=post><p>{PROSE}</p></article>"
 
@@ -35,6 +39,10 @@ BODY = f"<article class=post><p>{PROSE}</p></article>"
 def main_tag(html: str) -> str | None:
     found = parse(html).main_content()
     return None if found is None else found.tag
+
+
+def list_body(items: int) -> str:
+    return f"<div class=text><ul>{LIST_ITEM * items}</ul></div>"
 
 
 @pytest.mark.parametrize(
@@ -230,6 +238,55 @@ def test_methods_exist_on_document_and_element() -> None:
     body = doc.find("body")
     assert isinstance(body, Element)
     assert body.main_content() is not None
+
+
+def test_div_list_body_without_paragraphs_falls_back_to_article() -> None:
+    # #385: an <article> whose text lives in div/ul/li with no scoring <p> must not
+    # extract to empty; the semantic-container fallback surfaces the <article>.
+    html = f"<html lang=de><body><main><article><h1>Test</h1>{list_body(12)}</article></main></body></html>"
+    found = parse(html).main_content()
+    assert isinstance(found, Element)
+    assert found.tag == "article"
+    assert "empfehlenswert" in found.text
+
+
+def test_semantic_fallback_ignores_a_thin_container() -> None:
+    # A container below the visible-text floor is not a body; extraction stays empty.
+    assert parse("<article><ul><li>tiny</li></ul></article>").main_content() is None
+
+
+def test_semantic_fallback_uses_main_when_no_article() -> None:
+    found = parse(f"<body><main>{list_body(12)}</main></body>").main_content()
+    assert isinstance(found, Element)
+    assert found.tag == "main"
+
+
+def test_semantic_fallback_prefers_the_richest_article() -> None:
+    # Two paragraph-less articles both clear the floor; the one with more text wins,
+    # and <article> is preferred over the enclosing structure.
+    html = f"<body><article>{list_body(12)}</article><article>{list_body(5)}</article></body>"
+    found = parse(html).main_content()
+    assert isinstance(found, Element)
+    assert len(found.find_all("li")) == 12
+
+
+def test_body_class_with_unlikely_substring_is_not_stripped() -> None:
+    # #399: a body-level state class carrying an unlikely substring (has-localnav)
+    # must not zero the whole page; the multi-paragraph body still extracts.
+    body = f'<div class="content__article-body">{f"<p>{PROSE}</p>" * 4}</div>'
+    found = parse(f'<html><body class="has-localnav">{body}</body></html>').main_content()
+    assert isinstance(found, Element)
+    assert found.tag == "div"
+    assert found.attrs["class"] == ["content__article-body"]
+
+
+def test_landmark_only_body_is_rescued_on_retry() -> None:
+    # #411: a body living solely inside a <footer> must not be discarded; the retry
+    # keeps landmarks so the footer's paragraphs score.
+    found = parse(f"<body><footer class=content>{f'<p>{PROSE}</p>' * 4}</footer></body>").main_content()
+    assert isinstance(found, Element)
+    assert found.tag == "footer"
+    assert "A comet is an icy" in found.text
 
 
 # === article(): the content body plus harvested metadata ===================


### PR DESCRIPTION
Three differential audits turned up pages where `main_content()` and `article()` returned empty on a document that held an article. Each traced back to a scorer heuristic firing where it should not, and each dropped the whole body rather than nudging a ranking.

A div/list-structured body with no scoring `<p>`/`<td>`/`<pre>` produced no candidates, so a real `<article>` extracted to nothing (`#385`). A `<body>` whose class carried an unlikely-candidate substring such as `has-localnav` matched the negative regex and pruned the whole page from the root down (`#399`). A body living inside a `<footer>`, `<header>`, `<aside>`, or `<nav>` hit the boilerplate skip list with no fallback (`#411`).

The scorer now runs up to three passes over the same DOM walk and candidate accumulators. The first scores paragraphs with landmarks pruned, as before. When it finds nothing, a second pass keeps the landmark tags so a body wrapped in one still scores; the skip tags split into a hard group (scripts, form controls) that is always pruned and a landmark group that the retry keeps. When both passes come up empty, a semantic-container fallback surfaces the richest `<article>` (else `<main>`) that holds substantial visible text, discounted by link density so a link farm dressed as an `<article>` stays out. `read_should_skip` also stops pruning the `<html>`/`<body>` root: a class there is a site-wide state flag, not a content verdict, so an unlikely substring no longer zeros the page.

Pages that already extracted are unaffected: the retry and the fallback run only when the prior pass yields no winner, and a page with no scoring content and no substantial `<article>`/`<main>` still resolves to `None`.

closes #385
closes #399
closes #411
