### PR TITLE
🐛 fix(clean): sanitizer conformance and error types

### DIFF
--- a/docs/changelog/392.bugfix.rst
+++ b/docs/changelog/392.bugfix.rst
@@ -1,0 +1,3 @@
+:func:`turbohtml.clean.sanitize` in escape mode (``OnDisallowed.ESCAPE``) now writes a disallowed element's ``</tag>``
+only where the source actually closed it, so ``sanitize("I love <sarcasm> this", Policy.strict())`` yields ``I love
+&lt;sarcasm&gt; this`` rather than appending a ``&lt;/sarcasm&gt;`` the author never wrote.

--- a/docs/changelog/400.bugfix.rst
+++ b/docs/changelog/400.bugfix.rst
@@ -1,0 +1,3 @@
+A kept ``style`` attribute now has its declaration *values* scrubbed, not just their property names: a declaration whose
+value calls ``expression(...)`` or points a ``url(...)`` at a scheme outside the policy's ``url_schemes`` (such as
+``javascript:``) is dropped, closing a gap where dangerous CSS rode in on an allowlisted property.

--- a/docs/changelog/430.bugfix.rst
+++ b/docs/changelog/430.bugfix.rst
@@ -1,0 +1,3 @@
+Passing a non-set to a set-typed :class:`~turbohtml.clean.Policy` field (``tags``, ``url_schemes``,
+``remove_with_content``, ``css_properties``) now raises a :exc:`TypeError` naming the field and the type it got, instead
+of surfacing a bare C ``SystemError`` from deep in the sanitizing walk.

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -374,11 +374,17 @@ static int stack_push(th_tree *tree, th_node *node) {
 }
 
 static void maybe_clone_option(th_tree *tree, th_node *option);
+static int name_matches(const th_node *node, const th_token *token, int fold);
 
 static void stack_pop(th_tree *tree) {
     if (tree->open_len > 0) { /* GCOVR_EXCL_BR_LINE: only reached with a non-empty stack */
         tree->open_len--;
         th_node *popped = tree->open[tree->open_len];
+        /* record that an end tag named this element (as opposed to an implied or
+           EOF close) so escape-mode sanitizing reproduces the author's `</tag>` */
+        if (tree->closing_end_tag != NULL && name_matches(popped, tree->closing_end_tag, popped->ns != TH_NS_HTML)) {
+            popped->tag_flags |= TH_ELEM_CLOSED_BY_END_TAG;
+        }
         if (popped->ns == TH_NS_HTML && popped->atom == TH_TAG_OPTION) {
             /* "when an option element is popped off the stack ... run maybe
                clone an option into selectedcontent" */
@@ -1736,6 +1742,8 @@ static void run_drain(th_tree *tree, th_tokenizer *sm, th_run_state *run_state) 
             tok->atom = TH_TAG_UNKNOWN;
             tok->tag_flags = 0;
         }
+        /* the element(s) this end tag pops are the ones the source closed explicitly */
+        tree->closing_end_tag = tok->kind == TH_END_TAG ? tok : NULL;
         if (use_foreign_rules(tree, tok) && foreign_step(tree, tok)) {
             continue; /* handled under foreign-content rules */
         }

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -41,6 +41,13 @@ enum th_node_type {
 #define TH_DOCTYPE_HAS_PUBLIC 0x40u
 #define TH_DOCTYPE_HAS_SYSTEM 0x80u
 
+/* An element node reuses a spare tag_flags bit (the category bits from the atom
+   table only occupy 0x01..0x10) to record that the source actually closed it with
+   an end tag, as opposed to the parser closing it implicitly or at EOF. The
+   sanitizer's escape mode reads it to reproduce a disallowed element as visible
+   text without fabricating a `</tag>` the author never wrote. */
+#define TH_ELEM_CLOSED_BY_END_TAG 0x20u
+
 /* An attribute on an element node. The name is interned to an atom: a static
    compile-time id for common names (attr_atom.h), or a per-tree dynamic id for
    the rest. attr_record() recovers the name bytes for serialization and

--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -50,12 +50,16 @@ struct th_tree {
     int drop_newline;       /* drop a single leading LF after pre/listing/textarea */
     Py_ssize_t text_offset; /* leading code points of a reprocessed text token already consumed */
     int foster;             /* when set, inserts are foster-parented out of a table */
-    int quirks;             /* quirks mode: a <table> no longer closes an open <p> */
-    int has_nul;            /* the input contains a U+0000; otherwise text needs no NUL filtering */
-    int can_span;           /* input is borrowed and outlives the tree: text nodes may be
-                               zero-copy spans into it instead of materialized copies */
-    int track_positions;    /* record each element's source line/col in trailing node slots */
-    int kind;               /* borrowed input storage */
+    /* the end-tag token currently being processed, or NULL; stack_pop flags the
+       element it closes with TH_ELEM_CLOSED_BY_END_TAG so the sanitizer can tell a
+       source-closed element from a parser-closed one */
+    const th_token *closing_end_tag;
+    int quirks;          /* quirks mode: a <table> no longer closes an open <p> */
+    int has_nul;         /* the input contains a U+0000; otherwise text needs no NUL filtering */
+    int can_span;        /* input is borrowed and outlives the tree: text nodes may be
+                            zero-copy spans into it instead of materialized copies */
+    int track_positions; /* record each element's source line/col in trailing node slots */
+    int kind;            /* borrowed input storage */
     const void *data;
     Py_ssize_t length;
     int failed; /* an allocation failed; abandon the parse */

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -57,31 +57,6 @@ static int is_unsafe_tag(uint16_t atom) {
     }
 }
 
-/* HTML void elements, which serialize without an end tag. */
-static int is_void_tag(uint16_t atom) {
-    switch (atom) {
-    case TH_TAG_AREA:
-    case TH_TAG_BASE:
-    case TH_TAG_BASEFONT:
-    case TH_TAG_BR:
-    case TH_TAG_COL:
-    case TH_TAG_EMBED:
-    case TH_TAG_HR:
-    case TH_TAG_IMG:
-    case TH_TAG_INPUT:
-    case TH_TAG_KEYGEN:
-    case TH_TAG_LINK:
-    case TH_TAG_META:
-    case TH_TAG_PARAM:
-    case TH_TAG_SOURCE:
-    case TH_TAG_TRACK:
-    case TH_TAG_WBR:
-        return 1;
-    default:
-        return 0;
-    }
-}
-
 /* Attributes whose value is a URL, so its scheme is checked against the allowlist. Matched on the interned name bytes.
  */
 static int is_url_attr(const char *name, Py_ssize_t len) {
@@ -331,6 +306,89 @@ static int css_property_allowed(sanitizer *s, const Py_UCS4 *name, Py_ssize_t le
     return allowed;
 }
 
+/* Bytes that continue a CSS identifier, so `expression`/`url` is only recognized as a function name at a token boundary
+   (`background:curl(x)` is not a `url()`). */
+static int is_css_ident_char(Py_UCS4 c) {
+    Py_UCS4 lower = c | 0x20;
+    return (lower >= 'a' && lower <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_';
+}
+
+/* Does the lowercase ASCII `keyword` sit at value[pos:]? Returns the index just past it, or -1. */
+static Py_ssize_t css_match_keyword(const Py_UCS4 *value, Py_ssize_t pos, Py_ssize_t end, const char *keyword) {
+    Py_ssize_t index = 0;
+    while (keyword[index] != '\0') {
+        if (pos + index >= end || (value[pos + index] | 0x20) != (Py_UCS4)keyword[index]) {
+            return -1;
+        }
+        index++;
+    }
+    return pos + index;
+}
+
+/* Skip the whitespace and CSS comments a browser ignores between a function name and its opening paren, so a comment
+   spliced in as `url` then comment then `(...)` is not read as a bare identifier. */
+static Py_ssize_t css_skip_ws_comments(const Py_UCS4 *value, Py_ssize_t pos, Py_ssize_t end) {
+    while (pos < end) {
+        if (is_ascii_ws(value[pos])) {
+            pos++;
+        } else if (value[pos] == '/' && pos + 1 < end && value[pos + 1] == '*') {
+            pos += 2;
+            while (pos < end && !(value[pos] == '*' && pos + 1 < end && value[pos + 1] == '/')) {
+                pos++;
+            }
+            pos += pos < end ? 2 : 0; /* step over the closing star-slash when the comment was terminated */
+        } else {
+            break;
+        }
+    }
+    return pos;
+}
+
+/* Read the URL inside a `url(...)` starting at `pos` (just past the paren) and check its scheme against the allowlist,
+   the same scan the URL-attribute path uses, after stripping an optional surrounding quote so `url("javascript:...")`
+   cannot smuggle a scheme past the check. Returns 1 allow, 0 drop, -1 error. */
+static int css_url_scheme_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t pos, Py_ssize_t end) {
+    pos = css_skip_ws_comments(value, pos, end);
+    Py_UCS4 quote = 0;
+    if (pos < end && (value[pos] == '"' || value[pos] == '\'')) {
+        quote = value[pos++];
+    }
+    Py_ssize_t url_start = pos;
+    while (pos < end && value[pos] != ')' && (quote ? value[pos] != quote : !is_ascii_ws(value[pos]))) {
+        pos++;
+    }
+    return scheme_allowed(s, value + url_start, pos - url_start);
+}
+
+/* A declaration whose property name is allowlisted can still carry a dangerous value: IE's `expression(...)` runs
+   script, and `url(javascript:...)` a disallowed scheme. Reject the whole declaration in either case. Returns 1 allow,
+   0 drop, -1 error. */
+static int css_value_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end) {
+    for (Py_ssize_t pos = start; pos < end; pos++) {
+        if (pos > start && is_css_ident_char(value[pos - 1])) {
+            continue; /* mid-identifier: not a function-name boundary */
+        }
+        Py_ssize_t after_expr = css_match_keyword(value, pos, end, "expression");
+        if (after_expr >= 0) {
+            Py_ssize_t paren = css_skip_ws_comments(value, after_expr, end);
+            if (paren < end && value[paren] == '(') {
+                return 0;
+            }
+        }
+        Py_ssize_t after_url = css_match_keyword(value, pos, end, "url");
+        if (after_url >= 0) {
+            Py_ssize_t paren = css_skip_ws_comments(value, after_url, end);
+            if (paren < end && value[paren] == '(') {
+                int ok = css_url_scheme_allowed(s, value, paren + 1, end);
+                if (ok <= 0) {
+                    return ok;
+                }
+            }
+        }
+    }
+    return 1;
+}
+
 /* Append the declaration `value[start:end)` to `out` if the property name (the part before `colon`) is allowlisted,
    trimming surrounding whitespace and joining kept declarations with "; ". Returns 0, or -1 on error. */
 static int css_flush_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_ssize_t colon,
@@ -352,6 +410,13 @@ static int css_flush_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t 
     }
     if (!allowed) {
         return 0;
+    }
+    int value_ok = css_value_allowed(s, value, colon + 1, end);
+    if (value_ok < 0) { /* GCOVR_EXCL_BR_LINE: css_value_allowed only fails on allocation failure */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    if (!value_ok) {
+        return 0; /* an allowlisted property carrying expression()/url(disallowed-scheme) is still dropped */
     }
     /* output from the trimmed name start to the value's last non-whitespace byte (the leading whitespace was already
        trimmed into name_start, so a kept declaration is emitted without its surrounding whitespace) */
@@ -625,7 +690,10 @@ static int escape_element(sanitizer *s, th_node *element) {
     }
     th_node_insert_before(element->parent, open_node, element);
     hoist_children(element);
-    if (!is_void_tag(element->atom)) {
+    /* Only reproduce an end tag the source actually wrote: a void element or an
+       unclosed one (`<name of movie>`, `I love <sarcasm> this`) carries no close
+       tag, so escaping must not fabricate one. */
+    if (element->tag_flags & TH_ELEM_CLOSED_BY_END_TAG) {
         PyObject *tag = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, element->text, element->text_len);
         if (tag == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -708,6 +776,17 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
     return 0;
 }
 
+/* The set-typed policy fields reach a PySet_Contains in the walk, which raises a bare SystemError on a non-set. Reject
+   a wrong type up front with a message that names the offending Policy field, so a caller gets a clear TypeError. */
+static int require_anyset(PyObject *value, const char *field) {
+    if (!PyAnySet_Check(value)) {
+        PyErr_Format(PyExc_TypeError, "Policy.%s must be a set or frozenset, got %.100s", field,
+                     Py_TYPE(value)->tp_name);
+        return -1;
+    }
+    return 0;
+}
+
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
    attribute_filter, set_attributes, remove_with_content, css_properties) -> None. Filters the fragment in place;
    sanitizer.py serializes it. */
@@ -717,6 +796,11 @@ PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     if (!PyArg_ParseTuple(args, "OOOOpipOOOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
                           &s.set_attributes, &s.remove_with_content, &s.css_properties)) {
+        return NULL;
+    }
+    if (require_anyset(s.tags, "tags") < 0 || require_anyset(s.url_schemes, "url_schemes") < 0 ||
+        require_anyset(s.remove_with_content, "remove_with_content") < 0 ||
+        require_anyset(s.css_properties, "css_properties") < 0) {
         return NULL;
     }
     th_node *root;

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -168,6 +168,8 @@ class Sanitizer:
 
         :param html: the untrusted HTML fragment.
         :returns: the sanitized, safe HTML.
+        :raises TypeError: if a set-typed policy field (``tags``, ``url_schemes``, ``remove_with_content``,
+            ``css_properties``) holds a value that is not a set or frozenset.
         """
         policy = self.policy
         root = parse_fragment(html)
@@ -195,6 +197,8 @@ def sanitize(html: str, policy: Policy | None = None) -> str:
     :param html: the untrusted HTML fragment.
     :param policy: the policy to enforce; None uses bleach's default allowlist.
     :returns: the sanitized, safe HTML.
+    :raises TypeError: if a set-typed policy field (``tags``, ``url_schemes``, ``remove_with_content``,
+        ``css_properties``) holds a value that is not a set or frozenset.
     """
     return Sanitizer(policy).sanitize(html)
 

--- a/tests/features/test_sanitizer.py
+++ b/tests/features/test_sanitizer.py
@@ -101,6 +101,22 @@ def test_escape_reconstructs_attributes() -> None:
 
 
 @pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param("Favorite movie: <name of movie>", "Favorite movie: &lt;name of movie&gt;", id="unclosed-empty"),
+        pytest.param("I love <sarcasm> this", "I love &lt;sarcasm&gt; this", id="unclosed-wrapping-run"),
+        pytest.param("<p>hi", "&lt;p&gt;hi", id="unclosed-known-at-eof"),
+        pytest.param("<name of movie>x</name>", "&lt;name of movie&gt;x&lt;/name&gt;", id="source-closed-unknown"),
+        pytest.param("<div><p>x</div>", "&lt;div&gt;&lt;p&gt;x&lt;/div&gt;", id="source-closed-outer-implied-inner"),
+    ],
+)
+def test_escape_reproduces_only_source_end_tags(html: str, expected: str) -> None:
+    # escape mode renders the author's markup as text: a disallowed element gets a `</tag>` only where the source wrote
+    # one, never a fabricated close tag after an unclosed or void element
+    assert sanitize(html, Policy.strict()) == expected
+
+
+@pytest.mark.parametrize(
     ("disposition", "expected"),
     [
         pytest.param(OnDisallowed.ESCAPE, "&lt;div&gt;<b>x</b>&lt;/div&gt;", id="escape"),
@@ -294,6 +310,48 @@ def test_style_double_quoted_css_string() -> None:
     # a double-quoted CSS string (in a single-quoted attribute) holds separators safely
     out = sanitize("<p style='font-family: \"a;b:c\"; color: red'>x</p>", _style_policy())
     assert "color: red" in out
+
+
+@pytest.mark.parametrize(
+    ("style", "kept"),
+    [
+        pytest.param("width: expression(alert(1))", False, id="expression"),
+        pytest.param("width: EXPRESSION(alert(1))", False, id="expression-uppercase"),
+        pytest.param("width: expression (alert(1))", False, id="expression-space-before-paren"),
+        pytest.param("color: url(javascript:alert(1))", False, id="url-javascript"),
+        pytest.param("color: url('javascript:alert(1)')", False, id="url-javascript-single-quote"),
+        pytest.param("color: url( javascript:x )", False, id="url-javascript-spaced"),
+        pytest.param("color: url/* c */(javascript:x)", False, id="url-comment-before-paren"),
+        pytest.param("color: url(http://x/a.png)", True, id="url-http-allowed"),
+        pytest.param("color: url(http://x y)", True, id="url-allowed-then-space"),
+        pytest.param("color: url/* c */(http://x)", True, id="url-comment-then-allowed"),
+        pytest.param("color: url(/rel.png)", True, id="url-relative-allowed"),
+        pytest.param("color: url()", True, id="url-empty"),
+        pytest.param("color: expression", True, id="expression-bare-ident"),
+        pytest.param("color: expression z", True, id="expression-ident-then-word"),
+        pytest.param("color: url", True, id="url-bare-ident"),
+        pytest.param("color: url z", True, id="url-ident-then-word"),
+        pytest.param("color: ur", True, id="url-prefix-truncated"),
+        pytest.param("cursor: curl(x)", True, id="url-mid-identifier"),
+        pytest.param("color: url/x", True, id="url-slash-not-comment"),
+        pytest.param("color: url/", True, id="url-trailing-slash"),
+        pytest.param("color: url(", True, id="url-open-paren-at-end"),
+        pytest.param("color: url(http://x", True, id="url-unterminated-allowed"),
+        pytest.param("color: url/* unterminated", True, id="url-unterminated-comment"),
+        pytest.param("color: url/* x*", True, id="url-comment-trailing-asterisk"),
+        pytest.param("color: url/* a*b */(http://x)", True, id="url-comment-lone-asterisk-then-allowed"),
+        pytest.param("color: a-b_1c", True, id="value-identifier-punctuation"),
+    ],
+)
+def test_style_value_rejects_expression_and_bad_url_scheme(style: str, kept: bool) -> None:  # noqa: FBT001
+    # a kept property still has its value scrubbed: expression() and url(disallowed-scheme) drop the whole declaration
+    out = sanitize(f'<p style="{style}">x</p>', _style_policy())
+    assert ("style=" in out) is kept
+
+
+def test_style_double_quoted_url_scheme_is_stripped() -> None:
+    # a double-quoted url() (in a single-quoted attribute) cannot smuggle a disallowed scheme past the value scan
+    assert "style=" not in sanitize("""<p style='color: url("javascript:x")'>y</p>""", _style_policy())
 
 
 @pytest.mark.parametrize(
@@ -514,6 +572,45 @@ def test_sanitizer_is_reusable() -> None:
     sanitizer = Sanitizer(Policy.relaxed())
     assert sanitizer.sanitize("<h1>a</h1>") == "<h1>a</h1>"
     assert sanitizer.sanitize("<h2>b</h2>") == "<h2>b</h2>"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "type_name"),
+    [
+        pytest.param("tags", ["b"], "list", id="tags"),
+        pytest.param("url_schemes", ["http"], "list", id="url_schemes"),
+        pytest.param("remove_with_content", ["x"], "list", id="remove_with_content"),
+        pytest.param("css_properties", "color", "str", id="css_properties"),
+    ],
+)
+def test_non_set_policy_field_raises_typeerror(field: str, value: list[str] | str, type_name: str) -> None:
+    # a set-typed field given a non-set once reached a bare C SystemError deep in the walk; it now fails with a clear
+    # TypeError naming the offending field and the type it got
+    policy = Policy(**{field: value})  # ty: ignore[invalid-argument-type]  # the wrong type is what the guard rejects
+    with pytest.raises(TypeError, match=rf"Policy\.{field} must be a set or frozenset, got {type_name}"):
+        sanitize("<b>x", policy)
+
+
+class _TagSet(set[str]):
+    pass
+
+
+class _TagFrozenSet(frozenset[str]):
+    pass
+
+
+@pytest.mark.parametrize(
+    "tags",
+    [
+        pytest.param({"b"}, id="set"),
+        pytest.param(frozenset({"b"}), id="frozenset"),
+        pytest.param(_TagSet({"b"}), id="set-subclass"),
+        pytest.param(_TagFrozenSet({"b"}), id="frozenset-subclass"),
+    ],
+)
+def test_set_and_frozenset_tags_are_accepted(tags: frozenset[str]) -> None:
+    # every set-like type (including subclasses) passes the type guard and sanitizes normally
+    assert sanitize("<b>x</b>", Policy(tags=tags)) == "<b>x</b>"
 
 
 def test_escape_propagates_a_child_filter_error() -> None:


### PR DESCRIPTION
An audit against bleach, lxml, and a public-API error sweep turned up three ways the sanitizer strayed from its documented contract, one of which crashed the interpreter. This fixes all three in the C sanitize walk, keeping the Python layer a thin policy facade.

In escape mode (`OnDisallowed.ESCAPE`) a disallowed element came back with a `</tag>` the author never wrote, so `sanitize("I love <sarcasm> this", Policy.strict())` produced `I love &lt;sarcasm&gt; this&lt;/sarcasm&gt;`. 🩹 Escape mode serializes the parsed DOM, and the DOM does not record whether an end tag ever closed an element. The tree builder now sets a spare `tag_flags` bit (`TH_ELEM_CLOSED_BY_END_TAG`) when a matching end tag pops an element, and escape mode emits a close tag only for flagged elements, so an unclosed or void element reproduces without a fabricated `</tag>` while a source-closed one keeps its own.

A kept `style` attribute filtered declaration property names but never inspected their values, so `expression(...)` and `url(javascript:...)` rode in on an allowlisted property such as `width` or `color`. 🔒 The same CSS walk that filters names now rejects a declaration whose value calls `expression(` or points a `url()` at a scheme outside `url_schemes`, stripping a surrounding quote first so `url("javascript:...")` cannot hide the scheme.

Constructing a `Policy` with a non-set for a set-typed field (`Policy(tags=["b"])`) reached a `PySet_Contains` deep in the walk and raised a bare C `SystemError`. The walk entry now validates `tags`, `url_schemes`, `remove_with_content`, and `css_properties` and raises a `TypeError` naming the offending field and the type it got.

closes #392
closes #400
closes #430
