### PR TITLE
🐛 fix(build): table-model conformance

### DIFF
--- a/docs/changelog/408.bugfix.rst
+++ b/docs/changelog/408.bugfix.rst
@@ -1,0 +1,4 @@
+A ``rowspan=0`` cell in :meth:`~turbohtml.Element.rows`, :meth:`~turbohtml.Element.records`, and
+:meth:`~turbohtml.Node.tables` now stops at the end of its row group (``thead``/``tbody``/``tfoot``), matching the
+WHATWG table-forming algorithm, instead of growing to the last row of the whole table and pushing later row groups
+sideways into a spurious column. A fixed ``rowspan`` still spans across row-group boundaries.

--- a/src/turbohtml/_c/features/tables.c
+++ b/src/turbohtml/_c/features/tables.c
@@ -108,8 +108,10 @@ static int ensure_columns(grid_row *row, Py_ssize_t needed) {
 }
 
 /* Place a row's <td>/<th> cells into the grid, honoring spans: each cell takes the next free column, and a rowspan or
-   colspan fills every covered slot with a fresh copy of the trimmed cell text. -1 on allocation failure. */
-static int fill_row(th_tree *tree, table_grid *grid, Py_ssize_t row_index, th_node *tr) {
+   colspan fills every covered slot with a fresh copy of the trimmed cell text. group_remaining is the number of rows
+   from row_index to the end of this row's row group (thead/tbody/tfoot), the stop point for a rowspan=0 cell. -1 on
+   allocation failure. */
+static int fill_row(th_tree *tree, table_grid *grid, Py_ssize_t row_index, th_node *tr, Py_ssize_t group_remaining) {
     Py_ssize_t column = 0;
     for (th_node *child = tr->first_child; child != NULL; child = child->next_sibling) {
         if (child->type != TH_NODE_ELEMENT || (child->atom != TH_TAG_TD && child->atom != TH_TAG_TH)) {
@@ -125,8 +127,10 @@ static int fill_row(th_tree *tree, table_grid *grid, Py_ssize_t row_index, th_no
         Py_ssize_t rowspan = parse_span(child, TH_ATTR_ROWSPAN);
         if (rowspan < 0) {
             rowspan = 1; /* absent: a single row */
-        } else if (rowspan == 0 || rowspan > remaining) {
-            rowspan = remaining; /* 0 spans to the end of the table; an overlong span clamps to the rows that exist */
+        } else if (rowspan == 0) {
+            rowspan = group_remaining; /* 0 grows downward, stopping at the end of its row group (thead/tbody/tfoot) */
+        } else if (rowspan > remaining) {
+            rowspan = remaining; /* an overlong fixed span clamps to existing rows; it may cross group boundaries */
         }
         Py_ssize_t text_len;
         Py_UCS4 *raw = th_node_text(tree, child, &text_len);
@@ -203,6 +207,43 @@ static int collect_table_rows(th_node *table, th_node ***rows, Py_ssize_t *count
     return 0;
 }
 
+/* The row group a <tr> belongs to: its nearest thead/tbody/tfoot ancestor below `table`, or `table` itself when the row
+   sits directly in the table. A rowspan=0 cell grows downward only to the end of this group. A collected row always has
+   `table` as an ancestor, so the walk terminates there; its ancestors up to `table` are all elements. */
+static th_node *row_group(th_node *tr, th_node *table) {
+    for (th_node *ancestor = tr->parent; ancestor != table; ancestor = ancestor->parent) {
+        if (ancestor->atom == TH_TAG_THEAD || ancestor->atom == TH_TAG_TBODY || ancestor->atom == TH_TAG_TFOOT) {
+            return ancestor;
+        }
+    }
+    return table;
+}
+
+/* For each collected row, the number of rows from it to the end of its row group inclusive (>= 1). Rows of one group
+   are contiguous in the document-order walk, so a backward pass extends the run whenever a row shares its successor's
+   group. -1 on allocation failure. */
+static int group_run_lengths(th_node *table, th_node **rows, Py_ssize_t count, Py_ssize_t **remaining) {
+    if (count == 0) {
+        return 0;
+    }
+    th_node **groups = PyMem_Malloc((size_t)count * sizeof(th_node *));
+    Py_ssize_t *run = PyMem_Malloc((size_t)count * sizeof(Py_ssize_t));
+    if (groups == NULL || run == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        PyMem_Free(groups);              /* GCOVR_EXCL_LINE: allocation-failure path */
+        PyMem_Free(run);                 /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;                       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    for (Py_ssize_t index = 0; index < count; index++) {
+        groups[index] = row_group(rows[index], table);
+    }
+    for (Py_ssize_t index = count - 1; index >= 0; index--) {
+        run[index] = index + 1 < count && groups[index] == groups[index + 1] ? run[index + 1] + 1 : 1;
+    }
+    PyMem_Free(groups);
+    *remaining = run;
+    return 0;
+}
+
 /* Snapshot `table` into `grid` under the caller's critical section: gather its rows, then fill the dense grid. -1 on
    allocation failure (the partially built grid is left for free_grid to release). */
 static int build_grid_locked(th_tree *tree, th_node *table, table_grid *grid) {
@@ -215,22 +256,30 @@ static int build_grid_locked(th_tree *tree, th_node *table, table_grid *grid) {
         PyMem_Free(rows);                                     /* GCOVR_EXCL_LINE: allocation-failure path */
         return -1;                                            /* GCOVR_EXCL_LINE: allocation-failure path */
     }
+    Py_ssize_t *group_remaining = NULL;
+    if (group_run_lengths(table, rows, count, &group_remaining) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+        PyMem_Free(rows);                                              /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;                                                     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
     grid->row_count = count;
     if (count > 0) {
         grid->rows = PyMem_Calloc((size_t)count, sizeof(grid_row));
-        if (grid->rows == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-            grid->row_count = 0;  /* GCOVR_EXCL_LINE: allocation-failure path */
-            PyMem_Free(rows);     /* GCOVR_EXCL_LINE: allocation-failure path */
-            return -1;            /* GCOVR_EXCL_LINE: allocation-failure path */
+        if (grid->rows == NULL) {        /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            grid->row_count = 0;         /* GCOVR_EXCL_LINE: allocation-failure path */
+            PyMem_Free(rows);            /* GCOVR_EXCL_LINE: allocation-failure path */
+            PyMem_Free(group_remaining); /* GCOVR_EXCL_LINE: allocation-failure path */
+            return -1;                   /* GCOVR_EXCL_LINE: allocation-failure path */
         }
     }
     for (Py_ssize_t index = 0; index < count; index++) {
-        if (fill_row(tree, grid, index, rows[index]) < 0) { /* GCOVR_EXCL_BR_LINE: fill only fails on OOM */
-            PyMem_Free(rows);                               /* GCOVR_EXCL_LINE: allocation-failure path */
-            return -1;                                      /* GCOVR_EXCL_LINE: allocation-failure path */
+        if (fill_row(tree, grid, index, rows[index], group_remaining[index]) < 0) { /* GCOVR_EXCL_BR_LINE: OOM only */
+            PyMem_Free(rows);                                                       /* GCOVR_EXCL_LINE: OOM path */
+            PyMem_Free(group_remaining);                                            /* GCOVR_EXCL_LINE: OOM path */
+            return -1;                                                              /* GCOVR_EXCL_LINE: OOM path */
         }
     }
     PyMem_Free(rows);
+    PyMem_Free(group_remaining);
     return 0;
 }
 

--- a/tests/features/test_tables.py
+++ b/tests/features/test_tables.py
@@ -100,6 +100,30 @@ ROWS_CASES = [
         id="rowspan-beyond-last-row-clamped",
     ),
     pytest.param(
+        "<table><tbody><tr><td rowspan=0>A</td><td>B</td></tr><tr><td>C</td></tr></tbody>"
+        "<tbody><tr><td>D</td><td>E</td></tr></tbody></table>",
+        [["A", "B"], ["A", "C"], ["D", "E"]],
+        id="zero-rowspan-stops-at-row-group-end",
+    ),
+    pytest.param(
+        "<table><thead><tr><td rowspan=0>A</td><td>B</td></tr></thead>"
+        "<tbody><tr><td>C</td><td>D</td></tr></tbody></table>",
+        [["A", "B"], ["C", "D"]],
+        id="zero-rowspan-from-thead-stops-at-thead-end",
+    ),
+    pytest.param(
+        "<table><tbody><tr><td>C</td><td>D</td></tr></tbody>"
+        "<tfoot><tr><td rowspan=0>A</td><td>B</td></tr><tr><td>E</td></tr></tfoot></table>",
+        [["C", "D"], ["A", "B"], ["A", "E"]],
+        id="zero-rowspan-in-tfoot-stops-at-tfoot-end",
+    ),
+    pytest.param(
+        "<table><tbody><tr><td rowspan=3>A</td><td>B</td></tr><tr><td>C</td></tr></tbody>"
+        "<tbody><tr><td>D</td></tr></tbody></table>",
+        [["A", "B"], ["A", "C"], ["A", "D"]],
+        id="fixed-rowspan-crosses-row-group-boundary",
+    ),
+    pytest.param(
         "<table><tr><td>A</td><td rowspan=2>B</td></tr><tr><td colspan=3>C</td></tr></table>",
         [["A", "B", ""], ["C", "C", "C"]],
         id="overlapping-spans-later-cell-wins",
@@ -146,6 +170,43 @@ def test_huge_colspan_is_clamped(rows: Callable[[str], list[list[str]]]) -> None
     assert len(grid[0]) == 1000
     assert grid[0][0] == "A"
     assert grid[0][999] == "A"
+
+
+def _rehome_rows(destination: Element) -> None:
+    # The parser always wraps rows in a tbody, so move real <tr> elements under `destination` to give a table
+    # rows with no row-group ancestor: a rowspan=0 cell then has no group to stop at and grows to the last row.
+    source = parse_fragment(
+        "<table><tbody><tr><td rowspan=0>A</td><td>B</td></tr><tr><td>C</td></tr></tbody></table>",
+    ).find("table")
+    assert isinstance(source, Element)
+    body = source.find("tbody")
+    assert isinstance(body, Element)
+    for row in list(body.children):
+        row.extract()
+        destination.append(row)
+
+
+def _table_itself(table: Element) -> Element:
+    return table
+
+
+def _div_under(table: Element) -> Element:
+    wrapper = parse_fragment("<div></div>").find("div")
+    assert isinstance(wrapper, Element)
+    wrapper.extract()
+    table.append(wrapper)
+    return wrapper
+
+
+@pytest.mark.parametrize(
+    "receiver",
+    [pytest.param(_table_itself, id="rows-in-table"), pytest.param(_div_under, id="rows-under-a-div")],
+)
+def test_zero_rowspan_without_a_row_group_spans_to_table_end(receiver: Callable[[Element], Element]) -> None:
+    table = parse_fragment("<table></table>").find("table")
+    assert isinstance(table, Element)
+    _rehome_rows(receiver(table))
+    assert table.rows() == [["A", "B"], ["A", "C"]]
 
 
 RECORDS_CASES = [


### PR DESCRIPTION
A `rowspan="0"` cell read through `rows()`, `records()`, and `tables()` grew to the last row of the whole table rather than stopping at the end of its row group. 🐛 A table with two `<tbody>` sections lost its grid. The first cell spilled into the second body, pushed those cells one column right, and invented a spurious empty column. A differential audit against `pandas.read_html` surfaced it (closes #408).

The WHATWG table-forming algorithm makes a `rowspan="0"` cell grow downward and stop when its row group (`thead`, `tbody`, or `tfoot`) ends. `fill_row` now sizes such a cell from a per-row count of the rows remaining in its group. A one-time pass over the collected rows walks each `<tr>` up to its nearest row-group ancestor, and since rows of one group are contiguous in document order, a single backward sweep builds the counts. A fixed `rowspan` still clamps to the rows that exist and still crosses group boundaries.

Rows placed as direct children of a `<table>` with no row group form one anonymous group, so a `rowspan="0"` there reaches the last row.
