### PR TITLE
🐛 fix(clean): linkify boundary conformance

### DIFF
--- a/docs/changelog/405.bugfix.rst
+++ b/docs/changelog/405.bugfix.rst
@@ -1,0 +1,3 @@
+The link detector now trims a trailing ``}`` or ``'`` from a URL and balances ``{...}`` the way it already balanced
+parentheses and brackets, so a brace-scoped or single-quoted URL such as ``{http://example.com/foo_bar}`` links only
+``http://example.com/foo_bar``.

--- a/docs/changelog/406.bugfix.rst
+++ b/docs/changelog/406.bugfix.rst
@@ -1,0 +1,3 @@
+The link detector now autolinks a ``scheme://`` URL only when its scheme is ``http``, ``https``, ``ftp``, or one a
+config registers, rather than accepting any scheme. It leaves a typo scheme such as ``hppt://`` and a ``javascript://``
+payload as plain text.

--- a/docs/how-to/links.rst
+++ b/docs/how-to/links.rst
@@ -126,8 +126,9 @@ offsets, the matched text, and the normalized ``url``; ``has_link`` answers the 
     5 20 mailto:bob@example.com
     27 38 http://example.com
 
-Register custom ``tlds`` to detect bare domains on an internal suffix, and scheme-less ``schemes`` such as ``tel`` so
-their opaque URLs are found too (every ``scheme://`` URL is detected without registration):
+Register custom ``tlds`` to detect bare domains on an internal suffix, and ``schemes`` such as ``tel`` so their opaque
+URLs are found too (a ``scheme://`` URL autolinks when its scheme is ``http``/``https``/``ftp`` or one you register, so
+a typo scheme or a ``javascript://`` payload is left alone):
 
 .. testcode::
 

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -29,7 +29,8 @@ in ``<a>`` links, HTML-aware so it never links inside an existing ``<a>``, a raw
 A :class:`Linkify` configuration object carries the knobs: a callback receives each generated :class:`Link` and returns
 it to keep the link or ``None`` to leave the text bare, ``process_existing`` runs the callbacks over ``<a>`` tags
 already in the input (a callback reads ``Link.existing`` to tell the two apart), ``extra_tlds`` extends bare-domain
-detection beyond the built-in IANA table, and ``schemes`` restricts which explicit-scheme URLs autolink.
+detection beyond the built-in IANA table, and ``schemes`` sets which explicit-scheme URLs autolink (defaulting to the
+built-in ``http``/``https``/``ftp`` set, so a typo scheme or a ``javascript://`` payload stays plain text).
 
 .. autofunction:: linkify
 

--- a/src/turbohtml/_c/features/linkify.c
+++ b/src/turbohtml/_c/features/linkify.c
@@ -229,11 +229,14 @@ static Py_ssize_t scan_balanced(int kind, const void *data, Py_ssize_t begin, Py
     Py_ssize_t end = begin;
     int round = 0;
     int square = 0;
+    int curly = 0;
     while (pos < len) {
         Py_UCS4 c = READ(pos);
         if (!is_url_tail_char(c)) {
             break;
         }
+        /* Braces balance like parens and brackets, so a template path keeps its
+           ``/{id}`` but a brace-scoped ``{http://...}`` drops the stray closer. */
         if (c == '(') {
             round++;
         } else if (c == ')') {
@@ -248,12 +251,21 @@ static Py_ssize_t scan_balanced(int kind, const void *data, Py_ssize_t begin, Py
                 break;
             }
             square--;
+        } else if (c == '{') {
+            curly++;
+        } else if (c == '}') {
+            if (curly == 0) {
+                break;
+            }
+            curly--;
         }
         pos++;
         /* a closing bracket or a non-trailing-punctuation byte can end the link;
-           trailing . , ! ? : ; are valid inside it but never its last byte. '*' is
-           an RFC 3986 sub-delim that bleach and linkify_it keep, so it ends a link. */
-        if (round == 0 && square == 0 && c != '.' && c != ',' && c != '!' && c != '?' && c != ':' && c != ';') {
+           trailing . , ! ? : ; and a lone ' (a single-quoted URL's closer) are
+           valid inside it but never its last byte. '*' is an RFC 3986 sub-delim
+           that bleach and linkify_it keep, so it ends a link. */
+        if (round == 0 && square == 0 && curly == 0 && c != '.' && c != ',' && c != '!' && c != '?' && c != ':' &&
+            c != ';' && c != '\'') {
             end = pos;
         }
     }
@@ -304,14 +316,20 @@ static Py_ssize_t scan_scheme_start(int kind, const void *data, Py_ssize_t colon
     return pos;
 }
 
-/* Try to match a scheme:// URL whose ``:`` is at `colon`. */
+/* Try to match a scheme:// URL whose ``:`` is at `colon`. A non-NULL url_schemes
+   tuple restricts the scheme to that lowercased allowlist (http/https/ftp plus any
+   registered scheme), so a typo like ``hppt://`` or a ``javascript://`` payload is
+   not linked; NULL keeps the permissive, any-scheme scan the raw binding exposes. */
 static int match_url(int kind, const void *data, Py_ssize_t colon, Py_ssize_t start, Py_ssize_t len,
-                     Py_ssize_t *out_start, Py_ssize_t *out_end) {
+                     Py_ssize_t *out_start, Py_ssize_t *out_end, PyObject *url_schemes) {
     if (colon + 2 >= len || READ(colon + 1) != '/' || READ(colon + 2) != '/') {
         return 0;
     }
     Py_ssize_t scheme_start = scan_scheme_start(kind, data, colon, start);
     if (scheme_start < 0 || blocked_on_left(kind, data, scheme_start)) {
+        return 0;
+    }
+    if (url_schemes != NULL && !tuple_has_label(url_schemes, kind, data, scheme_start, colon)) {
         return 0;
     }
     /* Most URLs have no userinfo, so scan the host directly and only hunt for a
@@ -360,6 +378,13 @@ static int match_domain(int kind, const void *data, Py_ssize_t dot, Py_ssize_t s
         pos++;
     }
     if (pos == dot || blocked_on_left(kind, data, pos)) {
+        return 0;
+    }
+    /* A ``://`` immediately left of the host is the authority of a scheme URL that
+       match_url declined (an unregistered or typo scheme like ``hppt://``); its host
+       is not an independent bare domain, so the whole thing stays plain text. A bare
+       ``//`` with no colon (``nothttp//example.com``) is not scheme syntax and links. */
+    if (pos >= 3 && READ(pos - 1) == '/' && READ(pos - 2) == '/' && READ(pos - 3) == ':') {
         return 0;
     }
     Py_ssize_t host_end = scan_host(kind, data, pos, len, 1, extra_tlds);
@@ -433,8 +458,10 @@ static int append_span(PyObject *spans, Py_ssize_t start, Py_ssize_t end, enum t
 /* The shared scan: trigger on the few bytes that can begin a link and expand to
    its bounds, appending each (start, end, kind) span. extra_tlds extends the
    bare-domain/email TLD rule; schemes (NULL in the rewrite path) enables
-   registered scheme-less URLs. Returns the span list, or NULL on error. */
-static PyObject *do_scan(PyObject *text, int parse_email, int bare_domains, PyObject *extra_tlds, PyObject *schemes) {
+   registered scheme-less URLs; url_schemes (NULL for the permissive raw scan)
+   restricts which scheme://host schemes autolink. Returns the span list, or NULL. */
+static PyObject *do_scan(PyObject *text, int parse_email, int bare_domains, PyObject *extra_tlds, PyObject *schemes,
+                         PyObject *url_schemes) {
     int kind = PyUnicode_KIND(text);
     const void *data = PyUnicode_DATA(text);
     Py_ssize_t len = PyUnicode_GET_LENGTH(text);
@@ -452,7 +479,7 @@ static PyObject *do_scan(PyObject *text, int parse_email, int bare_domains, PyOb
         enum th_link_kind link_kind = TH_LINK_URL;
         int found = 0;
         if (c == ':') {
-            found = match_url(kind, data, pos, 0, len, &match_start, &match_end);
+            found = match_url(kind, data, pos, 0, len, &match_start, &match_end, url_schemes);
             if (!found && schemes != NULL) {
                 found = match_scheme_less(kind, data, pos, 0, len, &match_start, &match_end, schemes);
                 link_kind = TH_LINK_SCHEME;
@@ -476,34 +503,39 @@ static PyObject *do_scan(PyObject *text, int parse_email, int bare_domains, PyOb
     return spans;
 }
 
-/* _linkify_scan(text, parse_email, bare_domains, extra_tlds=()) -> list[(start, end, kind)]
-   extra_tlds is a tuple of lowercased custom TLDs extending the built-in table for
-   bare-domain and email host recognition; the rewrite path passes it, the bare scan omits it. */
+/* _linkify_scan(text, parse_email, bare_domains, extra_tlds=(), url_schemes=None)
+   -> list[(start, end, kind)]. extra_tlds is a tuple of lowercased custom TLDs
+   extending the built-in table for bare-domain and email host recognition.
+   url_schemes, when given, is a tuple of lowercased schemes the rewrite path allows
+   for scheme://host URLs; omitting it keeps the permissive any-scheme scan. */
 PyObject *turbohtml_linkify_scan(PyObject *Py_UNUSED(module), PyObject *args) {
     PyObject *text;
     int parse_email;
     int bare_domains;
     PyObject *extra_tlds = NULL;
-    if (!PyArg_ParseTuple(args, "Upp|O!:_linkify_scan", &text, &parse_email, &bare_domains, &PyTuple_Type,
-                          &extra_tlds)) {
+    PyObject *url_schemes = NULL;
+    if (!PyArg_ParseTuple(args, "Upp|O!O!:_linkify_scan", &text, &parse_email, &bare_domains, &PyTuple_Type,
+                          &extra_tlds, &PyTuple_Type, &url_schemes)) {
         return NULL;
     }
-    return do_scan(text, parse_email, bare_domains, extra_tlds, NULL);
+    return do_scan(text, parse_email, bare_domains, extra_tlds, NULL, url_schemes);
 }
 
-/* _linkify_find(text, emails, bare_domains, extra_tlds, schemes)
+/* _linkify_find(text, emails, bare_domains, extra_tlds, schemes, url_schemes=None)
    -> list[(start, end, kind)]. extra_tlds and schemes are tuples of lowercased
    names; an empty schemes tuple still enables the scheme-less path (matching
-   nothing), so the detector can register zero or more schemes uniformly. */
+   nothing), so the detector can register zero or more schemes uniformly. url_schemes
+   is the lowercased allowlist for scheme://host URLs; omitting it matches any scheme. */
 PyObject *turbohtml_linkify_find(PyObject *Py_UNUSED(module), PyObject *args) {
     PyObject *text;
     int emails;
     int bare_domains;
     PyObject *extra_tlds;
     PyObject *schemes;
-    if (!PyArg_ParseTuple(args, "UppO!O!:_linkify_find", &text, &emails, &bare_domains, &PyTuple_Type, &extra_tlds,
-                          &PyTuple_Type, &schemes)) {
+    PyObject *url_schemes = NULL;
+    if (!PyArg_ParseTuple(args, "UppO!O!|O!:_linkify_find", &text, &emails, &bare_domains, &PyTuple_Type, &extra_tlds,
+                          &PyTuple_Type, &schemes, &PyTuple_Type, &url_schemes)) {
         return NULL;
     }
-    return do_scan(text, emails, bare_domains, extra_tlds, schemes);
+    return do_scan(text, emails, bare_domains, extra_tlds, schemes, url_schemes);
 }

--- a/src/turbohtml/_linkify.py
+++ b/src/turbohtml/_linkify.py
@@ -31,6 +31,11 @@ _SCHEME_KIND = 2
 # path (an embedded redirect URL) as the link's own scheme.
 _SCHEME = re.compile(r"[a-zA-Z][a-zA-Z0-9+.\-]*://")
 
+# The ``scheme://host`` schemes autolinked when a config registers none: the fixed set linkify-it recognizes, so a typo
+# scheme or a ``javascript://`` payload stays plain text. A ``Linkify.schemes`` restricts to its own set (bleach), while
+# a ``Detector``'s ``schemes`` extends this one; the low-level scanner without an allowlist stays permissive.
+_DEFAULT_URL_SCHEMES = ("ftp", "http", "https")
+
 # Text inside these never becomes a link: an existing anchor (no nested links) and the raw-text elements whose content
 # is not markup. A caller's skip_tags is added on top.
 _NEVER_LINKIFY = frozenset({"a", "script", "style"})
@@ -129,8 +134,9 @@ class Linkify:
     :param parse_email: also autolink bare email addresses as ``mailto:`` links.
     :param process_existing: run the callbacks over ``<a>`` tags already present, not only freshly detected links.
     :param extra_tlds: top-level domains that make a bare domain a link, on top of the built-in IANA table.
-    :param schemes: restrict which explicit-scheme URLs autolink (``None`` keeps every scheme); a bare domain is
-        always treated as ``http`` and is governed by the TLD table, not ``schemes``.
+    :param schemes: the exact set of ``scheme://`` URL schemes that autolink; ``None`` keeps the built-in
+        ``http``/``https``/``ftp`` default, so a typo scheme or a ``javascript://`` payload stays plain text. A bare
+        domain is always treated as ``http`` and is governed by the TLD table, not ``schemes``.
     """
 
     callbacks: Iterable[Callback] = DEFAULT_CALLBACKS
@@ -156,7 +162,11 @@ class Linker:
         self.parse_email = config.parse_email
         self.process_existing = config.process_existing
         self.extra_tlds = tuple(sorted({tld.lower() for tld in config.extra_tlds})) if config.extra_tlds else ()
-        self.schemes = frozenset(scheme.lower() for scheme in config.schemes) if config.schemes is not None else None
+        self.url_schemes = (
+            tuple(sorted({scheme.lower() for scheme in config.schemes}))
+            if config.schemes is not None
+            else _DEFAULT_URL_SCHEMES
+        )
 
     def linkify(self, text: str) -> str:
         """
@@ -209,7 +219,7 @@ class Linker:
     def _linkify_text(self, node: Text) -> None:
         """Replace a text node with the text and anchors that the link spans in it imply."""
         data = node.data
-        spans = _linkify_scan(data, self.parse_email, True, self.extra_tlds)  # noqa: FBT003  # True enables bare domains
+        spans = _linkify_scan(data, self.parse_email, True, self.extra_tlds, self.url_schemes)  # noqa: FBT003  # True enables bare domains
         if not spans:
             return
         pieces: list[Element | Text] = []
@@ -228,9 +238,7 @@ class Linker:
         """Build the ``<a>`` for one matched link, running the callbacks; return ``None`` if a callback vetoes it."""
         if kind == _EMAIL_KIND:
             url = "mailto:" + matched
-        elif scheme := _SCHEME.match(matched):
-            if self.schemes is not None and scheme.group()[:-3].lower() not in self.schemes:
-                return None
+        elif _SCHEME.match(matched):  # the scanner already gated the scheme; a match here keeps its own scheme
             url = matched
         else:
             url = "http://" + matched
@@ -319,8 +327,9 @@ class Detector:
     :param emails: detect bare email addresses.
     :param bare_domains: detect bare domains (``example.com``) with no explicit scheme.
     :param tlds: custom top-level domains accepted for bare-domain matching, on top of the IANA table.
-    :param schemes: scheme-less schemes such as ``tel`` or ``bitcoin`` to detect as opaque URLs; every
-        ``scheme://`` URL is detected without registration.
+    :param schemes: extra schemes to detect, both as scheme-less opaque URLs (``tel:``, ``bitcoin:``) and as
+        ``scheme://`` authority URLs, on top of the built-in ``http``/``https``/``ftp`` set; an unregistered scheme
+        such as ``javascript://`` or a typo like ``hppt://`` is not detected.
     """
 
     def __init__(
@@ -336,6 +345,7 @@ class Detector:
         self.bare_domains = bare_domains
         self._tlds = tuple({tld.lower().removeprefix(".") for tld in tlds})
         self._schemes = tuple({scheme.lower().rstrip(":") for scheme in schemes})
+        self._url_schemes = tuple(sorted(set(_DEFAULT_URL_SCHEMES).union(self._schemes)))
 
     def find(self, text: str) -> list[LinkSpan]:
         """
@@ -344,7 +354,7 @@ class Detector:
         :param text: the text to scan.
         :returns: every link as a :class:`LinkSpan`, in the order it appears.
         """
-        spans = _linkify_find(text, self.emails, self.bare_domains, self._tlds, self._schemes)
+        spans = _linkify_find(text, self.emails, self.bare_domains, self._tlds, self._schemes, self._url_schemes)
         return [_span_from_match(text, start, end, kind) for start, end, kind in spans]
 
     def has_link(self, text: str) -> bool:
@@ -354,7 +364,7 @@ class Detector:
         :param text: the text to scan.
         :returns: whether the text contains at least one link.
         """
-        return bool(_linkify_find(text, self.emails, self.bare_domains, self._tlds, self._schemes))
+        return bool(_linkify_find(text, self.emails, self.bare_domains, self._tlds, self._schemes, self._url_schemes))
 
 
 __all__ = [

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -7,10 +7,21 @@ from .dom import Element
 
 def _register_markup(markup_type: type, /) -> None: ...
 def _linkify_scan(
-    text: str, parse_email: bool, bare_domains: bool, extra_tlds: tuple[str, ...] = ..., /
+    text: str,
+    parse_email: bool,
+    bare_domains: bool,
+    extra_tlds: tuple[str, ...] = ...,
+    url_schemes: tuple[str, ...] = ...,
+    /,
 ) -> list[tuple[int, int, int]]: ...
 def _linkify_find(
-    text: str, emails: bool, bare_domains: bool, extra_tlds: tuple[str, ...], schemes: tuple[str, ...], /
+    text: str,
+    emails: bool,
+    bare_domains: bool,
+    extra_tlds: tuple[str, ...],
+    schemes: tuple[str, ...],
+    url_schemes: tuple[str, ...] = ...,
+    /,
 ) -> list[tuple[int, int, int]]: ...
 def _register_links(link_type: type, /) -> None: ...
 def _register_structured_data(

--- a/tests/features/test_detector_find.py
+++ b/tests/features/test_detector_find.py
@@ -70,3 +70,21 @@ def test_find_respects_bare_domains_disabled() -> None:
 def test_find_scheme_url_still_found_without_bare_domains() -> None:
     spans = Detector(bare_domains=False).find("see https://example.com here")
     assert _tuples(spans) == [(4, 23, "https://example.com", "https://example.com", False)]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("{Scoped like http://example.com/foo_bar}", id="trailing-brace"),
+        pytest.param("'Quoted like http://example.com/foo_bar'", id="trailing-apostrophe"),
+    ],
+)
+def test_find_trims_a_trailing_brace_or_apostrophe(text: str) -> None:
+    assert _tuples(Detector().find(text)) == [
+        (13, 39, "http://example.com/foo_bar", "http://example.com/foo_bar", False),
+    ]
+
+
+def test_find_keeps_a_balanced_brace_in_the_path() -> None:
+    spans = Detector().find("http://example.com/{id}")
+    assert _tuples(spans) == [(0, 23, "http://example.com/{id}", "http://example.com/{id}", False)]

--- a/tests/features/test_detector_schemes.py
+++ b/tests/features/test_detector_schemes.py
@@ -50,3 +50,26 @@ def test_scheme_with_empty_opaque_part_is_skipped(text: str) -> None:
 def test_scheme_url_with_authority_takes_priority() -> None:
     spans = Detector(schemes=["http"]).find("http://example.com")
     assert _tuples(spans) == [(0, 18, "http://example.com", "http://example.com", False)]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("hppt://example.com", id="typo-scheme"),
+        pytest.param("javascript://example.com", id="javascript-scheme"),
+        pytest.param("xyzzy://foo.com", id="unregistered-scheme"),
+    ],
+)
+def test_unknown_authority_scheme_is_not_detected(text: str) -> None:
+    assert Detector().find(text) == []
+
+
+@pytest.mark.parametrize("scheme", ["http", "https", "ftp"])
+def test_builtin_authority_scheme_is_detected(scheme: str) -> None:
+    text = f"{scheme}://example.com"
+    assert _tuples(Detector().find(text)) == [(0, len(text), text, text, False)]
+
+
+def test_registered_scheme_extends_authority_matching() -> None:
+    spans = Detector(schemes=["git"]).find("git://example.com")
+    assert _tuples(spans) == [(0, 17, "git://example.com", "git://example.com", False)]

--- a/tests/features/test_linkify.py
+++ b/tests/features/test_linkify.py
@@ -67,6 +67,16 @@ def _no_callbacks() -> list[Callback]:
             id="trailing-dot-trimmed",
         ),
         pytest.param(
+            "{scoped http://example.com/foo_bar}",
+            '{scoped <a href="http://example.com/foo_bar">http://example.com/foo_bar</a>}',
+            id="brace-scoped-url-trims-brace",
+        ),
+        pytest.param(
+            "'quoted http://example.com/foo_bar'",
+            "'quoted <a href=\"http://example.com/foo_bar\">http://example.com/foo_bar</a>'",
+            id="single-quoted-url-trims-apostrophe",
+        ),
+        pytest.param(
             "https://cdn_1.example.org/x",
             '<a href="https://cdn_1.example.org/x">https://cdn_1.example.org/x</a>',
             id="underscore-in-host-label-kept",
@@ -257,6 +267,7 @@ def test_bare_domain_path_with_embedded_scheme_keeps_http_prefix() -> None:
         pytest.param("view-source://example.com", False, False, [(0, 25, 0)], id="scheme-with-hyphen"),
         pytest.param("a.b://example.com", False, False, [(0, 17, 0)], id="scheme-with-dot"),
         pytest.param("nothttp//example.com", False, True, [(9, 20, 0)], id="no-colon-slash-slash-falls-to-bare"),
+        pytest.param("foo/example.com", False, True, [(4, 15, 0)], id="single-slash-keeps-bare-domain"),
         pytest.param("mailto:bob", False, False, [], id="scheme-without-slashes-no-match"),
         pytest.param(":no scheme here", False, False, [], id="leading-colon-no-scheme"),
         pytest.param("xhttp://example.com", False, False, [(0, 19, 0)], id="arbitrary-scheme-matches-like-bleach"),
@@ -303,6 +314,13 @@ def test_bare_domain_path_with_embedded_scheme_keeps_http_prefix() -> None:
         pytest.param("http://example.com/a[b]c", False, False, [(0, 24, 0)], id="balanced-square-in-path"),
         pytest.param("http://example.com/a)b", False, False, [(0, 20, 0)], id="unbalanced-round-stops"),
         pytest.param("http://example.com/a]b", False, False, [(0, 20, 0)], id="unbalanced-square-stops"),
+        pytest.param("http://example.com/a{b}c", False, False, [(0, 24, 0)], id="balanced-curly-in-path"),
+        pytest.param("http://example.com/a}b", False, False, [(0, 20, 0)], id="unbalanced-curly-stops"),
+        pytest.param(
+            "{http://example.com/foo_bar}", False, False, [(1, 27, 0)], id="brace-scoped-trailing-brace-trimmed"
+        ),
+        pytest.param("http://example.com/foo'", False, False, [(0, 22, 0)], id="trailing-apostrophe-trimmed"),
+        pytest.param("http://example.com/o'reilly", False, False, [(0, 27, 0)], id="apostrophe-mid-path-kept"),
         pytest.param("(http://example.com/path)", False, False, [(1, 24, 0)], id="link-in-parens"),
         pytest.param("http://example.com/path.", False, False, [(0, 23, 0)], id="path-trailing-dot-trimmed"),
         pytest.param("http://example.com/a,b,", False, False, [(0, 22, 0)], id="path-trailing-comma-trimmed"),
@@ -343,6 +361,34 @@ def test_scanner_spans(
     assert _linkify_scan(text, parse_email, bare_domains) == spans
 
 
+@pytest.mark.parametrize(
+    ("text", "url_schemes", "spans"),
+    [
+        pytest.param("http://example.com", ("http", "https", "ftp"), [(0, 18, 0)], id="allowed-scheme-matches"),
+        pytest.param("ftp://example.com/file", ("http",), [], id="scheme-not-in-allowlist-skipped"),
+        pytest.param("javascript://example.com", ("http", "https", "ftp"), [], id="javascript-scheme-excluded"),
+        pytest.param("HTTP://example.com", ("http",), [(0, 18, 0)], id="allowlist-is-case-insensitive"),
+        pytest.param("xhttp://example.com", (), [], id="empty-allowlist-matches-nothing"),
+    ],
+)
+def test_scanner_url_schemes_restrict_authority(
+    text: str,
+    url_schemes: tuple[str, ...],
+    spans: list[tuple[int, int, int]],
+) -> None:
+    # a non-None url_schemes tuple restricts scheme://host matching to that allowlist; omitting it matches any scheme
+    assert _linkify_scan(text, False, False, (), url_schemes) == spans  # noqa: FBT003  # positional-only C binding
+
+
+def test_scanner_omitting_url_schemes_matches_any_scheme() -> None:
+    assert _linkify_scan("xyzzy://example.com", False, False) == [(0, 19, 0)]  # noqa: FBT003  # positional C binding
+
+
 def test_scanner_rejects_non_str_text() -> None:
     with pytest.raises(TypeError):
         _linkify_scan(123, False, False)  # noqa: FBT003  # ty: ignore[invalid-argument-type]  # the C arg check is the point
+
+
+def test_scanner_rejects_non_tuple_url_schemes() -> None:
+    with pytest.raises(TypeError):
+        _linkify_scan("http://x.com", False, False, (), ["http"])  # noqa: FBT003  # ty: ignore[invalid-argument-type]

--- a/tests/features/test_linkify_detection.py
+++ b/tests/features/test_linkify_detection.py
@@ -49,9 +49,25 @@ def test_schemes_does_not_gate_bare_domains() -> None:
     assert out == 'see <a href="http://example.com">example.com</a>'
 
 
-def test_schemes_none_allows_every_scheme() -> None:
+def test_schemes_none_allows_the_builtin_default_set() -> None:
     out = linkify("ftp://x.com", Linkify(callbacks=_no_callbacks()))
     assert out == '<a href="ftp://x.com">ftp://x.com</a>'
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("javascript://example.com", id="javascript-scheme"),
+        pytest.param("xyzzy://foo.com", id="typo-scheme"),
+    ],
+)
+def test_schemes_none_rejects_an_unknown_scheme(text: str) -> None:
+    assert linkify(text, Linkify(callbacks=_no_callbacks())) == text
+
+
+def test_schemes_registers_a_custom_scheme() -> None:
+    out = linkify("git://example.com and http://x.com", Linkify(callbacks=_no_callbacks(), schemes=["git"]))
+    assert out == '<a href="git://example.com">git://example.com</a> and http://x.com'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A differential audit against `linkify-it-py` turned up two boundary defects in the `turbohtml.clean` link detector, each filed as its own issue.

A brace-scoped or single-quoted URL kept its closing delimiter in the `href`: `{http://example.com/foo_bar}` linked to `http://example.com/foo_bar}` and `'...foo_bar'` to `...foo_bar'`. 🔗 The tail scanner balanced `()` and `[]` so a Wikipedia URL keeps its trailing paren, but it ignored `{}` and never trimmed a trailing `'`. It now balances `{}` alongside the other pairs and treats a lone trailing `'` like the trailing punctuation it already drops, so a `/{id}` template path survives while a stray closer does not. This closes #405.

The detector also autolinked any `scheme://host`, including a typo like `hppt://` or a `javascript://` payload. `match_url` now checks the scheme against an allowlist: the built-in `http`/`https`/`ftp` set that `linkify-it` recognizes, plus any scheme a config registers. A `Detector`'s `schemes` extends that set, `Linkify.schemes` replaces it to keep bleach's restrict semantics, and the low-level scanner without an allowlist stays permissive. When `match_url` rejects an unknown scheme, its host no longer falls through to bare-domain detection, so `hppt://example.com` yields no link instead of linking a bare `example.com`. This closes #406.

The `Linkify` scheme filter moves out of the Python `_build_anchor` and into the C scan, so the whole scheme policy lives in one place, and `Linkify.schemes=None` now resolves to the `http`/`https`/`ftp` default rather than every scheme.
