### PR TITLE
🐛 fix(extract): URL normalization conformance

### DIFF
--- a/docs/changelog/377.bugfix.rst
+++ b/docs/changelog/377.bugfix.rst
@@ -1,0 +1,4 @@
+``clean_url`` returns ``None`` for a URL carrying a lone surrogate instead of raising ``UnicodeEncodeError``. The
+surrogate has no UTF-8 form, so the URL is not a fetchable web URL, and ``courlan`` decides the same. ``normalize_url``
+raises a ``ValueError`` naming the offending component rather than leaking the encode error, and both functions now
+raise ``TypeError`` for a non-``str`` argument.

--- a/docs/changelog/391.bugfix.rst
+++ b/docs/changelog/391.bugfix.rst
@@ -1,0 +1,4 @@
+``base_url`` and ``meta_refresh`` apply the WHATWG path, query, and fragment percent-encode sets to the resolved URL,
+so a non-ASCII character or a raw space serializes to its escaped form (``£`` becomes ``%C2%A3``) rather than leaving an
+invalid URL string. Relative resolution and dot-segment removal were already correct; only the final percent-encode step
+was missing.

--- a/docs/changelog/391.bugfix.rst
+++ b/docs/changelog/391.bugfix.rst
@@ -1,4 +1,4 @@
-``base_url`` and ``meta_refresh`` apply the WHATWG path, query, and fragment percent-encode sets to the resolved URL,
-so a non-ASCII character or a raw space serializes to its escaped form (``£`` becomes ``%C2%A3``) rather than leaving an
+``base_url`` and ``meta_refresh`` apply the WHATWG path, query, and fragment percent-encode sets to the resolved URL, so
+a non-ASCII character or a raw space serializes to its escaped form (``£`` becomes ``%C2%A3``) rather than leaving an
 invalid URL string. Relative resolution and dot-segment removal were already correct; only the final percent-encode step
 was missing.

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -35,6 +35,139 @@ static PyObject *url_join(PyObject *base, PyObject *target) {
     return joined;
 }
 
+/* The characters each URL component keeps raw, complementing the WHATWG percent-encode sets (URL standard 1.3): every
+   byte outside its set is UTF-8 percent-encoded. The three sets share the RFC 3986 unreserved run; the query set drops
+   ' (special-query set) and keeps `, the path set keeps neither, and the fragment set keeps ' but not `. */
+#define URL_ALPHA "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+#define URL_UNRESERVED URL_ALPHA "0123456789-._~"
+static const char URL_ALPHABET[] = URL_ALPHA;
+static const char URL_SCHEME_TAIL[] = URL_ALPHA "0123456789+-.";
+static const char URL_PATH_KEEP[] = URL_UNRESERVED "!$%&'()*+,/:;=@[\\]^|";
+static const char URL_QUERY_KEEP[] = URL_UNRESERVED "!$%&()*+,/:;=?@[\\]^`{|}";
+static const char URL_FRAGMENT_KEEP[] = URL_UNRESERVED "!#$%&'()*+,/:;=?@[\\]^{|}";
+
+/* memchr against a literal set, never a chained range test: clang inlines these into the encode loop, where an
+   ``a || b || c`` of byte ranges fractures the macOS branch gate (a NUL byte or the terminator never matches). */
+static int url_in_set(unsigned char byte, const char *set, size_t set_len) {
+    return memchr(set, byte, set_len) != NULL;
+}
+
+/* Append s[start:end], percent-encoding every byte outside `keep`; returns the new write offset. */
+static Py_ssize_t url_encode_span(char *out, Py_ssize_t at, const char *bytes, Py_ssize_t start, Py_ssize_t end,
+                                  const char *keep, size_t keep_len) {
+    static const char HEX[] = "0123456789ABCDEF";
+    for (Py_ssize_t index = start; index < end; index++) {
+        unsigned char byte = (unsigned char)bytes[index];
+        if (url_in_set(byte, keep, keep_len)) {
+            out[at++] = (char)byte;
+        } else {
+            out[at++] = '%';
+            out[at++] = HEX[byte >> 4];
+            out[at++] = HEX[byte & 0x0F];
+        }
+    }
+    return at;
+}
+
+/* Replace any lone surrogate with U+FFFD, the scalar-value substitution the URL parser's input goes through (Web IDL
+   USVString), so the UTF-8 encode below cannot fail. Returns a new reference, the original when it is already scalar.
+ */
+static PyObject *url_scalarize(PyObject *url) {
+    int kind = PyUnicode_KIND(url);
+    const void *data = PyUnicode_DATA(url);
+    Py_ssize_t len = PyUnicode_GET_LENGTH(url);
+    Py_ssize_t index = 0;
+    while (index < len) {
+        Py_UCS4 point = PyUnicode_READ(kind, data, index);
+        if (point >= 0xD800 && point <= 0xDFFF) {
+            break;
+        }
+        index++;
+    }
+    if (index == len) {
+        return Py_NewRef(url); /* the common case: no surrogate, so no copy */
+    }
+    Py_UCS4 *buffer = PyMem_Malloc((size_t)len * sizeof(Py_UCS4));
+    if (buffer == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    for (Py_ssize_t at = 0; at < len; at++) {
+        Py_UCS4 point = PyUnicode_READ(kind, data, at);
+        buffer[at] = (point >= 0xD800 && point <= 0xDFFF) ? 0xFFFD : point;
+    }
+    PyObject *scalar = ucs4_to_str(buffer, len);
+    PyMem_Free(buffer);
+    return scalar; /* NULL on the excluded allocation-failure path */
+}
+
+/* Percent-encode a resolved URL's path, query, and fragment per the WHATWG sets, leaving the scheme and authority
+   verbatim; the authority's own bytes stay raw, matching this surface's non-IDNA host handling. Returns a new str. */
+static PyObject *url_percent_encode(PyObject *url) {
+    PyObject *scalar = url_scalarize(url);
+    if (scalar == NULL) { /* GCOVR_EXCL_BR_LINE: url_scalarize only fails on allocation */
+        return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    Py_ssize_t len;
+    const char *bytes = PyUnicode_AsUTF8AndSize(scalar, &len);
+    if (bytes == NULL) {   /* GCOVR_EXCL_BR_LINE: a scalarized string always UTF-8 encodes */
+        Py_DECREF(scalar); /* GCOVR_EXCL_LINE: encode-failure path */
+        return NULL;       /* GCOVR_EXCL_LINE: encode-failure path */
+    }
+    Py_ssize_t cursor = 0;
+    /* bytes is NUL-terminated, so bytes[0] on an empty URL reads the terminator and matches nothing */
+    if (url_in_set((unsigned char)bytes[0], URL_ALPHABET, sizeof(URL_ALPHABET) - 1)) {
+        Py_ssize_t scan = 1;
+        while (scan < len && url_in_set((unsigned char)bytes[scan], URL_SCHEME_TAIL, sizeof(URL_SCHEME_TAIL) - 1)) {
+            scan++;
+        }
+        if (scan < len && bytes[scan] == ':') {
+            cursor = scan + 1; /* a scheme runs from an alpha up to its ':' */
+        }
+    }
+    if (cursor + 1 < len && bytes[cursor] == '/' && bytes[cursor + 1] == '/') {
+        cursor += 2;
+        while (cursor < len && bytes[cursor] != '/' && bytes[cursor] != '?' && bytes[cursor] != '#') {
+            cursor++;
+        }
+    }
+    Py_ssize_t prefix_end = cursor;
+    while (cursor < len && bytes[cursor] != '?' && bytes[cursor] != '#') {
+        cursor++;
+    }
+    Py_ssize_t path_end = cursor;
+    Py_ssize_t query_start = -1;
+    if (cursor < len && bytes[cursor] == '?') {
+        query_start = ++cursor;
+        while (cursor < len && bytes[cursor] != '#') {
+            cursor++;
+        }
+    }
+    Py_ssize_t query_end = cursor;
+    Py_ssize_t fragment_start = cursor < len ? cursor + 1 : -1;
+    char *out = PyMem_Malloc((size_t)len * 3 + 1); /* every byte encodes to at most "%HH" */
+    if (out == NULL) {     /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(scalar); /* GCOVR_EXCL_LINE: allocation-failure path */
+        return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    memcpy(out, bytes, (size_t)prefix_end); /* the scheme and authority pass through unchanged */
+    Py_ssize_t written =
+        url_encode_span(out, prefix_end, bytes, prefix_end, path_end, URL_PATH_KEEP, sizeof(URL_PATH_KEEP) - 1);
+    if (query_start >= 0) {
+        out[written++] = '?';
+        written =
+            url_encode_span(out, written, bytes, query_start, query_end, URL_QUERY_KEEP, sizeof(URL_QUERY_KEEP) - 1);
+    }
+    if (fragment_start >= 0) {
+        out[written++] = '#';
+        written =
+            url_encode_span(out, written, bytes, fragment_start, len, URL_FRAGMENT_KEEP, sizeof(URL_FRAGMENT_KEEP) - 1);
+    }
+    PyObject *result = PyUnicode_DecodeUTF8(out, written, "strict");
+    PyMem_Free(out);
+    Py_DECREF(scalar);
+    return result; /* NULL on the excluded decode-failure path */
+}
+
 /* The value of `node`'s `name` attribute as a new str reference (the empty string when valueless), or NULL when the
    attribute is absent (or, on the excluded allocation-failure path, with an error set). */
 static PyObject *element_attr_str(th_tree *tree, th_node *node, const char *name, Py_ssize_t name_len) {
@@ -142,9 +275,15 @@ static PyObject *parse_meta_refresh(PyObject *content, PyObject *fallback) {
                 Py_DECREF(delay); /* GCOVR_EXCL_LINE */
                 return NULL;      /* GCOVR_EXCL_LINE */
             }
-            url = url_join(fallback, raw);
+            PyObject *joined = url_join(fallback, raw);
             Py_DECREF(raw);
-            if (url == NULL) {    /* GCOVR_EXCL_BR_LINE: url_join only fails on the import path */
+            if (joined == NULL) { /* GCOVR_EXCL_BR_LINE: url_join only fails on the import path */
+                Py_DECREF(delay); /* GCOVR_EXCL_LINE */
+                return NULL;      /* GCOVR_EXCL_LINE */
+            }
+            url = url_percent_encode(joined);
+            Py_DECREF(joined);
+            if (url == NULL) {    /* GCOVR_EXCL_BR_LINE: url_percent_encode only fails on allocation */
                 Py_DECREF(delay); /* GCOVR_EXCL_LINE */
                 return NULL;      /* GCOVR_EXCL_LINE */
             }
@@ -203,7 +342,14 @@ static PyObject *document_base_url(PyObject *self, PyObject *args, PyObject *kwa
         Py_DECREF(fallback); /* GCOVR_EXCL_LINE */
         return NULL;         /* GCOVR_EXCL_LINE */
     }
-    PyObject *result = PyUnicode_GET_LENGTH(stripped) == 0 ? Py_NewRef(fallback) : url_join(fallback, stripped);
+    PyObject *result;
+    if (PyUnicode_GET_LENGTH(stripped) == 0) {
+        result = Py_NewRef(fallback); /* a blank href leaves the fallback as the base */
+    } else {
+        PyObject *joined = url_join(fallback, stripped);
+        result = joined == NULL ? NULL : url_percent_encode(joined); /* GCOVR_EXCL_BR_LINE: import-only failure */
+        Py_XDECREF(joined);
+    }
     Py_DECREF(stripped);
     Py_DECREF(fallback);
     return result;

--- a/src/turbohtml/_urls.py
+++ b/src/turbohtml/_urls.py
@@ -177,7 +177,11 @@ def clean_url(url: str, options: UrlCleaning | None = None, /) -> str | None:
     :param url: the URL as found in the wild.
     :param options: the cleaning options; defaults to :class:`UrlCleaning` (drop trackers, keep slash and fragment).
     :returns: the cleaned, normalized URL, or ``None`` for anything that is not a fetchable web URL.
+    :raises TypeError: if ``url`` is not a ``str``.
     """
+    if not isinstance(url, str):
+        msg = f"url must be a str, got {type(url).__name__}"
+        raise TypeError(msg)
     active = options or _DEFAULT
     scrubbed = _scrub(url)
     try:
@@ -189,7 +193,10 @@ def clean_url(url: str, options: UrlCleaning | None = None, /) -> str | None:
         return None
     if active.language is not None and not _language_matches(parts, active.language, strict=active.strict):
         return None
-    return _normalize(parts, active)
+    try:
+        return _normalize(parts, active)
+    except ValueError:
+        return None  # an unencodable component (a lone surrogate) is not a fetchable URL, as courlan also decides
 
 
 def normalize_url(url: str, options: UrlCleaning | None = None, /) -> str:
@@ -208,8 +215,13 @@ def normalize_url(url: str, options: UrlCleaning | None = None, /) -> str:
     :param url: an absolute or relative URL; a relative one keeps its shape, only its components are normalized.
     :param options: the cleaning options; defaults to :class:`UrlCleaning` (drop trackers, keep slash and fragment).
     :returns: the normalized URL.
-    :raises ValueError: if the URL cannot be split into components (e.g. an unclosed IPv6 bracket).
+    :raises TypeError: if ``url`` is not a ``str``.
+    :raises ValueError: if the URL cannot be split into components (e.g. an unclosed IPv6 bracket) or carries a
+        character that cannot be percent-encoded (a lone surrogate).
     """
+    if not isinstance(url, str):
+        msg = f"url must be a str, got {type(url).__name__}"
+        raise TypeError(msg)
     return _normalize(urlsplit(url), options or _DEFAULT)
 
 
@@ -355,7 +367,14 @@ def _ascii_host(host: str) -> str:
 def _encode(text: str, unsafe: re.Pattern[str], safe: str) -> str:
     """Percent-encode a component's out-of-set characters, uppercasing escape hex, skipping already-clean input."""
     text = _uppercase_escapes(text)
-    return quote(text, safe=safe) if unsafe.search(text) else text
+    if not unsafe.search(text):
+        return text
+    try:
+        return quote(text, safe=safe)
+    except UnicodeEncodeError as exc:
+        # quote() UTF-8-encodes the component; a lone surrogate has no encoding, so the URL is not serializable
+        msg = f"URL component {text!r} has a character that cannot be percent-encoded: {exc.reason}"
+        raise ValueError(msg) from exc
 
 
 def _uppercase_escapes(text: str) -> str:

--- a/tests/features/test_extract_urls_clean.py
+++ b/tests/features/test_extract_urls_clean.py
@@ -101,6 +101,26 @@ def test_clean_strict_checks_language_subdomains(url: str, expected: str | None)
     assert clean_url(url, UrlCleaning(strict=True, language="en")) == expected
 
 
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        pytest.param("http://a.com/\udce9", None, id="surrogate-in-path"),
+        pytest.param("http://a.com/p?q=\udce9", None, id="surrogate-in-query"),
+        pytest.param("http://a.com/p#\udce9", None, id="surrogate-in-fragment"),
+        pytest.param("http://\udce9.com/", "http://\udce9.com/", id="surrogate-in-host-survives"),
+    ],
+)
+def test_clean_handles_lone_surrogates(url: str, expected: str | None) -> None:
+    # an unencodable URL is not fetchable, so clean_url returns None (as courlan does) rather than raising; a
+    # surrogate in the host never reaches the percent-encoder, so that URL still cleans
+    assert clean_url(url) == expected
+
+
+def test_clean_rejects_non_str() -> None:
+    with pytest.raises(TypeError, match="url must be a str"):
+        clean_url(123)  # ty: ignore[invalid-argument-type]  # a non-str exercises the TypeError guard
+
+
 def test_default_options_shared_across_calls() -> None:
     assert clean_url("https://example.org/x?utm_source=a") == clean_url(
         "https://example.org/x?utm_source=a", UrlCleaning()

--- a/tests/features/test_extract_urls_normalize.py
+++ b/tests/features/test_extract_urls_normalize.py
@@ -133,6 +133,17 @@ def test_normalize_rejects_unsplittable_input() -> None:
         normalize_url("http://[::1/x")
 
 
+def test_normalize_rejects_lone_surrogate() -> None:
+    # a lone surrogate has no UTF-8 form, so the component cannot be percent-encoded and the URL is not serializable
+    with pytest.raises(ValueError, match="cannot be percent-encoded"):
+        normalize_url("http://a.com/\udce9")
+
+
+def test_normalize_rejects_non_str() -> None:
+    with pytest.raises(TypeError, match="url must be a str"):
+        normalize_url(123)  # ty: ignore[invalid-argument-type]  # a non-str exercises the TypeError guard
+
+
 @pytest.mark.parametrize(
     "options",
     [

--- a/tests/features/test_url.py
+++ b/tests/features/test_url.py
@@ -23,6 +23,35 @@ def test_base_url_default_fallback() -> None:
     assert parse('<base href="page">').base_url() == "page"
 
 
+@pytest.mark.parametrize(
+    ("href", "fallback", "expected"),
+    [
+        pytest.param(
+            "http://example.org/sterling£", "https://example.org", "http://example.org/sterling%C2%A3", id="latin1-path"
+        ),
+        pytest.param(
+            "http://x/p q?a=b c&e=f'#h i",
+            "http://x",
+            "http://x/p%20q?a=b%20c&e=f%27#h%20i",
+            id="all-components-encoded",
+        ),
+        pytest.param("http://h?a=b c", "http://x", "http://h?a=b%20c", id="authority-then-query"),
+        pytest.param("http://h#f g", "http://x", "http://h#f%20g", id="authority-then-fragment"),
+        pytest.param("http://h/p#f g", "http://x", "http://h/p#f%20g", id="fragment-without-query"),
+        pytest.param("http://h", "http://x", "http://h", id="authority-only"),
+        pytest.param("ab/cd", "", "ab/cd", id="relative-without-scheme"),
+        pytest.param("/x", "", "/x", id="protocol-relative-root"),
+        pytest.param("http://x/a%20b?c=%7e", "http://x", "http://x/a%20b?c=%7e", id="existing-escapes-untouched"),
+        pytest.param(
+            "rel", "http://x/\U0001f389\udce9/", "http://x/%F0%9F%8E%89%EF%BF%BD/rel", id="high-char-and-surrogate"
+        ),
+    ],
+)
+def test_base_url_percent_encodes(href: str, fallback: str, expected: str) -> None:
+    # the resolved base URL applies the WHATWG path/query/fragment percent-encode sets, so it is a valid URL string
+    assert parse(f'<base href="{href}">').base_url(fallback) == expected
+
+
 _SITE = "http://s.com/"
 
 
@@ -34,8 +63,9 @@ _SITE = "http://s.com/"
         pytest.param("2.5;url=x", (2.5, _SITE + "x"), id="float-delay"),
         pytest.param("2.5", (2.5, _SITE), id="float-delay-only"),
         pytest.param("5;url=", (5.0, _SITE), id="url-prefix-empty-value"),
-        pytest.param("5;url=€page", (5.0, _SITE + "€page"), id="two-byte-url"),
-        pytest.param("5;url=\U0001f389", (5.0, _SITE + "\U0001f389"), id="four-byte-url"),
+        pytest.param("5;url=£x", (5.0, _SITE + "%C2%A3x"), id="two-byte-utf8-encoded"),
+        pytest.param("5;url=€page", (5.0, _SITE + "%E2%82%ACpage"), id="three-byte-utf8-encoded"),
+        pytest.param("5;url=\U0001f389", (5.0, _SITE + "%F0%9F%8E%89"), id="four-byte-utf8-encoded"),
         pytest.param("  7 ; url = y ", (7.0, _SITE + "y"), id="surrounding-whitespace"),
         pytest.param("3;url='q'", (3.0, _SITE + "q"), id="single-quoted-url"),
         pytest.param("8, z", (8.0, _SITE + "z"), id="comma-separator-no-prefix"),
@@ -48,6 +78,7 @@ _SITE = "http://s.com/"
         pytest.param("6;", (6.0, _SITE), id="separator-without-url"),
         pytest.param("2;ab", (2.0, _SITE + "ab"), id="short-url-after-separator"),
         pytest.param("0;url='unbalanced", (0.0, _SITE + "'unbalanced"), id="unbalanced-quote-kept"),
+        pytest.param("0;url=a:b", (0.0, "a:b"), id="opaque-scheme-no-authority"),
     ],
 )
 def test_meta_refresh_content(content: str, expected: tuple[float, str]) -> None:


### PR DESCRIPTION
`turbohtml.extract.clean_url` documents a `str | None` contract and swallows scraped junk, yet a URL decoded elsewhere with `errors="surrogateescape"` carrying a lone surrogate in its path, query, or fragment raised `UnicodeEncodeError` out of `quote()` rather than returning `None` (`#377`). A migrant leaning on `courlan.clean_url`, which returns `None` on the same input, got a crash instead. A related gap sat one surface over: `base_url()` and `meta_refresh()` handed back the resolved URL without percent-encoding, so a `<base href>` or refresh target holding a non-ASCII character or a raw space yielded an invalid URL string (`#391`).

`clean_url` now returns `None` for an unencodable component, treating it as not fetchable the way `courlan` does, while `normalize_url` raises a `ValueError` that names the offending component instead of leaking the encode error. Both reject a non-`str` argument with `TypeError`. 🔗 For the resolution surface, `base_url` and `meta_refresh` route the joined URL through a new C percent-encoder that applies the WHATWG path, query, and fragment percent-encode sets, keeps the scheme and authority verbatim, and folds a lone surrogate to U+FFFD the way the URL parser's USVString input does. The encoder walks the UTF-8 bytes and leaves existing `%XX` escapes alone, so `£` serializes to `%C2%A3` and a raw space to `%20`.

Relative resolution and dot-segment removal already matched the standard, so only the final serialize step moved. The `:raises:` notes on both public functions now cover the new `TypeError` and `ValueError` behavior.

closes #377
closes #391
