### PR TITLE
🐛 fix(clean): minify optional-end-tag omission

### DIFF
--- a/docs/changelog/412.bugfix.rst
+++ b/docs/changelog/412.bugfix.rst
@@ -1,0 +1,5 @@
+:func:`turbohtml.clean.minify` and the :class:`~turbohtml.Minify` serializer layout now keep the ``</rt>``, ``</rp>``,
+and ``</optgroup>`` end tags when the element is not inside the ancestor whose scope the parser needs to imply their
+close (``<ruby>`` for ``rt``/``rp``, ``<select>`` for ``optgroup``). Outside that scope a following ``rt``/``rp``/
+``optgroup`` start tag reparents into the element instead of closing it, so omitting the end tag reparsed to a different
+tree and broke the round-trip invariant.

--- a/src/turbohtml/_c/serialize/minify.c
+++ b/src/turbohtml/_c/serialize/minify.c
@@ -252,6 +252,25 @@ static int mini_starts_with_ws(th_tree *tree, th_node *node) {
     return node->type == TH_NODE_TEXT && node->text_len > 0 && mini_is_ascii_ws(need_text(tree, node)[0]);
 }
 
+/* Whether node lies within an html <atom> ancestor the parser would have "in scope",
+   walking the parent chain the way has_in_scope walks the open stack: an html scoping
+   element or any foreign ancestor bounds the search. rt/rp only imply-close a preceding
+   sibling inside a ruby, optgroup only inside a select; outside that scope a following
+   rt/rp/optgroup start tag reparents into the element instead, so its end tag must stay.
+   node itself is never a boundary (it is one of rt/rp/optgroup), so the walk starts at
+   its parent, which the caller's node != root guard keeps non-NULL. */
+static int mini_in_scope(const th_node *node, uint16_t atom) {
+    for (const th_node *up = node->parent; up->type == TH_NODE_ELEMENT; up = up->parent) {
+        if (up->ns == TH_NS_HTML && up->atom == atom) {
+            return 1;
+        }
+        if (up->ns != TH_NS_HTML || (up->tag_flags & TH_TAG_SCOPING)) {
+            return 0;
+        }
+    }
+    return 0;
+}
+
 /* The WHATWG optional-tag rule for node's end tag, evaluated against next (the next
    content sibling, stripped comments already skipped). This is the cheap test; the
    formatting-reconstruction guard is applied separately so its rightmost-path walk
@@ -272,9 +291,9 @@ static int mini_end_tag_rule(th_tree *tree, th_node *node, th_node *next) {
         return na == TH_TAG_DD || na == TH_TAG_DT || last;
     case TH_TAG_RT:
     case TH_TAG_RP:
-        return na == TH_TAG_RT || na == TH_TAG_RP || last;
+        return ((na == TH_TAG_RT || na == TH_TAG_RP) && mini_in_scope(node, TH_TAG_RUBY)) || last;
     case TH_TAG_OPTGROUP:
-        return na == TH_TAG_OPTGROUP || last;
+        return (na == TH_TAG_OPTGROUP && mini_in_scope(node, TH_TAG_SELECT)) || last;
     case TH_TAG_OPTION:
         return na == TH_TAG_OPTION || na == TH_TAG_OPTGROUP || last;
     case TH_TAG_THEAD:

--- a/tests/serialize/test_minify.py
+++ b/tests/serialize/test_minify.py
@@ -217,6 +217,8 @@ def test_keep_comment_when_off() -> None:
         pytest.param("<ruby>a<rt>b</rt><rt>c</rt></ruby>", "<ruby>a<rt>b<rt>c</ruby>", id="rt-before-rt"),
         pytest.param("<ruby>a<rt>b</rt><rp>c</rp></ruby>", "<ruby>a<rt>b<rp>c</ruby>", id="rt-before-rp"),
         pytest.param("<ruby>a<rt>b</rt></ruby>", "<ruby>a<rt>b</ruby>", id="rt-last"),
+        pytest.param("<rt>a</rt><rt>b</rt>", "<rt>a</rt><rt>b", id="rt-before-rt-outside-ruby-kept"),
+        pytest.param("<rt>a</rt><rp>b</rp>", "<rt>a</rt><rp>b", id="rt-before-rp-outside-ruby-kept"),
         pytest.param(
             "<select><optgroup><option>a</option></optgroup><optgroup><option>b</option></optgroup></select>",
             "<select><optgroup><option>a<optgroup><option>b</select>",
@@ -226,6 +228,11 @@ def test_keep_comment_when_off() -> None:
             "<select><optgroup><option>a</option></optgroup></select>",
             "<select><optgroup><option>a</select>",
             id="optgroup-last",
+        ),
+        pytest.param(
+            "<optgroup>a</optgroup><optgroup>b</optgroup>",
+            "<optgroup>a</optgroup><optgroup>b",
+            id="optgroup-before-optgroup-outside-select-kept",
         ),
         pytest.param(
             "<select><option>a</option><option>b</option></select>",
@@ -276,6 +283,36 @@ def test_keep_comment_when_off() -> None:
 )
 def test_omit_end_tags(source: str, expected: str) -> None:
     assert frag(source, strip_comments=False) == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        pytest.param("<rt></rt><rp>x</rp>", "<rt></rt><rp>x", id="rt-before-rp-in-body"),
+        pytest.param(
+            "<optgroup></optgroup><optgroup>x</optgroup>", "<optgroup></optgroup><optgroup>x", id="optgroup-in-body"
+        ),
+        pytest.param(
+            "<ruby><svg><foreignObject><rt></rt><rp>x</rp></foreignObject></svg></ruby>",
+            "<ruby><svg><foreignObject><rt></rt><rp>x</foreignObject></svg></ruby>",
+            id="rt-across-integration-point",
+        ),
+        pytest.param(
+            "<template><rt></rt><rt>b</rt></template>",
+            "<template><rt></rt><rt>b</template>",
+            id="rt-in-template-content",
+        ),
+    ],
+)
+def test_omit_keeps_end_tag_outside_required_ancestor(source: str, expected: str) -> None:
+    # rt/rp imply-close only inside a ruby, optgroup only inside a select; outside that
+    # scope -- directly in <body>, split from the ruby by an SVG integration point, or as
+    # a direct child of a template's content fragment -- the following start tag reparents
+    # into the element, so the end tag must survive.
+    once = parse(source).serialize(Html(layout=Minify()))
+    assert once == expected
+    assert parse(once).html == parse(source).html
+    assert parse(once).serialize(Html(layout=Minify())) == once
 
 
 def test_omit_keeps_p_end_inside_formatting() -> None:


### PR DESCRIPTION
A differential audit against minify-html surfaced a miscompile in `turbohtml.clean.minify`: it dropped `</rt>`, `</rp>`, and `</optgroup>` whenever the following sibling was a matching start tag. 🐛 The parser only implies the close of these elements inside a required ancestor, `ruby` for `rt`/`rp` and `select` for `optgroup`. Outside that scope the following sibling reparents inside the element, so `<rt></rt><rp>x</rp>` minified to `<rt><rp>x` and reparsed to a nested tree, breaking the round-trip invariant `parse(minify(x)) == parse(x)`. An SVG or MathML integration point between the element and its ancestor breaks the parser's scope the same way, so a plain ancestor check would still drop the tag and miscompile.

The fix gates the `rt`/`rp`/`optgroup` following-sibling omission on a new `mini_in_scope` helper that walks the parent chain the way the parser's `has_in_scope` walks the open stack, stopping at an html scoping element or any foreign ancestor. ✨ The "no more content in the parent" case stays unconditional, since the parent's own close still runs generate-implied-end-tags there and reconstructs the element. The check runs only after the cheap following-sibling test already matched, so it stays a per-element condition rather than a second walk.

closes #412
