### PR TITLE
👷 ci(bench): stabilize noise-prone CodSpeed benchmarks on real corpora

### DIFF
--- a/docs/changelog/455.misc.rst
+++ b/docs/changelog/455.misc.rst
@@ -1,0 +1,4 @@
+Stabilize the noise-prone CodSpeed benchmarks by re-homing the operations whose inline case was too small to clear
+Valgrind's heap-layout jitter floor. The document and text operations now run on the 235 kB whatwg spec, the markup ones
+on a War-and-Peace slice. Each registers under a new corpus-qualified benchmark id, so the flaky small identity retires
+and the large one is gated in its place. The ``pyperf`` competitor suite and the ``OPERATIONS`` registry are unchanged.

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -8,6 +8,10 @@ stylesheet and JS library for the minifiers, and the bench's own inline cases fo
 the operation list and the corpus, so a new operation added to ``OPERATIONS`` is benchmarked here automatically. The
 loaders are lazy so the corpus is read only when a benchmark runs (under ``--codspeed``); a case whose corpus is missing
 raises, and the test skips it.
+
+Operations whose inline case is too small to clear Valgrind's heap-jitter floor are re-homed on a large real corpus and
+surfaced under a corpus-qualified benchmark id (see :data:`_RESIZED`), so the noise-prone identity retires and a stable
+one takes its place without CodSpeed reading the input change as a regression.
 """
 
 from __future__ import annotations
@@ -78,20 +82,70 @@ _LOADERS["minify-css"] = partial(corpus.large_text, *corpus.STYLESHEETS[1][1:]) 
 _LOADERS["minify-js"] = partial(corpus.large_text, *corpus.JS_FILES[0][1:])  # underscore (67 kB)
 
 
+def _spec_case(kind: str) -> tuple[str, str]:
+    """Wrap the spec in the ``(kind, document)`` pair a tuple-shaped operation expects."""
+    return kind, _spec()
+
+
+def _book_text() -> str:
+    """Return a War-and-Peace plain-text slice: the string operations' large real input."""
+    return corpus.corpus("war-and-peace/2600.txt", _TEXT_BYTES)
+
+
+def _book_html() -> str:
+    """Return a War-and-Peace HTML slice: the markup operations' large real input."""
+    return corpus.corpus("war-and-peace/2600-h/2600-h.htm", _TEXT_BYTES)
+
+
+# An inline case is too few instructions under Valgrind to clear the heap-layout jitter floor, so it swings >5%
+# run-to-run (text-main and boilerplate tripped the required CodSpeed check on unrelated PRs). Re-home each on a large
+# real corpus under a new corpus-qualified id: the flaky small id retires with no base and the large one is gated
+# fresh, so the input change never reads as a regression. The synthetic tree builders, the fragment parser, the
+# single-selector translate, and the fixed URL batch have no document corpus to grow into and stay inline.
+_RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
+    "socialcard": ("socialcard-spec", _spec),
+    "structured": ("structured-spec", _spec),
+    "sanitize": ("sanitize-spec", _spec),
+    "linkify": ("linkify-spec", _spec),
+    "markdown-google": ("markdown-google-spec", _spec),
+    "article": ("article-spec", _spec),
+    "boilerplate": ("boilerplate-spec", _spec),
+    "date": ("date-spec", _spec),
+    "text-render": ("text-render-spec", _spec),
+    "text-collapsed": ("text-collapsed-spec", _spec),
+    "text-main": ("text-main-spec", _spec),
+    "text-annotated": ("text-annotated-spec", _spec),
+    "markdown": ("markdown-spec", partial(_spec_case, "default")),
+    "tables": ("tables-spec", partial(_spec_case, "rows")),
+    "extract-url": ("extract-url-spec", partial(_spec_case, "base")),
+    "markup": ("markup-book", _book_text),
+    "markup-op": ("markup-op-book", lambda: ("striptags", _book_html())),
+    "detect": ("detect-book", lambda: ("find", _book_text())),
+}
+
+
 def _inline(operation: str) -> object:
     """Return the first case the bench already defines inline for ``operation`` (no corpus needed)."""
     return INPUTS[operation]()[0][1]
 
 
 def loader_for(operation: str) -> Callable[[], object]:
-    """Return the lazy loader for ``operation``: a real corpus reader, or the bench's own inline case."""
+    """Return the lazy loader for ``operation``: a resized real corpus, the spec, or the bench's own inline case."""
+    if operation in _RESIZED:
+        return _RESIZED[operation][1]
     return _LOADERS.get(operation, partial(_inline, operation))
 
 
 def benchmarks() -> Iterator[tuple[str, object, Callable[[], object]]]:
-    """Yield ``(name, callable, load)`` for every turbohtml operation, in registry order."""
+    """
+    Yield ``(name, callable, load)`` for every turbohtml operation, in registry order.
+
+    A noise-prone inline operation is surfaced under its corpus-qualified id (see :data:`_RESIZED`) so CodSpeed
+    retires the flaky small-input benchmark and gates the large-input one as a fresh identity.
+    """
     for name, (run, _owner) in OPERATIONS.items():
-        yield name, run, loader_for(name)
+        identity = _RESIZED[name][0] if name in _RESIZED else name
+        yield identity, run, loader_for(name)
 
 
 __all__ = [


### PR DESCRIPTION
A CodSpeed benchmark whose operation has no corpus loader falls through to the bench's own inline snippet of 0.1 to 16 kB. Under Valgrind that snippet runs too few instructions to clear the heap-layout jitter floor, so the benchmark swings over 5% run-to-run, and `text-main` and `boilerplate` have already tripped the required `CodSpeed Performance Analysis` check on unrelated PRs. 👷 This carries on from the runner-pinning fix in #383, which removed the cross-CPU component of the same noise.

This PR re-homes each noise-prone operation on a large real corpus, the same corpora the already-quiet spec-based benchmarks share. The document, extraction, and text operations (`socialcard`, `structured`, `sanitize`, `linkify`, `markdown`, `markdown-google`, `tables`, `extract-url`, `article`, `boilerplate`, `date`, `text-render`, `text-collapsed`, `text-main`, `text-annotated`) run on the 235 kB whatwg spec. The string operations (`markup`, `markup-op`, `detect`) run on a 64 kB War-and-Peace slice. The synthetic tree builders (`build`, `construct`, `emit`), the fragment parser, the single-selector `translate`, and the fixed URL batch have no document corpus to grow into and stay inline.

Changing an existing benchmark's input would shift its baseline and CodSpeed would read the shift as a regression. So each resized benchmark registers under a new corpus-qualified id: `text-main` becomes `text-main-spec`, `markup` becomes `markup-book`, and so on. CodSpeed retires the old flaky id with no base and gates the new id fresh with no base, so this PR's own check reports zero regressions. 🟢 Only the benchmark identity and input in `tools/bench/ci.py` change; the `OPERATIONS` registry and the `pyperf` competitor suite in `tools/bench` stay as they were.

Per-iteration compute for the resized benchmarks, measured in walltime as the best of many warm runs, rises with the input:

| benchmark | before (inline) | after (corpus) |
| --- | --- | --- |
| `markup` -> `markup-book` | 0.04 µs | 23 µs |
| `markup-op` -> `markup-op-book` | 1.3 µs | 370 µs |
| `text-render` -> `text-render-spec` | 2.1 µs | 327 µs |
| `text-main` -> `text-main-spec` | 4.5 µs | 846 µs |
| `boilerplate` -> `boilerplate-spec` | 29 µs | 3.4 ms |
| `date` -> `date-spec` | 10 µs | 58 ms |

The input grows 15 to 2000 times and the instruction count rises with it, past the floor where the already-stable spec ops such as `find` and `select` stay quiet. Valgrind instruction counts are deterministic, so the green CodSpeed check on this PR is the floor proof.
