### PR TITLE
🐛 fix(build): reject invalid attribute names and void-element children

### DIFF
--- a/docs/changelog/413.bugfix.rst
+++ b/docs/changelog/413.bugfix.rst
@@ -1,0 +1,4 @@
+:class:`turbohtml.build.ElementMaker` (the ``E`` builder) and the :class:`~turbohtml.Element` constructor now reject an
+attribute name carrying ``<`` with :exc:`ValueError`, alongside the whitespace, ``=`` and quote characters they already
+refused. ``<`` in an attribute name is an unexpected-character-in-attribute-name parse error, so a name keeping it
+reparses differently and serializes non-conforming markup. The message names the offending attribute and character.

--- a/docs/changelog/414.bugfix.rst
+++ b/docs/changelog/414.bugfix.rst
@@ -1,0 +1,4 @@
+:class:`turbohtml.build.ElementMaker` (the ``E`` builder) now raises :exc:`ValueError` when children are passed to a
+void element such as ``br`` or ``img``, instead of storing them for the serializer to silently drop. A void element
+takes no content, so the discarded children vanished with no trace; the error names the void tag and surfaces the
+mistake at construction time.

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -2606,9 +2606,14 @@ PyObject *node_strip_tags(PyObject *self, PyObject *arg) {
 PyDoc_STRVAR(element_doc, "An element node: a tag, a namespace, attributes, and child nodes.\n\n"
                           ":param tag: the tag name.\n"
                           ":param attrs: initial attributes; a list value sets a token-list attribute and\n"
-                          "    None a valueless one.");
+                          "    None a valueless one.\n"
+                          ":param children: initial child nodes, appended in order.\n"
+                          ":raises ValueError: if the tag or an attribute name carries a character HTML\n"
+                          "    forbids there, or if children are given for a void element.");
 
 static PyObject *element_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
+
+static int append_build_children(PyObject *element, PyObject *tag, PyObject *children);
 
 static PyObject *element_append(PyObject *self, PyObject *child);
 
@@ -3193,8 +3198,10 @@ PyType_Spec element_spec = {
 
 /* Reject a tag or attribute name the HTML spec forbids, the way DOM
    createElement / setAttribute raise InvalidCharacterError: empty, or carrying
-   whitespace, a control, "/" or ">" (none of which round-trip), plus "<" in a
-   tag name and "=" or a quote in an attribute name. */
+   whitespace, a control, "/", ">" or "<" (none of which round-trip through the
+   tokenizer), plus "=" or a quote in an attribute name. "<" is rejected in an
+   attribute name too: it is an unexpected-character-in-attribute-name parse
+   error, so a name carrying it reparses differently and is non-conforming. */
 static int validate_name(PyObject *name, int is_attr) {
     Py_ssize_t len = PyUnicode_GET_LENGTH(name);
     if (len == 0) {
@@ -3205,13 +3212,13 @@ static int validate_name(PyObject *name, int is_attr) {
     const void *data = PyUnicode_DATA(name);
     for (Py_ssize_t index = 0; index < len; index++) {
         Py_UCS4 character = PyUnicode_READ(kind, data, index);
-        int bad = character <= ' ' || character == '/' || character == '>' ||
-                  (is_attr ? (character == '=' || character == '"' || character == '\'') : character == '<');
+        int bad = character <= ' ' || character == '/' || character == '>' || character == '<' ||
+                  (is_attr && (character == '=' || character == '"' || character == '\''));
         if (bad) {
             PyObject *ch = PyUnicode_FromOrdinal((int)character);
             if (ch != NULL) { /* GCOVR_EXCL_BR_LINE: a forbidden character is ASCII and always builds */
-                PyErr_Format(PyExc_ValueError, "%s name contains an invalid character: %R",
-                             is_attr ? "attribute" : "tag", ch);
+                PyErr_Format(PyExc_ValueError, "%s name %R contains an invalid character: %R",
+                             is_attr ? "attribute" : "tag", name, ch);
                 Py_DECREF(ch);
             }
             return -1;
@@ -3371,16 +3378,25 @@ PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs) {
 }
 
 static PyObject *element_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
-    static char *keywords[] = {"tag", "attrs", NULL};
+    static char *keywords[] = {"tag", "attrs", "children", NULL};
     PyObject *tag;
     PyObject *attrs = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "U|O", keywords, &tag, &attrs)) {
+    PyObject *children = NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "U|OO", keywords, &tag, &attrs, &children)) {
         return NULL;
     }
     if (validate_name(tag, 0) < 0) {
         return NULL;
     }
-    return make_element(type, tag, attrs);
+    PyObject *element = make_element(type, tag, attrs);
+    if (element == NULL) {
+        return NULL;
+    }
+    if (children != NULL && children != Py_None && append_build_children(element, tag, children) < 0) {
+        Py_DECREF(element);
+        return NULL;
+    }
+    return element;
 }
 
 /* Prepare child_obj to become a child of dest_parent in anchor's tree and return
@@ -3423,6 +3439,38 @@ static th_node *adopt_into(NodeObject *anchor, th_node *dest_parent, PyObject *c
     Py_SETREF(child->handle, Py_NewRef(anchor->handle));
     child->node = copy;
     return copy;
+}
+
+/* Attach a freshly built element's children, rejecting content on a void tag the
+   way the constructor rejects an invalid attribute name. A void element takes no
+   children per the HTML spec, so storing them only for the serializer to drop
+   would silently lose what the caller passed; a hard error at construction time
+   surfaces the programming mistake instead. */
+static int append_build_children(PyObject *element, PyObject *tag, PyObject *children) {
+    PyObject *sequence = PySequence_Fast(children, "children must be iterable");
+    if (sequence == NULL) {
+        return -1;
+    }
+    Py_ssize_t count = PySequence_Fast_GET_SIZE(sequence);
+    NodeObject *self = (NodeObject *)element;
+    if (count > 0 && th_tag_is_void(self->node->atom)) {
+        Py_DECREF(sequence);
+        PyErr_Format(PyExc_ValueError, "void element %R cannot have children", tag);
+        return -1;
+    }
+    int error = 0;
+    Py_BEGIN_CRITICAL_SECTION(self->handle);
+    for (Py_ssize_t index = 0; index < count; index++) {
+        th_node *node = adopt_into(self, self->node, PySequence_Fast_GET_ITEM(sequence, index));
+        if (node == NULL) {
+            error = 1;
+            break;
+        }
+        th_node_append_child(self->node, node);
+    }
+    Py_END_CRITICAL_SECTION();
+    Py_DECREF(sequence);
+    return error ? -1 : 0;
 }
 
 /* Whether new_obj is a node wrapping the same C node as ref: inserting a node

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -330,6 +330,10 @@ uint8_t th_tag_flags(uint16_t atom) {
     return 0;
 }
 
+int th_tag_is_void(uint16_t atom) {
+    return is_void_atom(atom);
+}
+
 /* --------------------------------------------------------------- nodes */
 
 /* node_pos, node_new and the node_append/node_remove/node_insert_before linkers

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -490,4 +490,9 @@ uint16_t th_tag_lookup(const char *bytes, Py_ssize_t len);
 /* The tree-construction category bitmask for an atom (0 for TH_TAG_UNKNOWN). */
 uint8_t th_tag_flags(uint16_t atom);
 
+/* Whether an atom names an HTML void element, which the spec forbids from having
+   children. The serializer uses the static-inline is_void_atom on its hot path;
+   this is the cold cross-TU entry the element constructor validates against. */
+int th_tag_is_void(uint16_t atom);
+
 #endif /* TURBOHTML_TREEBUILDER_H */

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -161,7 +161,12 @@ class Node:
 @final
 class Element(Node):
     __match_args__ = ("tag",)
-    def __init__(self, tag: str, attrs: Mapping[str, str | list[str] | None] | None = None) -> None: ...
+    def __init__(
+        self,
+        tag: str,
+        attrs: Mapping[str, str | list[str] | None] | None = None,
+        children: Iterable[Node] | None = None,
+    ) -> None: ...
     @property
     def tag(self) -> str: ...
     @property

--- a/src/turbohtml/build.py
+++ b/src/turbohtml/build.py
@@ -51,15 +51,19 @@ def _to_node(arg: Content) -> Node:
 
 
 def _build(tag: str, args: tuple[Content, ...]) -> Element:
-    """Build one element: a leading mapping sets its attributes, and the rest become children in order."""
+    """
+    Build one element: a leading mapping sets its attributes, and the rest become children in order.
+
+    :raises ValueError: if the tag or an attribute name carries a character HTML forbids there, or if a
+        void element such as ``br`` or ``img`` is given children.
+    :raises TypeError: if an attribute mapping is not the first argument.
+    """
     attrs: Attributes | None = None
     children = args
     if args and _is_attributes(args[0]):
         attrs = args[0]
         children = args[1:]
-    element = Element(tag, attrs)
-    element.extend(_to_node(arg) for arg in children)
-    return element
+    return Element(tag, attrs, [_to_node(arg) for arg in children])
 
 
 class _TagFactory:
@@ -72,7 +76,13 @@ class _TagFactory:
         self._tag = tag
 
     def __call__(self, *args: Content) -> Element:
-        """Build the element from a leading attribute mapping and the child nodes and strings that follow."""
+        """
+        Build the element from a leading attribute mapping and the child nodes and strings that follow.
+
+        :raises ValueError: if the tag or an attribute name carries a character HTML forbids there, or if a
+            void element such as ``br`` or ``img`` is given children.
+        :raises TypeError: if an attribute mapping is not the first argument.
+        """
         return _build(self._tag, args)
 
 
@@ -91,7 +101,13 @@ class ElementMaker:
         return _TagFactory(tag)
 
     def __call__(self, tag: str, /, *args: Content) -> Element:
-        """Build ``tag`` from a leading attribute mapping and the child nodes and strings that follow."""
+        """
+        Build ``tag`` from a leading attribute mapping and the child nodes and strings that follow.
+
+        :raises ValueError: if the tag or an attribute name carries a character HTML forbids there, or if a
+            void element such as ``br`` or ``img`` is given children.
+        :raises TypeError: if an attribute mapping is not the first argument.
+        """
         return _build(tag, args)
 
 

--- a/tests/dom/test_tree_construct.py
+++ b/tests/dom/test_tree_construct.py
@@ -136,6 +136,7 @@ def test_element_tag_is_rejected(tag: str) -> None:
         pytest.param("a b", id="space"),
         pytest.param("a/b", id="slash"),
         pytest.param("a>b", id="gt"),
+        pytest.param("a<b", id="lt"),
         pytest.param("a=b", id="eq"),
         pytest.param('a"b', id="dquote"),
         pytest.param("a'b", id="squote"),

--- a/tests/features/test_build.py
+++ b/tests/features/test_build.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -103,6 +104,58 @@ def test_a_separate_maker_builds_the_same_way(maker: ElementMaker) -> None:
 def test_non_leading_mapping_is_rejected() -> None:
     with pytest.raises(TypeError, match="must come first"):
         E.div("text", {"id": "b"})
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("a<b", id="less-than"),  # <  is the issue #413 regression: it used to slip through
+        pytest.param('a"b', id="double-quote"),
+        pytest.param("a'b", id="single-quote"),
+        pytest.param("a=b", id="equals"),
+        pytest.param("a b", id="space"),
+        pytest.param("a/b", id="slash"),
+        pytest.param("a>b", id="greater-than"),
+    ],
+)
+def test_invalid_attribute_name_is_rejected(name: str) -> None:
+    expected = rf"attribute name {re.escape(repr(name))} contains an invalid character: {re.escape(repr(name[1]))}"
+    with pytest.raises(ValueError, match=expected):
+        E.div({name: "x"}, "hi")
+
+
+@pytest.mark.parametrize(
+    ("build", "tag"),
+    [
+        pytest.param(lambda: E.br("x"), "br", id="br-text-child"),
+        pytest.param(lambda: E.img("x", E.span("y")), "img", id="img-mixed-children"),
+        pytest.param(lambda: E.hr(E.span("y")), "hr", id="hr-node-child"),
+        pytest.param(lambda: E("input", "x"), "input", id="call-form-input"),
+    ],
+)
+def test_void_element_rejects_children(build: Callable[[], Element], tag: str) -> None:
+    with pytest.raises(ValueError, match=rf"void element '{tag}' cannot have children"):
+        build()
+
+
+def test_non_node_child_is_rejected() -> None:
+    with pytest.raises(TypeError, match="child must be a node"):
+        E.div(42)  # ty: ignore[invalid-argument-type]  # neither a node nor a string
+
+
+def test_constructor_children_none_builds_empty() -> None:
+    # the builder always passes a list, so None reaches the constructor only directly
+    assert Element("div", None, None).serialize() == "<div></div>"
+
+
+def test_constructor_accepts_a_children_tuple() -> None:
+    # the builder always passes a list, so a tuple reaches the constructor only directly
+    assert Element("div", None, (Text("a"), Text("b"))).serialize() == "<div>ab</div>"
+
+
+def test_constructor_children_must_be_iterable() -> None:
+    with pytest.raises(TypeError, match="children must be iterable"):
+        Element("div", None, 42)  # ty: ignore[invalid-argument-type]  # children must be an iterable of nodes
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The `turbohtml.build.E` builder is meant to emit conforming markup, yet two paths let it emit or lose content. The attribute-name validator refused `"`, `'`, `>`, `=`, `/`, whitespace, and control characters but passed `<`, so `E.div({"a<b": "x"})` produced markup that reparses to a different tree ([#413](https://github.com/tox-dev/turbohtml/issues/413)). `<` in an attribute name is an unexpected-character-in-attribute-name parse error in the WHATWG tokenizer. `validate_name` now rejects it for attribute and tag names alike, and the error names the offending attribute and character.

Children handed to a void element vanished ([#414](https://github.com/tox-dev/turbohtml/issues/414)). `E.img("x", E.span("y"))` stored them on the `img`, then the serializer discarded them and the content was lost. The `Element` constructor now takes the builder's children and raises `ValueError` naming the void tag when a void element gets any, so the mistake fails at construction. DOM `append` and `extend` stay permissive, since the WHATWG DOM allows appending children to a void element.

`Element(tag, attrs, children)` routes the builder's children through the constructor and reuses the existing adopt path. The void check reuses the serializer's void-element predicate through a new `th_tag_is_void` entry point. Both errors carry an actionable message, and the affected builder docstrings gain a `:raises:` note.

closes #413
closes #414
