### PR TITLE
📝 docs(migration): standardize guides on a head-to-head format

### DIFF
--- a/docs/migration/airium.rst
+++ b/docs/migration/airium.rst
@@ -6,32 +6,82 @@
 
 `airium <https://gitlab.com/kamichal/airium>`_ assembles HTML in Python from the other direction than a parser: you open
 each element as a ``with a.tag(...)`` block on an ``Airium`` instance, call the instance for text, and let it track
-indentation as you nest, then stringify it. turbohtml replaces it with the terse :data:`turbohtml.build.E` builder.
+indentation as you nest, then stringify it. It is a pure-Python, zero-dependency builder whose reach is generation only
+-- it also ships a reverse tool (``python -m airium``) that turns existing HTML back into airium source. It is used to
+emit reports, templated pages, and snippets from Python without a template engine.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same construction ground with the terse :data:`turbohtml.build.E` builder, but every call returns a
+real :class:`~turbohtml.Element` in turbohtml's C-backed tree, so the markup you generate is also a document you can
+query, edit, re-serialize, or convert -- not a one-way string.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+*********************
+ turbohtml vs airium
+*********************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
 
-    from turbohtml.build import E
+    - - Dimension
+      - turbohtml
+      - airium
+    - - Scope
+      - Parse, build, query, edit, serialize, and convert one WHATWG tree
+      - One-way HTML generation from Python, plus an HTML-to-airium code generator
+    - - Feature breadth
+      - ``E`` builder, CSS ``select``, ``xpath``, ``find``/``find_all``, ``to_markdown``/``to_text``, indent or minify
+        layout
+      - Context-manager tag authoring, auto-indented pretty-print, void-tag handling, reverse codegen
+    - - Performance
+      - Builds in a C arena and serializes in C (about 5x faster on the bench below)
+      - Pure-Python string assembly with running indentation bookkeeping
+    - - Typing
+      - Ships ``.pyi`` stubs for the element, query, and serialize surface
+      - Dynamic ``__getattr__`` tag dispatch; no per-tag types
+    - - Dependencies
+      - Self-contained C extension (needs a wheel or a build)
+      - Pure Python, zero runtime dependencies, runs anywhere Python does
+    - - Maintenance
+      - Actively developed C core with a thin Python shim
+      - Small, stable, narrowly-scoped project
 
-    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
-    print(card.serialize())
+Feature overlap
+===============
 
-.. testoutput::
+The construction surface ports one-for-one:
 
-    <div class="card"><h1>Title</h1><p>body</p></div>
+- Elements with attributes: ``a.div(klass="card")`` becomes :data:`E.div({"class": "card"}) <turbohtml.build.E>`.
+- Nested children: airium's ``with`` blocks become positional children on the ``E`` call.
+- Text nodes: ``a("text")`` or the ``_t=`` kwarg becomes a plain string child.
+- ``data-*`` and boolean attributes: airium's ``data_i=`` (underscore to dash) and turbohtml's ``{"data-i": "1"}`` /
+  ``{"disabled": None}``.
+- Void tags close themselves in both.
+- Stringify: ``str(a)`` becomes :meth:`~turbohtml.Node.serialize`.
+- Pretty-printed output: airium indents by default; turbohtml opts in with ``serialize(Html(layout=Indent(2)))``.
 
-``E`` assembles the fragment in turbohtml's arena and serializes it in C; airium stays in Python and pretty-prints with
-indentation as it goes. The same ``<ul>`` of rows -- a class, a ``data`` attribute, and a text child apiece -- built
-both ways:
+What turbohtml adds
+===================
+
+- The result is a real :class:`~turbohtml.Element`, not a string, so the same call that builds the markup leaves a tree
+  you can walk and mutate with ``append``, ``insert``, ``remove``, and ``extend``.
+- Query the built tree with CSS :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.xpath`, and
+  :meth:`~turbohtml.Node.find`/``find_all`` -- airium has no query surface over what it emits.
+- Convert with :meth:`~turbohtml.Node.to_markdown` and :meth:`~turbohtml.Node.to_text`.
+- Round-trip: the same tree type parses arbitrary HTML back in, so generation and parsing share one API.
+- The arena build and C serializer run about five times faster than airium's Python assembly (see below).
+
+What airium has that turbohtml does not
+=======================================
+
+- ``with``-block authoring. airium spells nesting with context managers; turbohtml nests by passing children as
+  arguments. No context-manager equivalent -- restructure the ``with`` bodies into nested ``E`` calls.
+- HTML-to-source codegen. ``python -m airium page.html`` emits airium Python that reproduces the input. turbohtml has no
+  builder-code generator; it parses HTML into a tree, not into Python source. No equivalent.
+- Zero-dependency, pure-Python install. airium needs no compiled extension and runs in any restricted or wheel-less
+  environment. turbohtml ships a C extension, so it depends on a wheel or a local build.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/airium.json
@@ -40,9 +90,15 @@ both ways:
 :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can query, edit,
 and re-:meth:`~turbohtml.Node.serialize`.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import and drop the ``Airium`` instance; ``E`` is a module-level singleton:
+
+.. code-block:: python
+
+    from turbohtml.build import E  # was: from airium import Airium
 
 airium tracks structure by call depth inside ``with`` blocks; turbohtml tracks it in the tree:
 
@@ -52,10 +108,36 @@ airium tracks structure by call depth inside ``with`` blocks; turbohtml tracks i
 
     - - `airium <https://pypi.org/project/airium/>`__
       - turbohtml
+    - - ``a = Airium()``
+      - ``E`` (module-level singleton, no instance)
     - - ``with a.div(klass="card"):`` then ``a("text")``
       - :data:`E.div({"class": "card"}, "text") <turbohtml.build.E>`; nest by passing children, not by call depth
     - - ``a.li(klass="item", **{"data-i": "1"})``
       - :data:`E.li({"class": "item", "data-i": "1"}) <turbohtml.build.E>`
+    - - ``a("text")`` / ``_t="text"``
+      - a plain string child
+    - - ``str(a)``
+      - :meth:`element.serialize() <turbohtml.Node.serialize>`
+    - - ``str(a)`` with airium's default indentation
+      - :meth:`element.serialize(Html(layout=Indent(2))) <turbohtml.Node.serialize>`
+
+The same ``<ul>`` built both ways:
+
+.. code-block:: python
+
+    # airium
+    from airium import Airium
+
+    a = Airium()
+    with a.ul(), a.li(klass="item", **{"data-i": "1"}):
+        a("row")
+    html = str(a)
+
+    # turbohtml
+    from turbohtml.build import E
+
+    ul = E.ul(E.li({"class": "item", "data-i": "1"}, "row"))
+    html = ul.serialize()
 
 ``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
 attribute joins on a space so a class list reads naturally:
@@ -70,13 +152,17 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
-  Serialize the element you built, or append it under a parsed document when you need the full page shell.
-- airium pretty-prints with newlines and indentation; ``E`` serializes compact markup. Parse and re-serialize, or use a
-  formatter, when you need indented output.
+  Serialize the element you built, or append it under a parsed document when you need the full page shell. airium is the
+  same here -- you write the doctype and shell yourself.
+- A leading mapping is always read as attributes; to start an element with literal text, pass the string first
+  (``E.p("text", E.b("bold"))``). There is no ``_t=`` / ``klass=`` kwarg convention: attributes are a mapping and use
+  their real names (``"class"``, ``"data-i"``), so airium's underscore-to-dash rewriting does not apply.
+- airium pretty-prints with newlines and indentation by default; ``E`` serializes compact markup. Pass
+  ``serialize(Html(layout=Indent(2)))`` for indented output, or ``Html(layout=Minify())`` to minify.
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/beautifulsoup.rst
+++ b/docs/migration/beautifulsoup.rst
@@ -6,30 +6,113 @@
 
 `BeautifulSoup <https://www.crummy.com/software/BeautifulSoup/bs4/doc/>`_ is the long-standing convenience layer over a
 choice of HTML parsers (``html.parser``, ``lxml``, or ``html5lib``): you pick a backend, then navigate and search the
-resulting soup with a large, alias-rich API. It shares the most surface with turbohtml, so this is the deepest section.
+resulting soup with a large, alias-rich API. It also parses XML through the ``lxml-xml`` backend, decodes unknown byte
+streams with ``UnicodeDammit``, and matches CSS selectors through its ``soupsieve`` dependency. Its reach and forgiving
+API made it the default scraping tool for a generation of Python code, from one-off screen scrapes to production
+pipelines.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the HTML side of that ground with one engine. :func:`turbohtml.parse` runs the WHATWG algorithm in C,
+returns a fully type annotated :class:`~turbohtml.Document`, and exposes a single ``find``/``find_all``/``select``
+grammar plus XPath. It shares the most surface with turbohtml of any library here, so this is the deepest migration
+section.
 
-:func:`turbohtml.parse` returns a fully type annotated :class:`~turbohtml.Document` with no parser backend to choose,
-since it always runs the WHATWG algorithm in C. The search surface is one ``find``/``find_all``/``select`` grammar with
-:class:`~turbohtml.Axis` directions instead of a dozen directional finders. And it parses, queries, and serializes one
-to three orders of magnitude faster than BeautifulSoup over ``html.parser`` -- including text filtering
-(``find(text=...)`` against ``find_all(string=...)``), walking the tree (:attr:`~turbohtml.Node.descendants` against
-``soup.descendants``), and reading its text (:attr:`~turbohtml.Node.text` against ``soup.get_text()``):
+****************************
+ turbohtml vs BeautifulSoup
+****************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 18 41 41
+
+    - - Dimension
+      - turbohtml
+      - BeautifulSoup
+    - - Scope
+      - WHATWG HTML: parse, query, mutate, and serialize in one C engine
+      - HTML and XML navigation layer over a pluggable third-party parser
+    - - Feature breadth
+      - ``find`` grammar with :class:`~turbohtml.Axis`, CSS selectors, XPath, source positions, linkify, WHATWG
+        serialization formatters
+      - ``find`` grammar, CSS via ``soupsieve``, XML mode, ``UnicodeDammit`` encoding guessing, output-formatter
+        registry
+    - - Performance
+      - C core; one to three orders of magnitude faster than ``bs4`` over ``html.parser`` across parse, query, and
+        serialize
+      - Pure-Python navigation; speed tracks the chosen backend and is slowest on ``html.parser``
+    - - Typing
+      - Ships ``py.typed``; every public method annotated
+      - No inline types; relies on the third-party ``types-beautifulsoup4`` stubs
+    - - Dependencies
+      - Zero runtime dependencies (self-contained C extension)
+      - Requires ``soupsieve``; ``lxml`` or ``html5lib`` optional for those backends
+    - - Maintenance
+      - Actively developed, single-engine
+      - Mature, widely deployed, long release history
+
+Feature overlap
+===============
+
+These port one-to-one; the calls differ only in name (see the mapping table under `How to migrate`_):
+
+- Parsing markup into a navigable tree.
+- ``find`` / ``find_all`` by tag, attribute, ``class_``, and text.
+- CSS selectors via ``select`` / ``select_one``.
+- Directional navigation (parents, siblings, next/previous elements) — turbohtml folds these into ``find`` with an
+  :class:`~turbohtml.Axis`.
+- Tree mutation: ``decompose``, ``extract``, ``unwrap``, ``wrap``, ``insert_before``, ``insert_after``,
+  ``replace_with``.
+- Text access: ``get_text`` maps to :attr:`~turbohtml.Node.text`, :attr:`~turbohtml.Node.strings`, and
+  :attr:`~turbohtml.Node.stripped_strings`.
+- Pretty-printing via :meth:`~turbohtml.Node.serialize` with ``Html(layout=Indent(2))`` for ``prettify()``.
+- Source positions: ``sourceline`` / ``sourcepos`` map to :attr:`~turbohtml.Node.source_line` /
+  :attr:`~turbohtml.Node.source_col`.
+
+What turbohtml adds
+===================
+
+- **XPath.** :meth:`~turbohtml.Node.xpath` and :meth:`~turbohtml.Node.xpath_iter` evaluate expressions with namespaces,
+  variables, and extension functions. BeautifulSoup has no XPath support at all.
+- **A C engine.** Parsing, querying, text collection, and serialization all run in C, so migrating off ``html.parser``
+  is a large speedup with no backend to install.
+- **WHATWG-conformant serialization.** :class:`~turbohtml.Formatter` selection controls entities, and output matches the
+  spec by default; ``Formatter.NAMED_ENTITIES`` reproduces ``bs4``'s ``html`` formatter when you need it.
+- **Post-parse pruning.** :meth:`~turbohtml.Node.prune` trims a fully parsed tree to a CSS selector in one C pass.
+- **Zero runtime dependencies and full typing.** No ``soupsieve`` install, and every public API is annotated.
+
+What BeautifulSoup has that turbohtml does not
+==============================================
+
+- **XML parsing.** ``BeautifulSoup(markup, "lxml-xml")`` parses arbitrary XML. turbohtml runs the WHATWG *HTML*
+  algorithm only; there is no XML tree-builder. No equivalent — keep ``lxml`` for XML documents.
+- **Pluggable parser backends.** ``bs4`` lets you swap ``html.parser``, ``lxml``, and ``html5lib``. turbohtml always
+  runs its own WHATWG parser; this is a deliberate clean-break omission, not a gap you work around.
+- **Statistical encoding detection.** ``UnicodeDammit`` (and ``chardet`` / ``charset-normalizer``) guess an encoding
+  from byte frequency when there is no BOM or ``<meta charset>``. turbohtml sniffs only what the WHATWG algorithm reads,
+  then falls back to ``windows-1252``. Workaround: detect with ``charset-normalizer`` first and hand turbohtml the
+  decoded ``str`` (or bytes with an explicit ``encoding=``).
+- **Structural tree equality.** ``bs4`` compares two trees with ``==`` by name, attributes, and contents. turbohtml's
+  ``==`` is identity. Workaround: compare serializations (``a.html == b.html``) or walk the nodes.
+- **A named output-formatter registry.** ``bs4`` registers custom formatters by name. Workaround: pass a
+  :class:`~turbohtml.Formatter` per :meth:`~turbohtml.Node.serialize` call.
+
+Performance
+===========
+
+turbohtml parses, queries, and serializes one to three orders of magnitude faster than BeautifulSoup over
+``html.parser`` — including text filtering (``find(text=...)`` against ``find_all(string=...)``), walking the tree
+(:attr:`~turbohtml.Node.descendants` against ``soup.descendants``), and reading text (:attr:`~turbohtml.Node.text`
+against ``soup.get_text()``):
 
 .. bench-table::
     :file: bench/beautifulsoup.json
 
 The :doc:`/development/performance` page benchmarks the build and edit paths against BeautifulSoup too.
 
-*********
- Parsing
-*********
+****************
+ How to migrate
+****************
 
-Parsing returns a :class:`~turbohtml.Document` instead of a ``BeautifulSoup`` object. There is no parser name to pass,
-since turbohtml always runs the WHATWG algorithm:
+Swap the import and the constructor. There is no parser name to pass, since turbohtml always runs the WHATWG algorithm:
 
 .. code-block:: python
 
@@ -63,22 +146,8 @@ Bytes work too; pass the raw response and read the resolved encoding back from :
     café
     windows-1252
 
-********************
- Encoding detection
-********************
-
-``parse`` runs the WHATWG sniffing algorithm on bytes: a leading BOM, then a ``<meta charset>`` prescan, then a
-``windows-1252`` fallback. That covers what ``UnicodeDammit`` reads from the markup, and it stops there. turbohtml does
-not guess an encoding from the byte distribution. ``UnicodeDammit``'s optional statistical pass and the dedicated
-detectors (`charset-normalizer <https://github.com/jawah/charset_normalizer>`_, `chardet
-<https://github.com/chardet/chardet>`_, ``cchardet``) read byte frequency, so a markup-less stream, or a document with
-no BOM and no declaration, lands on ``windows-1252`` here where they would name, say, ``koi8-r``. When there is nothing
-to sniff, detect the encoding with ``charset-normalizer`` first and hand turbohtml the decoded ``str`` (or the bytes
-with an explicit ``encoding=``).
-
-*************
- The renames
-*************
+API mapping
+===========
 
 .. list-table::
     :header-rows: 1
@@ -110,6 +179,8 @@ with an explicit ``encoding=``).
       - :meth:`~turbohtml.Node.find` / :meth:`~turbohtml.Node.find_all` with ``text=``
     - - ``soup.select(".cls")``, ``soup.select_one(".cls")``
       - :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`
+    - - (no XPath)
+      - :meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.xpath_iter`
     - - ``BeautifulSoup(markup, parse_only=SoupStrainer("article"))``
       - ``turbohtml.parse(markup).prune("article")`` (:meth:`~turbohtml.Node.prune`)
     - - ``tag.decompose()``, ``tag.extract()``, ``tag.unwrap()``, ``tag.wrap(...)``
@@ -126,10 +197,6 @@ with an explicit ``encoding=``).
       - :meth:`~turbohtml.Element.normalize`
     - - ``tag.sourceline``, ``tag.sourcepos``
       - :attr:`~turbohtml.Node.source_line`, :attr:`~turbohtml.Node.source_col`
-
-***********
- Searching
-***********
 
 The ``find``/``find_all`` filter grammar covers what ``bs4`` spread across many methods. A keyword filter matches an
 attribute; ``class_`` and ``attrs`` match the rest; ``axis`` replaces the directional finders and ``recursive=False``:
@@ -162,78 +229,77 @@ attribute; ``class_`` and ``attrs`` match the rest; ``axis`` replaces the direct
     section
     section
 
-``text`` replaces ``bs4``'s ``find(string=...)`` search. The one shift: ``bs4`` returns the matching
-``NavigableString``, while ``text`` filters *elements* by their collected text (the whole subtree, as
-:attr:`~turbohtml.Node.text` returns), so it composes with the tag and attribute filters and a plain string is the full
-text rather than a substring (use a regex to search within):
+**********************
+ Gotchas and pitfalls
+**********************
 
-.. testcode::
+- **Indexing reaches children, not attributes.** ``node[i]`` indexes child nodes, so attributes are reached only through
+  ``.attrs``, never ``node["attr"]``. Multi-valued attributes (``class``, ``rel``, ...) read back as a ``list[str]``.
 
-    import re
+  .. testcode::
 
-    doc = parse("<ul><li>Buy now</li><li>Later</li></ul>")
-    print(doc.find("li", text="Buy now").text)
-    print([li.text for li in doc.find_all("li", text=re.compile(r"now"))])
+      a = parse('<a class="btn lg" href="/x">go</a>').find("a")
+      print(a.attrs["class"])
+      print(a[0])  # indexing reaches children, never attributes
 
-.. testoutput::
+  .. testoutput::
 
-    Buy now
-    ['Buy now']
+      ['btn', 'lg']
+      Text('go')
 
-*********************
- Attributes and text
-*********************
+- **No ``.string`` shortcut and no ``text``/``tail`` split.** Text is real child nodes (the WHATWG DOM shape), so there
+  is no ``.string`` and no `lxml <https://lxml.de>`_-style ``text``/``tail``; iterate the children or read
+  :attr:`~turbohtml.Node.text`:
 
-``.attrs`` is the single access point; there is no ``tag["x"]`` shortcut, because ``node[i]`` indexes child nodes.
-Multi-valued attributes (``class``, ``rel``, ...) read back as a ``list[str]``, and text is real child nodes (the WHATWG
-DOM shape), so there is no ``.string`` shortcut and no `lxml <https://lxml.de>`_-style ``text``/``tail`` split:
+  .. testcode::
 
-.. testcode::
+      p = parse("<p>Hello <b>bold</b> world</p>").find("p")
+      print((p.text, list(p.stripped_strings)))
 
-    a = parse('<a class="btn lg" href="/x">go</a>').find("a")
-    print(a.attrs["class"])
-    print(a[0])  # indexing reaches children, never attributes
-    p = parse("<p>Hello <b>bold</b> world</p>").find("p")
-    print((p.text, list(p.stripped_strings)))
+  .. testoutput::
 
-.. testoutput::
+      ('Hello bold world', ['Hello', 'bold', 'world'])
 
-    ['btn', 'lg']
-    Text('go')
-    ('Hello bold world', ['Hello', 'bold', 'world'])
+- **``text=`` filters elements, not ``NavigableString``.** ``bs4``'s ``find(string=...)`` returns the matching string
+  node; turbohtml's ``text=`` filters *elements* by their collected subtree text, so it composes with tag and attribute
+  filters. A plain string matches the full text; use a regex to search within:
 
-********
- Output
-********
+  .. testcode::
 
-The default serialization is WHATWG-conformant, so it differs from ``bs4``'s ``html`` formatter on named entities,
-attribute order, and ``<br>`` versus ``<br/>``. Choose ``Formatter.NAMED_ENTITIES`` to approximate ``bs4``:
+      import re
 
-.. testcode::
+      doc = parse("<ul><li>Buy now</li><li>Later</li></ul>")
+      print(doc.find("li", text="Buy now").text)
+      print([li.text for li in doc.find_all("li", text=re.compile(r"now"))])
 
-    from turbohtml import Formatter, Html
+  .. testoutput::
 
-    node = parse("<p>café &amp; co</p>").find("p")
-    print(node.html)
-    print(node.serialize(Html(formatter=Formatter.NAMED_ENTITIES)))
+      Buy now
+      ['Buy now']
 
-.. testoutput::
+- **Serialization is WHATWG-conformant by default.** Output differs from ``bs4``'s ``html`` formatter on named entities,
+  attribute order, and ``<br>`` versus ``<br/>``. Pick ``Formatter.NAMED_ENTITIES`` to approximate ``bs4``:
 
-    <p>café &amp; co</p>
-    <p>caf&eacute; &amp; co</p>
+  .. testcode::
 
-**********
- Pitfalls
-**********
+      from turbohtml import Formatter, Html
 
-- ``node[i]`` indexes children; attributes are reached through ``.attrs``, never ``node["attr"]``.
-- Text is real child nodes, so there is no ``.string`` shortcut and no ``text``/``tail``; iterate the children.
-- Default output is WHATWG-conformant; pick ``Formatter.NAMED_ENTITIES`` to come close to ``bs4``'s ``html`` formatter.
-- ``==`` compares identity, so two trees with the same markup are unequal. Where ``bs4`` code leaned on ``==`` between
-  trees, compare serializations (``a.html == b.html``) or walk the nodes.
-- ``SoupStrainer`` filtered the tree *during* parsing; turbohtml always runs the full WHATWG algorithm, then
+      node = parse("<p>café &amp; co</p>").find("p")
+      print(node.html)
+      print(node.serialize(Html(formatter=Formatter.NAMED_ENTITIES)))
+
+  .. testoutput::
+
+      <p>café &amp; co</p>
+      <p>caf&eacute; &amp; co</p>
+
+- **Encoding sniffing stops at the markup.** ``parse`` runs the WHATWG algorithm on bytes — BOM, then a ``<meta
+  charset>`` prescan, then a ``windows-1252`` fallback — which covers what ``UnicodeDammit`` reads from the markup but
+  does not guess from byte frequency. A stream with no BOM and no declaration lands on ``windows-1252`` where
+  ``charset-normalizer`` might name, say, ``koi8-r``. When there is nothing to sniff, detect first and hand turbohtml
+  the decoded ``str``.
+- **``==`` compares identity.** Two trees with the same markup are unequal. Where ``bs4`` code leaned on structural
+  ``==``, compare serializations (``a.html == b.html``) or walk the nodes.
+- **``SoupStrainer`` has no parse-time equivalent.** turbohtml always runs the full WHATWG algorithm, then
   :meth:`~turbohtml.Node.prune` trims the parsed tree to a CSS selector in one C pass, so a large document still yields
-  a small tree.
-- A couple of bs4 entry points are deliberate clean-break omissions: the choice of parser backend (turbohtml always runs
-  the WHATWG algorithm) and registering a named output formatter. Pick a :class:`~turbohtml.Formatter` per
-  :meth:`~turbohtml.Node.serialize` call instead.
+  a small tree — but the whole document is parsed first.

--- a/docs/migration/bleach.rst
+++ b/docs/migration/bleach.rst
@@ -4,26 +4,105 @@
 
 .. package-meta:: bleach mozilla/bleach
 
-`bleach <https://github.com/mozilla/bleach>`_ was the standard HTML allowlist sanitizer and linkifier, built on
-html5lib. It is end of life with no maintained successor, so its two jobs split across turbohtml: ``bleach.clean`` maps
-to ``turbohtml.clean`` and ``bleach.linkify`` maps to ``turbohtml.clean``.
+`bleach <https://github.com/mozilla/bleach>`_ was the standard Python HTML allowlist sanitizer and linkifier, built on
+html5lib. Two jobs live in one library: ``bleach.clean`` strips markup down to an allowed set of tags, attributes, and
+URL schemes so user-supplied HTML is safe to render, and ``bleach.linkify`` scans plain text for URLs and wraps them in
+``<a>`` tags. It powered comment fields, wikis, and message bodies across the Django ecosystem for a decade.
 
-***************
- Why turbohtml
-***************
+bleach reached end of life with no maintained successor. turbohtml covers both jobs from its ``turbohtml.clean`` module:
+``bleach.clean`` maps to the allowlist :class:`~turbohtml.clean.Sanitizer` (with a drop-in
+:func:`turbohtml.migration.bleach.clean` shim), and ``bleach.linkify`` maps to :func:`turbohtml.clean.linkify`. Both run
+their filtering in C, ship full type annotations, and take a frozen, thread-safe configuration.
 
-Both replacements are fully type annotated, run the filtering and link scan in C, and expose a frozen, thread-safe
-configuration where ``bleach.clean`` had a documented thread-safety footgun. The sanitizer leads bleach by an order of
-magnitude and the linkifier by five to twenty times:
+*********************
+ turbohtml vs bleach
+*********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
+
+    - - Dimension
+      - turbohtml
+      - bleach
+    - - Scope
+      - Full WHATWG parser, serializer, sanitizer, linkifier, selectors
+      - Sanitize and linkify only, over html5lib
+    - - Feature breadth
+      - Escape/strip/remove per tag, value-rewriting attribute filter, forced attributes, regenerable IANA TLD table
+      - Allow/strip tags, bool attribute callback, ``css_sanitizer`` for style scrubbing
+    - - Performance
+      - Filtering and link scan in C
+      - Pure-Python over html5lib
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - Untyped
+    - - Dependencies
+      - None (self-contained C extension)
+      - html5lib, plus tinycss2 for CSS sanitizing
+    - - Maintenance
+      - Active
+      - End of life, no successor
+
+Feature overlap
+===============
+
+The shared surface ports one-to-one:
+
+- ``bleach.clean(text, tags=, attributes=, protocols=, strip=, strip_comments=)`` ->
+  :func:`turbohtml.migration.bleach.clean` (same signature) or a native :class:`~turbohtml.clean.Policy` +
+  :class:`~turbohtml.clean.Sanitizer`.
+- ``bleach.linkify(text, ...)`` and the reusable ``Linker`` -> :func:`turbohtml.clean.linkify` and
+  :class:`turbohtml.clean.Linker`.
+- The ``nofollow`` and ``target_blank`` callbacks and ``DEFAULT_CALLBACKS`` keep their names in :mod:`turbohtml.clean`.
+- bleach's default allowed tags, attributes, and URL schemes are the turbohtml migration baseline (``DEFAULT_TAGS``,
+  ``DEFAULT_ATTRIBUTES``, ``DEFAULT_SCHEMES``), so an unconfigured ``clean`` behaves the same.
+
+What turbohtml adds
+===================
+
+- A frozen, thread-safe :class:`~turbohtml.clean.Policy`, where sharing a configured ``bleach.Cleaner`` across threads
+  was a documented footgun.
+- An :class:`~turbohtml.clean.OnDisallowed` enum that names escape, strip, and remove, where bleach overloaded the two
+  booleans ``strip`` and ``strip_comments``.
+- An ``attribute_filter`` that returns a replacement value or ``None`` to drop, where bleach's attribute callable only
+  returned a bool.
+- ``set_attributes`` to force attributes (for example ``rel="noopener"``) onto every kept instance of a tag, which
+  bleach could only approximate through a linkify callback.
+- A safety baseline that removes ``<script>``, ``on*`` handlers, and ``javascript:`` URLs by construction, so no policy
+  can re-admit them.
+- An IANA TLD table you can regenerate and extend with ``Linkify.extra_tlds``, where bleach shipped a frozen list.
+- Idempotent linkifying: an existing ``<a>`` is left untouched unless you opt in with ``Linkify.process_existing``.
+
+What bleach has that turbohtml does not
+=======================================
+
+- ``css_sanitizer`` (bleach's tinycss2-backed CSS cleaner) scrubbed both the ``style`` attribute and ``<style>`` element
+  contents. turbohtml's native sanitizer scrubs a kept ``style`` *attribute* against ``Policy.css_properties`` but drops
+  ``<style>`` element contents rather than cleaning them; the compat shim rejects a ``css_sanitizer`` argument with
+  ``NotImplementedError``. Workaround: pre-scrub or strip ``<style>`` before sanitizing.
+- A pluggable html5lib filter pipeline (``bleach.sanitizer.Cleaner(filters=[...])``) let you insert arbitrary html5lib
+  ``Filter`` classes into the clean pass. turbohtml has no equivalent filter chain; express the transform through
+  ``attribute_filter``, ``set_attributes``, or a post-parse walk over the tree instead.
+- A fully configurable safety baseline. bleach kept whatever you listed, including ``<script>`` if you allowed it;
+  turbohtml's baseline is fixed. No equivalent, by design.
+
+Performance
+===========
+
+The sanitizer leads bleach by an order of magnitude and the linkifier by five to twenty times:
 
 .. bench-table::
     :file: bench/bleach.json
 
-**************
- bleach.clean
-**************
+****************
+ How to migrate
+****************
 
-The bleach-compatible shim keeps ``clean``'s signature so the import is the only change:
+Sanitizing
+==========
+
+The bleach-compatible shim keeps ``clean``'s signature, so the import is the only change:
 
 .. code-block:: python
 
@@ -48,7 +127,7 @@ The bleach-compatible shim keeps ``clean``'s signature so the import is the only
     - - ``strip_comments=``
       - ``Policy.strip_comments``
     - - ``css_sanitizer=``
-      - ``Policy.css_properties``
+      - ``Policy.css_properties`` (style attribute only)
 
 ``clean(text, tags=..., attributes=..., protocols=..., strip=..., strip_comments=...)`` maps onto a
 :class:`~turbohtml.clean.Policy`. ``attributes`` accepts bleach's list, per-tag dict, or callable forms; ``strip``
@@ -65,22 +144,12 @@ chooses between dropping a disallowed tag and keeping its children (``True``) an
     &lt;p&gt;Hi <a href="http://x">link</a>&lt;/p&gt;&lt;script&gt;evil()&lt;/script&gt;
 
 For new code prefer the native :class:`~turbohtml.clean.Policy`/:class:`~turbohtml.clean.Sanitizer` API: a frozen,
-thread-safe policy, an :class:`~turbohtml.clean.OnDisallowed` enum that names escape/strip/remove where bleach
+thread-safe policy, an :class:`~turbohtml.clean.OnDisallowed` enum that names escape, strip, and remove where bleach
 overloaded two booleans, and an ``attribute_filter`` that rewrites or drops a value where bleach's callable only
 returned a bool.
 
-Pitfalls
-========
-
-- turbohtml's safety baseline (``<script>``, ``on*`` handlers, ``javascript:`` URLs) is not configurable, so even a
-  permissive ``attributes`` callable cannot re-admit them, where bleach faithfully kept whatever you allowed.
-- The bleach-compatible ``clean`` shim does not yet take a ``css_sanitizer`` argument (it raises), and ``<style>``
-  element contents are dropped rather than scrubbed; the native sanitizer scrubs a kept ``style`` *attribute* against
-  ``Policy.css_properties``.
-
-****************
- bleach.linkify
-****************
+Linkifying
+==========
 
 The entry points keep bleach's names, so the import changes and the common case is identical:
 
@@ -143,9 +212,17 @@ bleach's ``protocols`` maps to the ``Linkify.schemes`` field, which restricts th
 and bleach's custom-TLD support maps to ``Linkify.extra_tlds``, on top of a current IANA table you can regenerate where
 bleach shipped a frozen list. A bare domain such as ``example.com`` still links only when its last label is a known TLD.
 
-Pitfalls
-========
+**********************
+ Gotchas and pitfalls
+**********************
 
+- turbohtml's safety baseline (``<script>``, ``on*`` handlers, ``javascript:`` URLs) is not configurable, so even a
+  permissive ``attributes`` callable cannot re-admit them, where bleach faithfully kept whatever you allowed.
+- The bleach-compatible ``clean`` shim does not take a ``css_sanitizer`` argument; passing one raises
+  ``NotImplementedError``. ``<style>`` element contents are dropped rather than scrubbed. The native sanitizer scrubs a
+  kept ``style`` *attribute* against ``Policy.css_properties`` but leaves ``<style>`` contents out.
 - turbohtml leaves an existing ``<a>`` untouched so linkifying is idempotent, where bleach always reprocessed present
   links. Opt back in with the ``Linkify.process_existing`` field to run the callbacks over author-written anchors too
   (the callback reads ``Link.existing`` to branch).
+- Linkify callbacks read :class:`~turbohtml.clean.Link` fields (``url``, ``text``, ``attrs``), not bleach's
+  ``(namespace, name)`` tuple keys or the ``"_text"`` pseudo-key; a straight copy of a bleach callback will not run.

--- a/docs/migration/boilerpy3.rst
+++ b/docs/migration/boilerpy3.rst
@@ -4,33 +4,114 @@
 
 .. package-meta:: boilerpy3 jmriebold/BoilerPy3
 
-`boilerpy3 <https://github.com/jmriebold/BoilerPy3>`_ is the Python port of boilerpipe, the original boilerplate-removal
-library: an extractor (``ArticleExtractor``, ``CanolaExtractor``, ...) segments a page into text blocks, classifies each
-block content or boilerplate from word counts and link densities, and returns either the surviving text or the
-classified blocks.
+`boilerpy3 <https://github.com/jmriebold/BoilerPy3>`_ is the pure-Python port of boilerpipe, the original
+boilerplate-removal library. An extractor (``ArticleExtractor``, ``CanolaExtractor``, ``NumWordsRulesExtractor``, ...)
+parses a page with a built-in SAX handler, segments it into text blocks, classifies each block as content or boilerplate
+from word counts and link densities, and returns either the surviving text or the classified blocks. It runs on the
+standard library alone and is used to strip navigation, sidebars, and footers off article pages before indexing,
+summarization, or NLP.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that same ground with :func:`turbohtml.extract.boilerplate` and the C main-content scoring behind
+:meth:`~turbohtml.Node.main_content`: the scoring picks the content body, and each paragraph unit comes back as a
+:class:`~turbohtml.extract.Paragraph` carrying the same text-and-classification shape as boilerpy3's ``text_blocks``.
+Because the extraction sits on top of a full WHATWG parser, the same page is also available as a DOM you can query and
+serialize.
 
-:func:`turbohtml.extract.boilerplate` answers the same per-block question over the C main-content scoring
-:meth:`~turbohtml.Node.main_content` runs: the scoring picks the content body, every paragraph unit outside it is
-boilerplate, and a unit inside it must still clear the length and link-density thresholds of an
-:class:`~turbohtml.extract.Extraction` config. Each unit comes back a :class:`~turbohtml.extract.Paragraph`, the shape
-of boilerpy3's ``text_blocks`` entries. When you only want the surviving text (boilerpy3's ``get_content``),
-:meth:`~turbohtml.Node.main_text` is the one-call form, and :meth:`~turbohtml.Node.article` adds the metadata harvest
-beside it.
+************************
+ turbohtml vs boilerpy3
+************************
 
-Classifying every block of a full page -- navigation, a scored article, and a footer. turbohtml scores the tree in one C
-pass and classifies the units in a thin Python layer; boilerpy3 parses with its own SAX handler and classifies each
-block in Python. Numbers vary with input and hardware.
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - boilerpy3
+    - - Scope
+      - Full WHATWG HTML parser with DOM, query, serialize, and content extraction on top
+      - Boilerplate/content extraction only, over its own SAX pass
+    - - Feature breadth
+      - One C scoring model plus a threshold config (:class:`~turbohtml.extract.Extraction`) and article metadata
+      - A family of tuned extractors (``ArticleExtractor``, ``ArticleSentencesExtractor``, ``LargestContentExtractor``,
+        ``CanolaExtractor``, ...)
+    - - Performance
+      - C scoring pass over the parsed tree (see below)
+      - Python classification over a Python SAX parse
+    - - Typing
+      - Fully annotated, ships PEP 561 stubs
+      - Annotated pure-Python source
+    - - Dependencies
+      - Compiled C extension
+      - Standard library only, no compiled extension
+    - - Maintenance
+      - Actively developed
+      - Maintained port of the boilerpipe algorithm
+
+Feature overlap
+===============
+
+The shared surface ports one call to one call:
+
+- ``ArticleExtractor().get_content(html)`` -> :meth:`~turbohtml.Node.main_text` (or ``article().text``).
+- ``get_doc(html).text_blocks`` -> :func:`extract.boilerplate(html) <turbohtml.extract.boilerplate>`, a list of
+  :class:`~turbohtml.extract.Paragraph`.
+- ``block.text`` -> ``paragraph.text``, the same whitespace-normalized visible text.
+- ``block.is_content`` -> ``not paragraph.is_boilerplate``.
+- ``block.link_density`` and ``block.num_words`` cutoffs -> the ``max_link_density`` and ``min_length`` fields of
+  :class:`~turbohtml.extract.Extraction`.
+- ``KeepEverythingExtractor().get_content(html)`` -> :meth:`~turbohtml.Node.to_text`, the full visible text.
+
+What turbohtml adds
+===================
+
+- The extraction rides on a full WHATWG parse, so the same page is a DOM you can query, mutate, and serialize, not just
+  a text stream.
+- :meth:`~turbohtml.Node.article` harvests page metadata beside the body text: ``title``, ``byline``, ``date``,
+  ``description``, and ``lang``. boilerpy3's ``get_doc(html).title`` is the only metadata it exposes, and usually
+  ``None`` unless a title block was marked.
+- :class:`~turbohtml.extract.Extraction` tunes the per-paragraph thresholds directly, including a
+  :meth:`~turbohtml.extract.Extraction.justext` preset (a 70-character floor at 0.2 link density) and a
+  ``keep_headings`` switch.
+- :func:`turbohtml.parse` follows the WHATWG recovery rules and never raises on malformed markup, where boilerpy3 raises
+  ``HTMLExtractionError`` unless you pass ``raise_on_failure=False``.
+
+What boilerpy3 has that turbohtml does not
+==========================================
+
+- Several distinct, separately tuned extractor algorithms. ``ArticleExtractor`` maps to turbohtml's defaults,
+  ``NumWordsRulesExtractor``-style floors to ``min_length``, and ``KeepEverythingExtractor`` to
+  :meth:`~turbohtml.Node.to_text`, but there is no equivalent of ``CanolaExtractor``'s trained rule set or
+  ``ArticleSentencesExtractor``'s sentence-level shaping.
+- Multiple surviving content islands. boilerpy3 classifies each block from its neighbors, so two separate content
+  regions both survive; turbohtml first picks the single best-scoring content body, and only units inside it can be
+  content. If you need every island, walk :func:`~turbohtml.extract.boilerplate` output yourself.
+- Fetch convenience: ``get_content_from_url(url)`` and ``get_content_from_file(path)``. turbohtml has no fetcher; read
+  the page with ``urllib`` or ``httpx`` (or open the file) and pass the markup to :func:`~turbohtml.parse`.
+- Pure-Python install with no compiled extension, which can matter on platforms without a prebuilt turbohtml wheel.
+
+Performance
+===========
+
+turbohtml scores the tree in one C pass and classifies the units in a thin Python layer; boilerpy3 parses with its own
+SAX handler and classifies each block in Python. Numbers vary with input and hardware.
 
 .. bench-table::
     :file: bench/boilerpy3.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the extractor import for :func:`turbohtml.parse` and, when you want the classified blocks, the
+:func:`turbohtml.extract.boilerplate` helper:
+
+.. code-block:: python
+
+    from turbohtml import parse
+    from turbohtml.extract import boilerplate, Extraction
+
+The call mapping:
 
 .. list-table::
     :header-rows: 1
@@ -57,6 +138,8 @@ block in Python. Numbers vary with input and hardware.
     - - ``get_content_from_url(url)``
       - fetch the page yourself (``urllib`` or ``httpx``), then parse the markup
 
+Before and after, extracting the article body from a full page:
+
 .. testcode::
 
     from turbohtml import parse
@@ -75,18 +158,16 @@ block in Python. Numbers vary with input and hardware.
 
     A comet is an icy body that releases gas, forming a visible tail, as it nears the Sun.
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - boilerpy3 segments at inline/block transitions of its SAX stream, so a navigation list, a heading, and the first
   paragraph can fuse into one block; turbohtml emits one :class:`~turbohtml.extract.Paragraph` per block element, so
   expect more, smaller units at the same total text.
-- The extractor family collapses to configuration: ``ArticleExtractor`` maps to the defaults,
-  ``NumWordsRulesExtractor``-style floors to ``min_length``, and ``KeepEverythingExtractor`` to
-  :meth:`~turbohtml.Node.to_text`. There is no equivalent of ``CanolaExtractor``'s trained rule set.
-- boilerpy3 classifies each block from its neighbors, so two content islands both survive; turbohtml first picks the
-  single best-scoring content body and only units inside it can be good.
+- The ``min_length`` floor is a character count of normalized text, not a word count. boilerpy3's
+  ``NumWordsRulesExtractor`` thresholds are word counts, so a direct number carries over only loosely; tune against your
+  own pages.
 - ``get_doc(html).title`` is usually ``None`` (it needs a marked title block); ``article().title`` harvests the first
   ``<h1>``, ``og:title``, or ``<title>`` instead.
 - boilerpy3 raises ``HTMLExtractionError`` on markup its parser rejects unless ``raise_on_failure=False``;

--- a/docs/migration/calmjs-parse.rst
+++ b/docs/migration/calmjs-parse.rst
@@ -6,19 +6,119 @@
     :alt: calmjs.parse monthly downloads
     :target: https://pepy.tech/project/calmjs.parse
 
-`calmjs.parse <https://github.com/calmjs/calmjs.parse>`_ is a full JavaScript front end in pure Python: it parses to an
-AST and prints it back, and its ``minify_print`` with ``obfuscate=True`` renames identifiers like a real minifier. It is
-the most capable of the PyPI minifiers, but it parses only ES5 — modern syntax (arrow functions, ``let``/``const``,
-classes, template literals) raises a syntax error — and the pure-Python parse is slow.
+`calmjs.parse <https://github.com/calmjs/calmjs.parse>`_ is a full JavaScript front end in pure Python. It lexes and
+parses ES5 to a concrete AST (``es5(source)``), walks and rewrites that tree through its ``walkers`` and ``asttypes``
+modules, and prints it back with either ``pretty_print`` (readable, re-indented) or ``minify_print`` — whose
+``obfuscate=True`` renames local identifiers the way a real minifier does. It can also emit source maps for the printed
+output. Built for the calmjs Node.js integration toolchain, it is the most capable of the PyPI minifiers, but it parses
+only ES5: modern syntax (arrow functions, ``let``/``const``, classes, template literals) raises a syntax error, and the
+pure-Python parse is slow.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the minification slice of that surface. :func:`~turbohtml.minify_js` is the same parse-and-rename
+approach implemented in C, matching or beating calmjs.parse's output size while running about two orders of magnitude
+faster and accepting a much larger slice of the language. It does not expose an AST, a pretty-printer, or source maps —
+it is a minifier, not a general JavaScript toolkit.
 
-:func:`~turbohtml.minify_js` is the same parse-and-rename approach in C, and it now matches or beats calmjs.parse's size
-while running about two orders of magnitude faster. It also parses a much larger slice of the language, so scripts
-calmjs.parse rejects still minify. A script it cannot handle is the standalone call's :class:`ValueError` (and, inside
-HTML, a verbatim fallback) rather than a hard parser crash.
+***************************
+ turbohtml vs calmjs.parse
+***************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - calmjs.parse
+    - - Scope
+      - JavaScript minifier only (plus inline ``<script>`` minification in HTML)
+      - Full ES5 front end: lexer, parser, AST, walkers, pretty-printer, minifier, source maps
+    - - Feature breadth
+      - Whitespace/comment/number folding, identifier mangling, constant folding, dead-code elimination
+      - AST access and rewriting, beautify and minify printers, identifier obfuscation, source maps
+    - - Performance
+      - Native C, single-digit milliseconds on the corpus below
+      - Pure Python, hundreds of milliseconds on the same inputs
+    - - Typing
+      - Typed public API (:func:`~turbohtml.minify_js`, :class:`~turbohtml.JSMinify`)
+      - Untyped
+    - - Dependencies
+      - None (ships the C extension)
+      - ``ply`` (parser generator)
+    - - Maintenance
+      - Actively developed alongside the turbohtml serializer
+      - Maintained, stable, ES5-scoped
+
+Feature overlap
+===============
+
+The minification path ports 1:1:
+
+- Minify a source string to the shortest equivalent program: ``minify_print(es5(source))`` maps to
+  :func:`turbohtml.minify_js(source, JSMinify(mangle=False)) <turbohtml.minify_js>`.
+- Rename local identifiers: calmjs.parse's ``minify_print(es5(source), obfuscate=True)`` maps to turbohtml's default
+  ``mangle=True``.
+- Both fold whitespace, drop comments, and shorten numeric literals unconditionally.
+
+What turbohtml adds
+===================
+
+- Modern JavaScript: arrow functions, ``let``/``const``, classes, and template literals minify instead of raising a
+  syntax error.
+- Constant folding and dead-code elimination (:class:`~turbohtml.JSMinify` ``fold=True``), beyond calmjs.parse's
+  whitespace-and-rename minification.
+- A native-C pipeline that runs about forty to eighty times faster on the corpus below.
+- Inline-``<script>`` minification inside a full HTML document via ``Minify(minify_js=JSMinify())`` on
+  :meth:`~turbohtml.Node.serialize` — no separate JS toolchain step.
+- A typed surface: :func:`~turbohtml.minify_js` and the frozen :class:`~turbohtml.JSMinify` options object.
+
+What calmjs.parse has that turbohtml does not
+=============================================
+
+- A parsed AST. ``es5(source)`` returns a walkable, mutable concrete syntax tree; turbohtml exposes no JavaScript AST,
+  only the minified string. No equivalent — use calmjs.parse (or a Node-based tool) when you need to inspect or
+  programmatically rewrite JavaScript.
+- A pretty-printer. ``pretty_print`` re-indents and beautifies; turbohtml only shrinks. No equivalent.
+- Source maps. calmjs.parse can emit a source map for its printed output; turbohtml's minifier does not. No equivalent.
+- AST walkers and node types (``calmjs.parse.walkers``, ``calmjs.parse.asttypes``) for custom analysis or transformation
+  passes. No equivalent.
+
+Performance
+===========
+
+On the ES5 library ladder turbohtml reaches the smaller output, and the speed gap is large: on the same machine
+(``python -m bench minify-js``) calmjs.parse takes hundreds of milliseconds where turbohtml takes single-digit
+milliseconds. Each ratio is against turbohtml:
+
+.. bench-table::
+    :file: bench/calmjs-parse.json
+
+turbohtml beats calmjs.parse on size everywhere, at forty to eighty times less time and on modern JavaScript that
+calmjs.parse rejects outright, so for any build where minify time or modern syntax is in the loop turbohtml is the
+practical choice.
+
+****************
+ How to migrate
+****************
+
+Swap the parse-then-print pair for the single minify call:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - calmjs.parse
+      - turbohtml
+    - - ``from calmjs.parse import es5``
+      - ``import turbohtml``
+    - - ``from calmjs.parse.unparsers.es5 import minify_print``
+      - (none needed)
+    - - ``minify_print(es5(src), obfuscate=True)``
+      - ``turbohtml.minify_js(src)``
+    - - ``minify_print(es5(src))``
+      - ``turbohtml.minify_js(src, JSMinify(mangle=False))``
+    - - ``pretty_print(es5(src))``
+      - no equivalent (turbohtml only minifies)
 
 .. code-block:: python
 
@@ -33,13 +133,27 @@ HTML, a verbatim fallback) rather than a hard parser crash.
 
     turbohtml.minify_js(source)  # in C, modern syntax too
 
-On the ES5 library ladder turbohtml reaches the smaller output, and the speed gap is large: on the same machine
-(``python -m bench minify-js``) calmjs.parse takes hundreds of milliseconds where turbohtml takes single-digit
-milliseconds. Each ratio is against turbohtml:
+To keep readable local names while still folding whitespace and comments, pass a :class:`~turbohtml.JSMinify` with
+``mangle=False``:
 
-.. bench-table::
-    :file: bench/calmjs-parse.json
+.. code-block:: python
 
-turbohtml beats calmjs.parse on size everywhere, at forty to eighty times less time and on modern JavaScript that
-calmjs.parse rejects outright, so for any build where minify time or modern syntax is in the loop turbohtml is the
-practical choice.
+    from turbohtml import minify_js, JSMinify
+
+    minify_js(source, JSMinify(mangle=False))
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- Error type. calmjs.parse raises ``ECMASyntaxError`` on a script it cannot parse; turbohtml's standalone
+  :func:`~turbohtml.minify_js` raises :class:`ValueError` (with the construct, byte offset, and offending token), and
+  :class:`TypeError` if ``source`` is not a :class:`str`. Inside HTML the inline-``<script>`` pass instead leaves an
+  unminifiable script verbatim rather than raising.
+- Modern syntax is a hard stop in calmjs.parse (a syntax error), where turbohtml minifies it. A migration that was
+  silently skipping ES6+ files because they failed to parse will start minifying them.
+- No AST after the call. If existing code parses with ``es5()`` and then walks or mutates the tree, that path has no
+  turbohtml counterpart; only the minified string is returned.
+- Obfuscation scope. calmjs.parse's ``obfuscate=True`` renames local bindings and leaves globals alone unless
+  ``obfuscate_globals`` is set; turbohtml's ``mangle`` likewise renames only locals, so global-name behavior matches by
+  default.

--- a/docs/migration/chardet.rst
+++ b/docs/migration/chardet.rst
@@ -4,30 +4,130 @@
 
 .. package-meta:: chardet chardet/chardet
 
-`chardet <https://chardet.readthedocs.io/>`_ is the pure-Python universal character encoding detector:
-``chardet.detect(data)`` returns an ``{"encoding", "confidence", "language"}`` dict, ``detect_all`` ranks the
-candidates, and ``UniversalDetector`` accumulates a stream chunk by chunk. This guide also covers `cchardet
-<https://github.com/PyYoshi/cChardet>`_, whose ``cchardet.detect`` is the same call bound to the C uchardet engine.
+`chardet <https://chardet.readthedocs.io/>`_ is the pure-Python universal character encoding detector, the tool most
+projects reach for when they receive undeclared bytes from a file, a socket, or an HTTP body with no reliable
+``Content-Type``. ``chardet.detect(data)`` returns an ``{"encoding", "confidence", "language"}`` dict, ``detect_all``
+ranks the candidates, and ``UniversalDetector`` accumulates a stream chunk by chunk so a reader can stop as soon as the
+verdict is settled. It ships an ensemble of probers (escape-sequence, multi-byte, and single-byte frequency models) that
+vote on the most likely encoding, an approach inherited from Mozilla's original ``universalchardet``. It is a dependency
+of ``requests`` and countless scrapers and ETL pipelines. This guide also covers `cchardet
+<https://github.com/PyYoshi/cChardet>`_, whose ``cchardet.detect`` is the same call bound to the C ``uchardet`` engine.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with :func:`turbohtml.detect.detect`, a standalone entry point over the C detector it
+already ships for :func:`~turbohtml.parse`. It answers "what encoding are these bytes?" without an HTML parser in the
+call path, and returns a typed :class:`~turbohtml.detect.EncodingMatch` in place of chardet's dict.
 
-:func:`turbohtml.detect.detect` answers the same question from the C detector turbohtml already ships for
-:func:`~turbohtml.parse`: a port of Firefox's `chardetng <https://github.com/hsivonen/chardetng>`_, run after the WHATWG
-sniff (byte-order mark, then ``<meta>`` prescan), with the spec's windows-1252 fallback -- the algorithm a browser would
-use on the same bytes. Certain input short-circuits before any scoring, so ASCII, valid UTF-8, and real web pages
-resolve 50x to 2000x ahead of chardet's prober ensemble; declaration-less legacy single-byte text still runs about 3x
-ahead. Both libraries decode a 15-sample multilingual differential correctly, though chardet often names a sibling or
-superset (ISO-8859-7 for Greek windows-1253 bytes, GB18030 for GBK) where turbohtml reports the WHATWG encoding a
-browser would pick.
+**********************
+ turbohtml vs chardet
+**********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 18 41 41
+
+    - - Dimension
+      - turbohtml
+      - chardet
+    - - Scope
+      - WHATWG-conformant detection: a byte-order-mark sniff, an HTML ``<meta>`` prescan of the first 1024 bytes, then
+        the ``chardetng`` content detector with the spec's windows-1252 fallback -- the algorithm a browser runs on the
+        same bytes.
+      - Ensemble of probers voting on the most likely encoding; ignores HTML markup and never applies a browser's
+        windows-1252 fallback.
+    - - Feature breadth
+      - ``detect``, ``detect_all``, an incremental :class:`~turbohtml.detect.Detector`, plus a frozen
+        :class:`~turbohtml.detect.Detection` config for confidence floor, language hint, and allow/exclude constraints.
+      - ``detect``, ``detect_all``, ``UniversalDetector`` with a ``lang_filter``; no allow/exclude set, no language
+        hint.
+    - - Performance
+      - ASCII, valid UTF-8, and real web pages short-circuit before any scoring, resolving 50x to 2000x ahead; legacy
+        single-byte text runs about 3x ahead. See the table below.
+      - Prober ensemble runs every model on every input; no fast path for clean UTF-8 or ASCII.
+    - - Typing
+      - Fully typed: ``EncodingMatch``, ``Detection``, ``Detector`` are annotated dataclasses/classes with stubs.
+      - Returns untyped ``dict``; type stubs are third-party.
+    - - Dependencies
+      - None beyond the turbohtml C extension.
+      - Pure Python, no dependencies (``cchardet`` needs a C build).
+    - - Maintenance
+      - Actively developed alongside the parser; the detector is the same code the parser uses in production.
+      - Maintained but slow-moving; the model set has been stable for years.
+
+Feature overlap
+===============
+
+The detection surface ports one-to-one:
+
+- ``chardet.detect(data)`` -> :func:`turbohtml.detect.detect`, same three fields as a typed record.
+- ``chardet.detect_all(data)`` -> :func:`turbohtml.detect.detect_all`, ranked candidates best first.
+- ``UniversalDetector()`` with ``feed`` / ``close`` / ``reset`` / ``done`` / ``result`` ->
+  :class:`turbohtml.detect.Detector` with the same five members.
+- ``UniversalDetector(lang_filter=...)`` -> a :class:`~turbohtml.detect.Detection` ``allowed`` frozenset of the WHATWG
+  encoding names to keep.
+- chardet's implicit 0.2 minimum confidence -> :meth:`Detection.chardet() <turbohtml.detect.Detection.chardet>`.
+- ``cchardet.detect(data)`` (including the maintained ``faust-cchardet`` fork) -> :func:`turbohtml.detect.detect`.
+
+What turbohtml adds
+===================
+
+- HTML ``<meta>`` charset awareness: a declaration in the first 1024 bytes wins per the WHATWG prescan, so detection
+  agrees with what the browser and :func:`turbohtml.parse` would decode. chardet and cchardet ignore markup entirely.
+- Browser-faithful results: turbohtml reports the WHATWG canonical encoding a browser would pick, where chardet often
+  names a sibling or superset (ISO-8859-7 for Greek windows-1253 bytes, GB18030 for GBK).
+- A frozen :class:`~turbohtml.detect.Detection` config with a language hint, an ``allowed`` set, and a mutually
+  exclusive ``excluded`` set -- richer than chardet's single ``lang_filter``.
+- Fully typed results: :class:`~turbohtml.detect.EncodingMatch` instead of an untyped dict.
+- One detection path shared with parsing: standalone ``detect`` and ``parse(detect_encoding=True)`` always agree on the
+  same bytes.
+
+What chardet has that turbohtml does not
+========================================
+
+- A wider candidate set. turbohtml scores chardetng's list: UTF-8, ISO-2022-JP, five CJK encodings, and 19 single-byte
+  encodings. chardet's extras outside that set (UTF-16/32 without a byte-order mark, MacCyrillic, TIS-620, Johab)
+  resolve to the closest WHATWG candidate instead. No equivalent when you need one of those exact labels.
+- A raw CJK speed edge on the C fork. On CJK-heavy byte streams (the Shift_JIS row), ``cchardet``'s uchardet engine
+  outruns turbohtml, whose CJK scoring drives a CPython incremental codec per candidate. Workaround: keep
+  ``faust-cchardet`` for that one workload if it dominates; turbohtml leads on every other row.
+- The ``UTF-8-SIG`` label for a byte-order-mark-prefixed stream. turbohtml reports ``UTF-8``; decode with the
+  ``utf-8-sig`` codec when you need the mark stripped.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/chardet.json
 
-*************
- The renames
-*************
+Certain input short-circuits before any scoring, so ASCII, valid UTF-8, and real web pages resolve 50x to 2000x ahead of
+chardet's prober ensemble; declaration-less legacy single-byte text still runs about 3x ahead. Both libraries decode a
+15-sample multilingual differential correctly, though chardet often names a sibling or superset where turbohtml reports
+the WHATWG encoding a browser would pick. The one exception is CJK-heavy bytes, where ``cchardet``'s uchardet engine
+leads (the Shift_JIS row, 22x); turbohtml leads on the other rows.
+
+****************
+ How to migrate
+****************
+
+Swap the import and read the fields off the typed record instead of the dict:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `chardet <https://chardet.readthedocs.io/>`__
+      - turbohtml
+    - - ``chardet.detect(data)``
+      - :func:`~turbohtml.detect.detect`
+    - - ``chardet.detect_all(data)``
+      - :func:`~turbohtml.detect.detect_all`
+    - - ``UniversalDetector()`` / ``feed`` / ``close`` / ``reset`` / ``done`` / ``result``
+      - :class:`~turbohtml.detect.Detector` with the same five members
+    - - ``UniversalDetector(lang_filter=LanguageFilter.CJK)``
+      - ``Detection(allowed=frozenset({"gbk", "big5", "shift_jis", "euc-jp", "iso-2022-jp", "euc-kr"}))``
+    - - the implicit 0.2 minimum confidence
+      - ``Detection.chardet()``
+    - - ``cchardet.detect(data)``
+      - :func:`~turbohtml.detect.detect`
 
 The dict becomes a typed :class:`~turbohtml.detect.EncodingMatch` with the same three fields:
 
@@ -54,40 +154,15 @@ The dict becomes a typed :class:`~turbohtml.detect.EncodingMatch` with the same 
 
     windows-1251 Russian
 
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    - - `chardet <https://chardet.readthedocs.io/>`__
-      - turbohtml
-    - - ``chardet.detect(data)``
-      - :func:`~turbohtml.detect.detect`
-    - - ``chardet.detect_all(data)``
-      - :func:`~turbohtml.detect.detect_all`
-    - - ``UniversalDetector()`` / ``feed`` / ``close`` / ``reset`` / ``done`` / ``result``
-      - :class:`~turbohtml.detect.Detector` with the same five members
-    - - ``UniversalDetector(lang_filter=LanguageFilter.CJK)``
-      - ``Detection(allowed=frozenset({"gbk", "big5", "shift_jis", "euc-jp", "iso-2022-jp", "euc-kr"}))``
-    - - the implicit 0.2 minimum confidence
-      - ``Detection.chardet()``
-    - - ``cchardet.detect(data)``
-      - :func:`~turbohtml.detect.detect`
-
-**********
- cchardet
-**********
-
-The original ``cchardet`` package stopped at 2.1.7 (2021) and no longer compiles on Python 3.11+, where the
-``longintrepr.h`` header it includes left the public C API; the maintained fork `faust-cchardet
+The maintained ``cchardet`` story is a footnote: the original package stopped at 2.1.7 (2021) and no longer compiles on
+Python 3.11+, where the ``longintrepr.h`` header it includes left the public C API. The fork `faust-cchardet
 <https://github.com/faust-streaming/cChardet>`_ keeps the ``import cchardet`` name alive. Both expose only ``detect``
 and a ``UniversalDetector`` without ``detect_all``, and neither reports a language; the turbohtml calls above replace
-either package unchanged. One workload keeps the C fork ahead: on CJK-heavy byte streams (the Shift_JIS row, 22x) its
-uchardet engine outruns turbohtml, whose CJK scoring drives a CPython incremental codec per candidate; turbohtml leads
-on the other rows.
+either package unchanged.
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - Encoding names differ in spelling, not identity: turbohtml reports the WHATWG canonical name (``windows-1251``,
   ``Shift_JIS``), chardet its own casing (``Windows-1251``, ``CP932``), cchardet upper case. Every name turbohtml can

--- a/docs/migration/charset-normalizer.rst
+++ b/docs/migration/charset-normalizer.rst
@@ -4,29 +4,112 @@
 
 .. package-meta:: charset-normalizer jawah/charset_normalizer
 
-`charset-normalizer <https://charset-normalizer.readthedocs.io/>`_ is the detector ``requests`` ships with: it decodes
-the input under candidate codecs and scores each result's "chaos" and language coherence. ``from_bytes(data).best()``
-returns the winning ``CharsetMatch``, and a ``detect()`` shim mimics chardet's dict.
+`charset-normalizer <https://charset-normalizer.readthedocs.io/>`_ is the encoding detector ``requests`` ships with in
+place of chardet. It is a pure-Python library that decodes the input under every candidate codec CPython exposes, then
+scores each decode by a "chaos" (mess) metric and a language-coherence metric, keeping the cleanest reading.
+``from_bytes(data).best()`` returns the winning ``CharsetMatch``; ``from_path`` and ``from_fp`` do the same for files
+and streams, a ``detect()`` shim mimics chardet's dict, and a ``normalizer`` console command exposes the whole thing
+from the shell. Because it is pure Python with no compiled dependency, it installs anywhere and is the default fallback
+detector across the ``requests`` ecosystem.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same detection job with :func:`turbohtml.detect.detect`, a C implementation of the WHATWG sniffing
+pipeline (byte-order-mark and ``<meta>`` prescan) followed by Firefox's negative-matching ``chardetng`` scorer, so the
+common case of declared or structurally certain input resolves without running a full scoring sweep.
 
-:func:`turbohtml.detect.detect` runs Firefox's negative-matching design (`chardetng
-<https://github.com/hsivonen/chardetng>`_) in C: a single decode error disqualifies a candidate and character-pair
-frequencies score the survivors, after the WHATWG byte-order-mark and ``<meta>`` prescan steps. Declared or structurally
-certain input short-circuits, so ASCII, UTF-8, and real web pages resolve in microseconds -- 6x to 306x ahead of
-charset-normalizer, which always runs its scoring passes. On declaration-less legacy bytes the two trade wins (see the
-table). On a 15-sample multilingual differential every turbohtml answer decodes the bytes back to the source text;
-charset-normalizer garbles three, reading Czech ISO-8859-2 as cp1250, Turkish windows-1254 as cp1252, and KOI8-R Russian
-as shift_jis_2004.
+*********************************
+ turbohtml vs charset-normalizer
+*********************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - charset-normalizer
+    - - Scope
+      - Encoding detection as part of a WHATWG HTML engine; BOM + ``<meta>`` prescan then ``chardetng`` scoring
+      - Standalone encoding detection for arbitrary bytes; decode-and-score over every CPython codec
+    - - Feature breadth
+      - ``detect``, ``detect_all``, streaming ``Detector``, allow/exclude and language constraints
+      - Rich match objects (chaos, coherence, alphabets, multiple languages), file/stream helpers, CLI, explain logging
+    - - Performance
+      - C, short-circuits certain input in microseconds; 6x-306x ahead on declared/UTF-8/ASCII bytes (see table)
+      - Pure Python, always runs its per-codec decode and scoring passes
+    - - Typing
+      - Fully typed; frozen ``EncodingMatch`` / ``Detection`` records with shipped stubs
+      - Typed public API with inline annotations
+    - - Dependencies
+      - The turbohtml C extension (no third-party runtime deps)
+      - Pure Python, zero runtime dependencies
+    - - Maintenance
+      - Active, part of the turbohtml project
+      - Active, widely deployed as the ``requests`` chardet replacement
+
+Feature overlap
+===============
+
+Portable one-to-one between the two libraries:
+
+- Best-guess detection: ``from_bytes(data).best()`` maps to :func:`~turbohtml.detect.detect`.
+- All ranked candidates: iterating ``from_bytes(data)`` maps to :func:`~turbohtml.detect.detect_all`.
+- The chardet-compatible dict: ``charset_normalizer.detect(data)`` maps to :func:`~turbohtml.detect.detect` (read
+  ``match.encoding``, ``match.confidence``, ``match.language``).
+- Restricting the candidate set: ``cp_isolation=[...]`` maps to ``Detection(allowed=frozenset({...}))`` and
+  ``cp_exclusion=[...]`` to ``Detection(excluded=frozenset({...}))``.
+- Language of the winning model: ``best().language`` maps to :attr:`EncodingMatch.language
+  <turbohtml.detect.EncodingMatch>`.
+- A ``<meta>`` charset in the first bytes is honored by both (charset-normalizer's ``preemptive_behaviour``, on by
+  default, and turbohtml's prescan).
+
+What turbohtml adds
+===================
+
+- A WHATWG-conformant front end: the byte-order-mark check and ``<meta>`` prescan run before any statistical scoring,
+  matching what an HTML parser actually does with the bytes.
+- ``chardetng``'s negative matching: a single decode error disqualifies a candidate outright, then character-pair
+  frequencies rank the survivors. On a 15-sample multilingual differential every turbohtml answer round-trips back to
+  the source text; charset-normalizer garbles three (Czech ISO-8859-2 read as cp1250, Turkish windows-1254 as cp1252,
+  KOI8-R Russian as shift_jis_2004).
+- Microsecond short-circuits: declared or structurally certain input (BOM, ``<meta>``, valid UTF-8, ISO-2022-JP escape
+  sequences, pure ASCII) resolves without the scoring sweep charset-normalizer always runs.
+- A streaming :class:`~turbohtml.detect.Detector` (``feed`` / ``close`` / ``reset``, with a ``done`` early-stop flag)
+  that mirrors chardet's ``UniversalDetector`` and always agrees with :func:`~turbohtml.detect.detect` of the
+  concatenated bytes.
+- A ``Detection.chardet()`` preset that reproduces chardet's 0.2 minimum-confidence behavior.
+
+What charset-normalizer has that turbohtml does not
+===================================================
+
+- Arbitrary CPython codecs: charset-normalizer can propose any codec the interpreter ships (``big5hkscs``,
+  ``shift_jis_2004``, and other exotic encodings). turbohtml detects only ``chardetng``'s web-focused set (UTF-8,
+  ISO-2022-JP, five CJK encodings, 19 single-byte encodings). No equivalent for encodings outside that set.
+- A CLI: the ``normalizer`` command has no turbohtml counterpart. Workaround: call :func:`~turbohtml.detect.detect` from
+  a short script.
+- ``explain=True`` verbose logging of the scoring decision. Workaround: :func:`~turbohtml.detect.detect_all` exposes the
+  ranked candidates and their confidences as the introspection surface.
+- File and stream helpers ``from_path`` / ``from_fp``. Workaround: read the bytes yourself and pass them to
+  :func:`~turbohtml.detect.detect`, or feed chunks to :class:`~turbohtml.detect.Detector`.
+- Rich per-match analysis on ``CharsetMatch``: chaos/coherence scores, alphabet listings, and multiple candidate
+  languages. turbohtml reports a single ``confidence`` float and one ``language`` string per match. Workaround: none for
+  the alphabet and multi-language breakdown.
+- Chunked-scan tuning knobs (``steps``, ``chunk_size``). No equivalent; turbohtml scores over the whole input.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/charset-normalizer.json
 
-*************
- The renames
-*************
+Declared or structurally certain input short-circuits, so ASCII, UTF-8, and real web pages resolve in microseconds -- 6x
+to 306x ahead of charset-normalizer, which always runs its scoring passes. On declaration-less legacy bytes the two
+trade wins (see the table).
+
+****************
+ How to migrate
+****************
+
+Swap the import and call :func:`~turbohtml.detect.detect` in place of ``from_bytes(...).best()``:
 
 .. code-block:: python
 
@@ -40,19 +123,7 @@ as shift_jis_2004.
 
     match = detect(data)  # EncodingMatch
 
-.. testcode::
-
-    from turbohtml.detect import detect
-
-    raw = "Précédemment, la créativité française".encode("cp1252")
-    match = detect(raw)
-    print(match.encoding)
-    print(raw.decode(match.encoding))
-
-.. testoutput::
-
-    windows-1252
-    Précédemment, la créativité française
+API mapping:
 
 .. list-table::
     :header-rows: 1
@@ -77,18 +148,36 @@ as shift_jis_2004.
     - - ``best().could_be_from_charset`` (equal-fit codecs)
       - the runner-up entries of :func:`~turbohtml.detect.detect_all`
 
-**********
- Pitfalls
-**********
+A worked round-trip:
+
+.. testcode::
+
+    from turbohtml.detect import detect
+
+    raw = "Précédemment, la créativité française".encode("cp1252")
+    match = detect(raw)
+    print(match.encoding)
+    print(raw.decode(match.encoding))
+
+.. testoutput::
+
+    windows-1252
+    Précédemment, la créativité française
+
+**********************
+ Gotchas and pitfalls
+**********************
 
 - charset-normalizer's ``threshold`` bounds the *chaos* it tolerates (lower is stricter); :attr:`Detection.threshold
   <turbohtml.detect.Detection>` floors the *confidence* it requires (higher is stricter). The two numbers measure
   different things, so pick a new value rather than copying one across.
 - Names differ in spelling: charset-normalizer reports Python codec names (``cp1251``), turbohtml the WHATWG canonical
   (``windows-1251``). Both decode through :mod:`python:codecs`, so downstream ``bytes.decode`` calls keep working.
-- turbohtml honors a ``<meta>`` charset in the first 1024 bytes (charset-normalizer's ``preemptive_behaviour`` does the
-  same and is on by default in both).
-- There is no ``explain`` logging mode and no CLI; :func:`~turbohtml.detect.detect_all` is the introspection surface.
-- charset-normalizer can propose any codec CPython ships; turbohtml detects chardetng's web-focused candidate set
-  (UTF-8, ISO-2022-JP, five CJK, 19 single-byte encodings), which is why it cannot propose an exotic codec such as
-  ``shift_jis_2004`` for plain legacy text.
+- ``str(best())`` returns the decoded text directly; :func:`~turbohtml.detect.detect` returns only the encoding, so
+  decode explicitly with ``data.decode(match.encoding)``.
+- ``best()`` can be ``None`` when nothing scores; :func:`~turbohtml.detect.detect` always returns an
+  :class:`~turbohtml.detect.EncodingMatch`, but its ``encoding`` is ``None`` for empty input or when every candidate is
+  ruled out by ``threshold``, ``allowed``, or ``excluded``.
+- charset-normalizer can propose any codec CPython ships; turbohtml's web-focused candidate set will not surface an
+  exotic codec such as ``shift_jis_2004`` for plain legacy text, so results can differ on inputs outside common web
+  encodings.

--- a/docs/migration/courlan.rst
+++ b/docs/migration/courlan.rst
@@ -4,19 +4,106 @@
 
 .. package-meta:: courlan adbar/courlan
 
-`courlan <https://github.com/adbar/courlan>`_ is the URL cleaner and filter underneath ``trafilatura``:
-``clean_url``/``scrub_url`` strip markup damage, ``normalize_url`` canonicalizes, and ``extract_links`` pulls the
-followable links out of a page with regexes. turbohtml covers that surface in :mod:`turbohtml.extract`, sharing one
-frozen :class:`~turbohtml.extract.UrlCleaning` config across the three calls.
+`courlan <https://github.com/adbar/courlan>`_ is the URL cleaner and filter underneath ``trafilatura``. It scrubs the
+transport damage out of scraped URLs (``clean_url``/``scrub_url``), canonicalizes them for a crawl (``normalize_url``:
+query sorting, tracker removal, a strict content-parameter allowlist, a path-based language filter), decides whether a
+URL is worth fetching (``check_url``, ``is_navigation_page``, spam and content-type heuristics), pulls the followable
+links out of a page by regex (``extract_links``/``filter_links``), and manages a crawl frontier in memory
+(``UrlStore``). It is used wherever ``trafilatura`` scrapes: web-corpus building, focused crawling, deduplicating a link
+set before fetching.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the URL-hygiene half of that surface in :mod:`turbohtml.extract`. Three functions -- :func:`clean_url
+<turbohtml.extract.clean_url>`, :func:`normalize_url <turbohtml.extract.normalize_url>`, :func:`extract_links
+<turbohtml.extract.extract_links>` -- share one frozen :class:`~turbohtml.extract.UrlCleaning` config, produce the
+canonical form the `WHATWG URL standard <https://url.spec.whatwg.org/>`_ defines, and read links from the real parsed
+DOM rather than a markup regex. The crawl-policy half (frontier management, spam and navigation heuristics, HTTP
+probing) stays out of scope by design.
 
-:func:`turbohtml.extract.clean_url` and :func:`~turbohtml.extract.normalize_url` produce the canonical form the `WHATWG
-URL standard <https://url.spec.whatwg.org/>`_ defines -- the serialization a browser's address bar would show -- and
-layer courlan's crawl canonicalization (query sorting, tracker removal, the strict allowlist, the language filter) on
-top, about 2x faster per URL:
+**********************
+ turbohtml vs courlan
+**********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 18 41 41
+
+    - - Dimension
+      - turbohtml
+      - courlan
+    - - Scope
+      - WHATWG HTML parser with a URL-hygiene module (:mod:`turbohtml.extract`)
+      - URL cleaning, filtering, and crawl-frontier management for ``trafilatura``
+    - - Feature breadth
+      - clean, normalize, and link-extract over the parsed DOM, one frozen config
+      - clean/scrub/normalize/check, regex link extraction, ``UrlStore``, spam and navigation heuristics, a CLI
+    - - Performance
+      - ~2x per URL on cleaning, 1.4x-2.4x on link extraction including the parse (see below)
+      - baseline
+    - - Typing
+      - fully typed, ships ``py.typed`` and stubs
+      - ships type hints
+    - - Dependencies
+      - native C extension, no Python runtime deps
+      - pure Python, depends on ``tld`` for public-suffix lookups
+    - - Maintenance
+      - actively developed
+      - actively maintained under the ``trafilatura`` umbrella
+
+Feature overlap
+===============
+
+The URL-hygiene surface ports 1:1:
+
+- ``courlan.clean_url(url)`` -> :func:`turbohtml.extract.clean_url`, with ``scrub_url``'s markup-damage recovery folded
+  in (whitespace and control-character stripping, ``<![CDATA[]]>`` unwrap, ``&amp;`` un-escape, truncation at a stray
+  ``<``/``>``/``"``).
+- ``courlan.normalize_url(url, strict=..., language=..., trailing_slash=...)`` ->
+  :func:`~turbohtml.extract.normalize_url` with a :class:`~turbohtml.extract.UrlCleaning` config: query sorting, tracker
+  removal, the strict content-parameter allowlist, trailing-slash folding.
+- ``courlan.extract_links(page, url=..., external_bool=True, language=...)`` -> :func:`~turbohtml.extract.extract_links`
+  with ``external_only=True``.
+- ``courlan.is_external(url, reference)`` -> ``external_only=`` on :func:`~turbohtml.extract.extract_links`.
+- The keyword-argument spread across courlan's signatures collapses onto one immutable
+  :class:`~turbohtml.extract.UrlCleaning`; :meth:`UrlCleaning.w3lib <turbohtml.extract.UrlCleaning.w3lib>` reproduces
+  ``w3lib.url.canonicalize_url``'s mode (drop the fragment, keep every non-tracker parameter).
+
+What turbohtml adds
+===================
+
+- Link extraction reads anchors from the real WHATWG DOM, not a regex over the markup: links inside comments or scripts
+  never leak in, a ``<base href>`` is honored per HTML spec 4.2.3, and repeated navigation targets are cleaned once and
+  deduplicated across their ``http``/``https`` and trailing-slash twins.
+- Output follows the WHATWG URL serializer, the form a browser's address bar or an ``href`` getter returns (root slash
+  on special URLs, host punycoded to ASCII, empty path segments preserved).
+- ``query_allow`` and ``query_deny`` on :class:`~turbohtml.extract.UrlCleaning` give a per-call keep-list and drop-list
+  (``w3lib.url.url_query_cleaner``'s keep and ``remove=True`` modes), which courlan does not expose.
+- One frozen config drives all three functions, no per-call keyword drift, and no Python runtime dependency.
+
+What courlan has that turbohtml does not
+========================================
+
+- **Crawl-frontier management.** ``UrlStore`` (deduplicating, host-bucketed, visit-tracked in-memory URL storage) has no
+  equivalent; turbohtml cleans URLs but does not manage a crawl. Keep ``courlan.UrlStore`` for that layer.
+- **Crawl-policy filters.** ``check_url``'s content-type, spam/adult, and site-structure filters,
+  ``is_navigation_page``, ``is_not_crawlable``, ``filter_links``, and the ``with_redirects`` HTTP probe are out of
+  scope. They are fetch policy, not URL hygiene; keep courlan where you need them.
+- **Registrable-domain classification.** courlan compares hosts through the public-suffix list (``tld``), so
+  ``spam.example.co.uk`` versus ``example.co.uk`` classifies correctly. turbohtml's ``external_only`` boundary is the
+  ``www.``-less host with subdomains counting as internal; filter through a public-suffix library if you need the
+  registrable-domain rule.
+- **Content-based language scoring.** courlan's language filter can fall back to locale scoring of the content;
+  turbohtml consults only URL-based markers (a leading path segment, a ``lang``/``language`` query parameter, an
+  anchor's ``hreflang``, and in strict mode a language subdomain). No equivalent for the content-scoring path.
+- **Punycode-to-Unicode and slash collapsing.** courlan decodes punycode hosts to Unicode and collapses repeated
+  slashes; turbohtml keeps the WHATWG forms (ASCII host, empty segments preserved). No flag toggles this.
+- **A command-line interface.** courlan ships a CLI; turbohtml exposes the Python API only.
+
+Performance
+===========
+
+:func:`~turbohtml.extract.clean_url` and :func:`~turbohtml.extract.normalize_url` produce the WHATWG canonical form (the
+serialization a browser's address bar would show) and layer courlan's crawl canonicalization (query sorting, tracker
+removal, the strict allowlist, the language filter) on top, about 2x faster per URL:
 
 .. bench-table::
     :file: bench/courlan.json
@@ -32,9 +119,12 @@ Over the 290 URLs in courlan's own test suite the two libraries return identical
 to the WHATWG root-slash serialization for 90%; every remaining divergence is deliberate and listed under
 :ref:`courlan-divergences`.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import: ``courlan``'s free functions move to :mod:`turbohtml.extract`, and the keyword arguments courlan
+spreads across signatures collapse onto :class:`~turbohtml.extract.UrlCleaning`.
 
 .. list-table::
     :header-rows: 1
@@ -89,11 +179,11 @@ Link extraction takes the page markup plus the URL it was fetched from, and retu
 
 .. _courlan-divergences:
 
-**************************************
- Deliberate divergences and omissions
-**************************************
+**********************
+ Gotchas and pitfalls
+**********************
 
-turbohtml follows the WHATWG URL standard where courlan makes its own choices; each of these shows up in the 10% of
+turbohtml follows the WHATWG URL standard where courlan makes its own choices. Each of these shows up in the 10% of
 courlan's suite where outputs differ beyond the root slash:
 
 - **Root slash.** A host-only URL serializes as ``http://test.org/`` (the URL standard's serializer always emits the
@@ -105,15 +195,7 @@ courlan's suite where outputs differ beyond the root slash:
 - **Junk stays rejected.** ``http://1234`` or ``http://ab`` return ``None`` from :func:`~turbohtml.extract.clean_url`;
   courlan's ``clean_url`` passes them through and only ``check_url`` rejects.
 
-The content-type, spam/adult, navigation-page, and site-structure filters of ``check_url``/``filter_links``, the
-``with_redirects`` HTTP probe, the domain blocklist, and the embedded-URL salvage of ``scrub_url`` (recovering a target
-from a ``twitter.com/share?url=...`` wrapper) are deliberately out of scope: they are crawl policy, not URL hygiene. The
-language filter is the URL-based subset (path segment, ``lang`` parameter, and in strict mode a language subdomain);
-courlan's Babel-backed locale scoring is not consulted.
-
-**********
- Pitfalls
-**********
+Behavioral differences to watch when porting call sites:
 
 - ``extract_links`` returns every surviving link by default; ``external_only=True`` restricts to other sites. courlan's
   ``external_bool`` flag instead *splits* the set: ``False`` means internal links only. Filter the result by host when
@@ -126,3 +208,9 @@ courlan's Babel-backed locale scoring is not consulted.
   courlan's ``normalize_url`` raises ``ValueError`` on a language mismatch.
 - turbohtml keeps a non-tracker fragment by default (``#page2``, text fragments) like courlan, but
   ``UrlCleaning(strict=True)`` or ``strip_fragment=True`` drops it; courlan couples fragment removal to ``strict`` only.
+
+The content-type, spam/adult, navigation-page, and site-structure filters of ``check_url``/``filter_links``, the
+``with_redirects`` HTTP probe, the domain blocklist, and the embedded-URL salvage of ``scrub_url`` (recovering a target
+from a ``twitter.com/share?url=...`` wrapper) are out of scope: they are crawl policy, not URL hygiene. The language
+filter is the URL-based subset (path segment, ``lang`` parameter, and in strict mode a language subdomain); courlan's
+fuller language filter, which can score the linked content, is not consulted.

--- a/docs/migration/csscompressor.rst
+++ b/docs/migration/csscompressor.rst
@@ -4,14 +4,90 @@
 
 .. package-meta:: csscompressor sprymix/csscompressor
 
-`csscompressor <https://github.com/sprymix/csscompressor>`_ is a pure-Python port of the YUI CSS compressor. Like
-turbohtml it *rewrites* values -- colors to hex, redundant zeros and units dropped -- so it is in the same minifier
-class, not a whitespace-only stripper. ``csscompressor.compress`` maps to :func:`turbohtml.clean.minify_css`, which
-produces a smaller result and runs in C rather than chained regular expressions.
+`csscompressor <https://github.com/sprymix/csscompressor>`_ is a pure-Python port of the CSS half of the YUI Compressor.
+It is a value-rewriting minifier, not a whitespace-only stripper: it collapses whitespace, drops comments, and rewrites
+values -- colors to their shortest form, redundant zeros and units removed -- through a sequence of regular-expression
+passes. Its surface is one function, ``csscompressor.compress(css)``, plus ``compress_partitioned`` for splitting output
+under IE's 4095-selector limit. It has no runtime dependencies and is used as a drop-in CSS compressor in Python build
+pipelines that want YUI-equivalent output without a Java or Node step.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that ground with :func:`turbohtml.clean.minify_css`, the same value-rewriting minifier class
+implemented in C. It reaches a smaller result on real stylesheets, keeps custom-property values and string contents
+byte-exact, and runs in linear time where csscompressor's regex passes degrade on large input.
+
+****************************
+ turbohtml vs csscompressor
+****************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - csscompressor
+    - - Scope
+      - Value-safe CSS minifier (``minify_css``), plus inline ``style``-attribute minification
+      - Value-rewriting CSS compressor (``compress``), YUI Compressor port
+    - - Feature breadth
+      - Whitespace/comment removal, color and number shortening, constant ``calc()`` folding, box-longhand-to-shorthand
+        merging, adjacent equal-body rule merging, optional Baseline-year shorthands
+      - Whitespace/comment removal, color and number shortening, line wrapping, output partitioning
+    - - Performance
+      - Native C, linear time (40x-155x faster on the corpus below)
+      - Pure-Python regex passes, degrade on large stylesheets
+    - - Typing
+      - Typed public API (:func:`~turbohtml.clean.minify_css`, :class:`~turbohtml.clean.CSSMinify`)
+      - Untyped
+    - - Dependencies
+      - None (ships the C extension)
+      - None (pure Python)
+    - - Maintenance
+      - Actively developed alongside the turbohtml serializer
+      - Maintained, stable, YUI-scoped
+
+Feature overlap
+===============
+
+The compression path ports 1:1:
+
+- Minify a full stylesheet: ``csscompressor.compress(css)`` maps to :func:`turbohtml.clean.minify_css(css)
+  <turbohtml.clean.minify_css>`.
+- Both shorten colors to their shortest equivalent (``#ffffff`` to ``#fff``, ``rgb(255,0,0)`` to ``red``), drop
+  redundant leading and trailing zeros, and remove units on zero lengths.
+- Both strip comments and collapse insignificant whitespace between tokens.
+- Both keep ``/*! ... */`` bang comments (license or copyright banners) verbatim. turbohtml always preserves them;
+  csscompressor preserves them by default (``preserve_exclamation_comments=True``).
+
+What turbohtml adds
+===================
+
+- Constant ``calc()`` folding: ``calc(2px + 3px)`` becomes ``5px``. csscompressor leaves the expression intact.
+- Box-longhand-to-shorthand merging (``margin``, ``padding``, and friends) and merging of adjacent rules with equal
+  bodies. csscompressor does neither, so the size gap widens on framework CSS that leans on those forms.
+- Byte-exact custom-property values. turbohtml treats a ``--var`` value as the literal token stream ``var()`` splices
+  verbatim (`CSS Variables 1 §2 <https://www.w3.org/TR/css-variables-1/#defining-variables>`_); csscompressor rewrites
+  the whitespace inside it, so its output is not guaranteed to parse to the same cascade.
+- Opt-in Baseline-year shorthands via :class:`~turbohtml.clean.CSSMinify`: ``CSSMinify(baseline=2021)`` additionally
+  merges ``inset``, the flex ``gap``, and two-value ``overflow`` once they reached Baseline.
+- Inline ``style``-attribute minification via :func:`~turbohtml.clean.minify_css_inline` for bare declaration lists.
+- A typed surface: :func:`~turbohtml.clean.minify_css` and the frozen :class:`~turbohtml.clean.CSSMinify` options
+  object.
+- A native-C pipeline that stays linear where csscompressor's regex passes turn quadratic on large input.
+
+What csscompressor has that turbohtml does not
+==============================================
+
+- ``max_linelen``: csscompressor can wrap the output every *N* columns. turbohtml emits a single line, which is the
+  right shape once the bytes are gzipped on the wire. No equivalent, and none needed for network transfer.
+- ``compress_partitioned``: csscompressor can split the output into chunks under IE's 4095-selector-per-file limit.
+  turbohtml has no equivalent; split the source into separate stylesheets before minifying if you still target that
+  limit.
+- Dropping bang comments: csscompressor's ``preserve_exclamation_comments=False`` removes ``/*! ... */`` banners.
+  turbohtml always keeps them; strip the banner from the source before minifying if you need it gone.
+
+Performance
+===========
 
 turbohtml's output is smaller on every framework, including the custom-property-heavy ``bulma.css``, and its C engine is
 40x to 155x faster -- csscompressor's regex passes turn quadratic on a large stylesheet, where turbohtml stays linear.
@@ -25,9 +101,9 @@ verbatim, so its output is not guaranteed to parse to the same cascade. Each rat
 turbohtml also folds constant ``calc()``, merges box longhands into shorthands, and combines adjacent equal-bodied
 rules, none of which csscompressor attempts, so the size gap widens on framework CSS that leans on those forms.
 
-************************
- csscompressor.compress
-************************
+****************
+ How to migrate
+****************
 
 The import and the call name are the only change:
 
@@ -39,6 +115,21 @@ The import and the call name are the only change:
     # turbohtml
     from turbohtml.clean import minify_css
 
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - csscompressor
+      - turbohtml
+    - - ``from csscompressor import compress``
+      - ``from turbohtml.clean import minify_css``
+    - - ``compress(css)``
+      - ``minify_css(css)``
+    - - ``compress(css, max_linelen=N)``
+      - no equivalent (single-line output)
+    - - ``compress_partitioned(css, max_rules_per_file=N)``
+      - no equivalent (split the source before minifying)
+
 .. testcode::
 
     from turbohtml.clean import minify_css
@@ -49,9 +140,18 @@ The import and the call name are the only change:
 
     a{color:red;width:5px}
 
-Pitfalls
-========
+**********************
+ Gotchas and pitfalls
+**********************
 
-- csscompressor's ``max_linelen`` argument, which wraps the output every *N* columns, has no turbohtml equivalent:
-  turbohtml emits a single line, which is the right shape once the bytes are gzipped on the wire.
-- turbohtml takes no options at all; every rewrite it applies is value-safe, so there is nothing to configure.
+- turbohtml takes no per-call flags. ``compress``'s ``max_linelen`` and ``preserve_exclamation_comments`` arguments have
+  no counterpart; every rewrite turbohtml applies is value-safe, and the only knob is the frozen
+  :class:`~turbohtml.clean.CSSMinify` ``baseline`` year.
+- Custom-property values differ. csscompressor collapses whitespace inside a ``--var`` value; turbohtml keeps it
+  byte-exact. Output that fed a ``var()`` splice can change under csscompressor but not turbohtml, so byte-comparing the
+  two minifiers' results on custom-property-heavy CSS will show a difference by design.
+- Inline declarations need the inline entry point. A bare ``color:red;margin:0`` from a ``style`` attribute has no
+  selector or braces; pass it to :func:`~turbohtml.clean.minify_css_inline`, not :func:`~turbohtml.clean.minify_css`.
+- Output size shifts. turbohtml folds ``calc()``, merges shorthands, and combines equal-bodied rules, so its output is
+  smaller than csscompressor's rather than byte-identical; pin tests to turbohtml's output, not to a stored
+  csscompressor string.

--- a/docs/migration/cssselect.rst
+++ b/docs/migration/cssselect.rst
@@ -4,41 +4,127 @@
 
 .. package-meta:: cssselect scrapy/cssselect
 
-`cssselect <https://cssselect.readthedocs.io/>`_ translates a CSS selector to an XPath 1.0 expression; it is the engine
-behind ``lxml.cssselect``, parsel, and pyquery. :func:`turbohtml.convert.css_to_xpath` does the same job as a single C
-pass over the parsed selector, and :class:`turbohtml.convert.GenericTranslator` /
-:class:`turbohtml.convert.HTMLTranslator` keep cssselect's translator-object shape so a port is mechanical.
+`cssselect <https://cssselect.readthedocs.io/>`_ translates a CSS selector into an equivalent XPath 1.0 expression. It
+parses the selector in Python, walks the parsed tree, and emits an XPath string; it does not itself match against a
+document. That translator is the engine behind ``lxml.cssselect()``, `parsel <https://parsel.readthedocs.io/>`_ (and so
+Scrapy), and `pyquery <https://pyquery.readthedocs.io/>`_, wherever a library wants CSS syntax on top of an XPath
+evaluator. Its public surface is small: a ``GenericTranslator`` (XML rules) and an ``HTMLTranslator`` (HTML lowercasing
+rules), each exposing ``css_to_xpath(css, prefix="descendant-or-self::")``, plus the ``SelectorError`` /
+``SelectorSyntaxError`` / ``ExpressionError`` hierarchy.
 
-***************
- Why turbohtml
-***************
+:func:`turbohtml.convert.css_to_xpath` does the same job in a single C pass over the parsed selector, and
+:class:`turbohtml.convert.GenericTranslator` / :class:`turbohtml.convert.HTMLTranslator` keep cssselect's
+translator-object shape and error names so a port is mechanical. Because turbohtml runs a CSS selector engine and an
+XPath engine in the same process, the emitted XPath is validated differentially against the native CSS engine rather
+than trusted on its own.
 
-turbohtml runs both a CSS selector engine and an XPath engine in-process, so its test suite validates the translation
-differentially: for cssselect's own test corpus, the emitted XPath selects exactly the nodes turbohtml's native CSS
-engine matches, and libxml2 evaluates the emitted expression to the same node-set as cssselect's output. The C
-translator is 4x faster than cssselect on a bare type selector and 36x to 45x faster on realistic selectors, where
+************************
+ turbohtml vs cssselect
+************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - cssselect
+    - - Scope
+      - CSS-to-XPath translation as one feature of a full HTML5 parser, CSS/XPath query engine, and serializer
+      - CSS-to-XPath translation only; matching is left to the host XPath evaluator
+    - - Feature breadth
+      - Selectors 4 pseudo-classes with full complex arguments in ``:is()``/``:where()``/``:not()``/``:has()``, WHATWG
+        form and ``:empty`` semantics
+      - Selectors 3 plus documented approximations; several cases carry ``FIXME`` notes in the source
+    - - Performance
+      - C translator; 4x faster on a bare type selector, 36x-45x on realistic selectors (see below)
+      - Pure-Python tokenizer and parser dominate on anything past a trivial selector
+    - - Typing
+      - Fully typed, ships ``py.typed``
+      - No inline type annotations; third-party stubs only
+    - - Dependencies
+      - None (self-contained C extension)
+      - None at runtime
+    - - Maintenance
+      - Actively developed as part of turbohtml
+      - Stable and maintained by the Scrapy project, low change rate
+
+Feature overlap
+===============
+
+Portable 1:1 without behavior change:
+
+- ``GenericTranslator().css_to_xpath(css)`` and ``HTMLTranslator().css_to_xpath(css)`` — same method name and signature,
+  including the positional ``prefix`` second argument.
+- The default ``prefix="descendant-or-self::"`` and its role of scoping each translated arm to the context node's
+  subtree.
+- A comma-separated selector list translating to an XPath ``|`` union, one arm per selector.
+- The ``SelectorError`` base with ``SelectorSyntaxError`` and ``ExpressionError`` children, raised for the same two
+  failure modes (selector rejected by the grammar vs. valid selector with no XPath 1.0 form).
+
+What turbohtml adds
+===================
+
+- A plain :func:`turbohtml.convert.css_to_xpath` function, so callers who never wanted a translator object can skip it.
+- Full complex selectors inside logical pseudo-classes: ``:is(nav a)``, ``:where(...)``, ``:not(...)``, and the relative
+  ``:has(> a)`` / ``:has(+ a)`` / ``:has(~ a)`` forms.
+- WHATWG form-state pseudo-classes — ``:disabled``/``:enabled``/``:checked``/``:required``/``:optional``/
+  ``:read-only``/``:read-write`` — including the ``fieldset`` first-``legend`` exemption cssselect marks as a ``FIXME``,
+  and ``:nth-child(An+B of S)``.
+- Selectors 4 ``:empty`` (whitespace-only elements match) and the WHATWG case-insensitive attribute set (``type``,
+  ``lang``, ``rel``, ...) compared case-insensitively, as browsers do.
+- Context-free output: every emitted predicate avoids bare ``position()`` tests, so a translated fragment keeps its
+  meaning when embedded in a larger expression.
+- The native CSS engine itself (:meth:`turbohtml.Node.select`), so translation to XPath is optional rather than the only
+  way to run a selector.
+
+What cssselect has that turbohtml does not
+==========================================
+
+- A true XML / case-sensitive translation mode. cssselect's ``GenericTranslator`` matches element and attribute names
+  case-sensitively; turbohtml always applies the HTML lowercasing rules. ``HTMLTranslator(xhtml=True)`` accepts and
+  records the flag for signature compatibility but does not change the output. No equivalent for genuinely
+  case-sensitive XML selection.
+- The non-standard cssselect extensions ``:contains()`` and ``[attr!=value]``. These are not CSS and do not parse in
+  turbohtml; they raise ``SelectorSyntaxError``. Workaround: use the XPath ``contains(., ...)`` predicate directly, or
+  ``:not([attr=value])`` for negated attribute matching.
+- ``:scope`` anywhere other than the leftmost compound. turbohtml translates ``:scope > div`` but raises
+  ``ExpressionError`` for ``:scope`` deeper in a selector, matching cssselect's own leftmost-only behavior; neither is
+  more general here.
+
+Performance
+===========
+
+The C translator is 4x faster than cssselect on a bare type selector and 36x to 45x faster on realistic selectors, where
 cssselect's Python tokenizer dominates. Each ratio is against turbohtml:
 
 .. bench-table::
     :file: bench/cssselect.json
 
-The translation also covers ground cssselect leaves out, and follows the current specs where cssselect approximates:
+****************
+ How to migrate
+****************
 
-- ``:is()`` / ``:where()`` / ``:not()`` accept full complex selectors (``:is(nav a)``), and ``:has()`` accepts the
-  relative forms ``:has(> a)``, ``:has(+ a)``, ``:has(~ a)``.
-- ``:nth-child(An+B of S)``, ``:disabled``/``:enabled``/``:checked``/``:required``/``:optional``/
-  ``:read-only``/``:read-write`` translate per WHATWG HTML, including the ``fieldset`` first-``legend`` exemption
-  cssselect marks as a ``FIXME``.
-- ``:empty`` follows Selectors 4 (whitespace-only elements match); the WHATWG case-insensitive attribute set (``type``,
-  ``lang``, ``rel``, ...) compares values case-insensitively, as browsers do.
-- Every emitted predicate is context-free (no bare ``position()`` tests), so you can embed a fragment in a larger
-  expression without changing its meaning.
+Swap the import; cssselect's ``HTMLTranslator`` / ``GenericTranslator`` live under :mod:`turbohtml.convert` with the
+same method, and a bare :func:`~turbohtml.convert.css_to_xpath` function is available for call sites that never needed a
+translator object.
 
-*********************
- Translating the API
-*********************
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
 
-cssselect exposes ``css_to_xpath`` as a translator method; turbohtml keeps that shape and adds a plain function:
+    - - cssselect
+      - turbohtml
+    - - ``from cssselect import HTMLTranslator``
+      - ``from turbohtml.convert import HTMLTranslator``
+    - - ``HTMLTranslator().css_to_xpath(css)``
+      - ``HTMLTranslator().css_to_xpath(css)`` or ``css_to_xpath(css)``
+    - - ``GenericTranslator().css_to_xpath(css)``
+      - ``GenericTranslator().css_to_xpath(css)`` (HTML rules apply either way)
+    - - ``css_to_xpath(css, prefix="//")``
+      - ``css_to_xpath(css, prefix="//")``
+    - - ``from cssselect import SelectorSyntaxError, ExpressionError``
+      - ``from turbohtml.convert import SelectorSyntaxError, ExpressionError``
 
 .. code-block:: python
 
@@ -85,8 +171,9 @@ express, both under a common ``SelectorError``.
     invalid CSS selector "li:": expected an identifier at position 3
     :dir() cannot be expressed in XPath 1.0
 
-Pitfalls
-========
+**********************
+ Gotchas and pitfalls
+**********************
 
 - The emitted string differs from cssselect's; only the selected node-set is the contract. Compare results rather than
   expression text.
@@ -99,3 +186,6 @@ Pitfalls
 - ``[lang|="en"]``, ``[type=CHECKBOX]``, ``li:empty`` on whitespace-only elements, and ``:disabled`` on hidden inputs or
   around ``legend`` select per the current specs, so their node-sets can differ from cssselect's approximations (the
   differential suite pins each divergence).
+- ``SelectorSyntaxError`` subclasses ``SyntaxError`` and ``ExpressionError`` subclasses ``RuntimeError``, so a bare
+  ``except Exception`` still catches them, but code catching cssselect's classes by import must switch the import to
+  :mod:`turbohtml.convert`.

--- a/docs/migration/dominate.rst
+++ b/docs/migration/dominate.rst
@@ -5,18 +5,136 @@
 .. package-meta:: dominate Knio/dominate
 
 `dominate <https://github.com/Knio/dominate>`_ assembles HTML in Python from the other direction than a parser: you open
-a tag as a ``with`` block and nest children inside it (or pass them as arguments), then render the tree to a string.
-turbohtml replaces it with the terse :data:`turbohtml.build.E` builder.
+a tag as a ``with`` block and nest children inside it (or pass them as positional arguments), set attributes with
+keyword arguments (``cls`` for ``class``, ``data_i`` for ``data-i``), then render the tree to a string. It also
+scaffolds whole pages: ``dominate.document(title=...)`` emits a doctype with ``<html>``, ``<head>``, and ``<body>``, and
+exposes ``doc.head``/``doc.body`` to append into. It is a common way to build reports, emails, and server-rendered pages
+in Flask and other Python web stacks without a template language.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with the terse :data:`turbohtml.build.E` builder, but the value it hands back is a real
+:class:`~turbohtml.Element` in a parsed tree rather than a bespoke render object, so the whole query, edit, and
+serialize surface stays available on what you just built.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+***********************
+ turbohtml vs dominate
+***********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
+
+    - - Dimension
+      - turbohtml
+      - dominate
+    - - Scope
+      - Full WHATWG parser, serializer, builder, selectors, sanitizer, converters
+      - HTML generation only, from Python
+    - - Feature breadth
+      - ``E`` builder over a real tree: CSS/XPath query, edit, ``to_markdown``, compact/indent/minify layouts
+      - Context-manager nesting, full-page ``document`` scaffolding, pretty-print, ``text``/``raw``/``comment`` helpers
+    - - Performance
+      - Builds and serializes in C
+      - Pure Python
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - Untyped
+    - - Dependencies
+      - None (self-contained C extension)
+      - None (pure Python)
+    - - Maintenance
+      - Active
+      - Stable, infrequent releases
+
+Feature overlap
+===============
+
+The shared surface ports one-to-one:
+
+- ``div(child, cls="card")`` -> :data:`E.div({"class": "card"}, child) <turbohtml.build.E>`; attributes are a leading
+  mapping, children follow in the same call.
+- ``li("text", cls="item", data_i="1")`` -> :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`;
+  write the real attribute name as the dict key, with no ``cls`` alias or ``data_``-to-``data-`` rewrite to remember.
+- A string child becomes escaped text in both: dominate wraps it in ``text()``, ``E`` builds a :class:`~turbohtml.Text`
+  node.
+- A non-identifier tag such as a custom element -> :data:`E("my-card", ...) <turbohtml.build.E>`, the call form.
+- A class token list joins on a space: ``div(cls="card lg")`` -> ``E.div({"class": ["card", "lg"]})``.
+
+What turbohtml adds
+===================
+
+- The result is an ordinary :class:`~turbohtml.Element`, so :meth:`~turbohtml.Node.select`,
+  :meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.find`, :meth:`~turbohtml.Node.to_markdown`, and the full edit
+  API are available. dominate's tree offers only a limited ``get(tag=..., **kwargs)`` descendant search, no CSS or
+  XPath.
+- The markup serializes by exactly the WHATWG rules that parse it back, so a fragment round-trips; dominate hand-renders
+  its own string.
+- ``E`` assembles the fragment in turbohtml's arena and serializes it in C, about three times faster than dominate.
+- A :class:`~turbohtml.Minify` layout (whitespace collapse, optional-tag omission, JS/CSS minify) on top of the compact
+  and :class:`~turbohtml.Indent` layouts; dominate pretty-prints but does not minify.
+- Full type annotations with a ``py.typed`` marker.
+- You can :func:`turbohtml.parse` real markup and append an ``E`` fragment under it, mixing parsing and building in one
+  tree.
+
+What dominate has that turbohtml does not
+=========================================
+
+- Context-manager nesting: ``with div(): p("hi")`` auto-collects children created inside the block, and ``d += child``
+  appends in place. ``E`` has no context-manager or ``+=`` form. Workaround: pass children as positional arguments, or
+  build bottom-up and :meth:`~turbohtml.Element.append`.
+- Full-document scaffolding: ``dominate.document(title=...)`` emits a doctype plus ``<html>``/``<head>``/``<body>`` and
+  exposes ``doc.head``/``doc.body``. ``E`` builds a fragment with no wrapper. Workaround: :func:`turbohtml.parse` a
+  shell document and append into its ``<body>``, or write the page shell around the serialized fragment.
+- ``dominate.util.raw`` injects unescaped HTML into the tree. ``E`` always escapes a string into a
+  :class:`~turbohtml.Text` node. Workaround: :func:`turbohtml.parse` the raw markup and append the resulting nodes,
+  since turbohtml is a real parser.
+- Conditional comments: ``comment(p("IE"), condition="lt IE 9")`` renders ``<!--[if lt IE 9]>...<![endif]-->``.
+  turbohtml has a :class:`~turbohtml.Comment` node but no conditional-comment helper. Workaround: build a ``Comment``
+  node whose text carries the ``[if ...]`` guard and append it.
+
+Performance
+===========
+
+``E`` is about three times faster than dominate. The same ``<ul>`` of rows -- a class, a ``data`` attribute, and a text
+child apiece -- built both ways:
+
+.. bench-table::
+    :file: bench/dominate.json
+
+The decisive difference is the result type: ``E`` hands back a real :class:`~turbohtml.Element`, not a string, so the
+call that builds the markup also leaves a tree you can query, edit, and re-:meth:`~turbohtml.Node.serialize`.
+
+****************
+ How to migrate
+****************
+
+Swap the tag imports (and any ``document`` scaffolding) for the single ``E`` builder:
+
+.. code-block:: python
+
+    # dominate
+    from dominate.tags import div, h1, p
+
+    # turbohtml
+    from turbohtml.build import E
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `dominate <https://github.com/Knio/dominate>`__
+      - turbohtml
+    - - ``div(p("x"), cls="card")`` / ``with div():`` blocks
+      - :data:`E.div({"class": "card"}, E.p("x")) <turbohtml.build.E>`; nest by passing children, not a context manager
+    - - ``li("text", cls="item", data_i="1")``
+      - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
+    - - ``tag(...)`` for a non-identifier tag name
+      - :data:`E("tag", ...) <turbohtml.build.E>`, the call form
+    - - ``document(title="T")`` full page
+      - :func:`turbohtml.parse` a shell, then append the ``E`` fragment
+    - - ``str(tag)`` / ``tag.render(pretty=True)``
+      - :meth:`~turbohtml.Node.serialize` (compact) or ``serialize(Html(layout=Indent()))``
+
+A ``with``-block tree becomes one nested call, attributes leading and children following:
 
 .. testcode::
 
@@ -28,33 +146,6 @@ parse it back:
 .. testoutput::
 
     <div class="card"><h1>Title</h1><p>body</p></div>
-
-``E`` assembles the fragment in turbohtml's arena and serializes it in C; dominate stays in Python. The same ``<ul>`` of
-rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
-
-.. bench-table::
-    :file: bench/dominate.json
-
-``E`` is about three times faster than dominate, and the decisive difference is the result type: ``E`` hands back a real
-:class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can query, edit,
-and re-:meth:`~turbohtml.Node.serialize`.
-
-*************
- The renames
-*************
-
-dominate spells nesting with ``with`` blocks or positional children; the translation is mechanical:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    - - `dominate <https://github.com/Knio/dominate>`__
-      - turbohtml
-    - - ``div(p("x"), cls="card")`` / ``with`` blocks
-      - :data:`E.div({"class": "card"}, E.p("x")) <turbohtml.build.E>`; nest by passing children, not a context manager
-    - - ``tag(...)`` for a non-identifier tag name
-      - :data:`E("tag", ...) <turbohtml.build.E>`, the call form
 
 ``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
 attribute joins on a space so a class list reads naturally:
@@ -69,13 +160,19 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
   Serialize the element you built, or append it under a parsed document when you need the full page shell.
 - A leading mapping is always read as attributes; to start an element with literal text, pass the string first
   (``E.p("text", E.b("bold"))``).
+- ``E`` escapes strings into text nodes, so ``E.div("<b>")`` serializes as ``&lt;b&gt;``. dominate's ``raw()`` had no
+  escaping; to inject real markup, :func:`turbohtml.parse` it and append the nodes.
+- turbohtml serializes compact by default, where dominate pretty-prints. Pass ``Html(layout=Indent())`` to
+  :meth:`~turbohtml.Node.serialize` for indented output.
+- Write attribute names as plain dict keys (``{"data-i": "1"}``), not dominate's keyword conventions (``cls``, trailing
+  underscore for reserved words, ``data_``/``aria_`` underscore-to-dash).
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/extruct.rst
+++ b/docs/migration/extruct.rst
@@ -5,21 +5,139 @@
 .. package-meta:: extruct scrapinghub/extruct
 
 `extruct <https://github.com/scrapinghub/extruct>`_ pulls the machine-readable metadata a page embeds: JSON-LD,
-Microdata, RDFa, microformats, and the OpenGraph/Twitter card tags. It builds an lxml tree and runs a separate extractor
-per syntax you list.
+Microdata, RDFa, microformats, the OpenGraph/Twitter card tags, and Dublin Core. You call one ``extract(html)`` entry
+point, optionally naming a ``syntaxes`` list, and get back a dict keyed by syntax name. Under the hood it builds an lxml
+tree once and then runs a separate extractor per syntax you asked for, each on top of ``lxml``, ``w3lib``, ``mf2py``,
+and an RDFa/DublinCore stack.
 
-***************
- Why turbohtml
-***************
+It is a scraping-pipeline staple, developed by Zyte (formerly Scrapinghub) and used alongside Scrapy to lift structured
+product, article, and event data off crawled pages. turbohtml covers the same ground from the other direction: it is a
+WHATWG HTML parser first, and :meth:`~turbohtml.Document.structured_data` reads every supported format off the already
+parsed tree in a single C walk, so extraction is not a second tree build but a walk of the one you already have.
 
-:meth:`~turbohtml.Document.structured_data` pulls every supported format in one walk on the parsed document, so there is
-no extractor object to build or ``syntaxes`` list to configure, and the per-format helpers
-:meth:`~turbohtml.Document.json_ld`, :meth:`~turbohtml.Document.opengraph`, and :meth:`~turbohtml.Document.microdata`
-return just one format each. The locating runs in the C core under the per-tree critical section; only JSON-LD parsing
-stays in Python (the standard library :mod:`json`), and a block that is not valid JSON is skipped rather than raising --
-the robust default ``extruct`` also takes. The combined result is a frozen, fully typed
-:class:`~turbohtml.StructuredData` record whose five fields you read by attribute, so reading it never depends on which
-extractors you happened to enable:
+**********************
+ turbohtml vs extruct
+**********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - extruct
+    - - Scope
+      - Full WHATWG parser; structured data is one feature of many
+      - Focused metadata extractor, one job
+    - - Feature breadth
+      - JSON-LD, Microdata, OpenGraph/Twitter today; RDFa and microformats reserved (empty lists)
+      - JSON-LD, Microdata, RDFa, OpenGraph, microformats, Dublin Core
+    - - Performance
+      - One C walk of the parsed tree; ~9-11x faster on a combined page
+      - Builds an lxml tree, then one extractor per requested syntax
+    - - Typing
+      - Frozen, fully typed records (:class:`~turbohtml.StructuredData`, :class:`~turbohtml.MicrodataItem`),
+        ``py.typed``
+      - Plain dicts and lists, no shipped type hints
+    - - Dependencies
+      - Zero runtime deps (self-contained C extension)
+      - ``lxml``, ``w3lib``, ``mf2py``, plus an RDFa/DublinCore stack
+    - - Maintenance
+      - Actively developed single extension
+      - Mature, Zyte-backed, slower cadence
+
+Feature overlap
+===============
+
+The shared surface you can port one-to-one:
+
+- ``extruct.extract(html)`` -> :meth:`~turbohtml.Document.structured_data`, one call gathering every format.
+- ``syntaxes=["json-ld"]`` -> :meth:`~turbohtml.Document.json_ld`, each ``<script type="application/ld+json">`` block
+  decoded with the standard library :mod:`json`.
+- ``syntaxes=["opengraph"]`` -> :meth:`~turbohtml.Document.opengraph`, the ``og:``/``twitter:`` ``<meta>`` tags.
+- ``syntaxes=["microdata"]`` -> :meth:`~turbohtml.Document.microdata`, returning :class:`~turbohtml.MicrodataItem`
+  records with ``itemtype``, ``itemid``, and the nested ``itemprop`` values.
+- Both skip a malformed JSON-LD block rather than raising, the forgiving default ``extruct`` also takes.
+
+What turbohtml adds
+===================
+
+- A single walk over the parsed tree returns every format at once as a frozen, fully typed
+  :class:`~turbohtml.StructuredData` record whose five fields you read by attribute, so reading a result never depends
+  on which extractors you enabled.
+- The locating runs in the C core under the per-tree critical section; only JSON-LD decoding stays in Python.
+- The records hold no reference back into the tree, so they outlive the document they came from.
+- Standalone string entry points :func:`turbohtml.extract.microdata` and :func:`turbohtml.extract.opengraph` cover the
+  ``microdata`` and ``opengraph`` libraries' call shapes on the same C walk, so an extruct migration also folds those
+  in.
+- No third-party runtime dependency: no lxml, w3lib, or mf2py to install or pin.
+
+What extruct has that turbohtml does not
+========================================
+
+- **RDFa** and **microformats**: a documented later phase. :meth:`~turbohtml.Document.structured_data` returns the
+  :attr:`~turbohtml.StructuredData.rdfa` and :attr:`~turbohtml.StructuredData.microformats` fields as empty lists today.
+  Keep extruct for those two syntaxes until the phase lands; the field names are already in place so code that reads
+  them will not break.
+- **Dublin Core**: no equivalent. Read the ``<meta name="dc.*">`` tags yourself off the tree if you need them.
+- **``base_url`` resolution**: extruct's ``base_url`` argument resolves relative URLs inside extracted values; turbohtml
+  returns values verbatim. Resolve against your own base URL afterward with :func:`turbohtml.extract.normalize_url` or
+  :func:`urllib.parse.urljoin`.
+- **``uniform`` / ``return_html_node`` options**: no equivalent. turbohtml's output shape is fixed per format; there is
+  no normalized cross-syntax view or embedded lxml node handle.
+
+Performance
+===========
+
+``extruct`` starts from the raw HTML string, so it parses before it extracts: it builds an lxml tree and runs a separate
+extractor per syntax, where :meth:`~turbohtml.Document.structured_data` parses to the WHATWG tree and gathers every
+format in one C walk. On a product page carrying JSON-LD, Microdata, and OpenGraph at once, the single pass runs roughly
+nine to eleven times faster:
+
+.. bench-table::
+    :file: bench/extruct.json
+
+****************
+ How to migrate
+****************
+
+Swap the import and the extractor call for a parse plus a method on the document.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `extruct <https://github.com/scrapinghub/extruct>`__
+      - turbohtml
+    - - ``extruct.extract(html)``
+      - :meth:`~turbohtml.Document.structured_data`
+    - - ``extruct.extract(html, syntaxes=["json-ld"])``
+      - :meth:`~turbohtml.Document.json_ld`
+    - - ``extruct.extract(html, syntaxes=["opengraph"])``
+      - :meth:`~turbohtml.Document.opengraph`
+    - - ``extruct.extract(html, syntaxes=["microdata"])``
+      - :meth:`~turbohtml.Document.microdata`
+    - - ``extruct.extract(html, syntaxes=["rdfa", "microformat"])``
+      - the :attr:`~turbohtml.StructuredData.rdfa` / :attr:`~turbohtml.StructuredData.microformats` fields of the
+        :class:`~turbohtml.StructuredData` record (a later phase)
+
+Before, with extruct, each syntax comes back under a string key in a dict:
+
+.. code-block:: python
+
+    import extruct
+
+    html = (
+        '<head><meta property="og:title" content="Widget"></head>'
+        '<body><script type="application/ld+json">{"@type": "Product"}</script>'
+        '<div itemscope itemtype="https://schema.org/Offer"><span itemprop="price">9.99</span></div></body>'
+    )
+    data = extruct.extract(html, syntaxes=["json-ld", "opengraph", "microdata"])
+    print(data["json-ld"])
+    print(data["opengraph"])
+    print(data["microdata"])
+
+After, one walk returns a typed record whose fields you read by attribute:
 
 .. testcode::
 
@@ -42,38 +160,8 @@ extractors you happened to enable:
     {'og:title': 'Widget'}
     https://schema.org/Offer {'price': ['9.99']}
 
-``extruct`` starts from the raw HTML string, so it parses before it extracts: it builds an lxml tree and runs a separate
-extractor per syntax, where :meth:`~turbohtml.Document.structured_data` parses to the WHATWG tree and gathers every
-format in one C walk. On a product page carrying JSON-LD, Microdata, and OpenGraph at once, the single pass runs roughly
-nine to eleven times faster:
-
-.. bench-table::
-    :file: bench/extruct.json
-
-*************
- The renames
-*************
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    - - `extruct <https://github.com/scrapinghub/extruct>`__
-      - turbohtml
-    - - ``extruct.extract(html)``
-      - :meth:`~turbohtml.Document.structured_data`
-    - - ``extruct.extract(html, syntaxes=["json-ld"])``
-      - :meth:`~turbohtml.Document.json_ld`
-    - - ``extruct.extract(html, syntaxes=["opengraph"])``
-      - :meth:`~turbohtml.Document.opengraph`
-    - - ``extruct.extract(html, syntaxes=["microdata"])``
-      - :meth:`~turbohtml.Document.microdata`
-    - - ``extruct.extract(html, syntaxes=["rdfa", "microformat"])``
-      - the :attr:`~turbohtml.StructuredData.rdfa` / :attr:`~turbohtml.StructuredData.microformats` fields of the
-        :class:`~turbohtml.StructuredData` record (a later phase)
-
-The helpers return plain Python objects that hold no reference back into the tree, so you can keep them after the
-document is gone:
+The per-format helpers return the same plain objects, holding no reference back into the tree, so you can keep them
+after the document is gone:
 
 .. testcode::
 
@@ -84,9 +172,9 @@ document is gone:
 
     [{'@type': 'Article', 'name': 'Hi'}]
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - The OpenGraph result is a flat ``{key: value}`` mapping, not ``extruct``'s list of namespaced property tuples, and
   ``og:`` and ``twitter:`` tags share the one mapping because pages mix the ``property`` and ``name`` attributes freely.
@@ -94,6 +182,13 @@ document is gone:
   of a repeated key.
 - :attr:`~turbohtml.StructuredData.rdfa` and :attr:`~turbohtml.StructuredData.microformats` are a later phase:
   :meth:`~turbohtml.Document.structured_data` returns those two fields as empty lists today, so code that reads them
-  will not break when they land.
+  will not break when they land, but the values are not there yet.
 - A JSON-LD block whose body is not valid JSON is skipped rather than raising, matching ``extruct``'s default error
-  handling; pass the raw ``<script>`` text to :mod:`json` yourself if you need to see the decode error.
+  handling; ``extruct``'s ``errors="strict"`` mode has no turbohtml equivalent. Pass the raw ``<script>`` text to
+  :mod:`json` yourself if you need to see the decode error. A block whose payload is a scalar or ``null`` is also
+  dropped, since it is not a JSON-LD node object.
+- Extracted URL values are returned verbatim, not resolved against a base URL the way ``extruct``'s ``base_url``
+  argument resolves them. Post-process with :func:`turbohtml.extract.normalize_url` or :func:`urllib.parse.urljoin`.
+- turbohtml decodes the string to the WHATWG tree; ``extruct`` decodes bytes with ``w3lib`` per its ``encoding``
+  argument. Hand turbohtml already-decoded ``str`` and let it apply the WHATWG encoding rules rather than pre-forcing a
+  codec.

--- a/docs/migration/fast-html.rst
+++ b/docs/migration/fast-html.rst
@@ -4,31 +4,91 @@
 
 .. package-meta:: fast-html pcarbonn/fast_html
 
-`fast-html <https://github.com/pcarbonn/fast_html>`_ assembles HTML in Python from the other direction than a parser:
-each tag function takes its children first (one node or a list) and attributes as trailing keywords, yields the markup
-lazily as a generator of string fragments, and ``render`` joins them. turbohtml replaces it with the terse
-:data:`turbohtml.build.E` builder.
+`fast-html <https://github.com/pcarbonn/fast_html>`_ is a small pure-Python library that assembles HTML5 from the inside
+out. Each tag is a function that takes its children first (a single node or a list) and its attributes as trailing
+keyword arguments, with the usual underscore mangling (``class_`` to ``class``, ``data_i`` to ``data-i``). A tag yields
+its markup lazily as a generator of string fragments, and ``render`` joins those fragments into the final string. It
+escapes nothing and produces a string, not a tree, so it is a generation-only tool: composition happens in Python and
+the result is markup you hand off to a response or a file.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that ground with :data:`turbohtml.build.E`, a terse builder over :class:`~turbohtml.Element`:
+``E.<tag>(attrs, *children)``, where a leading mapping is the attributes and each child is a node or a string that
+becomes text. The difference is the result type. ``E`` hands back a real turbohtml tree, so the same call that builds
+the markup also leaves an element you can query, edit, and re-serialize, and the markup it produces serializes by
+exactly the rules that parse it back.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+************************
+ turbohtml vs fast-html
+************************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
 
-    from turbohtml.build import E
+    - - Dimension
+      - turbohtml
+      - fast-html
+    - - Scope
+      - Full HTML parse, query, edit, and serialize engine, with the ``E`` builder as one front end
+      - HTML generation only: tag functions that render to a string
+    - - Feature breadth
+      - Build, parse, CSS ``select``, ``find``, mutate, ``serialize``, ``to_markdown``, minify
+      - Tag functions, keyword-mangled attributes, lazy fragment rendering
+    - - Performance
+      - Builds in turbohtml's arena and serializes in C, about twice as fast on the corpus below
+      - Pure-Python generator that yields and joins string fragments
+    - - Typing
+      - Typed public API and shipped stubs (:data:`turbohtml.build.E`, :class:`~turbohtml.Element`)
+      - Untyped
+    - - Dependencies
+      - Ships the C extension, no Python dependencies
+      - Pure Python, zero dependencies
+    - - Maintenance
+      - Actively developed alongside the turbohtml serializer
+      - Small, stable, single-maintainer
 
-    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
-    print(card.serialize())
+Feature overlap
+===============
 
-.. testoutput::
+The construction path ports 1:1:
 
-    <div class="card"><h1>Title</h1><p>body</p></div>
+- Build an element with attributes and children: ``render(div([h1("Title"), p("body")], class_="card"))`` maps to
+  :data:`E.div({"class": "card"}, E.h1("Title"), E.p("body")) <turbohtml.build.E>` ``.serialize()``. Children are plain
+  arguments, with no list wrapper.
+- Nest elements by passing built nodes as children, to any depth.
+- Turn a string argument into a text child: ``li("text", ...)`` maps to ``E.li({...}, "text")``.
+- Set a valueless boolean attribute (``disabled``) by mapping its name to ``None``.
+
+What turbohtml adds
+===================
+
+- A real tree, not a string. The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface
+  (``append``, ``extend``, ``find``, ``select``, ``serialize``, ``to_markdown``) stays available; the builder only saves
+  the construction boilerplate.
+- Escaping. ``E`` builds text nodes, so ``E.div("<b>")`` serializes as ``&lt;b&gt;`` instead of emitting the markup
+  verbatim.
+- Round-tripping. The markup ``E`` generates serializes by the same rules that parse it back, so a built fragment and a
+  parsed one behave identically.
+- Splicing into parsed documents. Because a built node is a real tree, you can ``append`` it under a document you parsed
+  from existing HTML, not just render it in isolation.
+- A native-C serialize path, about twice as fast as fast-html on the corpus below.
+- A typed surface with shipped stubs.
+
+What fast-html has that turbohtml does not
+==========================================
+
+- Lazy, streaming output. A fast-html tag is a generator of string fragments, so a very large page can be streamed to a
+  socket or file without ever materializing the whole string. ``E`` builds the full tree in the arena and then
+  serializes it to a single string. Workaround: build and :meth:`~turbohtml.Node.serialize` top-level sections
+  separately and write them in a loop, rather than one document at a time.
+- A dependency-free pure-Python install. fast-html runs anywhere CPython does with no compiled extension; turbohtml
+  ships a C extension, so it needs a wheel for the platform or a build toolchain. No equivalent if a pure-Python install
+  is a hard requirement.
+- Keyword-argument attribute syntax (``class_="card"``). turbohtml takes a leading mapping instead. Minor: pass a dict,
+  writing the real attribute name as the key.
+
+Performance
+===========
 
 ``E`` assembles the fragment in turbohtml's arena and serializes it in C; fast-html stays in Python. The same ``<ul>``
 of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
@@ -40,26 +100,32 @@ of rows -- a class, a ``data`` attribute, and a text child apiece -- built both 
 :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can query, edit,
 and re-:meth:`~turbohtml.Node.serialize`.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
-fast-html takes children first and attributes last; turbohtml leads with the attributes:
+Swap the tag imports for the single builder. fast-html takes children first and attributes last; turbohtml leads with
+the attributes:
 
 .. list-table::
     :header-rows: 1
     :widths: 50 50
 
-    - - `fast-html <https://github.com/pcarbonn/fast_html>`__
+    - - fast-html
       - turbohtml
+    - - ``from fast_html import div, h1, p, li, render``
+      - ``from turbohtml.build import E``
     - - ``render(div([h1("Title"), p("body")], class_="card"))``
-      - :data:`E.div({"class": "card"}, E.h1("Title"), E.p("body")) <turbohtml.build.E>` ``.serialize()``; children are
-        plain arguments, no list wrapper
+      - :data:`E.div({"class": "card"}, E.h1("Title"), E.p("body")) <turbohtml.build.E>` ``.serialize()``
     - - ``li("text", class_="item", data_i="1")``
       - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
+    - - a non-identifier tag (a custom element)
+      - ``E("my-card", ...)``, the call form for any tag name
+    - - a class list
+      - a list value that joins on a space: ``{"class": ["card", "lg"]}``
 
-``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
-attribute joins on a space so a class list reads naturally:
+``E("tag", ...)`` is the call form for a tag that is not a Python identifier, and a list-valued attribute joins on a
+space so a class list reads naturally:
 
 .. testcode::
 
@@ -71,17 +137,32 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+Before and after, reusing the same card:
 
-- ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
-  Serialize the element you built, or append it under a parsed document when you need the full page shell.
-- fast-html mangles keyword arguments (``class_`` to ``class``, ``data_i`` to ``data-i``); ``E`` takes a plain mapping,
-  so write the real attribute name as the dict key -- no underscore convention to remember.
-- fast-html never escapes: ``render(div("<b>"))`` emits the markup verbatim. ``E`` builds text nodes, so the same call
-  serializes as ``&lt;b&gt;``; markup belongs in child elements, not strings.
-- A fast-html tag is a generator, consumed by the ``render`` that joins it; an :class:`~turbohtml.Element` is a tree you
-  can serialize as many times as you like.
-- The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
-  ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.
+.. code-block:: python
+
+    # fast-html
+    from fast_html import div, h1, p, render
+
+    render(div([h1("Title"), p("body")], class_="card"))  # a string, in Python
+
+    # turbohtml
+    from turbohtml.build import E
+
+    E.div({"class": "card"}, E.h1("Title"), E.p("body")).serialize()  # a tree, serialized in C
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- Fragment, not document. ``E`` builds a fragment: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no
+  doctype. Serialize the element you built, or append it under a parsed document when you need the full page shell.
+- Attribute names. fast-html mangles keyword arguments (``class_`` to ``class``, ``data_i`` to ``data-i``); ``E`` takes
+  a plain mapping, so write the real attribute name as the dict key, with no underscore convention to remember.
+- Escaping changes the output. fast-html never escapes: ``render(div("<b>"))`` emits the ``<b>`` markup verbatim. ``E``
+  builds text nodes, so the same call serializes as ``&lt;b&gt;``. Markup that used to pass through as a string must
+  become child elements.
+- Consumption. A fast-html tag is a generator, consumed once by the ``render`` that joins it; an
+  :class:`~turbohtml.Element` is a tree you can serialize as many times as you like.
+- Argument order. A mapping argument to ``E`` sets attributes and must come first; a mapping passed as a later child
+  raises :class:`TypeError` rather than being rendered.

--- a/docs/migration/goose3.rst
+++ b/docs/migration/goose3.rst
@@ -6,16 +6,85 @@
 
 `goose3 <https://goose3.readthedocs.io>`_ is an article extractor in the newspaper mold: ``Goose().extract(url=...)``
 (or ``raw_html=...``) fetches a page, scores the content body on an lxml tree, runs its cleaners over the winner, and
-returns an ``Article`` carrying the cleaned text alongside the harvested metadata, images, and embedded media.
+returns an ``Article`` carrying the cleaned text alongside the harvested metadata, images, and embedded media. It grew
+out of the original Java Goose and targets scraping pipelines that need the main story out of a news or blog page
+without hand-writing per-site selectors.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that ground with :meth:`~turbohtml.Node.article`: content-density scoring picks the body and a metadata
+harvest fills the :class:`~turbohtml.Article` record in one C pass over the parsed tree. It parses the markup you
+already have rather than fetching, so it slots into the same scraping pipeline behind whatever downloader you already
+use.
 
-:meth:`~turbohtml.Node.article` fills the same contract in one C pass over the parsed tree: the content-density scoring
-picks the body and the metadata harvest fills the :class:`~turbohtml.Article` record (``element``, ``text``, ``title``,
-``byline``, ``date``, ``description``, ``lang``) from the page's declared sources. turbohtml works on HTML you already
-have, so pair it with a downloader (``urllib`` or ``httpx``) where goose fetches for you.
+*********************
+ turbohtml vs goose3
+*********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - goose3
+    - - Scope
+      - WHATWG HTML parser with article extraction on parsed trees
+      - Article extractor: fetch, score, clean, and harvest metadata
+    - - Feature breadth
+      - Full DOM, selectors, serialization, ``article()``, ``opengraph()``, ``links()``
+      - Content scoring plus images, movies/tweets, and language-specific stopwords
+    - - Performance
+      - One C pass over the parsed tree
+      - lxml tree build, scoring, and a Python cleaner chain (see below)
+    - - Typing
+      - Fully typed, ships stubs
+      - No published type stubs
+    - - Dependencies
+      - Zero runtime dependencies (native C extension)
+      - lxml, requests, Pillow, and language/parsing helpers
+    - - Maintenance
+      - Actively maintained
+      - Community-maintained continuation of python-goose
+
+Feature overlap
+===============
+
+Port these 1:1:
+
+- ``Goose().extract(raw_html=html)`` -> ``parse(html).article()``.
+- ``article.cleaned_text`` -> ``article().text`` (layout-aware plain text of the scored body).
+- ``article.top_node`` -> ``article().element`` (the scored element, ``None`` when nothing reads as content).
+- ``article.title`` -> ``article().title``.
+- ``article.authors`` -> ``article().byline`` (see the pitfalls on the list-vs-string difference).
+- ``article.publish_date`` -> ``article().date``.
+- ``article.meta_description`` -> ``article().description``.
+- ``article.meta_lang`` -> ``article().lang``.
+- ``article.opengraph`` -> :meth:`doc.opengraph() <turbohtml.Document.opengraph>`.
+- ``article.links`` -> :meth:`doc.links() <turbohtml.Node.links>`.
+
+What turbohtml adds
+===================
+
+- A full WHATWG-conformant parser: the tree ``article()`` scores is the same DOM you query with CSS selectors,
+  serialize, or mutate, not a scraper-private intermediate.
+- Zero runtime dependencies. goose3 pulls in lxml, requests, and Pillow; turbohtml is a self-contained C extension.
+- Full type coverage with shipped stubs, so ``article()`` and its :class:`~turbohtml.Article` fields check under a type
+  checker.
+- The same extraction primitives outside article context: :meth:`doc.opengraph() <turbohtml.Document.opengraph>` and
+  :meth:`doc.links() <turbohtml.Node.links>` work on any parsed document.
+
+What goose3 has that turbohtml does not
+=======================================
+
+- Fetching: ``extract(url=...)`` downloads the page. turbohtml takes parsed HTML only, so pair it with ``urllib`` or
+  ``httpx``.
+- Image extraction (``top_image``, ``infographic``) and the Pillow-backed candidate scoring. No turbohtml equivalent.
+- Embedded media harvesting (``movies``, ``tweets``). No turbohtml equivalent.
+- Language-specific stopword configuration used to tune scoring per language. turbohtml scores on content density
+  without a per-language stopword list.
+- ``authors`` as a full list of names. ``article().byline`` keeps only the first author source as one string.
+
+Performance
+===========
 
 Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
 :meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; goose3 builds an lxml tree,
@@ -24,9 +93,12 @@ scores it, and runs its cleaner chain in Python. Numbers vary with input and har
 .. bench-table::
     :file: bench/goose3.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the fetch-and-extract call for a parse-then-``article()`` call. Where goose3 fetched the URL for you, download the
+markup first and pass it to :func:`turbohtml.parse`.
 
 .. list-table::
     :header-rows: 1
@@ -75,9 +147,9 @@ scores it, and runs its cleaner chain in Python. Numbers vary with input and har
 
     Comets | Ada Lovelace | 2024-05-06 | A short guide to comets.
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - goose3 downloads URLs (``extract(url=...)``); :meth:`~turbohtml.Node.article` takes parsed HTML. Fetch the page
   yourself and pass the markup to :func:`turbohtml.parse`.
@@ -87,5 +159,5 @@ scores it, and runs its cleaner chain in Python. Numbers vary with input and har
   ``article:published_time`` first for goose), so the same page can answer with two spellings of the same instant.
 - ``article().title`` prefers the first ``<h1>``, then ``og:title``, then ``<title>``; goose starts from ``<title>`` and
   splits site-name suffixes off, so pages whose ``<h1>`` and ``<title>`` disagree yield different titles.
-- goose's image (``top_image``, ``infography``) and embed (``movies``, ``tweets``) extraction, its language-specific
+- goose's image (``top_image``, ``infographic``) and embed (``movies``, ``tweets``) extraction, its language-specific
   stopword configuration, and video handling have no turbohtml equivalent and are out of scope.

--- a/docs/migration/htbuilder.rst
+++ b/docs/migration/htbuilder.rst
@@ -6,29 +6,90 @@
 
 `htbuilder <https://github.com/tvst/htbuilder>`_ assembles HTML in Python from the other direction than a parser: each
 element takes its attributes as keyword arguments in one call and its children in a second (``div(_class="card")(...)``,
-with ``_class`` mangled to ``class`` and ``data_i`` to ``data-i``), and stringifying the result renders it. turbohtml
-replaces it with the terse :data:`turbohtml.build.E` builder.
+with ``_class`` mangled to ``class`` and ``data_i`` to ``data-i``), and stringifying the result renders it. Tag
+callables (``div``, ``span``, ``img``, and the rest) are generated on import, and a set of helpers builds attribute
+values: ``classes()`` and ``styles()`` assemble ``class`` and ``style`` strings, and CSS unit functions (``px``, ``em``,
+``rem``, ``percent``, ``rgba``) format lengths and colors. It ships from the author of Streamlit and is used mostly to
+compose small HTML snippets inside Streamlit components. It is pure Python and renders to a string, not a tree.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that ground with the terse :data:`turbohtml.build.E` builder, a thin front end over
+:class:`~turbohtml.Element`. Every ``E.<tag>(...)`` call builds a real turbohtml tree in the arena and serializes it in
+C, so the same call that emits the markup also leaves a node you can query, edit, and re-serialize.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+************************
+ turbohtml vs htbuilder
+************************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
 
-    from turbohtml.build import E
+    - - Dimension
+      - turbohtml
+      - htbuilder
+    - - Scope
+      - HTML builder (:data:`~turbohtml.build.E`) over a full parse, query, edit, and serialize tree
+      - HTML string builder for composing snippets, mostly inside Streamlit components
+    - - Feature breadth
+      - Builds a real :class:`~turbohtml.Element`; spec-correct serialization and text escaping; the whole
+        ``append``/``find``/``select``/``serialize``/``to_markdown`` surface stays available
+      - Two-call element form, keyword-argument mangling, and ``classes``/``styles``/``fonts``/``params`` plus CSS unit
+        helpers for building attribute values
+    - - Performance
+      - Native C build and serialize, about 1.5x faster on the corpus below
+      - Pure-Python string assembly
+    - - Typing
+      - Typed public API (:data:`~turbohtml.build.E`, :class:`~turbohtml.Element`)
+      - Untyped
+    - - Dependencies
+      - None (ships the C extension)
+      - Pure Python
+    - - Maintenance
+      - Actively developed alongside the turbohtml serializer
+      - Maintained, small, Streamlit-scoped
 
-    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
-    print(card.serialize())
+Feature overlap
+===============
 
-.. testoutput::
+The construction surface ports 1:1:
 
-    <div class="card"><h1>Title</h1><p>body</p></div>
+- Build an element with attributes and children: ``div(_class="card")(h1("Title"))`` maps to :data:`E.div({"class":
+  "card"}, E.h1("Title")) <turbohtml.build.E>`.
+- Hyphenated and ``data-`` attributes: htbuilder's ``li(_class="item", data_i="1")("text")`` maps to
+  :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`.
+- A class token list: htbuilder's ``classes("card", "lg")`` maps to a space-joined list value, ``{"class": ["card",
+  "lg"]}``.
+- Rendering to a string: htbuilder stringifies the root; turbohtml calls :meth:`~turbohtml.Node.serialize`.
+
+What turbohtml adds
+===================
+
+- A real tree, not a string. ``E`` hands back an :class:`~turbohtml.Element`, so ``append``, ``find``, ``select``,
+  ``serialize``, and ``to_markdown`` all work on the result; htbuilder gives you a value whose only real operation is
+  ``str()``.
+- Spec-correct text escaping. ``E`` builds :class:`~turbohtml.Text` nodes, so ``E.div("<b>")`` serializes as
+  ``&lt;b&gt;``. htbuilder escapes nothing, so ``str(div("<b>"))`` emits the ``<b>`` markup verbatim.
+- Plain attribute names, no mangling to remember. ``E`` takes a mapping, so ``class`` and ``data-i`` are written as the
+  literal dict keys rather than the ``_class`` / ``data_i`` underscore convention.
+- Native-C build and serialize, so the fragment is assembled in the arena and written out in C rather than joined in
+  Python.
+- The rest of turbohtml: the same tree you built can be re-parsed, converted with :meth:`~turbohtml.Node.to_markdown`,
+  or edited in place, none of which htbuilder attempts.
+
+What htbuilder has that turbohtml does not
+==========================================
+
+- CSS value helpers. htbuilder's ``styles(padding=px(3), color=rgba(...))`` and the ``px``/``em``/``rem``/``percent``
+  unit functions build a ``style`` string for you. ``E`` has no equivalent; write the ``style`` value as a plain string
+  (``{"style": "padding:3px"}``).
+- ``classes()`` / ``fonts()`` / ``params()`` builder helpers. ``E`` covers ``classes`` with a list value (``{"class":
+  ["card", "lg"]}``); the ``fonts`` and ``params`` helpers have no direct counterpart, so build those attribute values
+  yourself.
+- Generated tag callables you can import by name (``from htbuilder import div, span``). ``E`` namespaces every tag under
+  one object instead: ``E.div``, ``E.span``, or ``E("div", ...)`` for a non-identifier tag.
+
+Performance
+===========
 
 ``E`` assembles the fragment in turbohtml's arena and serializes it in C; htbuilder stays in Python. The same ``<ul>``
 of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
@@ -40,11 +101,19 @@ of rows -- a class, a ``data`` attribute, and a text child apiece -- built both 
 back a real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can
 query, edit, and re-:meth:`~turbohtml.Node.serialize`.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
 htbuilder splits an element across two calls, attributes first and children second; turbohtml passes both to one call:
+
+.. code-block:: python
+
+    # htbuilder
+    from htbuilder import div, h1, li
+
+    # turbohtml
+    from turbohtml.build import E
 
 .. list-table::
     :header-rows: 1
@@ -57,8 +126,27 @@ htbuilder splits an element across two calls, attributes first and children seco
         follow in the same call
     - - ``li(_class="item", data_i="1")("text")``
       - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
-    - - ``classes("card", "lg")`` / ``styles(...)`` helpers
-      - a plain string, or a list value that joins on a space: ``{"class": ["card", "lg"]}``
+    - - ``classes("card", "lg")``
+      - a list value that joins on a space: ``{"class": ["card", "lg"]}``
+    - - ``styles(padding=px(3))``
+      - a plain string value: ``{"style": "padding:3px"}``
+    - - a non-identifier tag name
+      - :data:`E("tag", ...) <turbohtml.build.E>`, the call form
+    - - ``str(element)``
+      - :meth:`element.serialize() <turbohtml.Node.serialize>`
+
+Attributes are a leading mapping and children follow in the same call:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
 
 ``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
 attribute joins on a space so a class list reads naturally:
@@ -73,9 +161,9 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
   Serialize the element you built, or append it under a parsed document when you need the full page shell.
@@ -83,5 +171,7 @@ attribute joins on a space so a class list reads naturally:
   so write the real attribute name as the dict key -- no underscore convention to remember.
 - htbuilder renders lazily, escaping nothing: ``str(div("<b>"))`` emits the ``<b>`` markup verbatim. ``E`` builds text
   nodes, so the same call serializes as ``&lt;b&gt;``; markup belongs in child elements, not strings.
+- A leading mapping is always read as attributes; to start an element with literal text, pass the string first
+  (``E.p("text", E.b("bold"))``).
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/html-sanitizer.rst
+++ b/docs/migration/html-sanitizer.rst
@@ -4,24 +4,108 @@
 
 .. package-meta:: html-sanitizer matthiask/html-sanitizer
 
-`html-sanitizer <https://github.com/matthiask/html-sanitizer>`_ is an allowlist sanitizer over lxml, configured with a
-``settings`` dict carrying ``tags`` (a set), ``attributes`` (a per-tag dict), ``add_nofollow``, a ``sanitize_href``
-scheme check, and whitespace/tag-merging normalization.
+`html-sanitizer <https://github.com/matthiask/html-sanitizer>`_ is an allowlist HTML sanitizer built on lxml, from the
+author of FeinCMS and django-content-editor. You configure it with a ``settings`` dict: ``tags`` (a set of allowed
+elements), ``attributes`` (allowed attribute names keyed by tag), ``empty`` and ``separate`` (tags that may stay empty
+or must not merge with an adjacent twin), a ``sanitize_href`` scheme check, ``add_nofollow``, ``autolink``, and
+``element_preprocessors``/``element_postprocessors`` hooks. Beyond dropping disallowed markup it normalizes the tree:
+collapsing whitespace, merging adjacent identical tags, and dropping empty ones. It is the sanitizer behind Django CMS
+and rich-text-editor stacks that store user-authored HTML.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same allowlist job from its ``turbohtml.clean`` module. The move is a
+settings-to-:class:`~turbohtml.clean.Policy` translation rather than a rethink, and turbohtml runs the filtering in C
+over its own WHATWG tree builder instead of an lxml parse.
 
-``turbohtml.clean`` shares the allowlist stance, so the move is a settings-to-:class:`~turbohtml.clean.Policy`
-translation rather than a rethink, but it adds full static typing, a frozen thread-safe policy, and the WHATWG tree
-builder in C instead of an lxml parse, leading html-sanitizer by one to two orders of magnitude:
+*****************************
+ turbohtml vs html-sanitizer
+*****************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
+
+    - - Dimension
+      - turbohtml
+      - html-sanitizer
+    - - Scope
+      - Full WHATWG parser, serializer, sanitizer, linkifier, minifier, selectors
+      - Allowlist sanitize with whitespace and typographic normalization, over lxml
+    - - Feature breadth
+      - Escape/strip/remove per tag, value-rewriting attribute filter, forced attributes, CSS-property scrubbing, fixed
+        safety baseline
+      - Tag/attribute allowlist, tag merging, whitespace and typographic cleanup, autolink, pre/post-processor hooks
+    - - Performance
+      - Filtering in C on a native tree
+      - Pure Python over an lxml parse
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - Untyped
+    - - Dependencies
+      - None (self-contained C extension)
+      - lxml
+    - - Maintenance
+      - Active
+      - Active, single maintainer
+
+Feature overlap
+===============
+
+The shared allowlist surface ports one-to-one:
+
+- ``Sanitizer(settings).sanitize(text)`` -> :func:`turbohtml.clean.sanitize` with a :class:`~turbohtml.clean.Policy`, or
+  a reusable :class:`~turbohtml.clean.Sanitizer`.
+- ``settings["tags"]`` (a set) -> ``Policy.tags`` (a ``frozenset``).
+- ``settings["attributes"]`` (per-tag dict) -> ``Policy.attributes`` (per-tag ``frozenset``; ``"*"`` as key matches
+  every tag).
+- ``sanitize_href`` scheme check -> ``Policy.url_schemes`` plus ``Policy.allow_relative_urls``.
+- ``add_nofollow=True`` -> ``Policy.add_link_rel = frozenset({"nofollow"})``.
+
+What turbohtml adds
+===================
+
+- A frozen, thread-safe :class:`~turbohtml.clean.Policy` you build once and reuse across threads.
+- An :class:`~turbohtml.clean.OnDisallowed` enum that names three outcomes for a disallowed tag: ``ESCAPE`` (render as
+  text), ``STRIP`` (unwrap, keep children), and ``REMOVE`` (drop the subtree). html-sanitizer only unwraps.
+- ``Policy.remove_with_content`` and a fixed safety baseline that drops ``<script>``, ``on*`` event handlers, and
+  ``javascript:`` URLs by construction, so no allowlist can re-admit them and script text never leaks into the output.
+- ``Policy.css_properties``: when ``style`` is allowed, its declarations are scrubbed against a safe property set.
+- ``Policy.attribute_filter`` to rewrite or drop any surviving attribute value, and ``Policy.set_attributes`` to force
+  attribute values onto every kept instance of a tag.
+- ``Policy.add_link_rel`` generalizes ``add_nofollow`` to any ``rel`` token set (for example ``noopener``,
+  ``noreferrer``).
+- Ready-made :meth:`Policy.strict() <turbohtml.clean.Policy.strict>`, :meth:`~turbohtml.clean.Policy.basic`, and
+  :meth:`~turbohtml.clean.Policy.relaxed` presets.
+
+What html-sanitizer has that turbohtml does not
+===============================================
+
+- Whitespace collapsing, adjacent-tag merging, and empty-tag dropping (the ``whitespace``, ``separate``, and ``empty``
+  settings) run as part of every ``sanitize`` call. turbohtml has no direct port; do the normalization with a walk over
+  the returned tree.
+- ``keep_typographic`` rewrites quotes and dashes to typographic characters. No equivalent.
+- ``element_preprocessors`` and ``element_postprocessors`` insert arbitrary structural transforms into the pass.
+  turbohtml's ``attribute_filter`` covers value-level rewriting, but structural post-processing is left to a walk over
+  the tree.
+- ``sanitize_href`` is an arbitrary callable, so it can rewrite or reject a URL on any rule. turbohtml checks a scheme
+  allowlist (``url_schemes`` plus ``allow_relative_urls``); custom per-URL logic goes through ``attribute_filter``
+  instead.
+- ``autolink`` fuses URL detection into the sanitize call. turbohtml linkifies with a separate
+  :func:`turbohtml.clean.linkify` pass rather than a sanitizer setting.
+
+Performance
+===========
+
+turbohtml leads html-sanitizer by one to two orders of magnitude, the WHATWG tree builder in C standing in for the lxml
+parse:
 
 .. bench-table::
     :file: bench/html-sanitizer.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import and translate the ``settings`` dict into a :class:`~turbohtml.clean.Policy`:
 
 .. code-block:: python
 
@@ -29,6 +113,18 @@ builder in C instead of an lxml parse, leading html-sanitizer by one to two orde
     from html_sanitizer import Sanitizer
 
     Sanitizer({"tags": {"a", "p"}, "attributes": {"a": {"href"}}, "add_nofollow": True}).sanitize(text)
+
+    # turbohtml
+    from turbohtml.clean import sanitize, Policy
+
+    sanitize(
+        text,
+        Policy(
+            tags=frozenset({"a", "p"}),
+            attributes={"a": frozenset({"href"})},
+            add_link_rel=frozenset({"nofollow"}),
+        ),
+    )
 
 .. list-table::
     :header-rows: 1
@@ -38,14 +134,14 @@ builder in C instead of an lxml parse, leading html-sanitizer by one to two orde
       - turbohtml
     - - ``Sanitizer(settings).sanitize(text)``
       - :func:`turbohtml.clean.sanitize` with a :class:`~turbohtml.clean.Policy`
-    - - ``tags``
+    - - ``settings["tags"]``
       - ``Policy.tags``
-    - - ``attributes``
+    - - ``settings["attributes"]``
       - ``Policy.attributes``
     - - ``add_nofollow``
       - ``Policy.add_link_rel`` (``{"nofollow"}``)
     - - ``sanitize_href`` schemes
-      - ``Policy.url_schemes``
+      - ``Policy.url_schemes`` (+ ``Policy.allow_relative_urls``)
 
 .. testcode::
 
@@ -66,11 +162,15 @@ builder in C instead of an lxml parse, leading html-sanitizer by one to two orde
 
     <p>Hi <a href="http://x" rel="nofollow">l</a></p>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
-- The whitespace normalization and tag-merging html-sanitizer performs (``empty``, ``separate``, ``whitespace``) has no
-  direct port; do it with a walk over the returned tree.
-- Its ``element_preprocessors``/``element_postprocessors`` hooks have no direct port either. turbohtml's
-  ``attribute_filter`` covers value-level rewriting, but structural post-processing is left to a walk over the tree.
+- Disallowed-tag default differs. html-sanitizer unwraps a tag outside the allowlist and keeps its children; turbohtml
+  escapes it to visible text. For parity, set ``on_disallowed_tag=OnDisallowed.STRIP`` on the policy.
+- No whitespace or tag-merging normalization. html-sanitizer collapses whitespace, merges adjacent identical tags, and
+  drops empty ones; turbohtml preserves the tree it parsed. Add a post-sanitize walk if you rely on that cleanup.
+- The ``element_preprocessors``/``element_postprocessors`` hooks have no direct port. ``attribute_filter`` handles
+  value-level rewriting; structural changes need a walk over the returned tree.
+- turbohtml's safety baseline is fixed. It removes ``<script>``, ``on*`` handlers, and ``javascript:`` URLs even when a
+  policy would admit them, so a policy that names ``script`` in ``tags`` still cannot keep it.

--- a/docs/migration/html-text.rst
+++ b/docs/migration/html-text.rst
@@ -4,17 +4,99 @@
 
 .. package-meta:: html-text zytedata/html-text
 
-`html-text <https://github.com/zytedata/html-text>`_ (Zyte) pulls the visible text out of a page, optionally guessing
-block layout from the tags. It builds an lxml tree and walks it in Python.
+`html-text <https://github.com/zytedata/html-text>`_ (Zyte) extracts the visible text from a page. It strips
+``<script>`` and ``<style>``, inserts newlines around block tags, and optionally guesses block layout so the output
+reads like the rendered page rather than a raw token dump. Zyte ships it as a feature-extraction step for web scraping
+and machine-learning pipelines, where the text feeds classifiers or search indexes. Under the hood it builds an lxml
+tree and walks it in Python, with parsel-bound helpers for reading text off an already-selected node.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with :meth:`~turbohtml.Node.to_text`: one fully type annotated C tree walk that renders
+layout-aware plain text, plus the :attr:`~turbohtml.Node.strings` / :attr:`~turbohtml.Node.stripped_strings` iterators
+for the collapsed word stream html-text returns with layout guessing off.
 
-:meth:`~turbohtml.Node.to_text` is the same call in one fully type annotated C walk: ``extract_text`` maps to
-:meth:`~turbohtml.Node.to_text`, and the raw word stream html-text returns with layout guessing off maps to the
-:attr:`~turbohtml.Node.strings` / :attr:`~turbohtml.Node.stripped_strings` iterators (or the
-:attr:`~turbohtml.Node.text` concatenation).
+************************
+ turbohtml vs html-text
+************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - html-text
+    - - Scope
+      - Full WHATWG parser, DOM, CSS/XPath selection, and text/Markdown/HTML serialization
+      - Visible-text extraction from an lxml tree
+    - - Feature breadth
+      - Layout profiles, link and image rendering, aligned tables, wrap width, bullet markers, annotated text
+      - Layout guessing on/off, punctuation-space guessing, custom newline tag sets
+    - - Performance
+      - Single C tree walk (see :doc:`inscriptis <inscriptis>`-shared benchmark below)
+      - lxml tree build plus a Python walk
+    - - Typing
+      - Fully annotated with shipped stubs
+      - Untyped
+    - - Dependencies
+      - None (self-contained C extension)
+      - lxml and parsel
+    - - Maintenance
+      - Active, broad HTML surface
+      - Zyte-maintained, stable and narrow in scope
+
+Feature overlap
+===============
+
+Port these 1:1:
+
+- ``extract_text(html)`` (layout-guessed visible text) maps to ``parse(html).to_text()``.
+- ``extract_text(html, guess_layout=False)`` (collapsed word stream) maps to ``" ".join(parse(html).stripped_strings)``.
+- The raw word list html-text collects maps to the :attr:`~turbohtml.Node.strings` /
+  :attr:`~turbohtml.Node.stripped_strings` iterators, or the :attr:`~turbohtml.Node.text` concatenation.
+
+What turbohtml adds
+===================
+
+- Column-aligned table layout. :meth:`~turbohtml.Node.to_text` renders ``<table>`` as aligned columns; html-text emits
+  the cells as a flat text run.
+- A :class:`~turbohtml.PlainText` config that renders link targets (``links`` = ``"inline"`` / ``"footnote"``), image
+  alt text (``images``), wrapped prose (``width``), and custom list markers (``bullet``), none of which html-text
+  produces.
+- Annotated text through :meth:`~turbohtml.Node.to_annotated_text`, pairing the text with labeled spans.
+- WHATWG-conformant parsing of malformed markup, where html-text inherits lxml's non-spec recovery.
+- No lxml or parsel dependency, full type annotations, and the surrounding DOM, selection, and serialization surface.
+
+What html-text has that turbohtml does not
+==========================================
+
+- Parsel integration. ``cleaned_selector`` and ``selector_to_text`` read text off a ``parsel.Selector``. turbohtml has
+  no parsel binding; select the node with turbohtml's own CSS/XPath and call :meth:`~turbohtml.Node.to_text` on it (see
+  :doc:`parsel <parsel>`).
+- Punctuation-space guessing on the word stream. html-text's ``guess_punct_space`` suppresses spaces before punctuation
+  when joining inline text. Joining :attr:`~turbohtml.Node.stripped_strings` with a single space has no equivalent
+  toggle; :meth:`~turbohtml.Node.to_text` handles inline concatenation correctly, so prefer it when the spacing matters.
+- Per-tag newline control. html-text accepts ``newline_tags`` / ``double_newline_tags`` sets. turbohtml selects spacing
+  through the ``layout`` profile (``"extended"`` / ``"strict"``) rather than a per-tag override; no equivalent for
+  renaming which tags break lines.
+
+Performance
+===========
+
+.. bench-table::
+    :file: bench/html-text.json
+
+The same text benchmark that backs the :doc:`inscriptis <inscriptis>` comparison also runs html-text's ``extract_text``:
+:meth:`~turbohtml.Node.to_text` walks the tree once in C, where html-text builds an lxml tree and collects its text in
+Python. html-text skips the column-aligned table layout :meth:`~turbohtml.Node.to_text` renders, so its margin behind
+turbohtml narrows on table-heavy input while staying near an order of magnitude. The ``word stream`` row turns layout
+guessing off (``extract_text(guess_layout=False)``) against joining the :attr:`~turbohtml.Node.stripped_strings`
+iterator, the collapsed visible text both return without layout.
+
+****************
+ How to migrate
+****************
+
+Swap the import and the call:
 
 .. code-block:: python
 
@@ -30,21 +112,7 @@ block layout from the tags. It builds an lxml tree and walks it in Python.
     turbohtml.parse(html).to_text()  # layout-aware text
     " ".join(turbohtml.parse(html).stripped_strings)  # collapsed word stream
 
-The same text benchmark that backs the :doc:`inscriptis <inscriptis>` comparison also runs html-text's ``extract_text``:
-:meth:`~turbohtml.Node.to_text` walks the tree once in C, where html-text builds an lxml tree and collects its text in
-Python.
-
-.. bench-table::
-    :file: bench/html-text.json
-
-html-text skips the column-aligned table layout :meth:`~turbohtml.Node.to_text` renders, so its margin behind turbohtml
-narrows on table-heavy input while staying near an order of magnitude. The ``word stream`` row turns layout guessing off
-(``extract_text(guess_layout=False)``) against joining the :attr:`~turbohtml.Node.stripped_strings` iterator, the
-collapsed visible text both return without layout.
-
-*************
- The renames
-*************
+API mapping:
 
 .. list-table::
     :header-rows: 1
@@ -57,11 +125,11 @@ collapsed visible text both return without layout.
     - - ``extract_text(html, guess_layout=False)``
       - ``" ".join(parse(html).stripped_strings)``
     - - the ``guess_layout`` toggle
-      - a :class:`~turbohtml.PlainText` config's ``layout`` (``"strict"``/``"extended"``)
+      - a :class:`~turbohtml.PlainText` config's ``layout`` (``"strict"`` / ``"extended"``)
     - - the raw word list
       - :attr:`~turbohtml.Node.strings` / :attr:`~turbohtml.Node.stripped_strings`
     - - the parsel-bound ``cleaned_selector`` / ``selector_to_text``
-      - out of scope -- see :doc:`parsel <parsel>`
+      - out of scope; see :doc:`parsel <parsel>`
 
 .. testcode::
 
@@ -74,14 +142,19 @@ collapsed visible text both return without layout.
     Hello bold world
     ['Hello', 'bold', 'world']
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
-- ``extract_text``'s ``guess_layout`` toggle corresponds to the ``layout`` (``"extended"``/``"strict"``) profile on a
+- ``extract_text``'s ``guess_layout`` toggle maps to the ``layout`` (``"extended"`` / ``"strict"``) profile on a
   :class:`~turbohtml.PlainText` config passed to :meth:`~turbohtml.Node.to_text`; the :doc:`inscriptis <inscriptis>`
   page covers the full ``PlainText`` option surface.
 - For the collapsed word stream html-text returns with layout guessing off, join the
   :attr:`~turbohtml.Node.stripped_strings` iterator rather than reaching for ``to_text``.
+- Joining stripped strings puts a space between every token, including before punctuation. html-text's
+  ``guess_punct_space`` avoids that; when the spacing matters, call :meth:`~turbohtml.Node.to_text`, which concatenates
+  inline text without the spurious spaces.
+- html-text emits table cells as a flat run, so its output differs from the column-aligned block
+  :meth:`~turbohtml.Node.to_text` renders on table-heavy pages.
 - html-text's parsel-bound helpers (``cleaned_selector``, ``selector_to_text``) are out of scope; the :doc:`parsel
   <parsel>` page covers reading text off a selected node.

--- a/docs/migration/html2text.rst
+++ b/docs/migration/html2text.rst
@@ -4,23 +4,96 @@
 
 .. package-meta:: html2text Alir3z4/html2text
 
-`html2text <https://github.com/Alir3z4/html2text>`_ converts HTML to Markdown with a streaming ``HTMLParser`` subclass
-and a wide option surface, including a ``google_doc`` mode that reads the inline CSS a Google Docs export carries.
+`html2text <https://github.com/Alir3z4/html2text>`_ converts HTML to Markdown. It subclasses the standard library
+``HTMLParser`` and streams tokens through a large, well-worn option surface: list markers, emphasis and strong markers,
+link styles (inline or reference), image handling, table rendering, line wrapping at ``body_width``, Unicode folding via
+its ``UNIFIABLE`` table, and a ``google_doc`` mode that reads the inline CSS a Google Docs HTML export carries. It ships
+a command-line converter alongside the library and is a long-standing default for turning arbitrary web HTML into
+readable Markdown in scrapers, mail-to-text pipelines, and documentation tooling.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same conversion through :meth:`~turbohtml.Node.to_markdown`, a single fully typed method on the
+parsed WHATWG tree. It walks the tree in C instead of driving a Python ``HTMLParser``, and groups the flat html2text
+options into named config dataclasses so each concept has one name.
 
-:meth:`~turbohtml.Node.to_markdown` replaces an ``html2text`` call with one fully type annotated method on the parsed
-tree. It walks the WHATWG tree in C rather than driving a Python ``HTMLParser``, converting a page roughly fifty times
-faster while covering the same options, including the Google Docs mode:
+************************
+ turbohtml vs html2text
+************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - html2text
+    - - Scope
+      - Full WHATWG HTML parser and tree with Markdown, plain-text, and HTML serialization
+      - HTML-to-Markdown conversion only
+    - - Feature breadth
+      - Same Markdown option surface (lists, inline marks, links, images, tables, wrapping, code, Google Docs mode) plus
+        text extraction, selectors, and sanitization on the shared tree
+      - Broad, mature Markdown-conversion options including ``google_doc`` and CLI flags
+    - - Performance
+      - C tree walk, roughly 50x faster on the benchmark below
+      - Pure-Python ``HTMLParser`` subclass
+    - - Typing
+      - Fully type annotated, config via frozen dataclasses
+      - Untyped public API
+    - - Dependencies
+      - Compiled C extension (prebuilt wheels)
+      - Pure Python, no compiled dependency
+    - - Maintenance
+      - Actively developed
+      - Long-standing, widely deployed, stable
+
+Feature overlap
+===============
+
+Port these html2text calls 1:1 onto :meth:`~turbohtml.Node.to_markdown` with a :class:`~turbohtml.Markdown` config:
+
+- ``html2text.html2text(text)`` -> ``turbohtml.parse(text).to_markdown()``.
+- List markers, emphasis/strong markers, and quote characters (``ul_item_mark``, ``emphasis_mark``, ``strong_mark``,
+  ``open_quote``, ``close_quote``).
+- Link handling: ignore, skip-internal, inline vs reference style, and ``baseurl`` prefixing.
+- Image handling: markdown, alt-only, ignore, or raw HTML, plus a default alt string.
+- Table rendering: markdown, strip, or raw HTML, with column padding.
+- Line wrapping at a width, for list items and links.
+- Unicode folding (``unicode_snob``), code marking and block style, single-line-break spacing, aggressive escaping.
+- The ``google_doc`` inline-CSS mode and its list-indent step.
+
+What turbohtml adds
+===================
+
+- One parsed tree serves Markdown, layout-aware plain text (:meth:`~turbohtml.Node.to_text`), and HTML
+  (:meth:`~turbohtml.Node.serialize`); html2text is Markdown-only.
+- Convert any subtree by calling :meth:`~turbohtml.Node.to_markdown` on a selected element
+  (``doc.find("article").to_markdown()``) instead of pre-slicing the HTML string.
+- Full spec-compliant WHATWG parsing feeds the conversion, so malformed markup is repaired the same way a browser does
+  before it is rendered to Markdown.
+- Grouped, frozen-dataclass config (``Markdown.Links``, ``Markdown.Images``, ``Markdown.Tables`` ...) is fully typed and
+  discoverable, versus html2text's flat set of untyped instance attributes.
+
+What html2text has that turbohtml does not
+==========================================
+
+- A command-line converter and ``python -m html2text`` entry point. turbohtml exposes Markdown as a library method only;
+  wrap ``turbohtml.parse(open(path).read()).to_markdown()`` in a short script for equivalent shell use.
+- Pure-Python install with no compiled extension. html2text runs anywhere a Python interpreter does; turbohtml needs a
+  prebuilt wheel (or a C toolchain to build from source) for the target platform.
+- ``baseurl`` in html2text and ``Markdown.Links(base_url=...)`` both prefix rather than fully resolve; neither does
+  RFC-3986 resolution, so there is no gap here, but do not expect turbohtml to add it.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/html2text.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import and the call:
 
 .. code-block:: python
 
@@ -112,12 +185,15 @@ or ``700``--``900`` becomes ``strong``, ``font-style:italic`` becomes ``emphasis
 
     **Quarterly** revenue
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - :meth:`~turbohtml.Node.to_markdown` is a method on any node, so convert a subtree by calling it on the element you
   selected (``doc.find("article").to_markdown()``) instead of slicing the HTML string first.
 - Layout-aware plain text (the ``inscriptis`` role, :meth:`~turbohtml.Node.to_text`) is a separate method; for the
   unstructured concatenation read :attr:`~turbohtml.Node.text`.
-- ``base_url`` does simple prefixing rather than full RFC-3986 URL resolution.
+- ``base_url`` does simple prefixing rather than full RFC-3986 URL resolution, matching html2text's ``baseurl``.
+- html2text wraps prose at ``body_width`` (78) by default; turbohtml wraps only when you set
+  ``Markdown.Wrapping(width=...)``. Set it explicitly to reproduce wrapped output, or leave it unset for unwrapped
+  Markdown.

--- a/docs/migration/html5-parser.rst
+++ b/docs/migration/html5-parser.rst
@@ -5,25 +5,105 @@
 .. package-meta:: html5-parser kovidgoyal/html5-parser
 
 `html5-parser <https://html5-parser.readthedocs.io>`_ wraps gumbo, the C WHATWG parser, and hands the result back as an
-`lxml <https://lxml.de>`_/ElementTree tree. It is turbohtml's closest direct competitor: a native parse with no
-pure-Python pass.
+`lxml <https://lxml.de>`_/ElementTree tree. It is a parse-only front end: gumbo tokenizes and tree-builds in C, then the
+nodes are copied into whatever backend you pick with ``treebuilder`` (``lxml`` by default, or ``lxml_html``, ``etree``,
+``dom``, ``soup``). Everything after the parse — querying, mutation, serialization — is the chosen backend's job, not
+html5-parser's. It ships in `calibre <https://calibre-ebook.com>`_ and is a common drop-in wherever a WHATWG-correct
+tree is wanted inside an existing lxml pipeline.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with a single library: it parses the same WHATWG tree in its own C engine, then keeps
+you inside a fully typed :class:`~turbohtml.Document` for querying, editing, and serialization, with no ``libxml2`` or
+gumbo build dependency to carry.
 
-The difference is what you get back. ``html5_parser.parse`` returns a read-oriented lxml element built on ``libxml2``,
-while :func:`turbohtml.parse` returns a fully type annotated :class:`~turbohtml.Document` with a mutable, natively typed
-tree and a real ``<template>`` content document, and no ``libxml2``/gumbo build dependency. html5-parser builds its tree
-through gumbo into ``libxml2``, where turbohtml runs its own C engine straight into the native tree, so parsing the same
-document is more than an order of magnitude faster:
+***************************
+ turbohtml vs html5-parser
+***************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 16 42 42
+
+    - - Dimension
+      - turbohtml
+      - html5-parser
+    - - Scope
+      - Parse, query, mutate, and serialize in one library
+      - Parse only; the returned tree is handed to lxml/etree/dom/soup for everything else
+    - - Feature breadth
+      - CSS :meth:`~turbohtml.Node.select`, XPath 1.0 :meth:`~turbohtml.Node.xpath`, the
+        :meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.find_all` grammar, a full edit surface, Markdown/plain-text
+        renderers, sanitizer, linkifier, structured-data extraction
+      - Whatever the selected backend exposes (lxml's XPath/cssselect, ElementTree's API, BeautifulSoup's, minidom's)
+    - - Performance
+      - Native C engine straight into the native tree; see the table below
+      - Native gumbo parse copied into a libxml2/backend tree
+    - - Typing
+      - Fully type annotated with bundled stubs
+      - Untyped; static types come from the chosen backend (e.g. lxml-stubs)
+    - - Dependencies
+      - Self-contained C extension, no ``libxml2``/gumbo
+      - Links ``libxml2`` and bundles gumbo; the default path also needs ``lxml``
+    - - Maintenance
+      - Actively developed
+      - Stable and maintained by the calibre author, low churn
+
+Feature overlap
+===============
+
+Both are native WHATWG parsers with no pure-Python pass, so the parse call and the tree walk port directly:
+
+- ``html5_parser.parse(markup)`` for ``str`` or ``bytes`` input maps to :func:`turbohtml.parse`.
+- Encoding control (``transport_encoding``/``fallback_encoding``) maps to the ``encoding`` and ``detect_encoding``
+  arguments of :func:`turbohtml.parse`.
+- The root element (``return_root=True``, the default) is :attr:`doc.root <turbohtml.Document.root>`.
+- XPath 1.0 querying is at parity: ``root.xpath(...)`` maps to :meth:`~turbohtml.Node.xpath`, and both stop at XPath 1.0
+  with EXSLT (libxml2 has no XPath 2.0/XQuery either).
+- Element accessors port exactly as in the :ref:`From lxml <migration-lxml>` section, since html5-parser returns lxml's
+  tree: ``el.get``/``el.attrib`` become :attr:`~turbohtml.Element.attrs`, ``el.getparent()`` becomes
+  :attr:`~turbohtml.Node.parent`.
+
+What turbohtml adds
+===================
+
+- CSS selection built in: :meth:`~turbohtml.Node.select`/:meth:`~turbohtml.Node.select_one` plus the
+  :meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.find_all` filter grammar, with no ``lxml.cssselect`` detour.
+- A full mutation surface on the typed tree, so edits do not require pulling in libxml2 semantics.
+- Serialization in the same library: the :attr:`~turbohtml.Node.html` property, :meth:`~turbohtml.Node.encode`, and the
+  :class:`~turbohtml.Markdown`/:class:`~turbohtml.PlainText`/:class:`~turbohtml.Html` renderers.
+- Text extraction as first-class API: :attr:`~turbohtml.Node.text`, :attr:`~turbohtml.Node.strings`,
+  :attr:`~turbohtml.Node.stripped_strings`.
+- A real ``<template>`` content document, and source positions built in via ``parse(..., positions=True)``.
+- Higher-level extraction that html5-parser leaves to your pipeline: the sanitizer, the linkifier, and structured-data
+  parsing.
+- Full static typing across the tree, where html5-parser is untyped.
+
+What html5-parser has that turbohtml does not
+=============================================
+
+- **Pluggable treebuilders.** ``treebuilder='etree'``, ``'dom'``, or ``'soup'`` returns a stdlib ElementTree,
+  ``xml.dom.minidom``, or BeautifulSoup tree directly. turbohtml returns only its own :class:`~turbohtml.Document`; to
+  feed one of those ecosystems you serialize with :attr:`~turbohtml.Node.html` and reparse in the target library.
+- **The libxml2 stack on the returned tree.** Because the default output is an lxml element, XSLT,
+  DTD/RelaxNG/XML-Schema validation, and C14N are one call away. turbohtml has no equivalent for these; only XPath 1.0
+  is at parity.
+- **Namespaced XHTML output.** ``maybe_xhtml`` and ``namespace_elements`` produce libxml2 namespace-prefixed nodes for
+  XHTML and foreign content. turbohtml builds the WHATWG HTML tree (SVG/MathML foreign content included) but does not
+  expose it as namespaced libxml2 elements.
+- **Line numbers as attributes.** ``line_number_attr`` writes each element's source line into an attribute on the tree
+  itself. turbohtml records source positions with ``positions=True``, but as node metadata, not as injected attributes.
+
+Performance
+===========
+
+html5-parser builds its tree through gumbo into ``libxml2``, where turbohtml runs its own C engine straight into the
+native tree, so parsing the same document is more than an order of magnitude faster:
 
 .. bench-table::
     :file: bench/html5-parser.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
 .. code-block:: python
 
@@ -31,6 +111,36 @@ document is more than an order of magnitude faster:
     from html5_parser import parse
 
     root = parse(markup)  # an lxml.etree element
+
+Swap the import for turbohtml's :func:`~turbohtml.parse`, which returns a :class:`~turbohtml.Document` instead of a bare
+root element:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `html5-parser <https://html5-parser.readthedocs.io>`__
+      - turbohtml
+    - - ``parse(markup)``
+      - :func:`turbohtml.parse`
+    - - ``parse(markup, return_root=True)`` (root element)
+      - :attr:`doc.root <turbohtml.Document.root>`
+    - - ``parse(markup, return_root=False)`` (ElementTree)
+      - the :class:`~turbohtml.Document` itself
+    - - ``parse(markup, transport_encoding=..., fallback_encoding=...)``
+      - :func:`parse(markup, encoding=..., detect_encoding=...) <turbohtml.parse>`
+    - - ``root.xpath("//td")``
+      - :meth:`~turbohtml.Node.xpath`
+    - - ``root.cssselect("td")`` (via lxml)
+      - :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`
+    - - ``el.get(...)`` / ``el.attrib``
+      - :attr:`~turbohtml.Element.attrs`
+    - - ``el.text`` / ``el.tail``
+      - child :class:`~turbohtml.Text` nodes, or the :attr:`~turbohtml.Node.text` property
+    - - ``el.getparent()``
+      - :attr:`~turbohtml.Node.parent`
+    - - ``treebuilder='etree' | 'dom' | 'soup'``
+      - no equivalent; serialize with :attr:`~turbohtml.Node.html` and reparse in the target library
 
 .. testcode::
 
@@ -43,19 +153,20 @@ document is more than an order of magnitude faster:
 
     cell
 
-Because the tree it returns is lxml's, the element accessors port exactly as in the :ref:`From lxml <migration-lxml>`
-section: ``el.get``/``el.attrib`` become :attr:`~turbohtml.Element.attrs`, the ``el.text``/``el.tail`` string pair
-becomes child :class:`~turbohtml.Text` nodes, ``el.getparent()`` becomes :attr:`~turbohtml.Node.parent`, and
-``el.xpath(...)`` maps to turbohtml's XPath 1.0 :meth:`~turbohtml.Node.xpath` (or CSS :meth:`~turbohtml.Node.select` and
-the :meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.find_all` grammar).
+**********************
+ Gotchas and pitfalls
+**********************
 
-**********
- Pitfalls
-**********
-
-Like :ref:`From lxml <migration-lxml>`, the gap is the rest of the libxml2 stack the returned tree would otherwise
-carry, dropped on purpose with the ``libxml2``/gumbo build dependency:
-
-- XSLT, DTD/RelaxNG/XML-Schema validation, and C14N have no equivalent. XPath is at parity: both run XPath 1.0 with
-  EXSLT (libxml2 has no XPath 2.0/XQuery either).
-- The ``.text``/``.tail`` model becomes real :class:`~turbohtml.Text` nodes rather than the two string fields.
+- **Return type.** html5-parser hands back a bare lxml root element (or an ElementTree with ``return_root=False``);
+  turbohtml hands back a :class:`~turbohtml.Document`. Reach the root through :attr:`doc.root
+  <turbohtml.Document.root>`.
+- **The text/tail model.** lxml's two string fields (``.text``, ``.tail``) become real :class:`~turbohtml.Text` child
+  nodes. Read a subtree's visible text through the :attr:`~turbohtml.Node.text` property instead of stitching the pair
+  together.
+- **The rest of the libxml2 stack is gone on purpose.** Dropping the ``libxml2``/gumbo build dependency also drops XSLT,
+  DTD/RelaxNG/XML-Schema validation, and C14N. If a pipeline depends on those, keep html5-parser for that stage.
+- **Encoding.** html5-parser distinguishes ``transport_encoding`` (an authoritative label) from ``fallback_encoding`` (a
+  guess). turbohtml's ``encoding`` is the explicit label and ``detect_encoding=True`` opts into sniffing; there is no
+  separate fallback slot.
+- **Namespaces.** Without ``maybe_xhtml``/``namespace_elements`` there is nothing to port; with them, expect the
+  turbohtml tree to be plain WHATWG HTML rather than namespace-prefixed libxml2 nodes.

--- a/docs/migration/html5lib.rst
+++ b/docs/migration/html5lib.rst
@@ -5,25 +5,133 @@
 .. package-meta:: html5lib html5lib/html5lib-python
 
 `html5lib <https://html5lib.readthedocs.io>`_ is the reference pure-Python implementation of the WHATWG parsing
-algorithm: it tokenizes and builds a tree that you select through a treebuilder (an :mod:`xml.etree.ElementTree` element
-by default, or DOM, or lxml), and it is the conformance baseline other parsers are checked against.
+algorithm. It tokenizes a byte or character stream and builds a tree through a *treebuilder* you select at call time: an
+:mod:`xml.etree.ElementTree` element by default, or ``dom``, or ``lxml``. On top of the tree it ships treewalkers that
+convert between representations, a configurable serializer, a filter chain (whitespace collapsing, optional-tag
+omission, alphabetical attributes, meta-charset injection), and a now-deprecated sanitizer. Because it tracks the spec
+closely, it is the conformance baseline other parsers are checked against, and it is the ``html5lib`` backend
+BeautifulSoup and others parse through.
 
-***************
- Why turbohtml
-***************
+turbohtml runs the same WHATWG algorithm in C and covers that ground with one engine. :func:`turbohtml.parse` returns a
+single fully type annotated :class:`~turbohtml.Document` with navigation, ``find``/``select``/XPath querying, and WHATWG
+serialization built in, so there is no foreign tree behind a treebuilder choice and no separate walk-and-serialize step.
 
-turbohtml runs the same WHATWG algorithm, so the *tree* matches, but it produces one typed hierarchy with navigation,
-search, and serialization built in instead of a foreign tree behind a treebuilder choice. The algorithm runs in C, so
-parsing, tokenizing, and fragment parsing run 25 to 70 times faster than the pure-Python implementation
-(:func:`turbohtml.parse_fragment` parses an ``innerHTML``-style snippet in its container context, the same WHATWG
-fragment algorithm html5lib's :func:`~html5lib.html5parser.parseFragment` runs):
+***********************
+ turbohtml vs html5lib
+***********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 18 41 41
+
+    - - Dimension
+      - turbohtml
+      - html5lib
+    - - Scope
+      - WHATWG HTML: parse, tokenize, query, mutate, and serialize in one C engine
+      - WHATWG HTML parse and tokenize into a pluggable third-party tree, plus treewalkers and a serializer
+    - - Feature breadth
+      - One typed tree with :meth:`~turbohtml.Node.find` grammar, CSS :meth:`~turbohtml.Node.select`, XPath, and WHATWG
+        serialization formatters
+      - etree/DOM/lxml treebuilders, treewalkers, serializer filters, deprecated sanitizer; no built-in query API
+    - - Performance
+      - C core; parse, tokenize, and fragment parse run 25 to 70 times faster
+      - Pure Python; the reference implementation, tuned for correctness not speed
+    - - Typing
+      - Ships ``py.typed``; every public method annotated
+      - No inline types and no published stubs
+    - - Dependencies
+      - Zero runtime dependencies (self-contained C extension)
+      - Requires ``webencodings`` and ``six``; ``lxml`` optional for that treebuilder, ``chardet`` optional for sniffing
+    - - Maintenance
+      - Actively developed, single-engine
+      - Mature and stable; the conformance reference, with an infrequent release cadence
+
+Feature overlap
+===============
+
+These port one-to-one; the calls differ only in name (see the mapping table under `How to migrate`_):
+
+- Parsing a full document with the WHATWG algorithm: ``html5lib.parse`` maps to :func:`turbohtml.parse`.
+- Fragment parsing in a container context: ``html5lib.parseFragment`` maps to :func:`turbohtml.parse_fragment`, the same
+  WHATWG ``innerHTML`` fragment algorithm.
+- Tokenizing without building a tree: the html5lib tokenizer maps to :func:`turbohtml.tokenize` and
+  :class:`turbohtml.Tokenizer`, yielding :class:`~turbohtml.Token` values tagged by :class:`~turbohtml.TokenType`.
+- Serializing a tree back to markup: ``html5lib.serialize`` maps to :meth:`~turbohtml.Node.serialize` and
+  :attr:`~turbohtml.Node.html`.
+
+What turbohtml adds
+===================
+
+- **A C engine.** Parsing, tokenizing, fragment parsing, and serialization all run in C, 25 to 70 times faster than the
+  pure-Python reference.
+- **A built-in query API.** html5lib hands back a tree and stops; you navigate etree/DOM yourself. turbohtml carries
+  :meth:`~turbohtml.Node.find` / :meth:`~turbohtml.Node.find_all`, CSS :meth:`~turbohtml.Node.select`, and
+  :meth:`~turbohtml.Node.xpath` on the tree it returns.
+- **One typed tree.** :class:`~turbohtml.Document`, :class:`~turbohtml.Element`, :class:`~turbohtml.Text`, and the other
+  node types are sealed, pattern-matchable, and annotated, instead of a foreign tree chosen through a treebuilder.
+- **Plain tag names with a separate namespace.** :attr:`~turbohtml.Element.tag` stays plain (``div``) and the namespace
+  rides on :attr:`~turbohtml.Element.namespace` as a :class:`~turbohtml.Namespace`, rather than being folded into a
+  Clark-notation name (``{http://www.w3.org/1999/xhtml}div``).
+- **WHATWG-conformant serialization by default** through :class:`~turbohtml.Formatter` selection, with no serializer
+  object to construct.
+- **Zero runtime dependencies and full typing.** No ``webencodings`` or ``six`` install, and ``py.typed`` ships.
+
+What html5lib has that turbohtml does not
+=========================================
+
+- **Pluggable treebuilders.** ``html5lib.parse(s, treebuilder="dom")`` (or ``"lxml"``, or the default ``"etree"``)
+  returns whichever tree you name. turbohtml always returns its own typed tree; this is a deliberate clean-break
+  omission. Workaround: if you need an ``ElementTree`` or ``lxml`` tree specifically, keep html5lib for that call.
+- **Treewalkers.** html5lib converts one tree representation into another through ``html5lib.getTreeWalker``. turbohtml
+  has a single representation, so there is nothing to walk between. No equivalent, and none needed.
+- **Serializer filters.** html5lib's serializer chains filters for optional-tag omission, alphabetical attribute order,
+  meta-charset injection, and whitespace. turbohtml serializes WHATWG-conformant output selected by
+  :class:`~turbohtml.Formatter`; it does not expose that filter registry. Workaround: pick the closest ``Formatter`` and
+  layout; for optional-tag omission there is no equivalent.
+- **A (deprecated) sanitizer.** html5lib ships ``html5lib.filters.sanitizer``, deprecated since 1.1. turbohtml has no
+  sanitizer. Workaround: use a dedicated sanitizer such as ``nh3`` or ``bleach`` (see :doc:`nh3` and :doc:`bleach`).
+- **Optional statistical encoding detection.** With ``chardet`` installed, html5lib's input stream can guess an encoding
+  from byte frequency when there is no BOM or ``<meta charset>``. turbohtml sniffs only what the WHATWG algorithm reads,
+  then falls back to ``windows-1252``. Workaround: detect with ``charset-normalizer`` first and hand turbohtml the
+  decoded ``str`` (or bytes with an explicit ``encoding=``).
+
+Performance
+===========
+
+The algorithm runs in C, so parsing, tokenizing, and fragment parsing run 25 to 70 times faster than the pure-Python
+implementation (:func:`turbohtml.parse_fragment` parses an ``innerHTML``-style snippet in its container context, the
+same WHATWG fragment algorithm html5lib's :func:`~html5lib.html5parser.parseFragment` runs):
 
 .. bench-table::
     :file: bench/html5lib.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import. There is no treebuilder to name, since turbohtml always returns its own typed tree:
+
+.. code-block:: python
+
+    # html5lib
+    import html5lib
+
+    doc = html5lib.parse("<table><tr><td>x", treebuilder="etree")
+
+.. testcode::
+
+    from turbohtml import parse
+
+    doc = parse("<table><tr><td>x")  # the same tree html5lib and a browser build
+    print(doc.find("td").text)
+
+.. testoutput::
+
+    x
+
+API mapping
+===========
 
 .. list-table::
     :header-rows: 1
@@ -39,26 +147,54 @@ fragment algorithm html5lib's :func:`~html5lib.html5parser.parseFragment` runs):
       - :func:`turbohtml.parse_fragment`
     - - the html5lib tokenizer
       - :func:`turbohtml.tokenize`, :class:`turbohtml.Tokenizer`
+    - - ``html5lib.serialize(tree)``
+      - :meth:`~turbohtml.Node.serialize`, :attr:`~turbohtml.Node.html`
     - - ``el.tag`` namespaced (``{http://www.w3.org/1999/xhtml}div``)
       - :attr:`~turbohtml.Element.tag` plus :class:`~turbohtml.Namespace` on :attr:`~turbohtml.Element.namespace`
     - - the treebuilder's own walk and ``el.attrib``
       - :attr:`~turbohtml.Node.children`, :meth:`~turbohtml.Node.find` / :meth:`~turbohtml.Node.select`,
         :attr:`~turbohtml.Element.attrs`
 
+Because turbohtml returns a queryable tree, the walk-the-etree step after parsing collapses into a ``find`` or
+``select`` call:
+
 .. testcode::
 
-    doc = parse("<table><tr><td>x")  # the same tree html5lib and a browser build
-    print(doc.find("td").text)
+    doc = parse('<ul><li class="x">a</li><li>b</li></ul>')
+    print([li.text for li in doc.find_all("li")])
+    print(doc.select_one("li.x").text)
 
 .. testoutput::
 
-    x
+    ['a', 'b']
+    a
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
-- html5lib gives you a foreign tree (ElementTree, DOM, or lxml) and you pick a treebuilder; turbohtml has one typed
-  tree, so there is nothing to choose and the node types are sealed and pattern-matchable.
-- html5lib's ElementTree output namespaces names; turbohtml keeps ``tag`` plain and carries the namespace separately as
-  :attr:`~turbohtml.Element.namespace`.
+- **One tree, no treebuilder.** html5lib's output shape depends on the ``treebuilder`` you pass; turbohtml has one
+  sealed typed tree, so the node types are fixed and pattern-matchable and there is nothing to select.
+- **Tag names are plain, namespaces are separate.** html5lib's etree treebuilder namespaces element names in Clark
+  notation (``{http://www.w3.org/1999/xhtml}div``, and default ``namespaceHTMLElements=True``). turbohtml keeps
+  :attr:`~turbohtml.Element.tag` plain and carries the namespace on :attr:`~turbohtml.Element.namespace`:
+
+  .. testcode::
+
+      from turbohtml import Namespace
+
+      svg = parse("<svg><rect/></svg>").find("rect")
+      print((svg.tag, svg.namespace is Namespace.SVG))
+
+  .. testoutput::
+
+      ('rect', True)
+
+- **Attributes read through ``attrs``, not ``attrib``.** html5lib's etree tree exposes ``el.attrib``; turbohtml uses
+  :attr:`~turbohtml.Element.attrs`, and multi-valued attributes (``class``, ``rel``, ...) read back as a ``list[str]``.
+- **Encoding sniffing stops at the markup.** ``parse`` runs the WHATWG byte path — BOM, then a ``<meta charset>``
+  prescan, then a ``windows-1252`` fallback. html5lib with ``chardet`` installed can additionally guess from byte
+  frequency; where that matters, detect the encoding first and hand turbohtml the decoded ``str``.
+- **No serializer object or filter chain.** html5lib builds a serializer and threads filters through it; turbohtml
+  serializes directly with :meth:`~turbohtml.Node.serialize` and a :class:`~turbohtml.Formatter`, and does not offer
+  optional-tag omission or attribute reordering.

--- a/docs/migration/htmldate.rst
+++ b/docs/migration/htmldate.rst
@@ -4,35 +4,92 @@
 
 .. package-meta:: htmldate adbar/htmldate
 
-`htmldate <https://htmldate.readthedocs.io/>`_ is the standalone publication-date finder underneath ``trafilatura``:
-``find_date(html)`` reads a page's ``<meta>`` tags, JSON-LD, ``<time>`` elements, URL, and visible text and returns the
-date as a string. :func:`turbohtml.extract.dates` covers that surface off the parsed DOM, with the knobs on one frozen
-:class:`~turbohtml.extract.DateExtraction` config.
+`htmldate <https://htmldate.readthedocs.io/>`_ is the standalone publication-date finder that sits underneath
+``trafilatura``. Its one entry point, ``find_date(html)``, reads a page's ``<meta>`` tags, JSON-LD, ``<time>`` elements,
+canonical URL, and visible text, then returns the date as a formatted string. It leans on ``lxml`` for parsing and an
+optional ``dateparser`` fallback for free-form and multilingual phrasings, which makes it the go-to date extractor for
+news scraping and corpus building in the trafilatura ecosystem.
 
-***************
- Why turbohtml
-***************
+:func:`turbohtml.extract.dates` covers the same ground off the already-parsed WHATWG tree. It scores the identical
+signals in htmldate's stage-priority order, carries htmldate's knobs on one frozen
+:class:`~turbohtml.extract.DateExtraction` config, and returns a :class:`~turbohtml.extract.PublicationDate` that names
+which signal the date came from instead of a bare string. No second parse, no ``lxml`` or ``dateparser`` dependency.
 
-turbohtml reads the same signals htmldate reads, but over the WHATWG tree and the
-:meth:`~turbohtml.Document.structured_data` engine it already builds, so no second parse and no ``dateparser`` /
-``lxml`` dependency is pulled in. The result is a :class:`~turbohtml.extract.PublicationDate` that names the signal the
-date came from, not a bare string:
+***********************
+ turbohtml vs htmldate
+***********************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 18 41 41
 
-    from turbohtml.extract import DateExtraction, dates
+    - - Dimension
+      - turbohtml
+      - htmldate
+    - - Scope
+      - Full WHATWG HTML5 parser with a date engine as one extractor among many (metadata, links, text, structured data)
+      - Single-purpose publication-date finder over an ``lxml`` tree
+    - - Feature breadth
+      - Same five signals (meta, JSON-LD, time, URL, text) scored off the DOM; standard-library date parsing
+      - Same five signals plus boilerplate pruning, occurrence scoring, and ``dateparser`` for wide locale coverage
+    - - Performance
+      - 2x-4x faster on boilerplate pages with no date metadata (early exit over structured signals)
+      - Edges ahead on clean metadata pages where the header lookup returns first
+    - - Typing
+      - Fully typed; returns a :class:`~turbohtml.extract.PublicationDate` NamedTuple or ``None``
+      - Typed hints; returns ``str`` or ``None``
+    - - Dependencies
+      - No third-party runtime dependencies (bundled C extension)
+      - ``lxml``, ``charset_normalizer``, ``dateutil``, ``urllib3``; ``dateparser`` optional
+    - - Maintenance
+      - Active, part of turbohtml
+      - Active, maintained by Adrien Barbaresi alongside trafilatura
 
-    page = (
-        '<meta property="article:published_time" content="2016-12-23T10:00:00Z">'
-        '<meta property="article:modified_time" content="2017-02-01">'
-    )
-    print(dates(page))
-    print(dates(page, DateExtraction(original=True)))
+Feature overlap
+===============
 
-.. testoutput::
+The date-finding surface ports one-to-one:
 
-    PublicationDate(date='2017-02-01', signal='meta')
-    PublicationDate(date='2016-12-23', signal='meta')
+- ``find_date(html)`` maps to :func:`turbohtml.extract.dates`, reading the same signals in the same priority order.
+- ``original_date`` maps to ``DateExtraction(original=True)``: prefer the first-published date over the last-modified
+  one.
+- ``outputformat`` maps to ``DateExtraction(output_format=...)``, an :meth:`~datetime.date.strftime` string.
+- ``min_date`` / ``max_date`` map to ``DateExtraction(min_date=..., max_date=...)``.
+- ``extensive_search`` maps to ``DateExtraction(extensive_search=...)``, gating the visible-text scan.
+- The ``<meta>``, JSON-LD ``datePublished`` / ``dateModified``, ``<time>``, and canonical-URL vocabularies are drawn
+  from htmldate's own key lists, so the same tags win on both.
+
+What turbohtml adds
+===================
+
+- **Signal provenance.** The result names which engine won (``"meta"``, ``"json-ld"``, ``"time"``, ``"url"``,
+  ``"text"``); htmldate returns only the string, so you cannot tell a hard metadata date from a text guess.
+- **No second parse.** The date is read off the tree turbohtml already built, not a fresh ``lxml`` parse of the markup.
+- **One extractor of many.** The same parsed document feeds turbohtml's metadata, link, text, and structured-data
+  extractors; htmldate does dates only.
+- **No third-party runtime dependencies.** htmldate pulls in ``lxml``, ``charset_normalizer``, ``dateutil``, and
+  ``urllib3``.
+
+.. _htmldate-divergences:
+
+What htmldate has that turbohtml does not
+=========================================
+
+- **Boilerplate pruning.** htmldate deletes comments, navigation, and footers before scanning text, then picks the most
+  frequent plausible date. turbohtml scores the structured signals first and falls back to the modal date in visible
+  text without pruning the tree. Workaround: strip boilerplate yourself before calling ``dates`` when a page buries its
+  real date among navigation timestamps.
+- **``dateparser`` locale reach.** htmldate parses free-form and wide-locale date phrases through ``dateparser``.
+  turbohtml uses standard-library parsing: ISO 8601, common numeric spellings, an 8-digit stamp, and a compact
+  English/German/French/Spanish/Italian month vocabulary. No equivalent for languages or phrasings outside that set.
+- **``url=`` parameter.** htmldate accepts an explicit ``url`` argument as a date signal. turbohtml has no such
+  parameter; it reads the date from the markup's own ``<link rel=canonical>`` or ``og:url``. Workaround: pass markup
+  that carries the canonical link.
+- **String bounds.** htmldate's ``min_date`` / ``max_date`` also accept ISO strings. turbohtml requires
+  :class:`datetime.date` objects.
+
+Performance
+===========
 
 Both libraries are parse-bound. On clean metadata pages htmldate's header lookup returns first and edges ahead; on
 boilerplate pages with no date metadata turbohtml's early exit over the structured signals runs 2x-4x faster than
@@ -44,11 +101,14 @@ htmldate's tree-pruning text scoring:
 Over the 200 real-world news pages in htmldate's ``mediacloud`` evaluation set the two agree on 91% of inputs, and
 turbohtml matches the gold date on 85% (htmldate 89%). On htmldate's 55 hand-picked edge-case pages -- blogs and sparse
 pages tuned into htmldate's own suite -- turbohtml trails (69% against 96%): those need the boilerplate pruning and
-occurrence scoring called out under :ref:`htmldate-divergences`.
+occurrence scoring called out under `What htmldate has that turbohtml does not`_.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import and the call. The keyword arguments htmldate spreads across ``find_date`` live on one immutable config,
+and the date carries its provenance:
 
 .. list-table::
     :header-rows: 1
@@ -69,8 +129,25 @@ occurrence scoring called out under :ref:`htmldate-divergences`.
     - - ``find_date(html, url=...)``
       - reads the page's own ``<link rel=canonical>`` / ``og:url``; pass markup that carries it
 
-The keyword arguments htmldate spreads across ``find_date`` live on one immutable config, and the date carries its
-provenance:
+The default reads the most recent date the page reports; ``original=True`` returns the first-published one:
+
+.. testcode::
+
+    from turbohtml.extract import DateExtraction, dates
+
+    page = (
+        '<meta property="article:published_time" content="2016-12-23T10:00:00Z">'
+        '<meta property="article:modified_time" content="2017-02-01">'
+    )
+    print(dates(page))
+    print(dates(page, DateExtraction(original=True)))
+
+.. testoutput::
+
+    PublicationDate(date='2017-02-01', signal='meta')
+    PublicationDate(date='2016-12-23', signal='meta')
+
+Text scanning and bounds behave as htmldate's do, and an out-of-window date returns ``None``:
 
 .. testcode::
 
@@ -86,29 +163,9 @@ provenance:
     PublicationDate(date='2016-07-04', signal='text')
     None
 
-.. _htmldate-divergences:
-
-**************************************
- Deliberate divergences and omissions
-**************************************
-
-turbohtml scores the structured date signals off the DOM; htmldate layers heavier heuristics on top, and skipping them
-is where the two part ways on sparse pages:
-
-- **No boilerplate pruning.** htmldate deletes comments, navigation, and footers before scanning text, then picks the
-  most frequent plausible date. turbohtml scores the structured signals (meta, JSON-LD, time, URL) first and only falls
-  back to the modal date in the visible text, without pruning the tree.
-- **No ``dateparser`` fallback.** Date strings are parsed with the standard library: ISO 8601, the common numeric
-  spellings, an 8-digit stamp, and a compact English/German/French/Spanish/Italian month vocabulary. htmldate's
-  ``dateparser`` reaches more locales and free-form phrasings.
-- **A date, with its source.** :func:`~turbohtml.extract.dates` returns which signal won (``"meta"``, ``"json-ld"``,
-  ``"time"``, ``"url"``, ``"text"``); htmldate returns only the string. Read ``.date`` for the drop-in value.
-- **Bounds are dates.** ``min_date`` / ``max_date`` are :class:`datetime.date` objects, defaulting to 1995-01-01 and
-  today; htmldate also accepts ISO strings.
-
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - The default prefers the *modification* date (the most recent the page reports), matching htmldate's default. Pass
   ``DateExtraction(original=True)`` for the first-published date.
@@ -118,3 +175,7 @@ is where the two part ways on sparse pages:
   page that carries the canonical link when the URL is the only date signal.
 - ``extensive_search`` is on by default, as in htmldate; turn it off to read only the structured signals and never scan
   visible text.
+- ``min_date`` / ``max_date`` must be :class:`datetime.date` objects, defaulting to 1995-01-01 and today. htmldate also
+  accepts ISO strings; convert them with :meth:`datetime.date.fromisoformat` first.
+- Dates outside turbohtml's month vocabulary (locales beyond English, German, French, Spanish, Italian) fall through the
+  text stage. Rely on the structured signals for those pages, or keep htmldate's ``dateparser`` path for the tail.

--- a/docs/migration/htmlmin.rst
+++ b/docs/migration/htmlmin.rst
@@ -4,30 +4,115 @@
 
 .. package-meta:: htmlmin mankyd/htmlmin
 
-`htmlmin <https://github.com/mankyd/htmlmin>`_ is a pure-Python minifier built on the standard library's ``HTMLParser``;
-``htmlmin.minify(html, **flags)`` collapses whitespace runs to one space and can drop comments and redundant attribute
-quotes, and ``htmlmin.Minifier`` exposes the same folds over incremental input. Its last release, 0.1.12 from 2017,
-imports the ``cgi`` module Python 3.13 removed, so it no longer installs on current interpreters.
+`htmlmin <https://github.com/mankyd/htmlmin>`_ is a pure-Python HTML minifier built on the standard library's
+``HTMLParser``. ``htmlmin.minify(html, **flags)`` collapses whitespace runs to a single space and can optionally drop
+comments, reduce empty attributes, and remove redundant attribute quotes; ``htmlmin.Minifier`` exposes the same folds
+over incremental input, and the package also ships a WSGI middleware and a decorator for minifying responses in web
+frameworks. It sees wide use through those integrations in Django and Flask stacks. Its last release, 0.1.12 from 2017,
+imports the ``cgi`` module Python 3.13 removed, so it no longer installs on current interpreters; the maintained
+``htmlmin2`` fork restores the import but changes nothing else.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with :func:`turbohtml.clean.minify`, one call that minifies a document over the WHATWG
+tree turbohtml already builds, configured by the frozen :class:`~turbohtml.Minify` options object. It applies the same
+whitespace, comment, and attribute folds, adds a fold htmlmin lacks (omitting the tags the WHATWG rules make optional),
+and does the work in a compiled C serializer instead of a Python token loop.
 
-:func:`turbohtml.clean.minify` minifies a document with one call over the WHATWG tree turbohtml already builds,
-configured by the frozen :class:`~turbohtml.Minify` options object. On the folds the two share (collapsing insignificant
-whitespace, dropping comments, and unquoting attributes) it runs fourteen to twenty times faster, parse included, and it
-also omits the tags the WHATWG rules make optional, a fold htmlmin does not have. Output sizes stay within one percent
-of each other on the benchmark pages; turbohtml's is the smaller on three of the four.
+**********************
+ turbohtml vs htmlmin
+**********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - htmlmin
+    - - Scope
+      - Full WHATWG parser plus serializer; minify is one output layout
+      - HTML minification only, over ``HTMLParser``
+    - - Feature breadth
+      - Whitespace, comment, attribute-quote folds plus optional-tag omission and optional inline JS/CSS minification
+      - Whitespace, comment, empty-attribute, boolean-attribute, and quote folds; incremental ``Minifier``; WSGI
+        middleware and framework decorator
+    - - Performance
+      - C serializer over an already-built tree; 14-20x faster, parse included (see below)
+      - Pure-Python ``HTMLParser`` token loop
+    - - Typing
+      - Fully typed, frozen :class:`~turbohtml.Minify` options object
+      - Untyped ``**flags`` keyword arguments
+    - - Dependencies
+      - Self-contained C extension, no runtime dependencies
+      - Pure Python; last release does not install on Python 3.13+ (use ``htmlmin2``)
+    - - Maintenance
+      - Actively maintained
+      - Upstream last released 2017; community ``htmlmin2`` fork carries compatibility fixes only
+
+Feature overlap
+===============
+
+These folds port one-to-one; each htmlmin flag becomes a field on :class:`~turbohtml.Minify`:
+
+- Whitespace collapsing — ``htmlmin.minify(html)`` (on by default) maps to ``Minify(collapse_whitespace=True)`` (also
+  the default).
+- Comment removal — ``remove_comments=True`` maps to ``Minify(strip_comments=True)`` (the turbohtml default; comments go
+  unless you opt out).
+- Attribute-quote removal and empty-attribute reduction — ``remove_optional_attribute_quotes`` and
+  ``reduce_empty_attributes`` map to the single ``Minify(unquote_attributes=True)``, which also collapses an empty value
+  to a bare attribute name.
+
+What turbohtml adds
+===================
+
+- Optional-tag omission — ``Minify(omit_optional_tags=True)`` drops the start and end tags the WHATWG rules make
+  optional (``</li>``, ``</p>``, ``<tbody>``, and so on). htmlmin keeps every tag.
+- Character-reference resolution — ``&eacute;`` serializes as the shorter literal ``é``; htmlmin passes references
+  through unchanged.
+- Inline JavaScript minification — ``Minify(minify_js=JSMinify())`` rewrites ``<script>`` bodies with the shipped JS
+  minifier. htmlmin never touches script bodies.
+- Inline and standalone CSS minification — :func:`turbohtml.clean.minify_css` shrinks ``<style>`` bodies and standalone
+  stylesheets. htmlmin never touches ``<style>`` bodies.
+- A real parse — the input runs through the full WHATWG algorithm, so malformed markup is repaired to the same tree a
+  browser builds before it is serialized.
+
+What htmlmin has that turbohtml does not
+========================================
+
+- ``remove_empty_space`` / ``remove_all_empty_space`` — htmlmin can delete inter-element whitespace outright. turbohtml
+  has no equivalent by design: dropping that whitespace can change rendering, so every run collapses to a single space
+  and the output reparses to the same tree. No equivalent.
+- ``reduce_boolean_attributes`` — htmlmin can rewrite ``checked="checked"`` to ``checked``. turbohtml leaves boolean
+  attributes written in full. No equivalent.
+- ``keep_pre`` / ``pre_tags`` / ``pre_attr`` — htmlmin lets you configure which tags and per-attribute markers preserve
+  whitespace. turbohtml always preserves whitespace inside ``<pre>`` and ``<textarea>`` (significant per WHATWG) and
+  offers no per-attribute opt-out. Workaround: none needed for the common case; the preservation is automatic and
+  spec-driven, but the configurability is gone.
+- ``htmlmin.Minifier`` incremental input — htmlmin can feed input in chunks. :func:`~turbohtml.clean.minify` takes the
+  whole document in one call. Workaround: accumulate the document, then minify once.
+- WSGI middleware and framework decorator — htmlmin ships ``htmlmin.middleware.HTMLMinMiddleware`` and a decorator to
+  minify HTTP responses in place. turbohtml has no built-in web-framework integration. Workaround: call
+  :func:`~turbohtml.clean.minify` on the rendered response body in your own middleware or view wrapper.
+- ``htmlmin`` command-line tool — htmlmin installs a console script. turbohtml exposes no minify CLI. Workaround: a
+  two-line ``python -c`` invocation of :func:`~turbohtml.clean.minify`.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/htmlmin.json
 
+On the folds the two share (collapsing insignificant whitespace, dropping comments, and unquoting attributes) turbohtml
+runs fourteen to twenty times faster, parse included. Output sizes stay within one percent of each other on the
+benchmark pages; turbohtml's is the smaller on three of the four.
+
 The benchmark installs `htmlmin2 <https://pypi.org/project/htmlmin2/>`__ 0.1.13, the fork that fixes the ``cgi`` import
 and changes nothing else, because htmlmin 0.1.12 itself cannot build on Python 3.13 or later.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import and drop the per-flag keywords for the options object:
 
 .. code-block:: python
 
@@ -40,16 +125,6 @@ and changes nothing else, because htmlmin 0.1.12 itself cannot build on Python 3
     from turbohtml.clean import minify
 
     minify(html)
-
-.. testcode::
-
-    from turbohtml.clean import minify
-
-    print(minify("<ul>  <li>  one  </li>  <li>  two  </li>  </ul>"))
-
-.. testoutput::
-
-    <ul> <li> one </li> <li> two </li> </ul>
 
 Each fold is a field on :class:`~turbohtml.Minify`, so a flag becomes one keyword on the options object:
 
@@ -80,15 +155,27 @@ Each fold is a field on :class:`~turbohtml.Minify`, so a flag becomes one keywor
     - - ``htmlmin.Minifier`` incremental input
       - not supported -- :func:`~turbohtml.clean.minify` takes the whole document
 
-**********
- Pitfalls
-**********
+The default call minifies with every fold engaged:
+
+.. testcode::
+
+    from turbohtml.clean import minify
+
+    print(minify("<ul>  <li>  one  </li>  <li>  two  </li>  </ul>"))
+
+.. testoutput::
+
+    <ul> <li> one </li> <li> two </li> </ul>
+
+**********************
+ Gotchas and pitfalls
+**********************
 
 - Every fold is round-trip safe, so minifying is idempotent and the output reparses to the input tree. The two minifiers
   do not produce byte-for-byte identical output, though: turbohtml drops optional tags htmlmin keeps and resolves
   character references htmlmin passes through, so port against behavior rather than string equality.
-- htmlmin strips comments only when asked (``remove_comments=False`` is its default); turbohtml strips them unless you
-  pass ``Minify(strip_comments=False)``.
+- The comment default flips. htmlmin strips comments only when asked (``remove_comments=False`` is its default);
+  turbohtml strips them unless you pass ``Minify(strip_comments=False)``.
 - ``minify`` parses the input as a full document, so a bare fragment gains the ``<html>``/``<body>`` structure the
   WHATWG algorithm infers; call it on whole pages, not detached fragments.
 - htmlmin never touches ``<style>`` and ``<script>`` bodies. turbohtml also leaves them verbatim by default, and can go

--- a/docs/migration/htpy.rst
+++ b/docs/migration/htpy.rst
@@ -6,45 +6,125 @@
 
 `htpy <https://htpy.dev>`_ assembles HTML in Python from the other direction than a parser: each element is an object
 whose attributes come from a call (``li(class_="item")``) and whose children sit in a ``[...]`` subscript (``ul[li("a"),
-li("b")]``), and stringifying the root renders the tree. turbohtml replaces it with the terse :data:`turbohtml.build.E`
-builder.
+li("b")]``), and stringifying the root renders the tree. Attributes can also be a leading CSS-selector string
+(``div(".card")``) or a mapping, children accept strings, other elements, and iterables or generators, and it escapes
+through markupsafe so a :class:`markupsafe.Markup` value passes through unescaped. It is a typed alternative to a
+template language, used to render server-side HTML in Django, Flask, Starlette, and FastAPI, and it can stream a page
+out as chunks for async responses.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with the terse :data:`turbohtml.build.E` builder, but the value it hands back is a real
+:class:`~turbohtml.Element` in a parsed tree rather than a render-only object, so the whole query, edit, and serialize
+surface stays available on what you just built.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+*******************
+ turbohtml vs htpy
+*******************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
 
-    from turbohtml.build import E
+    - - Dimension
+      - turbohtml
+      - htpy
+    - - Scope
+      - Full WHATWG parser, serializer, builder, selectors, sanitizer, converters
+      - HTML generation only, from Python
+    - - Feature breadth
+      - ``E`` builder over a real tree: CSS/XPath query, edit, ``to_markdown``, compact/indent/minify layouts
+      - Element objects, selector-string and conditional-class attributes, iterable children, markupsafe escaping,
+        ``fragment`` grouping, chunked streaming, ``html2htpy`` CLI
+    - - Performance
+      - Builds and serializes in C
+      - Pure Python over markupsafe
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - Fully annotated, ``py.typed``
+    - - Dependencies
+      - None (self-contained C extension)
+      - markupsafe
+    - - Maintenance
+      - Active
+      - Active
 
-    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
-    print(card.serialize())
+Feature overlap
+===============
 
-.. testoutput::
+The shared surface ports one-to-one:
 
-    <div class="card"><h1>Title</h1><p>body</p></div>
+- ``div(class_="card")[h1("Title")]`` -> :data:`E.div({"class": "card"}, E.h1("Title")) <turbohtml.build.E>`; attributes
+  are a leading mapping, children follow in the same call instead of a subscript.
+- ``li(class_="item", data_i="1")["text"]`` -> :data:`E.li({"class": "item", "data-i": "1"}, "text")
+  <turbohtml.build.E>`; write the real attribute name as the dict key, with no ``class_`` alias or
+  ``data_``-to-``data-`` rewrite to remember.
+- A string child becomes escaped text in both: htpy escapes through markupsafe, ``E`` builds a :class:`~turbohtml.Text`
+  node.
+- A non-identifier tag such as a custom element -> :data:`E("my-card", ...) <turbohtml.build.E>`, the call form.
+- A class token list joins on a space: ``div(class_="card lg")`` -> ``E.div({"class": ["card", "lg"]})``.
 
-``E`` assembles the fragment in turbohtml's arena and serializes it in C; htpy stays in Python. The same ``<ul>`` of
-rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
+What turbohtml adds
+===================
+
+- The result is an ordinary :class:`~turbohtml.Element`, so :meth:`~turbohtml.Node.select`,
+  :meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.find`, :meth:`~turbohtml.Node.to_markdown`, and the full edit
+  API are available. htpy's element is a render-only object with no query surface.
+- The markup serializes by exactly the WHATWG rules that parse it back, so a fragment round-trips; htpy renders its own
+  string and cannot read it back into a tree.
+- ``E`` assembles the fragment in turbohtml's arena and serializes it in C, about two and a half times faster than htpy.
+- A :class:`~turbohtml.Minify` layout (whitespace collapse, optional-tag omission, JS/CSS minify) on top of the compact
+  and :class:`~turbohtml.Indent` layouts; htpy renders compact only.
+- No third-party dependency: turbohtml is a self-contained C extension, where htpy pulls in markupsafe.
+- You can :func:`turbohtml.parse` real markup and append an ``E`` fragment under it, mixing parsing and building in one
+  tree.
+
+What htpy has that turbohtml does not
+=====================================
+
+- Selector-string attributes: ``div("#main.card.lg")`` sets id and classes from one CSS-selector string. ``E`` takes an
+  explicit mapping. Workaround: write ``E.div({"id": "main", "class": ["card", "lg"]})``.
+- Conditional-class mapping: ``div(class_={"active": is_active, "hidden": False})`` keeps only the true keys. ``E``
+  takes a plain class value. Workaround: build the list yourself, ``E.div({"class": [name for name, on in flags if
+  on]})``.
+- Iterable and generator children in the subscript: ``ul[(li(x) for x in items)]`` consumes the generator, and ``None``
+  or ``False`` children are dropped. ``E`` takes positional arguments. Workaround: splat and filter first,
+  ``E.ul(*(E.li(x) for x in items if x is not None))``.
+- markupsafe pass-through: a :class:`markupsafe.Markup` child is emitted unescaped without reparsing. ``E`` always
+  escapes a string into a :class:`~turbohtml.Text` node. Workaround: :func:`turbohtml.parse` the trusted markup and
+  append the resulting nodes, since turbohtml is a real parser.
+- ``fragment[...]`` groups several children with no wrapper element and renders them as adjacent siblings. ``E.<tag>``
+  always produces one rooted element. Workaround: serialize each child and concatenate, or parse the concatenation into
+  a fragment.
+- Chunked streaming: an htpy element iterates as byte chunks, so a large page can stream to an async response before it
+  is fully built. ``E`` builds the whole tree, then :meth:`~turbohtml.Node.serialize` returns one string. Workaround:
+  serialize and send the finished string; there is no incremental builder emit.
+- The ``html2htpy`` CLI converts existing HTML into htpy builder source. turbohtml has no code generator. Workaround:
+  :func:`turbohtml.parse` the HTML at runtime instead of generating builder code.
+
+Performance
+===========
+
+``E`` is about two and a half times faster than htpy. The same ``<ul>`` of rows -- a class, a ``data`` attribute, and a
+text child apiece -- built both ways:
 
 .. bench-table::
     :file: bench/htpy.json
 
-``E`` is about two and a half times faster than htpy, and the decisive difference is the result type: ``E`` hands back a
-real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can query,
-edit, and re-:meth:`~turbohtml.Node.serialize`.
+The decisive difference is the result type: ``E`` hands back a real :class:`~turbohtml.Element`, not a string, so the
+call that builds the markup also leaves a tree you can query, edit, and re-:meth:`~turbohtml.Node.serialize`.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
-htpy carries attributes in the call and children in a subscript; turbohtml passes both to one call:
+Swap the per-tag imports for the single ``E`` builder:
+
+.. code-block:: python
+
+    # htpy
+    from htpy import div, h1, p
+
+    # turbohtml
+    from turbohtml.build import E
 
 .. list-table::
     :header-rows: 1
@@ -57,6 +137,27 @@ htpy carries attributes in the call and children in a subscript; turbohtml passe
         arguments
     - - ``li(class_="item", data_i="1")["text"]``
       - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
+    - - ``div(class_={"active": on})`` conditional classes
+      - :data:`E.div({"class": [...]}) <turbohtml.build.E>`; build the token list before the call
+    - - ``ul[(li(x) for x in items)]`` iterable children
+      - :data:`E.ul(*(E.li(x) for x in items)) <turbohtml.build.E>`; splat the iterable into arguments
+    - - ``Markup(raw)`` child
+      - :func:`turbohtml.parse` the raw markup, then append the nodes
+    - - ``str(element)``
+      - :meth:`~turbohtml.Node.serialize` (compact) or ``serialize(Html(layout=Indent()))``
+
+htpy carries attributes in the call and children in a subscript; turbohtml passes both to one call:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
 
 ``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
 attribute joins on a space so a class list reads naturally:
@@ -71,13 +172,23 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
-- ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
-  Serialize the element you built, or append it under a parsed document when you need the full page shell.
-- htpy spells attributes with keyword arguments (``class_``, ``data_i``); ``E`` takes a plain mapping, so a hyphenated
-  name like ``data-i`` is written as the dict key directly rather than an underscore the builder rewrites.
+- ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype,
+  where importing htpy's ``html`` element renders a leading ``<!doctype html>``. Serialize the element you built, or
+  append it under a parsed document when you need the full page shell.
+- Attribute names are plain dict keys (``{"data-i": "1"}``), not htpy's keyword conventions (``class_``, the trailing
+  underscore for reserved words, the ``data_``/``aria_`` underscore-to-dash rewrite, or the ``".card"`` selector
+  string).
+- A leading mapping is always read as attributes; to start an element with literal text, pass the string first
+  (``E.p("text", E.b("bold"))``).
+- ``E`` takes children as positional arguments, so a generator must be splatted (``E.ul(*(E.li(x) for x in items))``);
+  htpy consumes an iterable placed directly in the ``[...]`` subscript.
+- htpy drops ``None`` and ``False`` children; ``E`` appends every argument, so filter conditionals out before the call.
+- ``E`` escapes strings into text nodes, so ``E.div("<b>")`` serializes as ``&lt;b&gt;``. htpy emits a
+  :class:`markupsafe.Markup` value unescaped; to inject real markup here, :func:`turbohtml.parse` it and append the
+  nodes.
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/hyperpython.rst
+++ b/docs/migration/hyperpython.rst
@@ -6,48 +6,121 @@
 
 `hyperpython <https://github.com/fabiommendes/hyperpython>`_ assembles HTML in Python from the other direction than a
 parser: each element takes keyword attributes in a call and children in a ``[...]`` subscript
-(``div(class_="card")[h1("Title")]``), and stringifying the root renders the tree. The library is unmaintained and no
-longer imports on Python 3.11 or newer -- its ``sidekick`` dependency crashes at import time unless pinned to
-``sidekick<0.7``, and it pins ``markupsafe<2`` -- so porting is also the unblock for current interpreters and dependency
-stacks. turbohtml replaces it with the terse :data:`turbohtml.build.E` builder.
+(``div(class_="card")[h1("Title")]``), and stringifying the root renders the tree. It also carries the ``h("tag", attrs,
+children)`` call form for dynamic tags, escapes string children through ``markupsafe``, and offers ``Blob``/``safe``
+escape hatches for raw markup. It was built to generate fragments inside Django and other Python web stacks without a
+template language.
 
-***************
- Why turbohtml
-***************
+The library is unmaintained and no longer imports on Python 3.11 or newer: its ``sidekick`` dependency crashes at import
+time unless pinned to ``sidekick<0.7``, and it pins ``markupsafe<2``. Porting is also the unblock for current
+interpreters and dependency stacks. turbohtml covers the same construction ground with the terse
+:data:`turbohtml.build.E` builder, but the value it hands back is a real :class:`~turbohtml.Element` in a parsed tree
+rather than a render object, so the whole query, edit, and serialize surface stays available on what you just built.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+**************************
+ turbohtml vs hyperpython
+**************************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
 
-    from turbohtml.build import E
+    - - Dimension
+      - turbohtml
+      - hyperpython
+    - - Scope
+      - Full WHATWG parser, serializer, builder, selectors, sanitizer, converters
+      - HTML generation only, from Python
+    - - Feature breadth
+      - ``E`` builder over a real tree: CSS/XPath query, edit, ``to_markdown``, compact/indent/minify layouts
+      - Subscript nesting, ``h`` call form, ``markupsafe`` escaping, ``Blob``/``safe`` raw hatches, framework helpers
+    - - Performance
+      - Builds and serializes in C
+      - Pure Python
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - Untyped
+    - - Dependencies
+      - None (self-contained C extension)
+      - ``sidekick<0.7`` and ``markupsafe<2``
+    - - Maintenance
+      - Active
+      - Unmaintained; does not import on Python 3.11+
 
-    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
-    print(card.serialize())
+Feature overlap
+===============
 
-.. testoutput::
+The shared surface ports one-to-one:
 
-    <div class="card"><h1>Title</h1><p>body</p></div>
+- ``div(class_="card")[h1("Title")]`` -> :data:`E.div({"class": "card"}, E.h1("Title")) <turbohtml.build.E>`; attributes
+  are a leading mapping, children follow in the same call.
+- ``li(class_="item", data_i="1")["text"]`` -> :data:`E.li({"class": "item", "data-i": "1"}, "text")
+  <turbohtml.build.E>`; write the real attribute name as the dict key, with no ``class_`` alias or
+  ``data_``-to-``data-`` rewrite to remember.
+- ``h("tag", {"class": "x"}, children)`` -> :data:`E("tag", {"class": "x"}, *children) <turbohtml.build.E>`, the call
+  form for a dynamic or non-identifier tag.
+- A string child becomes escaped text in both: hyperpython routes it through ``markupsafe``, ``E`` builds a
+  :class:`~turbohtml.Text` node.
+- A class token list joins on a space: ``div(class_="card lg")`` -> ``E.div({"class": ["card", "lg"]})``.
 
-``E`` assembles the fragment in turbohtml's arena and serializes it in C; hyperpython stays in Python. The same ``<ul>``
-of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways (hyperpython measured on its last
-importable dependency pin):
+What turbohtml adds
+===================
+
+- The result is an ordinary :class:`~turbohtml.Element`, so :meth:`~turbohtml.Node.select`,
+  :meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.find`, :meth:`~turbohtml.Node.to_markdown`, and the full edit
+  API are available. hyperpython hands back a render object with no CSS or XPath query surface.
+- The markup serializes by exactly the WHATWG rules that parse it back, so a fragment round-trips; hyperpython
+  hand-renders its own string.
+- ``E`` assembles the fragment in turbohtml's arena and serializes it in C, about two and a half times faster than
+  hyperpython.
+- A :class:`~turbohtml.Minify` layout (whitespace collapse, optional-tag omission, JS/CSS minify) on top of the compact
+  and :class:`~turbohtml.Indent` layouts.
+- Full type annotations with a ``py.typed`` marker; hyperpython is untyped.
+- No pinned dependencies and it runs on current interpreters, where hyperpython needs ``sidekick<0.7`` and
+  ``markupsafe<2`` and stops importing on Python 3.11+.
+- You can :func:`turbohtml.parse` real markup and append an ``E`` fragment under it, mixing parsing and building in one
+  tree.
+
+What hyperpython has that turbohtml does not
+============================================
+
+- Subscript children: ``div(class_="card")[h1("Title")]`` reads the nesting in a ``[...]`` block. ``E`` has no subscript
+  form. Workaround: pass children as positional arguments after the attribute mapping, ``E.div({"class": "card"},
+  E.h1("Title"))``.
+- Keyword attribute syntax: ``div(class_="card", data_i="1")`` mangles ``class_`` to ``class`` and ``data_i`` to
+  ``data-i``. ``E`` takes a plain mapping instead, ``{"class": "card", "data-i": "1"}``, so there is no rename to
+  memorize but also no keyword form.
+- ``Blob``/``safe`` inject unescaped HTML into the tree. ``E`` always escapes a string into a :class:`~turbohtml.Text`
+  node. Workaround: :func:`turbohtml.parse` the raw markup and append the resulting nodes, since turbohtml is a real
+  parser.
+- Framework-oriented component helpers aimed at Django rendering. turbohtml is a standalone parser and builder with no
+  framework integration layer. Workaround: serialize the ``E`` fragment and hand the string to the framework.
+
+Performance
+===========
+
+``E`` is about two and a half times faster than hyperpython. The same ``<ul>`` of rows -- a class, a ``data`` attribute,
+and a text child apiece -- built both ways (hyperpython measured on its last importable dependency pin):
 
 .. bench-table::
     :file: bench/hyperpython.json
 
-``E`` is about two and a half times faster than hyperpython, and the decisive difference is the result type: ``E`` hands
-back a real :class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can
-query, edit, and re-:meth:`~turbohtml.Node.serialize`.
+The decisive difference is the result type: ``E`` hands back a real :class:`~turbohtml.Element`, not a string, so the
+call that builds the markup also leaves a tree you can query, edit, and re-:meth:`~turbohtml.Node.serialize`.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
-hyperpython carries attributes in the call and children in a subscript; turbohtml passes both to one call:
+Swap the per-tag imports for the single ``E`` builder:
+
+.. code-block:: python
+
+    # hyperpython
+    from hyperpython import div, h1, p
+
+    # turbohtml
+    from turbohtml.build import E
 
 .. list-table::
     :header-rows: 1
@@ -62,6 +135,21 @@ hyperpython carries attributes in the call and children in a subscript; turbohtm
       - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`
     - - ``h("tag", {"class": "x"}, children)``
       - :data:`E("tag", {"class": "x"}, *children) <turbohtml.build.E>`, the call form
+    - - ``str(elem)`` / ``elem.render()``
+      - :meth:`~turbohtml.Node.serialize` (compact) or ``serialize(Html(layout=Indent()))``
+
+A subscript tree becomes one nested call, attributes leading and children following:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
 
 ``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
 attribute joins on a space so a class list reads naturally:
@@ -76,15 +164,19 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
   Serialize the element you built, or append it under a parsed document when you need the full page shell.
-- hyperpython mangles keyword arguments (``class_`` to ``class``, ``data_i`` to ``data-i``); ``E`` takes a plain
-  mapping, so write the real attribute name as the dict key -- no underscore convention to remember.
-- Both escape string children by default; hyperpython's ``Blob``/``safe`` escape hatches have no equivalent, so express
-  raw markup as child elements (or parse it into nodes first).
+- A leading mapping is always read as attributes; to start an element with literal text, pass the string first
+  (``E.p("text", E.b("bold"))``).
+- ``E`` escapes strings into text nodes, so ``E.div("<b>")`` serializes as ``&lt;b&gt;``. hyperpython's
+  ``Blob``/``safe`` had no escaping; to inject real markup, :func:`turbohtml.parse` it and append the nodes.
+- Write attribute names as plain dict keys (``{"data-i": "1"}``), not hyperpython's keyword mangling (``class_``,
+  ``data_i``).
+- turbohtml serializes compact by default. Pass ``Html(layout=Indent())`` to :meth:`~turbohtml.Node.serialize` for
+  indented output.
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/inscriptis.rst
+++ b/docs/migration/inscriptis.rst
@@ -4,24 +4,105 @@
 
 .. package-meta:: inscriptis weblyzard/inscriptis
 
-`inscriptis <https://github.com/weblyzard/inscriptis>`_ renders HTML to *layout-aware* plain text: it keeps the visual
-structure, most visibly by laying tables out as aligned columns, and can tag the output with labeled annotation spans.
-It builds an lxml tree and a CSS model in Python.
+`inscriptis <https://github.com/weblyzard/inscriptis>`_ converts HTML to *layout-aware* plain text. Instead of stripping
+tags, it drives a CSS model so the output keeps the page's visual structure: tables become aligned columns, block
+elements get blank lines and indentation, and list items keep their bullets. On top of that it can emit *annotations* —
+labeled ``(start, end, label)`` spans over the rendered text, driven by a per-tag rule map — which makes it a common
+preprocessing step for information-extraction and NLP pipelines that need clean, human-readable text with provenance. It
+parses with lxml and evaluates its CSS model in Python.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with :meth:`~turbohtml.Node.to_text` (the layout-aware renderer) and
+:meth:`~turbohtml.Node.to_annotated_text` (the annotated variant), both configured through the frozen
+:class:`~turbohtml.PlainText` dataclass. The whole layout pass runs in the C extension over a tree turbohtml already
+owns, so text extraction is one native walk with no lxml dependency.
 
-:meth:`~turbohtml.Node.to_text` is the same idea in one fully type annotated C walk, replacing ``get_text``, and
-:meth:`~turbohtml.Node.to_annotated_text` ports the annotation surface. Doing the whole layout natively makes it roughly
-twenty times faster:
+*************************
+ turbohtml vs inscriptis
+*************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - inscriptis
+    - - Scope
+      - Full WHATWG parser, mutable DOM, selectors, serializers; text rendering is one output mode
+      - HTML-to-text conversion only (plus annotations)
+    - - Feature breadth
+      - Layout text, annotations, plus Markdown, HTML serialization, CSS/XPath selectors, encoding detection
+      - Layout text and annotations, with a fully user-editable CSS profile
+    - - Performance
+      - Native C layout walk, roughly 20x faster (see below)
+      - lxml tree plus a Python CSS model
+    - - Typing
+      - Fully type annotated, ships ``py.typed`` stubs
+      - Type hints on the public API
+    - - Dependencies
+      - No runtime dependencies (self-contained C extension)
+      - Depends on lxml / libxml2
+    - - Maintenance
+      - Actively developed alongside the parser core
+      - Actively maintained by weblyzard
+
+Feature overlap
+===============
+
+The layout-text and annotation surface ports one-to-one:
+
+- ``get_text(html)`` -> :meth:`turbohtml.parse(html).to_text() <turbohtml.Node.to_text>`.
+- ``get_annotated_text(html, ParserConfig(annotation_rules=...))`` ->
+  :meth:`turbohtml.parse(html).to_annotated_text(rules) <turbohtml.Node.to_annotated_text>`, returning the rendered text
+  plus a list of ``(start, end, label)`` triples over its code-point offsets.
+- ``ParserConfig`` rendering options -> :class:`~turbohtml.PlainText` fields (``display_links`` -> ``links``,
+  ``display_images`` -> ``images``, ``table_cell_separator`` -> ``table_cell_separator``, the CSS profile -> ``layout``,
+  the list bullet -> ``bullet``).
+- Annotation rule keys use the same grammar: a bare tag (``"h1"``), ``tag#attr`` to require an attribute,
+  ``tag#attr=value`` to match one whitespace-separated token, and the tag-less ``#attr`` / ``#attr=value`` forms to
+  match across any tag. The value is the list of labels to attach.
+- The annotation *output processors* port as pure functions over the ``(text, spans)`` pair:
+  :func:`turbohtml.annotation_surface` groups matched substrings by label (inscriptis's ``SurfaceExtractor``), and
+  :func:`turbohtml.annotation_tags` weaves the spans back into the text as ``<label>...</label>`` markup, innermost span
+  closing first (inscriptis's XML / inline-tag processor).
+
+What turbohtml adds
+===================
+
+- **A real DOM.** ``to_text`` is one method on a parsed tree, so the same document can be queried with CSS/XPath
+  selectors, mutated, and re-serialized. inscriptis only ever hands back a string.
+- **Word wrapping.** :class:`~turbohtml.PlainText` takes ``width`` to reflow prose at a column; inscriptis leaves
+  wrapping to the caller.
+- **Other output modes** on the same node: :meth:`~turbohtml.Node.to_markdown`, :meth:`~turbohtml.Node.serialize`, and
+  the raw :attr:`~turbohtml.Node.text` concatenation with no layout at all.
+- **No lxml dependency** and a native C layout pass, which is where the speedup comes from.
+
+What inscriptis has that turbohtml does not
+===========================================
+
+- **A user-editable CSS model.** inscriptis lets you pass a custom CSS profile (per-tag ``display``, ``margin``,
+  ``padding``, ``white-space`` rules) through ``ParserConfig(css=...)``. turbohtml exposes only the fixed
+  ``layout="strict"`` / ``layout="extended"`` profiles, not per-tag overrides. Workaround: pick the closest profile and
+  post-process, or mutate the tree before ``to_text``.
+- **The ``inscript`` command-line tool.** turbohtml has no shipped CLI for text conversion; call
+  ``turbohtml.parse(...).to_text()`` from a short script.
+- **Anchor and caption toggles.** inscriptis's ``display_anchors`` (render ``id`` targets) and ``deduplicate_captions``
+  have no direct :class:`~turbohtml.PlainText` equivalent. Workaround: strip or dedupe the relevant nodes on the tree
+  before rendering.
+
+Performance
+===========
+
+Doing the whole layout natively makes text extraction roughly twenty times faster:
 
 .. bench-table::
     :file: bench/inscriptis.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the module-level ``get_text`` for a parse-then-render call:
 
 .. code-block:: python
 
@@ -35,26 +116,14 @@ twenty times faster:
 
     turbohtml.parse(html).to_text()
 
-.. testcode::
-
-    html = "<h1>Sales</h1><table><tr><th>Region</th><th>Total</th></tr><tr><td>North</td><td>120</td></tr></table>"
-    print(parse(html).to_text())
-
-.. testoutput::
-
-    Sales
-
-    Region  Total
-    North   120
-
-The ``ParserConfig`` options map onto :class:`~turbohtml.PlainText` config fields passed to
+The ``ParserConfig`` rendering options map onto :class:`~turbohtml.PlainText` fields passed to
 :meth:`~turbohtml.Node.to_text`:
 
 .. list-table::
     :header-rows: 1
     :widths: 50 50
 
-    - - `inscriptis <https://github.com/weblyzard/inscriptis>`__
+    - - `inscriptis <https://github.com/weblyzard/inscriptis>`__ ``ParserConfig``
       - turbohtml :class:`~turbohtml.PlainText`
     - - ``display_links``
       - ``links`` (``"none"``/``"inline"``/``"footnote"``)
@@ -69,13 +138,22 @@ The ``ParserConfig`` options map onto :class:`~turbohtml.PlainText` config field
     - - (no equivalent)
       - ``width`` adds word wrapping, which inscriptis leaves to the caller
 
-*************
- Annotations
-*************
+Layout text renders tables as aligned columns, the same as inscriptis:
 
-inscriptis can also tag the rendered text with labeled spans through ``get_annotated_text`` and an ``annotation_rules``
-mapping. :meth:`~turbohtml.Node.to_annotated_text` is the same call: it returns the rendered text together with a list
-of ``(start, end, label)`` triples over its code-point offsets, taking every ``to_text`` option as well.
+.. testcode::
+
+    html = "<h1>Sales</h1><table><tr><th>Region</th><th>Total</th></tr><tr><td>North</td><td>120</td></tr></table>"
+    print(parse(html).to_text())
+
+.. testoutput::
+
+    Sales
+
+    Region  Total
+    North   120
+
+Annotations port the same way. ``get_annotated_text`` becomes :meth:`~turbohtml.Node.to_annotated_text`, which takes the
+rule map directly and accepts every ``to_text`` option as well:
 
 .. code-block:: python
 
@@ -104,14 +182,7 @@ of ``(start, end, label)`` triples over its code-point offsets, taking every ``t
     Some bold words.
     [('heading', 'Title'), ('emphasis', 'bold')]
 
-Rule keys follow inscriptis: a bare tag (``"h1"``), a ``tag#attr`` to require an attribute, a ``tag#attr=value`` to
-match one whitespace-separated token of it, and the tag-less ``#attr`` / ``#attr=value`` forms to match across any tag.
-The value is the list of labels to attach.
-
-inscriptis also ships *annotation output processors* that render those spans. Both are ported as pure functions over the
-``(text, spans)`` pair: :func:`turbohtml.annotation_surface` is the surface-form extractor (group the matched substrings
-by label) and :func:`turbohtml.annotation_tags` is the inline-tagged (XML) exporter (weave the spans back into the text
-as ``<label>...</label>`` markup, innermost span closing first).
+The annotation output processors map onto two pure functions over the ``(text, spans)`` pair:
 
 .. list-table::
     :header-rows: 1
@@ -142,13 +213,15 @@ as ``<label>...</label>`` markup, innermost span closing first).
 
     Up <metric>12%</metric> on the year.
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - Links are hidden by default (matching inscriptis); pass ``PlainText(links="inline")`` for ``text (url)`` or
   ``PlainText(links="footnote")`` for numbered references collected at the end.
 - :meth:`~turbohtml.Node.to_text` renders structure, not styling: there is no bold or color, and headings are plain
   text. For the raw concatenation with no layout at all, read :attr:`~turbohtml.Node.text`.
 - Annotation offsets count code points into the returned string; a table cell is labeled at its position in the laid-out
-  grid, so the span covers the cell's column-aligned text rather than the source order.
+  grid, so the span covers the cell's column-aligned text rather than its source order.
+- turbohtml's ``layout`` is a two-value profile (``"strict"`` / ``"extended"``), not the full editable CSS model
+  inscriptis exposes; if you relied on a custom CSS profile, reshape the tree before rendering instead.

--- a/docs/migration/jsmin.rst
+++ b/docs/migration/jsmin.rst
@@ -7,17 +7,118 @@
     :target: https://pepy.tech/project/jsmin
 
 `jsmin <https://github.com/tikitu/jsmin>`_ is the Python port of Douglas Crockford's ``jsmin``: a character-level state
-machine that removes comments and whitespace. Like the original it does not rename or fold anything, and being a
-pure-Python character loop it is slow on large files.
+machine that walks the source one byte at a time and removes comments and insignificant whitespace. Like the original it
+does not rename a binding or fold a constant — it only deletes bytes that the tokenizer proves are optional — so its
+output stays close to the source size. Being a pure-Python character loop it is slow on large files, and because it
+tracks state by hand rather than parsing it can mishandle the regex-versus-division ``/`` in some inputs. It ships a
+single ``jsmin(str) -> str`` entry point and nothing else.
 
-***************
- Why turbohtml
-***************
+:func:`~turbohtml.minify_js` covers the same ground with a real front end: it lexes and parses to an arena AST in C,
+renames function-local bindings, folds constants, and prints the result. It always does at least what jsmin does (strip
+whitespace, comments and number literals) and, with its optional passes on, shrinks well past what a whitespace-only
+tool can reach.
 
-:func:`~turbohtml.minify_js` replaces the call and wins on both axes — it is faster and it shrinks more. turbohtml
-parses to an arena AST in C and then renames function-local bindings and folds constants, so it produces smaller output
-than jsmin's whitespace-only pass while running an order of magnitude quicker. Inline ``<script>`` minification, which
-jsmin leaves entirely to you, is a :class:`~turbohtml.JSMinify` on :class:`~turbohtml.Minify`.
+********************
+ turbohtml vs jsmin
+********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - jsmin
+    - - Scope
+      - Full HTML parser plus a standalone JS minifier and inline ``<script>`` minification
+      - JavaScript-only, whitespace and comment removal
+    - - Feature breadth
+      - Whitespace, comment and number-literal folding always on; optional local-binding renaming and constant folding
+        with dead-code elimination
+      - Whitespace and comment removal only; no renaming, no folding
+    - - Performance
+      - Parse-and-optimize front end in C, an order of magnitude faster than jsmin's Python loop
+      - Pure-Python character loop, slow on large files
+    - - Typing
+      - Typed API with bundled stubs; ``JSMinify`` is a frozen dataclass
+      - Untyped ``jsmin(str) -> str``
+    - - Dependencies
+      - Self-contained C extension
+      - Pure Python, no dependencies
+    - - Maintenance
+      - Actively developed
+      - Stable port of the Crockford algorithm, infrequent releases
+
+Feature overlap
+===============
+
+The shared surface ports 1:1 — a single call that takes a JavaScript string and returns a smaller one:
+
+- ``jsmin(source)`` maps directly to :func:`turbohtml.minify_js(source) <turbohtml.minify_js>`.
+- Whitespace and comment stripping is unconditional in both, so turbohtml is a drop-in for the plain call.
+- Neither tool needs a browser, DOM, or Node runtime; both operate on the string in-process.
+
+What turbohtml adds
+===================
+
+- **Local-binding renaming.** ``JSMinify(mangle=True)`` (the default) renames bindings local to a function to short
+  names, the bulk of the size win. jsmin never renames anything.
+- **Constant folding and dead-code elimination.** ``JSMinify(fold=True)`` (the default) evaluates constant expressions
+  and drops unreachable code. jsmin does neither.
+- **Number-literal minification.** turbohtml rewrites numeric literals to their shortest form unconditionally; jsmin
+  leaves them as written.
+- **A real parse, not a character loop.** Because turbohtml tokenizes against ECMA-262 it distinguishes a regex literal
+  from a division operator by grammar rather than by hand-tracked state.
+- **Inline ``<script>`` minification.** Pass a :class:`~turbohtml.JSMinify` as :class:`~turbohtml.Minify`'s
+  ``minify_js`` and ``<script>`` bodies are minified during HTML serialization. Only scripts whose ``type`` marks them
+  as JavaScript are rewritten; a ``type="application/json"`` or ``importmap`` payload is left byte-for-byte. jsmin only
+  ever sees a bare script string you extract yourself.
+- **Typed surface.** A bundled stub and the frozen ``JSMinify`` dataclass give static checkers full signatures.
+
+What jsmin has that turbohtml does not
+======================================
+
+- **Pure-Python, zero-dependency install.** jsmin is a single Python module with no compiled extension. turbohtml ships
+  a C extension; if a pure-Python wheel is a hard requirement, jsmin still fits where turbohtml cannot.
+- **Guaranteed pass-through of any input.** jsmin's byte-level loop emits *something* for every input. turbohtml parses,
+  so a construct its parser does not handle raises :class:`ValueError` for the standalone call. For the inline
+  ``<script>`` path there is an equivalent to jsmin's leniency: a script the parser cannot handle is emitted verbatim,
+  so one bad ``<script>`` never breaks the document. For the standalone call, wrap it in ``try/except ValueError`` and
+  fall back to the original source if you need the same never-fail behavior.
+
+Performance
+===========
+
+On the library ladder (``python -m bench minify-js``) turbohtml runs about three to five times faster than jsmin and its
+output is up to half the size, because jsmin only deletes whitespace where turbohtml renames every local binding and
+runs the structural folds. Each ratio is against turbohtml:
+
+.. bench-table::
+    :file: bench/jsmin.json
+
+Unlike the regex-based :doc:`rjsmin <rjsmin>`, jsmin has no speed advantage to trade for its simpler output, so there is
+no case where it beats :func:`~turbohtml.minify_js`.
+
+****************
+ How to migrate
+****************
+
+Swap the import and the call. jsmin exposes one function; turbohtml exposes the same shape plus an options object.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - jsmin
+      - turbohtml
+    - - ``from jsmin import jsmin``
+      - ``import turbohtml``
+    - - ``jsmin(source)``
+      - ``turbohtml.minify_js(source)``
+    - - (whitespace/comments only)
+      - ``turbohtml.minify_js(source, JSMinify(mangle=False, fold=False))`` for the closest whitespace-only match
+    - - (renaming, no equivalent)
+      - ``turbohtml.minify_js(source, JSMinify(mangle=False))`` keeps readable names while still folding
 
 .. code-block:: python
 
@@ -31,12 +132,31 @@ jsmin leaves entirely to you, is a :class:`~turbohtml.JSMinify` on :class:`~turb
 
     turbohtml.minify_js(source)  # smaller output, in C
 
-On the library ladder (``python -m bench minify-js``) turbohtml runs about three to five times faster than jsmin and its
-output is up to half the size, because jsmin only deletes whitespace where turbohtml renames every local binding and
-runs the structural folds. Each ratio is against turbohtml:
+To minify inline ``<script>`` content — which jsmin leaves entirely to you — pass a :class:`~turbohtml.JSMinify` to the
+HTML serializer instead of extracting the script by hand:
 
-.. bench-table::
-    :file: bench/jsmin.json
+.. code-block:: python
 
-Unlike the regex-based :doc:`rjsmin <rjsmin>`, jsmin has no speed advantage to trade for its simpler output, so there is
-no case where it beats :func:`~turbohtml.minify_js`.
+    import turbohtml
+    from turbohtml import Html, Minify, JSMinify
+
+    doc = turbohtml.parse("<p>hi<script>function plus(a, b) { return a + b; }</script>")
+    doc.serialize(Html(layout=Minify(minify_js=JSMinify())))
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- **Renaming is on by default.** ``turbohtml.minify_js(source)`` renames local bindings, which jsmin never does. If a
+  consumer reflects on function-local variable names (rare), pass ``JSMinify(mangle=False)``. Top-level names are global
+  and are never renamed regardless of the setting.
+- **Unparsable input raises instead of passing through.** jsmin emits something for any string; the standalone
+  :func:`~turbohtml.minify_js` raises :class:`ValueError` on a construct its parser does not handle. Catch it and fall
+  back to the source if you relied on jsmin's never-fail behavior. The inline ``<script>`` path does not raise — it
+  emits the offending script verbatim.
+- **Number literals change form.** turbohtml rewrites numeric literals to their shortest equivalent; jsmin leaves them
+  verbatim. The value is preserved, but a byte-for-byte diff against jsmin output will differ here even with the
+  optional passes off.
+- **Script ``type`` gates the inline path.** Only scripts marked as JavaScript are rewritten during HTML serialization;
+  ``application/json`` and ``importmap`` payloads are left untouched. jsmin has no such awareness because it never sees
+  the surrounding document.

--- a/docs/migration/justext.rst
+++ b/docs/migration/justext.rst
@@ -4,32 +4,117 @@
 
 .. package-meta:: justext miso-belica/jusText
 
-`justext <https://github.com/miso-belica/jusText>`_ removes boilerplate from a web page paragraph by paragraph: it
-segments the document at block-tag boundaries and classifies each paragraph good or bad from its length, link density,
-and the density of stopwords for a chosen language, returning the paragraph objects rather than an assembled article.
+`justext <https://github.com/miso-belica/jusText>`_ removes boilerplate from a web page paragraph by paragraph. It
+parses the page with lxml, segments the document at block-tag boundaries, and classifies each paragraph from its length,
+link density, and the density of stopwords for a chosen language, then runs a context-sensitive revision pass that
+reclassifies borderline paragraphs from their neighbors. It returns the paragraph objects rather than an assembled
+article, so callers keep the per-paragraph classification and diagnostics. It is a common front end for search indexing,
+corpus building, and NLP pipelines that need clean prose off article pages.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that same per-paragraph question with :func:`turbohtml.extract.boilerplate` on top of the C
+main-content scoring behind :meth:`~turbohtml.Node.main_content`: the scoring picks the content body, every unit outside
+it is boilerplate, and a unit inside it must still clear the length and link-density thresholds of an
+:class:`~turbohtml.extract.Extraction` config. Each unit comes back as a :class:`~turbohtml.extract.Paragraph` with
+justext's ``text`` / ``is_boilerplate`` / ``is_heading`` shape, and because the scoring reads structure and prose
+density it needs no stoplist and no language input.
 
-:func:`turbohtml.extract.boilerplate` answers the same per-paragraph question over the C main-content scoring
-:meth:`~turbohtml.Node.main_content` runs: the scoring picks the content body, every paragraph unit outside it is
-boilerplate, and a unit inside it must still clear the length and link-density thresholds of an
-:class:`~turbohtml.extract.Extraction` config. The result is one :class:`~turbohtml.extract.Paragraph` per unit with
-justext's ``text`` / ``is_boilerplate`` / ``is_heading`` shape, and no stoplist to pick: the scoring reads structure and
-prose density, so it needs no language input. When you only want the surviving text, :meth:`~turbohtml.Node.main_text`
-skips the per-paragraph records entirely.
+**********************
+ turbohtml vs justext
+**********************
 
-Classifying every paragraph of a full page -- navigation, a scored article, and a footer. turbohtml scores the tree in
-one C pass and classifies the units in a thin Python layer; justext builds an lxml tree, then segments and scores each
-paragraph in Python. Numbers vary with input and hardware.
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - justext
+    - - Scope
+      - Full WHATWG HTML parser with DOM, query, serialize, and content extraction on top
+      - Per-paragraph boilerplate classification only, over an lxml parse
+    - - Feature breadth
+      - One C scoring model plus a threshold config (:class:`~turbohtml.extract.Extraction`) and article metadata
+      - Length, link-density, and per-language stopword-density classifier with a context-sensitive revision pass
+    - - Performance
+      - C scoring pass over the parsed tree (see below)
+      - Python classification over an lxml parse
+    - - Typing
+      - Fully annotated, ships PEP 561 stubs
+      - Pure-Python source, no shipped type stubs
+    - - Dependencies
+      - Compiled C extension
+      - lxml plus the bundled per-language stoplists
+    - - Maintenance
+      - Actively developed
+      - Maintained by its author
+
+Feature overlap
+===============
+
+The shared surface ports one call to one call:
+
+- ``justext.justext(html, get_stoplist("English"))`` -> :func:`extract.boilerplate(html)
+  <turbohtml.extract.boilerplate>`, a list of :class:`~turbohtml.extract.Paragraph`; no stoplist argument.
+- ``paragraph.text`` -> ``paragraph.text``, the same whitespace-normalized visible text.
+- ``paragraph.is_boilerplate`` -> ``paragraph.is_boilerplate``.
+- ``paragraph.is_heading`` -> ``paragraph.is_heading``.
+- ``length_low`` and ``max_link_density`` cutoffs -> the ``min_length`` and ``max_link_density`` fields of
+  :class:`~turbohtml.extract.Extraction`, with :meth:`~turbohtml.extract.Extraction.justext` carrying justext's
+  70-character floor and 0.2 link density.
+- ``no_headings=True`` -> :class:`Extraction(keep_headings=False) <turbohtml.extract.Extraction>`.
+- joining the good paragraphs into the article text -> :meth:`~turbohtml.Node.main_text` (or ``article().text``), the
+  one-call form.
+
+What turbohtml adds
+===================
+
+- The classification is language-independent: the scoring reads structure and prose density, so ports drop the
+  ``get_stoplist`` call and every language and stopword-threshold argument. Pages in any language classify the same way.
+- The extraction rides on a full WHATWG parse, so the same page is a DOM you can query, mutate, and serialize, not just
+  a paragraph stream.
+- :meth:`~turbohtml.Node.article` harvests page metadata beside the body text: ``title``, ``byline``, ``date``,
+  ``description``, and ``lang``. justext returns paragraphs only.
+- :meth:`~turbohtml.Node.main_text` assembles the surviving prose in one call, skipping the per-paragraph records when
+  you only want the article body.
+- :func:`turbohtml.parse` follows the WHATWG recovery rules over any malformed markup rather than lxml's HTML parser.
+
+What justext has that turbohtml does not
+========================================
+
+- Per-language stopword density. justext ships stoplists (``get_stoplist("English")``, ``get_stoplists()``) and scores
+  paragraphs partly on stopword ratio; turbohtml has no stopword signal at all, so the two disagree on prose that is
+  short but stopword-rich. No equivalent, by design the scoring is structural.
+- Intermediate classes. justext labels each paragraph ``good`` / ``bad`` / ``short`` / ``neargood`` (via
+  ``paragraph.class_type`` and the context-free ``cf_class``); turbohtml's ``is_boilerplate`` is a final yes or no.
+  There is no equivalent of the ``short`` and ``neargood`` middle states.
+- The context-sensitive revision pass. justext reclassifies ``neargood`` and ``short`` paragraphs from their neighbors
+  within ``max_heading_distance``; turbohtml classifies each unit against the single scored content body with no
+  neighbor pass. No equivalent.
+- Per-paragraph diagnostics: ``paragraph.xpath`` / ``dom_path``, ``word_count``, ``stopwords_density``, and
+  ``links_density``. :class:`~turbohtml.extract.Paragraph` carries only ``text``, ``is_boilerplate``, and
+  ``is_heading``; query the parsed DOM yourself for anything more.
+
+Performance
+===========
+
+turbohtml scores the tree in one C pass and classifies the units in a thin Python layer; justext builds an lxml tree,
+then segments and scores each paragraph in Python. Numbers vary with input and hardware.
 
 .. bench-table::
     :file: bench/justext.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the ``justext`` import for the :func:`turbohtml.extract.boilerplate` helper and, when you want to tune the
+thresholds, :class:`~turbohtml.extract.Extraction`:
+
+.. code-block:: python
+
+    from turbohtml.extract import boilerplate, Extraction
+
+The call mapping:
 
 .. list-table::
     :header-rows: 1
@@ -53,6 +138,8 @@ paragraph in Python. Numbers vary with input and hardware.
     - - joining the good paragraphs into the article text
       - ``doc.main_text()`` (or ``article().text``), the one-call form
 
+Before and after, classifying every paragraph of a full page -- navigation, a scored article, and a footer:
+
 .. testcode::
 
     from turbohtml.extract import boilerplate
@@ -75,18 +162,23 @@ paragraph in Python. Numbers vary with input and hardware.
     False False A comet is an icy body that releases gas, forming a visible tail, as it nears the Sun.
     True False Share this!
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - There is no stoplist and no stopword thresholds (``stopwords_low`` / ``stopwords_high``): turbohtml classifies from
   the content scoring plus length and link density, so ports drop the ``get_stoplist`` call and any language plumbing.
-  Pages in any language classify the same way.
 - justext has no notion of *where* the article is -- each paragraph stands alone -- while turbohtml first picks the
   content body and only paragraphs inside it can be good. On a page with several disjoint content islands, only the
   best-scoring island survives.
 - There are no ``neargood`` / ``short`` intermediate classes and no context-sensitive revision pass: ``is_boilerplate``
-  is a final yes or no.
-- justext's defaults are tuned stricter than turbohtml's: pass :meth:`Extraction.justext()
+  is a final yes or no, so paragraphs justext would rescue from a good neighbor stay boilerplate here.
+- justext's defaults are tuned stricter than turbohtml's. Pass :meth:`Extraction.justext()
   <turbohtml.extract.Extraction.justext>` to keep its 70-character floor and 0.2 link density when you want output close
   to a justext port, or stay with the defaults to keep shorter prose paragraphs.
+- ``min_length`` is a character count of normalized text, not the word count justext's ``length_low`` implies, so a
+  direct number carries over only loosely; tune it against your own pages.
+- justext decodes bytes through ``encoding`` / ``default_encoding`` / ``enc_errors``.
+  :func:`turbohtml.extract.boilerplate` takes a decoded ``str``; when you hold bytes of unknown encoding, decode them
+  with :func:`turbohtml.parse` under ``detect_encoding=True`` (or an explicit ``encoding=``) and read the body through
+  :meth:`~turbohtml.Node.main_text` or :meth:`~turbohtml.Node.article`, which run on the parsed document.

--- a/docs/migration/lightningcss.rst
+++ b/docs/migration/lightningcss.rst
@@ -5,15 +5,84 @@
 .. package-meta:: lightningcss
 
 `lightningcss <https://pypi.org/project/lightningcss/>`_ binds the Rust CSS engine behind Parcel to Python through
-``process_stylesheet``. It is a cascade-aware optimizer: besides minifying, it drops declarations overridden elsewhere
-in the sheet and rewrites syntax for a browser-target set, so it reaches a smaller result than a value-safe minifier
-can. ``lightningcss.process_stylesheet(code, minify=True)`` maps to :func:`turbohtml.clean.minify_css`, which trades a
-little size for output that is value-safe with no target list to configure, minifies faster, and survives malformed
-input.
+``process_stylesheet``. It is a cascade-aware optimizer, not just a minifier: alongside whitespace and value compaction
+it drops declarations overridden elsewhere in the sheet, merges rules, adds or strips vendor prefixes, and rewrites
+syntax down to a configured browser-target set, so it can reach a smaller result than a value-safe minifier can. That
+target-driven approach makes it the CSS transform stage in Parcel and a common build-time optimizer for web bundles.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with :func:`turbohtml.clean.minify_css`, a value-safe minifier. It applies only
+transforms that hold on any conformant browser, so its default output needs no target list, parses to the same cascade
+everywhere, minifies faster, and recovers from malformed input that lightningcss rejects. The
+:class:`~turbohtml.clean.CSSMinify` ``baseline`` year opts into newer-syntax shorthand merges when you are ready to
+require them.
+
+***************************
+ turbohtml vs lightningcss
+***************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - lightningcss
+    - - Scope
+      - Value-safe CSS minify (full sheet and inline declarations)
+      - Cascade-aware CSS optimizer: minify, prefix, bundle, CSS modules
+    - - Feature breadth
+      - Whitespace + value compaction, shortest colors, unit/number trimming, constant ``calc()`` folding, shorthand and
+        adjacent-rule merges
+      - All of that plus cross-sheet dead-declaration removal, target-driven syntax rewriting, vendor prefixing,
+        ``@import`` bundling
+    - - Performance
+      - 2-3x faster minify on the shared corpus (see Performance)
+      - Smaller output on most inputs by trading target configuration for size
+    - - Typing
+      - Fully typed, frozen ``CSSMinify`` config object
+      - Typed bindings over the Rust engine
+    - - Dependencies
+      - Native C extension in turbohtml, no extra dependency
+      - Native Rust extension
+    - - Maintenance
+      - Maintained within turbohtml
+      - Tracks the Parcel/lightningcss Rust project
+
+Feature overlap
+===============
+
+The minify surface ports 1:1:
+
+- ``lightningcss.process_stylesheet(css, minify=True)`` -> :func:`turbohtml.clean.minify_css`.
+- Whitespace collapse, shortest hex/color forms, redundant unit and leading-zero trimming, and constant ``calc()``
+  folding are applied by both.
+- Adjacent-rule and shorthand merging: turbohtml merges the value-safe cases by default and the newer-syntax cases
+  (``inset``, flex ``gap``, two-value ``overflow``) when you set ``baseline``.
+
+What turbohtml adds
+===================
+
+- Value-safe by construction: every transform round-trips to the same cascade on any conformant browser, so there is no
+  target list to configure and no way to emit syntax a target cannot parse.
+- WHATWG error recovery: turbohtml minifies malformed stylesheets that lightningcss's parser rejects, for example a
+  media query in ``foundation.css`` that the WHATWG rules accept.
+- Faster runs: 2-3x quicker minify on the shared corpus.
+- Inline-declaration minify via :func:`turbohtml.clean.minify_css_inline` for bare ``style``-attribute declaration
+  lists, without a surrounding selector or braces.
+- Custom-property values and string contents stay byte-exact, as CSS Variables 1 requires.
+
+What lightningcss has that turbohtml does not
+=============================================
+
+- Cross-sheet cascade optimization: lightningcss removes declarations overridden elsewhere in the sheet. turbohtml does
+  not, because the result depends on which browsers you support; there is no value-safe equivalent.
+- Target-driven syntax rewriting to a browser-target set. turbohtml's ``baseline`` gates newer-syntax shorthand merges
+  but does not rewrite down to an arbitrary older-target set.
+- Vendor prefixing (adding or removing prefixes for a target). No equivalent; turbohtml preserves the input's prefixes.
+- ``@import`` bundling and CSS-modules transforms. No equivalent; turbohtml minifies a single stylesheet in place.
+
+Performance
+===========
 
 lightningcss produces the smaller output on most of the corpus -- up to five percent under turbohtml -- because it
 optimizes for a browser-target set: it removes declarations overridden across the sheet and emits syntax those targets
@@ -30,9 +99,9 @@ is against turbohtml:
 Reach for lightningcss when you can pin a browser-target set and want the last few percent of size; reach for turbohtml
 when you want value-safe output with no configuration, faster runs, and tolerance of real-world CSS.
 
-*********************************
- lightningcss.process_stylesheet
-*********************************
+****************
+ How to migrate
+****************
 
 The import and the call are the only change:
 
@@ -47,6 +116,20 @@ The import and the call are the only change:
     from turbohtml.clean import minify_css
 
     minify_css(css)
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - lightningcss
+      - turbohtml
+    - - ``process_stylesheet(css, minify=True)``
+      - :func:`turbohtml.clean.minify_css`
+    - - ``process_stylesheet(css, minify=True, targets=...)``
+      - :func:`turbohtml.clean.minify_css` with :class:`~turbohtml.clean.CSSMinify` (``baseline`` gates newer-syntax
+        merges)
+    - - No equivalent (full-sheet input only)
+      - :func:`turbohtml.clean.minify_css_inline` for ``style``-attribute declaration lists
 
 .. testcode::
 
@@ -71,12 +154,16 @@ much as lightningcss's targets gate its own:
 
     a{inset:0}
 
-Pitfalls
-========
+**********************
+ Gotchas and pitfalls
+**********************
 
 - lightningcss removes declarations overridden elsewhere in the sheet and rewrites syntax for its targets; turbohtml
   does neither by default, because both depend on which browsers you support. Set ``baseline`` to recover the
   newer-syntax merges, but the whole-sheet cascade optimization has no value-safe equivalent.
 - lightningcss aborts on a stylesheet its parser rejects; turbohtml follows the WHATWG error-recovery rules, so it
   minifies inputs like ``foundation.css`` that lightningcss will not parse.
+- lightningcss can add or drop vendor prefixes for a target; turbohtml preserves the input's prefixes as written.
+- turbohtml keeps custom-property values and string contents byte-exact; do not expect the internal whitespace of a
+  ``var()`` value or a string literal to be collapsed.
 - Both are native extensions (Rust versus C), so neither offers a pure-Python fallback.

--- a/docs/migration/linkify-it-py.rst
+++ b/docs/migration/linkify-it-py.rst
@@ -4,27 +4,109 @@
 
 .. package-meta:: linkify-it-py tsutsu3/linkify-it-py
 
-`linkify-it-py <https://github.com/tsutsu3/linkify-it-py>`_ is the pure-Python link scanner `markdown-it-py
-<https://github.com/executablebooks/markdown-it-py>`_ pulls in: it scans plain text and returns the link spans it finds,
-leaving the caller to turn them into ``<a>`` tags and to skip text that is already markup.
+`linkify-it-py <https://github.com/tsutsu3/linkify-it-py>`_ is the pure-Python link scanner that `markdown-it-py
+<https://github.com/executablebooks/markdown-it-py>`_ pulls in. It is a faithful port of the JavaScript ``linkify-it``:
+given a run of plain text, ``LinkifyIt().match(text)`` returns the link spans it finds and ``LinkifyIt().test(text)``
+reports whether any exist. It knows URLs with a ``scheme://`` authority, bare domains gated by an IANA TLD table, and a
+set of fuzzy heuristics for bare IPs, ``@`` mentions, and email addresses. Its scope stops at *locating* links: turning
+a span into an ``<a>`` tag and skipping text that is already markup are the caller's job, which is why markdown-it-py
+wraps it in its own autolink rule.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with an HTML-aware, fully type-annotated API. :class:`~turbohtml.clean.Detector`
+locates spans the way ``match``/``test`` do, and :func:`~turbohtml.clean.linkify` goes one step further: it parses the
+HTML, rewrites eligible text runs into ``<a>`` tags, and leaves URLs that already sit inside an ``<a>``, ``<script>``,
+or a skipped tag alone. The candidate scan runs in C, so the detection primitives outrun the Python scanner even though
+they do strictly more work per call.
 
-turbohtml does both jobs, fully type annotated: :func:`~turbohtml.clean.linkify` rewrites HTML (and, being HTML-aware,
-leaves a URL already inside an ``<a>`` or ``<script>`` alone), while :class:`~turbohtml.clean.Detector` matches spans
-the way linkify-it-py's ``match`` does. The candidate scan runs in C, so both the full rewrite and the bare detection
-primitives (:meth:`Detector.find <turbohtml.clean.Detector.find>` against ``LinkifyIt().match``, and
-:meth:`~turbohtml.clean.Detector.has_link` against ``LinkifyIt().test``) outrun the Python scanner that does strictly
-less work. The one close row is ``has_link`` on prose, where ``test`` short-circuits on the first link near the start:
+****************************
+ turbohtml vs linkify-it-py
+****************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - linkify-it-py
+    - - Scope
+      - Detect spans *and* rewrite HTML into ``<a>`` tags, markup-aware
+      - Detect spans in plain text only; caller rewrites and skips markup
+    - - Feature breadth
+      - URLs, bare domains, ``mailto:`` emails, registered scheme-less schemes (``tel:``, ``bitcoin:``); HTML walk with
+        skip tags and existing-anchor handling
+      - URLs, bare domains, emails, plus fuzzy IP / ``@``-mention / fuzzy-email heuristics and pluggable custom schemes
+    - - Performance
+      - C candidate scan; several times faster on rewrite and detection (see below)
+      - Pure-Python scanner
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - Typed public surface
+    - - Dependencies
+      - Single package, C extension bundled
+      - Pure Python, depends on ``uc-micro-py``
+    - - Maintenance
+      - Active, part of the turbohtml project
+      - Active, tracks the JS ``linkify-it`` upstream
+
+Feature overlap
+===============
+
+The plain-text detection surface ports one-to-one:
+
+- ``LinkifyIt().match(text)`` -> :meth:`Detector().find(text) <turbohtml.clean.Detector.find>`, returning a list of
+  spans (or an empty list rather than ``None``).
+- A ``Match`` (``index`` / ``last_index`` / ``url`` / ``text`` / ``schema``) -> a :class:`~turbohtml.clean.LinkSpan`
+  (``start`` / ``end`` / ``url`` / ``text`` / ``is_email``).
+- ``LinkifyIt().test(text)`` -> :meth:`~turbohtml.clean.Detector.has_link`.
+- ``LinkifyIt().tlds(list)`` -> the ``tlds`` argument to :class:`~turbohtml.clean.Detector` (added on top of the
+  built-in IANA table).
+- ``LinkifyIt().add(schema, rule)`` for opaque scheme-less schemes -> the ``schemes`` argument, which registers schemes
+  such as ``tel:`` or ``bitcoin:`` both as opaque and as ``scheme://`` URLs.
+
+What turbohtml adds
+===================
+
+- :func:`~turbohtml.clean.linkify` rewrites HTML directly. linkify-it-py only reports spans; you would write the anchor
+  construction, the entity escaping, and the "is this already inside a link" walk yourself.
+- Markup awareness: the rewrite leaves URLs inside an existing ``<a>``, inside raw-text elements like ``<script>`` and
+  ``<style>``, and inside caller-named skip tags (``pre``, ``code``) untouched.
+- A :class:`~turbohtml.clean.Linkify` configuration object with callbacks that can adjust or veto each link (for
+  example, add ``rel="nofollow"``), and ``process_existing`` to rerun those callbacks over anchors already in the input.
+- ``mailto:`` normalization and ``http://`` scheme-fill for bare domains are done for you on both the ``LinkSpan.url``
+  and the rewritten ``href``.
+- The scan runs in a C extension.
+
+What linkify-it-py has that turbohtml does not
+==============================================
+
+- Fuzzy heuristics. linkify-it-py has opt-in ``fuzzy_link``, ``fuzzy_ip``, and ``fuzzy_email`` modes that catch bare
+  IPv4 addresses and looser ``user@host`` shapes. turbohtml covers the common web, ``mailto:``, bare-domain, and
+  registered-scheme cases and does not attempt the fuzzy set. No equivalent; keep linkify-it-py where those matches
+  matter.
+- Arbitrary custom link rules. ``add(schema, rule)`` accepts a validator object with a ``validate`` callback for bespoke
+  grammars. turbohtml's ``schemes`` argument registers additional schemes but does not take a custom matcher.
+  Workaround: post-filter :meth:`Detector.find <turbohtml.clean.Detector.find>` results, or handle the bespoke shape
+  before the scan.
+- ``schema`` on the match tells you which rule fired (``"http:"``, ``"mailto:"``, ``""`` for a bare domain).
+  :class:`~turbohtml.clean.LinkSpan` exposes ``is_email`` and the normalized ``url`` instead of the raw schema label;
+  read the scheme off ``url`` if you need it.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/linkify-it-py.json
 
-*************
- The renames
-*************
+Both the full rewrite and the bare detection primitives (:meth:`Detector.find <turbohtml.clean.Detector.find>` against
+``LinkifyIt().match``, and :meth:`~turbohtml.clean.Detector.has_link` against ``LinkifyIt().test``) outrun the Python
+scanner. The one close row is ``has_link`` on prose, where ``test`` short-circuits on the first link near the start.
+
+****************
+ How to migrate
+****************
+
+Swap the import and construct a reusable :class:`~turbohtml.clean.Detector` instead of a ``LinkifyIt``:
 
 .. code-block:: python
 
@@ -42,8 +124,8 @@ less work. The one close row is ``has_link`` on prose, where ``test`` short-circ
       - turbohtml
     - - ``LinkifyIt().match(text)``
       - :meth:`Detector().find(text) <turbohtml.clean.Detector.find>`
-    - - ``Match`` (``index``/``last_index``/``url``/``schema``)
-      - :class:`~turbohtml.clean.LinkSpan` (``start``/``end``/``url``/``text``)
+    - - ``Match`` (``index`` / ``last_index`` / ``url`` / ``schema``)
+      - :class:`~turbohtml.clean.LinkSpan` (``start`` / ``end`` / ``url`` / ``text`` / ``is_email``)
     - - ``LinkifyIt().test(text)``
       - :meth:`~turbohtml.clean.Detector.has_link`
     - - ``add(schema, rule)`` (scheme-less schemes)
@@ -64,9 +146,33 @@ less work. The one close row is ``has_link`` on prose, where ``test`` short-circ
 
     4 23 https://example.com
 
-**********
- Pitfalls
-**********
+To rewrite HTML rather than list spans, reach for :func:`~turbohtml.clean.linkify`, which has no linkify-it-py
+counterpart:
 
-- linkify-it-py reaches further into fuzzy IP and email heuristics; turbohtml covers the common web, ``mailto:``,
-  bare-domain, and registered-scheme cases and trades that breadth for being HTML-aware and several times faster.
+.. testcode::
+
+    from turbohtml.clean import linkify
+
+    print(linkify("visit example.com for more"))
+
+.. testoutput::
+
+    visit <a href="http://example.com" rel="nofollow">example.com</a> for more
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- ``match`` returns ``None`` when nothing is found; :meth:`Detector.find <turbohtml.clean.Detector.find>` returns an
+  empty list. Replace ``if matches is not None`` with a plain truthiness or length check.
+- Offsets differ in name only: linkify-it-py's ``index`` / ``last_index`` are turbohtml's ``start`` / ``end``, both
+  half-open into the scanned string.
+- linkify-it-py hands back the URL exactly as matched and leaves scheme-filling to you via ``Match.url`` versus
+  ``Match.text``. turbohtml normalizes ``LinkSpan.url`` up front: a bare domain gets ``http://``, an email gets
+  ``mailto:``, and ``LinkSpan.text`` keeps the original substring.
+- Scheme allowlisting is stricter by default. turbohtml autolinks ``http`` / ``https`` / ``ftp`` and whatever you pass
+  in ``schemes``; a typo scheme or a ``javascript://`` payload stays plain text. If you relied on linkify-it-py
+  registering an extra scheme through ``add``, pass it in ``schemes`` instead.
+- :func:`~turbohtml.clean.linkify` parses its input as HTML, so it escapes text and skips ``<script>`` / ``<style>`` /
+  ``<a>`` content. Feeding it plain text is fine, but any ``<`` and ``&`` are treated as markup, not literal characters.
+  For plain-text-only work that must not be HTML-parsed, use :class:`~turbohtml.clean.Detector`.

--- a/docs/migration/lxml-html-clean.rst
+++ b/docs/migration/lxml-html-clean.rst
@@ -4,28 +4,107 @@
 
 .. package-meta:: lxml_html_clean fedora-python/lxml_html_clean
 
-`lxml-html-clean <https://github.com/fedora-python/lxml_html_clean>`_ is the ``Cleaner`` split out of
-``lxml.html.clean``. It is a **blocklist**: you toggle off categories of dangerous content (``scripts``, ``javascript``,
-``style``, ``comments``, ``embedded``, ``frames``, ``forms``, ``meta``, ...) and everything else survives, so a tag the
-library has not heard of passes through.
+`lxml-html-clean <https://github.com/fedora-python/lxml_html_clean>`_ is the ``Cleaner`` that used to live in
+``lxml.html.clean``, split into its own package when lxml dropped the module. It cleans HTML by **blocklist**: you
+toggle off categories of dangerous content (``scripts``, ``javascript``, ``style``, ``comments``, ``embedded``,
+``frames``, ``forms``, ``meta``, ``annoying_tags``, ...) and everything the toggles do not name survives. A tag the
+library has never heard of passes through untouched. ``Cleaner`` runs in Python over an lxml element tree parsed by
+libxml2, so it inherits lxml's runtime dependency and its non-WHATWG HTML parser. It is the standard choice for projects
+already built on lxml that need to scrub user HTML in place.
 
-***************
- Why turbohtml
-***************
+``turbohtml.clean`` covers the same ground from the other direction: :func:`~turbohtml.clean.sanitize` filters against
+an **allowlist** driven by a :class:`~turbohtml.clean.Policy`, parses with the WHATWG algorithm browsers use, and runs
+the filtering walk in C.
 
-``turbohtml.clean`` takes the opposite, safer stance: it is an **allowlist**, so nothing survives unless a
-:class:`~turbohtml.clean.Policy` names it, which is why the safety baseline holds against markup the author never
-anticipated. It is fully type annotated and runs the filtering walk in C rather than over an lxml tree, leading the
-blocklist cleaner by an order of magnitude:
+******************************
+ turbohtml vs lxml-html-clean
+******************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 16 42 42
+
+    - - Dimension
+      - turbohtml
+      - lxml-html-clean
+    - - Scope
+      - Allowlist HTML sanitizer, plus linkify and HTML/CSS minify in one module
+      - Blocklist ``Cleaner`` extracted from ``lxml.html.clean``; sanitization only
+    - - Feature breadth
+      - Policy presets (``strict``/``basic``/``relaxed``), per-tag attribute allowlists, ``style`` scrubbing, link
+        ``rel`` injection, attribute-filter hook
+      - ~20 category toggles, ``host_whitelist`` for embedded media, ``safe_attrs``, ``add_nofollow``, in-place tree
+        mutation
+    - - Performance
+      - C filtering walk; order of magnitude faster (see below)
+      - Python traversal over a libxml2-parsed lxml tree
+    - - Typing
+      - Fully type annotated
+      - No type annotations shipped
+    - - Dependencies
+      - Self-contained C extension, no runtime dependencies
+      - Requires lxml (libxml2 / libxslt)
+    - - Maintenance
+      - Actively developed
+      - Community-maintained successor to the removed ``lxml.html.clean``
+
+Feature overlap
+===============
+
+The shared surface ports directly:
+
+- Strip scripting: ``Cleaner(scripts=True, javascript=True)`` becomes the non-overridable safety baseline that removes
+  script elements, event-handler attributes, and ``javascript:`` URLs on every policy.
+- Restrict the kept tag set: ``allow_tags=`` maps to :class:`~turbohtml.clean.Policy` ``tags``.
+- Drop an element with its whole subtree: ``kill_tags=`` maps to ``Policy.remove_with_content``.
+- Drop comments: ``comments=True`` maps to ``Policy.strip_comments`` (on by default).
+- Constrain attributes: ``safe_attrs_only`` / ``safe_attrs=`` map to the per-tag ``Policy.attributes`` allowlist.
+- Force ``rel`` tokens on links: ``add_nofollow=True`` maps to ``Policy.add_link_rel`` (e.g.
+  ``frozenset({"nofollow"})``).
+- Remove forms, frames, and embedded media: leave those tags out of ``Policy.tags`` instead of toggling ``forms``,
+  ``frames``, ``embedded``.
+
+What turbohtml adds
+===================
+
+- Allowlist model: nothing survives unless the policy names it, so markup the author never anticipated cannot slip
+  through a missing toggle.
+- WHATWG parsing: the input is parsed by the same algorithm browsers use, so the cleaned tree matches what a browser
+  would build, not what libxml2's HTML parser produces.
+- ``style`` attribute scrubbing against ``Policy.css_properties``, dropping any declaration whose property is not
+  allowed.
+- ``Policy.attribute_filter``, a per-attribute callback that gets the last word on every surviving value, and
+  ``Policy.add_link_rel`` to inject ``rel`` tokens.
+- ``Policy.on_disallowed_tag`` (:class:`~turbohtml.clean.OnDisallowed`) to choose escape, strip, or remove for a tag
+  outside the allowlist.
+- Companion :func:`~turbohtml.clean.linkify`, :func:`~turbohtml.clean.minify`, and value-safe
+  :func:`~turbohtml.clean.minify_css` in the same module.
+
+What lxml-html-clean has that turbohtml does not
+================================================
+
+- ``host_whitelist``: allow embedded media (``iframe``, ``embed``) only from named hosts. turbohtml has no built-in host
+  allowlist; implement one in a ``Policy.attribute_filter`` that parses the ``src`` host and returns ``None`` to drop a
+  disallowed value.
+- In-place cleaning of an existing lxml element or subtree: ``Cleaner`` mutates the tree you already hold.
+  :func:`~turbohtml.clean.sanitize` takes an HTML string and returns an HTML string, so there is no in-tree equivalent.
+- ``annoying_tags``: a named toggle for presentational cruft (``blink``, ``marquee``). turbohtml has no dedicated flag;
+  exclude those tags from ``Policy.tags`` (the allowlist already drops them by default).
+
+Performance
+===========
+
+``turbohtml.clean`` runs the filtering walk in C rather than over an lxml tree, leading the blocklist cleaner by an
+order of magnitude:
 
 .. bench-table::
     :file: bench/lxml-html-clean.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
-Porting inverts the model. Instead of switching dangerous things off, declare the small set you keep:
+Swap the import and invert the model: instead of switching dangerous categories off, declare the small set you keep.
 
 .. code-block:: python
 
@@ -42,12 +121,18 @@ Porting inverts the model. Instead of switching dangerous things off, declare th
       - turbohtml
     - - ``Cleaner(...).clean_html(text)``
       - :func:`turbohtml.clean.sanitize` with a :class:`~turbohtml.clean.Policy`
-    - - ``host_whitelist=``, ``allow_tags=``
-      - ``Policy.tags`` and ``Policy.attribute_filter``
+    - - ``allow_tags=``
+      - ``Policy.tags``
+    - - ``safe_attrs_only=``, ``safe_attrs=``
+      - ``Policy.attributes``
     - - ``kill_tags=`` (drop element with content)
       - ``Policy.remove_with_content``
-    - - ``add_nofollow=``
+    - - ``comments=True``
+      - ``Policy.strip_comments``
+    - - ``add_nofollow=True``
       - ``Policy.add_link_rel``
+    - - ``host_whitelist=``
+      - ``Policy.attribute_filter`` (no built-in host allowlist)
 
 .. testcode::
 
@@ -67,10 +152,16 @@ Porting inverts the model. Instead of switching dangerous things off, declare th
 The ``javascript:`` URL is gone because ``http``/``https``/``mailto`` are the only schemes the policy admits, and the
 ``<script>`` is escaped rather than executed.
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - turbohtml scrubs a kept ``style`` attribute against ``Policy.css_properties`` but drops ``<style>`` elements, where
-  ``Cleaner`` scrubs their text too.
-- ``Cleaner`` rewrites a disallowed scheme to an empty ``href`` where turbohtml drops the attribute outright.
+  ``Cleaner`` scrubs their text and keeps the element.
+- ``Cleaner`` rewrites a disallowed scheme to an empty ``href``; turbohtml drops the attribute outright.
+- A tag outside the allowlist is escaped by default (``OnDisallowed.ESCAPE``), so ``<script>`` shows up as text rather
+  than vanishing; pass ``on_disallowed_tag=OnDisallowed.STRIP`` or ``REMOVE`` to match ``Cleaner``'s removal behavior.
+- turbohtml strips comments by default (``strip_comments=True``); ``Cleaner`` keeps them unless you set
+  ``comments=True``.
+- turbohtml parses per WHATWG, so malformed markup yields the tree a browser builds; ``Cleaner`` parses with libxml2 and
+  can produce a different structure for the same broken input.

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -6,34 +6,114 @@
 
 .. package-meta:: lxml lxml/lxml
 
-`lxml <https://lxml.de>`_ is the libxml2/libxslt binding that most Python HTML and XML processing has been built on:
+`lxml <https://lxml.de>`_ is the libxml2/libxslt binding that most Python HTML and XML processing has been built on.
 ``lxml.html`` parses documents into ElementTree-style elements with ``.text``/``.tail`` strings, and the wider stack
-adds XPath, XSLT, and schema validation.
+adds XPath, XSLT, RelaxNG/DTD/XML-Schema validation, and C14N. It is the default reach for scraping, feed parsing, and
+XML pipelines because it wraps a fast, battle-tested C library and exposes the full ElementTree API.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the HTML side of that ground with a native C core of its own. :func:`turbohtml.parse` builds the WHATWG
+document tree libxml2's HTML parser does not, returns a fully type annotated :class:`~turbohtml.Document`, and folds
+XPath 1.0 (with EXSLT), CSS selection, and the ``find``/``find_all`` grammar into one node API instead of separate
+``findall``/``xpath``/``cssselect`` entry points. It does not attempt XSLT, schema validation, or generic XML; it
+targets browser-accurate HTML parsing and the query/edit/serialize surface around it.
 
-:func:`turbohtml.parse` builds the WHATWG document tree that libxml2's HTML parser does not, returns a fully type
-annotated :class:`~turbohtml.Document`, and folds XPath, CSS, and the ``find``/``find_all`` grammar into one node API
-instead of separate ``findall``/``xpath``/``cssselect`` entry points. It parses two to four times faster than lxml while
-matching a browser on malformed input, and stays ahead across the operational surface -- fragment parsing, CSS
-selection, text and tree walks, the link helpers, XPath, and the node-path generators:
+*******************
+ turbohtml vs lxml
+*******************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - lxml
+    - - Scope
+      - WHATWG HTML5 parse, serialize, edit, CSS, XPath 1.0 + EXSLT, link helpers
+      - Generic XML and HTML via libxml2, plus XSLT, schema validation, C14N
+    - - Feature breadth
+      - Browser-accurate HTML tree, one node API for XPath/CSS/find, streaming parse, builder
+      - Full ElementTree API, XPath 1.0, XSLT 1.0, DTD/RelaxNG/XML-Schema, iterparse
+    - - Performance
+      - Parses two to four times faster than lxml; stays ahead across the operational surface
+      - Mature libxml2 C core; streaming evaluation narrows on multi-megabyte inputs
+    - - Typing
+      - Fully type annotated, ships stubs
+      - Partial; relies on third-party stub packages
+    - - Dependencies
+      - Self-contained native C extension
+      - Bundles or links libxml2 and libxslt
+    - - Maintenance
+      - Newer, WHATWG-spec-driven
+      - Long-established, widely deployed, actively maintained
+
+Feature overlap
+===============
+
+These port one-to-one from ``lxml.html``/``lxml.etree`` to turbohtml:
+
+- Parsing a document (``lxml.html.document_fromstring``) and a fragment (``lxml.html.fromstring``).
+- Element identity and attributes: ``el.tag``, ``el.get``/``el.set``/``el.attrib``, the ``el.classes`` set operations.
+- Tree navigation: ``getparent``, ``getnext``, ``getprevious``, ``iterdescendants``, ``iterancestors``, ``list(el)``.
+- Queries: ``findall`` and ``xpath`` (XPath 1.0), ``cssselect`` (CSS), precompiled ``etree.XPath`` objects, node-set
+  ``$variable`` bindings, ``namespaces=`` prefix maps, and custom XPath callables.
+- The EXSLT ``re:``, ``set:``, ``str:``, ``math:``, and ``date:`` function namespaces.
+- Locator generation (``getroottree().getpath``), link iteration and rewriting (``iterlinks``, ``make_links_absolute``,
+  ``rewrite_links``), source positions (``sourceline``), tree edits (``drop_tag``, ``drop_tree``), the
+  ``lxml.builder.E`` builder, and serialization (``lxml.html.tostring``).
+
+What turbohtml adds
+===================
+
+- A WHATWG-conformant parse: malformed input lands in the same tree a browser builds, where libxml2's HTML parser does
+  not follow the HTML5 tree-construction algorithm.
+- One node API. XPath, CSS, and the ``find``/``find_all`` grammar are methods on every node rather than three separate
+  extension entry points, and a callable or ``extensions=`` mapping that returns an :class:`~turbohtml.Element` is
+  marshaled straight back into the evaluator's node-set.
+- Built-in EXSLT. The ``re:``, ``set:``, ``str:``, ``math:``, and ``date:`` namespaces dispatch in the compiled-C XPath
+  engine with no per-call registration; lxml has to register ``libexslt`` and re-resolve the namespace map on each
+  evaluation.
+- :meth:`~turbohtml.Element.css_path`, a unique CSS-selector locator, which lxml has no equivalent for.
+- Full type annotations and shipped stubs across the whole surface.
+
+What lxml has that turbohtml does not
+=====================================
+
+The wider libxml2 toolchain is a deliberate clean-break scope cut:
+
+- XSLT (``lxml.etree.XSLT``): no equivalent.
+- Schema validation (DTD, RelaxNG, XML-Schema, Schematron): no equivalent.
+- C14N canonicalization: no equivalent.
+- Generic XML parsing and namespaced XML documents: turbohtml targets HTML; use lxml for arbitrary XML.
+- XPath is at parity, not a gap. Both are XPath 1.0, and both run EXSLT. The only pieces out of scope are the
+  node-synthesizing ``str:tokenize``/``str:split`` and the implicit current-date ``date:`` forms.
+
+Performance
+===========
+
+turbohtml parses two to four times faster than lxml while matching a browser on malformed input, and stays ahead across
+the operational surface: fragment parsing, CSS selection, text and tree walks, the link helpers, XPath, and the
+node-path generators.
 
 .. bench-table::
     :file: bench/lxml.json
 
 The :doc:`/development/performance` page benchmarks the full serializer, builder, editor, CSS, XPath 1.0, and EXSLT
-surface against lxml directly.
+surface against lxml directly, and sweeps the node-path generators across every page size. Compiling a hot expression
+once with :class:`~turbohtml.XPath` (the parse happens at construction, so the call site only supplies the context node
+and any ``$name`` variables) stays ahead of lxml per evaluation, as the precompiled ``//a[@href]`` row shows. On the
+EXSLT cases, a ``re:test`` predicate runs several times ahead of lxml even though ``re:`` dispatches to Python's
+:mod:`re` where lxml uses C ``libexslt``, because it skips the per-call namespace resolution; lxml's streaming
+evaluation narrows the node-set reductions on the multi-megabyte inputs.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
-:func:`turbohtml.parse` replaces ``lxml.html.document_fromstring`` and returns a :class:`~turbohtml.Document`;
-:func:`turbohtml.parse_fragment` replaces ``lxml.html.fromstring`` for a fragment. The biggest change is the tree shape:
-lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtml models it as real child
-:class:`~turbohtml.Text` nodes, so you iterate children instead of reading two string fields.
+The two parse entry points swap directly: :func:`turbohtml.parse` replaces ``lxml.html.document_fromstring`` and
+:func:`turbohtml.parse_fragment` replaces ``lxml.html.fromstring``. The biggest change is the tree shape. lxml stores
+text as an element's ``.text`` and ``.tail`` strings; turbohtml models it as real child :class:`~turbohtml.Text` nodes,
+so you iterate :attr:`~turbohtml.Node.children` instead of reading two string fields.
 
 .. list-table::
     :header-rows: 1
@@ -77,6 +157,8 @@ lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtm
         for a CSS selector)
     - - ``lxml.html.Element("div")``, ``etree.SubElement(p, "div")``
       - :class:`~turbohtml.Element`, :meth:`p.append(Element("div")) <turbohtml.Element.append>`
+    - - ``lxml.builder.E.ul(E.li("a"), E.li("b"))``
+      - :data:`turbohtml.build.E` (``E.<tag>(attrs, *children)`` with a leading attribute mapping)
     - - ``el.drop_tag()``, ``el.drop_tree()``
       - :meth:`~turbohtml.Node.unwrap`, :meth:`~turbohtml.Node.decompose`
     - - ``el.sourceline``
@@ -85,8 +167,12 @@ lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtm
       - :meth:`~turbohtml.Node.links`
     - - ``el.make_links_absolute(base)``, ``el.rewrite_links(fn)``
       - :meth:`~turbohtml.Node.resolve_links`, :meth:`~turbohtml.Node.rewrite_links`
+    - - ``etree.iterparse(...)``
+      - :class:`turbohtml.IncrementalParser` (``feed`` chunks, ``close`` for the :class:`~turbohtml.Document`)
     - - ``lxml.html.tostring(el)``
       - :attr:`~turbohtml.Node.html`
+
+A query-and-select flow ports directly:
 
 .. testcode::
 
@@ -99,16 +185,8 @@ lxml stores text as an element's ``.text`` and ``.tail`` strings, while turbohtm
     [Element('a')]
     /x
 
-*******
- XPath
-*******
-
-When one expression runs against many nodes, precompile it once with :class:`~turbohtml.XPath` instead of calling
-:meth:`~turbohtml.Node.xpath`, which reparses the expression on every call. This is the same move as reaching for
-``lxml.etree.XPath`` over a bare ``el.xpath``: the parse happens at construction, and the call site only supplies the
-context node and any ``$name`` variables. turbohtml's compiled program is tree-independent, so a single object evaluates
-against many documents, and it stays ahead of lxml per evaluation (the precompiled ``//a[@href]`` row in the table
-above).
+Precompile a hot XPath the same way you would reach for ``lxml.etree.XPath`` over a bare ``el.xpath``. turbohtml's
+compiled program is tree-independent, so a single object evaluates against many documents:
 
 .. testcode::
 
@@ -122,72 +200,8 @@ above).
 
     ['/x']
 
-lxml registers custom XPath callables through ``etree.FunctionNamespace``; turbohtml passes them per call through the
-``extensions=`` mapping of :meth:`~turbohtml.Node.xpath`. Both dispatch a Python callable per match, but lxml
-re-resolves its namespace and function table on every evaluation while turbohtml binds the mapping once against the
-compiled expression, and a callable that returns an :class:`~turbohtml.Element` (or an iterable of them) is marshaled
-straight back into the evaluator's node-set so the next path step stays on the all-C fast path.
-
-Both engines accept a node-set ``$variable``, so a prior result feeds a later expression without re-querying:
-:meth:`el.xpath("$rows/td", rows=el.xpath("//tr")) <turbohtml.Node.xpath>` binds the node-set lxml's
-``tree.xpath("$rows/td", rows=tree.xpath("//tr"))`` would. turbohtml normalizes the bound node-set into the compiled
-program once and walks the following step over interned atoms, so binding a prior result and reusing it stays ahead of
-lxml across page sizes.
-
-A namespace-prefixed name test ports unchanged: pass the same ``namespaces=`` mapping to :meth:`~turbohtml.Node.xpath`
-that you give lxml. turbohtml binds the prefix at evaluation time against the per-tree cached program and resolves the
-suffix to an interned atom, while lxml re-reads the namespace map on every call, so ``//svg:rect`` with
-``namespaces={"svg": "http://www.w3.org/2000/svg"}`` runs several times faster across page sizes.
-
-``el.getroottree().getpath(el)`` ports to :meth:`~turbohtml.Element.xpath_path` (a positional XPath) or
-:meth:`~turbohtml.Element.css_path` (a unique CSS selector, which lxml has no equivalent for). Both walk only the
-element's ancestor chain under the per-tree lock instead of indexing siblings from the root, so generating the locator
-for every node runs several times ahead of ``getpath`` (the ``css_path``/``xpath_path`` rows in the table above).
-
-The :doc:`/development/performance` page benchmarks the rest of the XPath surface against lxml, and sweeps the node-path
-generators across every page size.
-
-**********
- Pitfalls
-**********
-
-- No ``text``/``tail``. A node's children are its text runs and elements interleaved; read :attr:`~turbohtml.Node.text`
-  for the concatenation.
-- lxml parses with libxml2, which is not WHATWG-conformant, so malformed input lands in a different tree than the one
-  turbohtml (and a browser) builds.
-- For a document that arrives in pieces, ``etree.iterparse`` is replaced by :class:`turbohtml.IncrementalParser`: feed
-  ``str`` or ``bytes`` chunks with ``feed`` and call ``close`` for the finished :class:`~turbohtml.Document`. The parser
-  never holds the whole source at once, so you can parse a stream larger than the source buffer you would otherwise
-  materialize for :func:`turbohtml.parse`.
-- The wider libxml2 toolchain is a deliberate clean-break scope cut: XSLT, DTD/RelaxNG/XML-Schema validation, and C14N
-  have no turbohtml equivalent. XPath is at parity, not a gap: both are XPath 1.0, and the EXSLT ``re:``, ``set:``,
-  ``str:``, ``math:``, and ``date:`` namespaces ``libexslt`` adds are built into :meth:`~turbohtml.Node.xpath`,
-  :meth:`~turbohtml.Node.xpath_one`, and :meth:`~turbohtml.Node.xpath_iter` (lxml has to register them, and has no XPath
-  2.0/XQuery either), so an lxml ``el.xpath(...)`` call ports straight to :meth:`~turbohtml.Node.xpath` — only the
-  node-synthesizing ``str:tokenize``/``str:split`` and the implicit current-date ``date:`` forms stay out of scope.
-
-*******
- EXSLT
-*******
-
-turbohtml's EXSLT namespaces dispatch in the same compiled-C XPath engine as the core functions, so an EXSLT predicate
-through :meth:`~turbohtml.Node.xpath` costs no registration: the prefix is built in. lxml resolves the namespace map and
-routes each call through a ``libexslt`` function you register with ``namespaces=``, so the same expression carries a
-per-call setup cost. lxml *can* run the same EXSLT, so this is a direct race, not a no-competitor note: a ``re:test``
-predicate runs several times ahead even though ``re:`` dispatches to Python's :mod:`re` where lxml uses C libexslt,
-because it skips the per-call namespace resolution; ``set:distinct`` stays in C on both sides. The
-:doc:`/development/performance` page sweeps these EXSLT cases — alongside the structural axes, predicates, and the core
-function library — across every page size, where lxml's streaming evaluation narrows the node-set reductions on the
-multi-megabyte inputs.
-
-****************************
- The builder (lxml.builder)
-****************************
-
-``lxml.builder``'s ``E`` assembles a tree from nested calls -- ``E.ul(E.li("a"), E.li("b"))`` -- and you serialize it
-with ``lxml.html.tostring``. :data:`turbohtml.build.E` reads the same way, ``E.<tag>(attrs, *children)`` with a leading
-mapping for attributes, and hands back a real :class:`~turbohtml.Element` rather than an lxml node, so the edit, query,
-and serialize surface above stays available on what you build:
+The builder reads like ``lxml.builder.E`` but hands back a real :class:`~turbohtml.Element`, so the query, edit, and
+serialize surface stays available on what you build:
 
 .. testcode::
 
@@ -198,3 +212,23 @@ and serialize surface above stays available on what you build:
 .. testoutput::
 
     <ul><li class="item">one</li><li class="item">two</li></ul>
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- No ``text``/``tail``. A node's children are its text runs and elements interleaved; read :attr:`~turbohtml.Node.text`
+  for the concatenation.
+- Different tree on malformed input. lxml parses with libxml2, which is not WHATWG-conformant, so broken markup lands in
+  a different tree than the one turbohtml (and a browser) builds. Do not expect byte-identical trees when porting
+  scrapers that leaned on libxml2's recovery quirks.
+- Custom XPath functions bind per call, not globally. lxml registers callables through ``etree.FunctionNamespace``;
+  turbohtml passes them through the ``extensions=`` mapping of :meth:`~turbohtml.Node.xpath`, bound once against the
+  compiled expression rather than a process-wide table.
+- Streaming differs. For a document that arrives in pieces, ``etree.iterparse`` is replaced by
+  :class:`turbohtml.IncrementalParser`: feed ``str`` or ``bytes`` chunks with ``feed`` and call ``close`` for the
+  finished :class:`~turbohtml.Document`. It never holds the whole source at once, but it does not expose lxml's
+  event-driven element callbacks; you walk the completed tree.
+- EXSLT is built in but not exhaustive. The node-synthesizing ``str:tokenize``/``str:split`` and the implicit
+  current-date ``date:`` forms stay out of scope; every other ``re:``/``set:``/``str:``/``math:``/``date:`` form ports
+  straight through with no registration.

--- a/docs/migration/markdownify.rst
+++ b/docs/migration/markdownify.rst
@@ -5,22 +5,106 @@
 .. package-meta:: markdownify matthewwithanm/python-markdownify
 
 `markdownify <https://github.com/matthewwithanm/python-markdownify>`_ converts HTML to Markdown by walking a
-BeautifulSoup tree, with a per-tag ``convert_<tag>`` override system for customizing the output.
+BeautifulSoup tree. Its distinctive design is the ``MarkdownConverter`` class with a per-tag ``convert_<tag>`` override
+system: subclass the converter, define a ``convert_a`` or ``convert_img`` method, and it replaces the built-in rendering
+for that element. On top of that it exposes a flat set of keyword options (heading style, bullets, the shared strong/em
+symbol, escaping toggles, autolinks, table header inference, line-break style, document trimming, and tag allow/deny
+filters) and a command-line converter. It is a common choice for turning scraped or user-submitted HTML into Markdown in
+content pipelines, documentation tooling, and chat/mail ingestion.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same conversion through :meth:`~turbohtml.Node.to_markdown`, a single fully typed method on the
+parsed WHATWG tree. It walks the tree in C off the WHATWG parse instead of running a second Python walk over a
+BeautifulSoup tree, and groups markdownify's flat options into named config dataclasses so each concept has one name.
 
-:meth:`~turbohtml.Node.to_markdown` replaces a ``markdownify`` call with one method on the parsed tree. It is fully type
-annotated, exposes one keyword per concept, and runs the conversion in C off the WHATWG tree instead of a second Python
-walk over a BeautifulSoup tree, so it converts a page two orders of magnitude faster:
+**************************
+ turbohtml vs markdownify
+**************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - markdownify
+    - - Scope
+      - Full WHATWG HTML parser and tree with Markdown, plain-text, and HTML serialization
+      - HTML-to-Markdown conversion over a BeautifulSoup tree
+    - - Feature breadth
+      - Same Markdown option surface (headings, lists, inline marks, links, images, tables, wrapping, code, escaping)
+        plus per-tag converters, text extraction, selectors, and sanitization on the shared tree
+      - Mature Markdown-conversion options, ``convert_<tag>`` subclass overrides, and a CLI
+    - - Performance
+      - C tree walk off the WHATWG parse, roughly two orders of magnitude faster on the benchmark below
+      - Pure-Python walk over a BeautifulSoup tree the parser must build first
+    - - Typing
+      - Fully type annotated, config via frozen dataclasses
+      - Untyped public API
+    - - Dependencies
+      - Compiled C extension (prebuilt wheels)
+      - Pure Python, but requires ``beautifulsoup4`` and a bs4 parser
+    - - Maintenance
+      - Actively developed
+      - Actively developed
+
+Feature overlap
+===============
+
+Port these markdownify calls 1:1 onto :meth:`~turbohtml.Node.to_markdown` with a :class:`~turbohtml.Markdown` config:
+
+- ``markdownify(text)`` -> ``turbohtml.parse(text).to_markdown()``.
+- Heading style: ATX, closed ATX, or setext/underlined (``heading_style``).
+- List bullets, cycled by nesting depth (``bullets``).
+- Sub/superscript wrappers (``sub_symbol``, ``sup_symbol``).
+- Escaping of asterisks, underscores, and miscellaneous Markdown characters (``escape_asterisks``,
+  ``escape_underscores``, ``escape_misc``).
+- Autolinks and href-as-title (``autolinks``, ``default_title``).
+- Table header inference (``table_infer_header``).
+- Line-break style and document trimming (``newline_style``, ``strip_document``).
+- Default code-fence language (``code_language``).
+- Tag allow/deny filters (``strip``, ``convert``) and per-tag output overrides (``convert_<tag>``).
+
+What turbohtml adds
+===================
+
+- One parsed tree serves Markdown, layout-aware plain text (:meth:`~turbohtml.Node.to_text`), and HTML
+  (:meth:`~turbohtml.Node.serialize`); markdownify is Markdown-only.
+- Convert any subtree by calling :meth:`~turbohtml.Node.to_markdown` on a selected element
+  (``doc.find("article").to_markdown()``) instead of pre-slicing the HTML string.
+- Full spec-compliant WHATWG parsing feeds the conversion, so malformed markup is repaired the same way a browser does
+  before it is rendered to Markdown, with no separate BeautifulSoup parser to pick or install.
+- Independent strong and emphasis markers (``Markdown.Inline(strong=..., emphasis=...)``), a strict superset of
+  markdownify's single ``strong_em_symbol`` that derives both from one character.
+- Grouped, frozen-dataclass config (``Markdown.Links``, ``Markdown.Images``, ``Markdown.Tables`` ...) is fully typed and
+  discoverable, versus markdownify's flat set of untyped keyword options.
+- Reference-style links, image-render modes, transliteration, and a Google Docs inline-CSS mode
+  (``Markdown.google_doc()``) that markdownify does not expose.
+
+What markdownify has that turbohtml does not
+============================================
+
+- A command-line converter (``python -m markdownify`` / the ``markdownify`` console script). turbohtml exposes Markdown
+  as a library method only; wrap ``turbohtml.parse(open(path).read()).to_markdown()`` in a short script for equivalent
+  shell use.
+- Subclass-based extension: markdownify lets a ``MarkdownConverter`` subclass override any ``convert_<tag>`` method and
+  call the parent implementation with ``super()``. turbohtml's ``Markdown(converters=...)`` maps a tag name to a
+  callable receiving the element and its already-rendered child Markdown, which covers per-tag replacement but not
+  ``super()`` chaining onto the built-in renderer.
+- ``keep_inline_images_in`` restricts which parent tags keep an inline image; turbohtml's ``Markdown.Images(mode=...)``
+  is document-wide, with no per-parent-tag equivalent.
+- ``bs4_options`` for parser selection. turbohtml always runs the WHATWG algorithm, so there is no parser to configure.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/markdownify.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import and the call:
 
 .. code-block:: python
 
@@ -44,8 +128,8 @@ walk over a BeautifulSoup tree, so it converts a page two orders of magnitude fa
 
     Some **bold** text.
 
-The defaults emit opinionated GitHub-Flavored Markdown, and the grouped :class:`~turbohtml.Markdown` config fields cover
-markdownify's surface with one name per concept:
+The defaults emit opinionated GitHub-Flavored Markdown, and the markdownify options map onto the grouped
+:class:`~turbohtml.Markdown` config fields with one name per concept:
 
 .. list-table::
     :header-rows: 1
@@ -75,6 +159,8 @@ markdownify's surface with one name per concept:
       - ``Markdown.Document(line_break=...)`` (``"spaces"``/``"backslash"``)
     - - ``strip_document``
       - ``Markdown.Document(trim=...)`` (``"strip"``/``"lstrip"``/``"rstrip"``/``"none"``)
+    - - ``wrap``, ``wrap_width``
+      - ``Markdown.Wrapping(width=...)`` (``0`` leaves lines unwrapped)
     - - ``code_language``
       - ``Markdown.Code(language=...)``
     - - ``strip``, ``convert``
@@ -82,14 +168,32 @@ markdownify's surface with one name per concept:
     - - ``convert_<tag>`` overrides
       - ``Markdown(converters=...)`` argument
 
-**********
- Pitfalls
-**********
+Subclassing ``MarkdownConverter`` to override ``convert_<tag>`` becomes a mapping of tag name to a ``callable(element,
+content) -> str``. Each callable receives the :class:`~turbohtml.Element` and its already-rendered child Markdown and
+returns the replacement text:
+
+.. code-block:: python
+
+    from turbohtml import Markdown
+
+
+    def convert_a(element, content):
+        return f"[{content}]({element.attrs.get('href', '')})"
+
+
+    turbohtml.parse(text).to_markdown(Markdown(converters={"a": convert_a}))
+
+**********************
+ Gotchas and pitfalls
+**********************
 
 - The bold and italic markers are independent (``Markdown.Inline(strong=...)`` and ``Markdown.Inline(emphasis=...)``),
-  where markdownify derives both from one ``strong_em_symbol``; set both to reproduce its behavior.
+  where markdownify derives both from one ``strong_em_symbol``; set both to reproduce its behavior (``strong_em_symbol``
+  ``"_"`` becomes ``Markdown.Inline(strong="__", emphasis="_")``).
 - :meth:`~turbohtml.Node.to_markdown` is a method on any node, so convert a subtree by calling it on the element you
   selected (``doc.find("article").to_markdown()``) instead of slicing the HTML string first.
 - markdownify's parser-selection options (``bs4_options``) are dropped, since turbohtml always runs the WHATWG
-  algorithm.
+  algorithm; malformed markup is repaired to the same tree a browser would build.
 - ``Markdown.Links(base_url=...)`` does simple prefixing rather than full RFC-3986 URL resolution.
+- markdownify's ``strip_document`` defaults to ``STRIP``; turbohtml's ``Markdown.Document(trim=...)`` also defaults to
+  ``"strip"``, so document-edge trimming matches by default.

--- a/docs/migration/markupsafe.rst
+++ b/docs/migration/markupsafe.rst
@@ -6,27 +6,98 @@
 
 `markupsafe <https://markupsafe.palletsprojects.com>`_ is the safe-string library behind `Jinja2
 <https://jinja.palletsprojects.com>`_, `WTForms <https://wtforms.readthedocs.io>`_, and `Werkzeug
-<https://werkzeug.palletsprojects.com>`_: it provides a ``Markup`` string subclass and an ``escape`` function so a
-template engine can interpolate untrusted values into HTML without escaping safe markup twice.
+<https://werkzeug.palletsprojects.com>`_. It ships a ``Markup`` string subclass and an ``escape`` function so a template
+engine can interpolate untrusted values into HTML without escaping trusted markup twice. Its scope is deliberately
+narrow: HTML escaping and a safe-string type, with a small C accelerator for the escape itself. It carries no parser and
+no DOM; ``striptags`` and ``unescape`` are regex scans over the string.
 
-***************
- Why turbohtml
-***************
+``turbohtml.migration.markupsafe`` reimplements that whole surface -- ``Markup``, ``escape``, ``escape_silent``,
+``soft_str``, and ``EscapeFormatter`` -- fully type annotated, with the escape and every ``Markup`` operation backed by
+turbohtml's C extension. Because turbohtml already has a WHATWG tokenizer and HTML5 reference table, ``striptags`` and
+``unescape`` run on that real parser rather than a regex, so they resolve references and tag boundaries the regex scan
+can miss.
 
-``turbohtml.migration.markupsafe`` is a drop-in for markupsafe's public surface, fully type annotated, with the escape
-and every ``Markup`` operation implemented in C. It also keeps one name per concept: :meth:`~turbohtml.escape` and the
-tokenizer back the same primitives the rest of the library uses. The escape runs two to three times faster than
-markupsafe's own C escape on the small, mostly-clean strings a template engine interpolates under autoescape, and the
-other ``Markup`` operations stay ahead too -- ``striptags`` and ``unescape`` run on turbohtml's tokenizer and HTML5
-reference resolution rather than markupsafe's regex scan, and the composing operations (``format``, ``join``) escape
-each untrusted operand through the same C ``escape``:
+*************************
+ turbohtml vs markupsafe
+*************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 18 41 41
+
+    - - Dimension
+      - turbohtml
+      - markupsafe
+    - - Scope
+      - Safe-string escaping as one module of a full HTML parser/serializer stack
+      - Focused HTML escaping and a ``Markup`` safe-string type
+    - - Feature breadth
+      - Full markupsafe surface plus tokenizer-backed ``striptags``/``unescape`` and the rest of turbohtml
+      - ``Markup``, ``escape``, ``escape_silent``, ``soft_str``, ``EscapeFormatter``
+    - - Performance
+      - C escape 2-3x faster on the small clean strings autoescape interpolates (see below)
+      - C-accelerated ``escape``; regex ``striptags``/``unescape``
+    - - Typing
+      - Fully annotated, ships type stubs
+      - Typed (ships ``py.typed``)
+    - - Dependencies
+      - Single self-contained package, C extension bundled
+      - Single self-contained package, optional C speedup
+    - - Maintenance
+      - Active, part of the turbohtml project
+      - Active, maintained by the Pallets team
+
+Feature overlap
+===============
+
+The public surface ports 1:1 -- the names, signatures, and escaping semantics match, so a Jinja2, WTForms, or Werkzeug
+project only changes the import:
+
+- :class:`~turbohtml.migration.markupsafe.Markup` -- the ``str`` subclass, including the ``__html__`` protocol, the
+  composing operators (``+``, ``%``, ``*``), and the full text-returning ``str`` method surface kept as ``Markup``.
+- :func:`~turbohtml.migration.markupsafe.escape` -- returns a ``Markup``, honors ``__html__``, leaves an existing
+  ``Markup`` untouched.
+- :func:`~turbohtml.migration.markupsafe.escape_silent` -- like ``escape`` but maps ``None`` to an empty ``Markup``.
+- :func:`~turbohtml.migration.markupsafe.soft_str` -- coerces to ``str`` without escaping.
+- :class:`~turbohtml.migration.markupsafe.EscapeFormatter` -- the subclassable ``string.Formatter`` behind
+  :meth:`~turbohtml.migration.markupsafe.Markup.format`, cooperating through ``super()`` for a template sandbox.
+- :meth:`~turbohtml.migration.markupsafe.Markup.striptags` and :meth:`~turbohtml.migration.markupsafe.Markup.unescape`.
+
+What turbohtml adds
+===================
+
+- The escape and every ``Markup`` operation run in C, so autoescaping stays a single C call and the small-string escape
+  runs 2-3x faster than markupsafe's own C escape.
+- :meth:`~turbohtml.migration.markupsafe.Markup.striptags` parses with the WHATWG tokenizer instead of scanning for
+  ``<``, so a comment containing ``<`` cannot end tag removal early and references resolve during stripping.
+- :meth:`~turbohtml.migration.markupsafe.Markup.unescape` uses the full HTML5 named-reference table, resolving
+  references the regex scan can miss.
+- Everything else turbohtml is: the same ``escape`` and tokenizer primitives back parsing, serialization, and the
+  selector engine, so a project that adopts the safe-string also gets a parser under one name-per-concept API.
+
+What markupsafe has that turbohtml does not
+===========================================
+
+- **Drop-in package identity.** turbohtml does not register itself as the ``markupsafe`` distribution, so it will not
+  transparently replace the installed package for code that does ``import markupsafe``. Adoption is an explicit
+  per-project import swap. No equivalent: change the import line.
+- **The ``soft_unicode`` alias** was removed in markupsafe 3.0 and is absent here too; use
+  :func:`~turbohtml.migration.markupsafe.soft_str`.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/markupsafe.json
 
-*************
- The renames
-*************
+The escape runs two to three times faster than markupsafe's own C escape on the small, mostly-clean strings a template
+engine interpolates under autoescape, and the other ``Markup`` operations stay ahead too -- ``striptags`` and
+``unescape`` run on turbohtml's tokenizer and HTML5 reference resolution rather than markupsafe's regex scan, and the
+composing operations (``format``, ``join``) escape each untrusted operand through the same C ``escape``.
+
+****************
+ How to migrate
+****************
 
 A Jinja2, WTForms, or Werkzeug project changes only the import line:
 
@@ -90,14 +161,16 @@ emits, honors the ``__html__`` protocol, and leaves an existing ``Markup`` untou
     <B>SAFE</B>
     True
 
-Two methods are upgrades rather than reimplementations: :meth:`~turbohtml.migration.markupsafe.Markup.striptags` and
-:meth:`~turbohtml.migration.markupsafe.Markup.unescape` run on turbohtml's tokenizer and HTML5 reference resolution, so
-they are faster and resolve references markupsafe's regex-based stripping can miss.
+**********************
+ Gotchas and pitfalls
+**********************
 
-**********
- Pitfalls
-**********
-
+- Two methods are upgrades rather than reimplementations: :meth:`~turbohtml.migration.markupsafe.Markup.striptags` and
+  :meth:`~turbohtml.migration.markupsafe.Markup.unescape` run on turbohtml's tokenizer and HTML5 reference resolution.
+  They resolve references markupsafe's regex stripping can miss and treat comments as real nodes, so the plain text a
+  page produces can differ where the input contains comments, malformed tags, or named references.
+- ``striptags`` collapses runs of whitespace to single spaces, matching markupsafe; do not rely on the exact incidental
+  whitespace of either implementation.
 - The ``soft_unicode`` alias that markupsafe 3.0 removed is absent here too; use
   :func:`~turbohtml.migration.markupsafe.soft_str`.
 - turbohtml does not register itself as ``markupsafe``, so adoption stays an explicit per-project import rather than a

--- a/docs/migration/markyp.rst
+++ b/docs/migration/markyp.rst
@@ -7,32 +7,87 @@
 `markyp <https://github.com/volfpeter/markyp>`_ assembles HTML in Python from the other direction than a parser: its
 `markyp-html <https://github.com/volfpeter/markyp-html>`_ package provides one element class per tag, split across topic
 modules (``markyp_html.block.div``, ``markyp_html.text.h1``, ``markyp_html.lists.li``), each taking children
-positionally and attributes as trailing keywords, and stringifying the root renders the tree. turbohtml replaces both
-packages with the terse :data:`turbohtml.build.E` builder.
+positionally and attributes as trailing keywords, and stringifying the root renders the tree. It is a pure-Python
+generator: markyp itself is the tiny element core, markyp-html the HTML tag layer, and a small ecosystem of companion
+packages (``markyp-bootstrap``, ``markyp-highlightjs``, ``markyp-fontawesome``) wraps component libraries on top. A
+``webpage(...)`` factory builds the full HTML5 document shell. It is used to emit reports, templated pages, and
+component markup from Python without a template engine.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same construction ground with the terse :data:`turbohtml.build.E` builder, replacing both packages,
+but every call returns a real :class:`~turbohtml.Element` in turbohtml's C-backed tree, so the markup you generate is
+also a document you can query, edit, re-serialize, or convert -- not a one-way string.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+*********************
+ turbohtml vs markyp
+*********************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
 
-    from turbohtml.build import E
+    - - Dimension
+      - turbohtml
+      - markyp
+    - - Scope
+      - Parse, build, query, edit, serialize, and convert one WHATWG tree
+      - One-way HTML generation from Python, one element class per tag
+    - - Feature breadth
+      - ``E`` builder, CSS ``select``, ``xpath``, ``find``/``find_all``, ``to_markdown``/``to_text``, indent or minify
+        layout
+      - Per-tag classes across topic modules, a ``webpage`` page-shell factory, pretty-printed output, companion
+        component packages
+    - - Performance
+      - Builds in a C arena and serializes in C
+      - Pure-Python string assembly (about a third faster on the microbenchmark below)
+    - - Typing
+      - Ships ``.pyi`` stubs for the element, query, and serialize surface
+      - A concrete class per tag imported from its topic module; attributes stay untyped keywords
+    - - Dependencies
+      - Self-contained C extension (needs a wheel or a build)
+      - Pure Python over the small ``markyp`` core; runs anywhere Python does
+    - - Maintenance
+      - Actively developed C core with a thin Python shim
+      - Small, narrowly-scoped project with a companion-package ecosystem
 
-    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
-    print(card.serialize())
+Feature overlap
+===============
 
-.. testoutput::
+The construction surface ports one-for-one:
 
-    <div class="card"><h1>Title</h1><p>body</p></div>
+- Elements with attributes: ``div(class_="card")`` becomes :data:`E.div({"class": "card"}) <turbohtml.build.E>`.
+- Nested children: markyp's positional children become positional children on the ``E`` call.
+- Text nodes: a string argument becomes a plain string child in both.
+- ``data-*`` and boolean attributes: markyp's ``**{"data-i": "1"}`` and turbohtml's ``{"data-i": "1"}`` / ``{"disabled":
+  None}``.
+- Void tags close themselves in both.
+- Stringify: ``str(root)`` becomes :meth:`~turbohtml.Node.serialize`.
 
-``E`` assembles the fragment in turbohtml's arena and serializes it in C; markyp stays in Python. The same ``<ul>`` of
-rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
+What turbohtml adds
+===================
+
+- The result is a real :class:`~turbohtml.Element`, not a string, so the same call that builds the markup leaves a tree
+  you can walk and mutate with ``append``, ``insert``, ``remove``, and ``extend``.
+- Query the built tree with CSS :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.xpath`, and
+  :meth:`~turbohtml.Node.find`/``find_all`` -- markyp has no query surface over what it emits.
+- Convert with :meth:`~turbohtml.Node.to_markdown` and :meth:`~turbohtml.Node.to_text`.
+- Round-trip: the same tree type parses arbitrary HTML back in, so generation and parsing share one API.
+- No per-tag imports: any tag is named on ``E`` (or built via ``E("tag", ...)`` for a non-identifier name), so there is
+  no ``markyp_html.block`` / ``markyp_html.text`` module to track.
+
+What markyp has that turbohtml does not
+=======================================
+
+- Companion component packages. ``markyp-bootstrap``, ``markyp-highlightjs``, and ``markyp-fontawesome`` add typed
+  wrappers for Bootstrap components, syntax highlighting, and icons on top of the element core. turbohtml builds raw
+  elements only; there is no component library -- write the component markup as ``E`` calls yourself.
+- A ``webpage(...)`` page-shell factory. markyp ships a one-call helper that emits a complete HTML5 document (doctype,
+  ``<html>``, ``<head>``, ``<body>``). turbohtml has no shell factory: build the shell with :data:`E.html(E.head(...),
+  E.body(...)) <turbohtml.build.E>`, or append your fragment under a parsed document.
+- Pure-Python, wheel-less install. markyp needs no compiled extension and runs in any restricted environment. turbohtml
+  ships a C extension, so it depends on a wheel or a local build.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/markyp.json
@@ -41,12 +96,17 @@ markyp renders about a third faster than ``E`` on this microbenchmark -- it conc
 decisive difference is the result type: ``E`` hands back a real :class:`~turbohtml.Element`, not a string, so the call
 that builds the markup also leaves a tree you can query, edit, and re-:meth:`~turbohtml.Node.serialize`.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
-markyp imports one class per tag from a topic module and trails the attributes; turbohtml names any tag on ``E`` and
-leads with them:
+Swap the per-tag imports for the single ``E`` singleton; there is no topic module to import from:
+
+.. code-block:: python
+
+    from turbohtml.build import E  # was: from markyp_html.block import div; from markyp_html.text import h1, p
+
+markyp trails the attributes after positional children; turbohtml leads with a mapping and names any tag on ``E``:
 
 .. list-table::
     :header-rows: 1
@@ -62,6 +122,25 @@ leads with them:
     - - ``webpage(...)`` for the full page shell
       - build it: :data:`E.html(E.head(...), E.body(...)) <turbohtml.build.E>`, or append the fragment under a parsed
         document
+    - - ``str(root)``
+      - :meth:`element.serialize() <turbohtml.Node.serialize>`
+
+The same ``<div class="card">`` built both ways:
+
+.. code-block:: python
+
+    # markyp
+    from markyp_html.block import div
+    from markyp_html.text import h1, p
+
+    card = div(h1("Title"), p("body"), class_="card")
+    html = str(card)
+
+    # turbohtml
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    html = card.serialize()
 
 ``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
 attribute joins on a space so a class list reads naturally:
@@ -76,15 +155,19 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
-  Serialize the element you built, or append it under a parsed document when you need the full page shell.
+  Serialize the element you built, or append it under a parsed document when you need the full page shell -- markyp's
+  ``webpage(...)`` writes that shell for you, ``E`` does not.
 - markyp strips a trailing underscore (``class_`` to ``class``) but keeps other underscores, so hyphenated names need an
-  unpacked dict already; ``E`` takes the real attribute name as a plain dict key everywhere.
+  unpacked dict already; ``E`` takes the real attribute name as a plain dict key everywhere (``"class"``, ``"data-i"``).
+- A leading mapping is always read as attributes; to start an element with literal text, pass the string first
+  (``E.p("text", E.b("bold"))``).
 - markyp pretty-prints -- a newline between children and a space after a bare tag name (``<h1 >``); ``E`` serializes
-  compact markup. Parse and re-serialize, or use a formatter, when you need indented output.
+  compact markup. Pass ``serialize(Html(layout=Indent(2)))`` for indented output, or ``Html(layout=Minify())`` to
+  minify.
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/mechanicalsoup.rst
+++ b/docs/migration/mechanicalsoup.rst
@@ -4,25 +4,115 @@
 
 .. package-meta:: MechanicalSoup MechanicalSoup/MechanicalSoup
 
-`MechanicalSoup <https://github.com/MechanicalSoup/MechanicalSoup>`_ is a stateful browser: it fetches pages with
-`requests <https://requests.readthedocs.io>`_, parses them with `BeautifulSoup
-<https://www.crummy.com/software/BeautifulSoup/>`_, and fills and submits their forms. turbohtml replaces the parsing
-and form-reading half; the HTTP session, page navigation, and submission (``StatefulBrowser``, ``open``,
-``submit_selected``) stay out of scope -- fetch with `httpx <https://www.python-httpx.org>`_ or ``requests`` and post
-the result yourself.
+`MechanicalSoup <https://github.com/MechanicalSoup/MechanicalSoup>`_ is a stateful headless browser for Python. It wires
+together three libraries: it fetches pages with `requests <https://requests.readthedocs.io>`_, parses them with
+`BeautifulSoup <https://www.crummy.com/software/BeautifulSoup/>`_, and adds a ``StatefulBrowser`` that remembers the
+current page and form so you can follow links, fill in fields, and submit without hand-assembling each request. It is
+built for scripting sites that have no API -- logging in, walking paginated results, posting a form -- where you want
+requests-level control but not a full JavaScript engine like Selenium or Playwright.
 
-***************
- Why turbohtml
-***************
+turbohtml replaces the parsing and form-reading half of that stack. Once a page is fetched, turbohtml parses it with a
+WHATWG-conformant C parser and exposes the form controls through typed methods, so ``select_form``, reading and setting
+fields, and collecting the pairs to submit all become calls on the parsed tree. The HTTP session, navigation, and the
+actual POST stay out of scope: you drive those with ``requests`` or `httpx <https://www.python-httpx.org>`_ and hand
+turbohtml's output to your client.
 
-Once the page is parsed, ``select_form`` becomes :meth:`~turbohtml.Node.select_one`, reading or setting a field through
-``browser[name] = value`` becomes :attr:`~turbohtml.Element.field_value` and :attr:`~turbohtml.Element.checked`, and the
-name/value pairs MechanicalSoup would submit come from :meth:`~turbohtml.Element.form_data` -- one typed method on the
-parsed form instead of a stateful browser object.
+*****************************
+ turbohtml vs MechanicalSoup
+*****************************
 
-*************
- The renames
-*************
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - MechanicalSoup
+    - - Scope
+      - HTML parsing, CSS queries, and typed form-control reading/writing on the parsed tree
+      - Stateful browser: HTTP session, link/form navigation, and submission on top of requests + BeautifulSoup
+    - - Feature breadth
+      - Spec parser, CSS/XPath selectors, serialization, typed form data; no HTTP or session state
+      - ``StatefulBrowser`` with cookies, history, form auto-fill and submit; parsing delegated to BeautifulSoup
+    - - Performance
+      - WHATWG parser in C; see below
+      - Bounded by requests I/O and BeautifulSoup's Python parsing
+    - - Typing
+      - Ships type stubs; ``field_value``, ``checked``, and ``form_data`` are typed
+      - No bundled type stubs
+    - - Dependencies
+      - Self-contained C extension, no runtime deps
+      - Depends on ``requests`` and ``beautifulsoup4`` (plus a BeautifulSoup parser backend)
+    - - Maintenance
+      - Actively developed alongside the turbohtml parser
+      - Actively maintained, thin layer over its two dependencies
+
+Feature overlap
+===============
+
+The surface you can port 1:1 is the form-reading and page-querying half:
+
+- Selecting a form on the page: ``browser.select_form("form")`` -> :meth:`~turbohtml.Node.select_one` or
+  :meth:`~turbohtml.Node.find`.
+- Reading a control's value: ``form[name]`` -> :attr:`~turbohtml.Element.field_value`.
+- Setting a control's value: ``browser[name] = value`` / ``form.set(name, value)`` ->
+  :attr:`~turbohtml.Element.field_value` assignment.
+- Checkbox and radio state: ``form.check(name)`` -> :attr:`~turbohtml.Element.checked`.
+- The name/value pairs a submit would send: what ``browser.submit_selected()`` posts ->
+  :meth:`~turbohtml.Element.form_data`.
+
+What turbohtml adds
+===================
+
+- A WHATWG-conformant HTML parser in C rather than BeautifulSoup's Python tree builder, so malformed markup is fixed up
+  the way a browser would.
+- :meth:`~turbohtml.Element.form_data` applies the WHATWG form-submission rules directly: unnamed, disabled, and button
+  controls are skipped, unchecked checkboxes and radios contribute nothing, and a ``select`` yields one pair per
+  selected option. MechanicalSoup reproduces this by walking the BeautifulSoup tree itself.
+- Full CSS selector support plus XPath for locating forms and fields, not just tag/attribute lookups.
+- Bundled type stubs for the form API.
+- No runtime dependencies: turbohtml is a single C extension, where MechanicalSoup pulls in ``requests`` and
+  ``beautifulsoup4``.
+
+What MechanicalSoup has that turbohtml does not
+===============================================
+
+- **Stateful browsing.** ``StatefulBrowser`` keeps the current page, form, cookies, and history, and ``open``,
+  ``follow_link``, and ``submit_selected`` drive them. turbohtml has no HTTP or session layer. Workaround: fetch with
+  ``requests`` or ``httpx`` (which manage cookies and redirects for you) and parse each response with turbohtml.
+- **One-call form submission.** ``submit_selected`` reads the form, builds the request, and posts it in a single call,
+  honoring the form's ``action`` and ``method``. turbohtml gives you the data via :meth:`~turbohtml.Element.form_data`;
+  you POST it yourself. No equivalent one-call submit.
+- **Link and page navigation helpers.** ``links()``, ``follow_link``, and ``get_current_page`` operate on browser state.
+  turbohtml can find the same anchors with :meth:`~turbohtml.Node.select`, but resolving them against the current URL
+  and fetching is your code's job.
+- **``launch_browser``** to open the current page in a real browser for debugging has no turbohtml equivalent.
+
+Performance
+===========
+
+Not directly benchmarked.
+
+****************
+ How to migrate
+****************
+
+Swap the import and let your HTTP client stay separate from parsing:
+
+.. code-block:: python
+
+    import mechanicalsoup
+
+    browser = mechanicalsoup.StatefulBrowser()
+
+becomes
+
+.. code-block:: python
+
+    import requests
+    from turbohtml import parse
+
+API mapping:
 
 .. list-table::
     :header-rows: 1
@@ -43,6 +133,8 @@ parsed form instead of a stateful browser object.
     - - the data ``browser.submit_selected()`` posts
       - ``form.form_data()`` (hand to your HTTP client)
 
+Before and after, reading a value and collecting the submission pairs:
+
 .. testcode::
 
     form = parse(
@@ -59,13 +151,28 @@ parsed form instead of a stateful browser object.
     a@b.c
     [('email', 'a@b.c'), ('plan', 'pro'), ('terms', 'yes')]
 
-**********
- Pitfalls
-**********
+The list :meth:`~turbohtml.Element.form_data` returns drops straight into :func:`urllib.parse.urlencode` or a
+``requests``/``httpx`` ``data=`` argument, so submitting is one call on your own client:
 
-- :meth:`~turbohtml.Element.form_data` follows the WHATWG submission rules MechanicalSoup relied on BeautifulSoup plus
-  its own walk to reproduce -- unnamed, disabled, button, and unchecked checkbox/radio controls are skipped, and a
-  ``select`` contributes one pair per selected option.
-- The result drops straight into :func:`urllib.parse.urlencode` or an ``httpx``/``requests`` ``data=`` argument.
-- ``select_one`` returns the first matching form; on a page with several forms pass a more specific selector to reach
-  the one you mean.
+.. code-block:: python
+
+    import requests
+
+    response = requests.post(action_url, data=form.form_data(), timeout=30)
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- **No session state.** MechanicalSoup carried cookies and the current page across ``open``/``submit`` calls. With
+  turbohtml you reuse a ``requests.Session`` (or an ``httpx.Client``) for cookies and redirects, and re-parse each
+  response; turbohtml holds no navigation state.
+- **Submission is spec-driven, not a tree walk.** :meth:`~turbohtml.Element.form_data` follows the WHATWG rules:
+  unnamed, disabled, and button controls are skipped, unchecked checkbox/radio controls contribute nothing, and a
+  ``select`` produces one pair per selected option. If you relied on MechanicalSoup including a differently-shaped set
+  of controls, compare the ``form_data`` output against what you posted before.
+- **Selector reaches the wrong form on multi-form pages.** ``select_one("form")`` returns the first match. On a page
+  with several forms, pass a specific selector (an ``id``, ``name``, or ``action`` attribute) to reach the one you mean,
+  the same way you would target a form in the browser.
+- **Parse bytes, not text.** Hand :func:`turbohtml.parse` the response ``content`` (bytes) so turbohtml applies WHATWG
+  encoding detection, rather than pre-decoding to ``str`` with a guessed codec.

--- a/docs/migration/metadata_parser.rst
+++ b/docs/migration/metadata_parser.rst
@@ -5,29 +5,97 @@
 .. package-meta:: metadata_parser jvanasco/metadata_parser
 
 `metadata_parser <https://github.com/jvanasco/metadata_parser>`_ reads the social-card metadata a page advertises: the
-OpenGraph (``og:``) and Twitter (``twitter:``) ``<meta>`` tags, plus the Dublin Core and plain ``name``/``content``
-pairs. It builds a ``MetadataParser`` over the HTML and groups the tags into per-namespace dicts on
-``parsed_result.metadata`` (``["og"]``, ``["twitter"]``, ``["dc"]``, ``["meta"]``) that you read by key.
+OpenGraph (``og:``) and Twitter (``twitter:``) ``<meta>`` tags, plus Dublin Core (``dc``), plain ``name``/``content``
+pairs, and page-level links such as ``canonical`` and ``shortlink``. It builds a ``MetadataParser`` over the HTML (or
+fetches it for you from a URL), parses with BeautifulSoup, and groups the tags into per-namespace dicts on
+``parsed_result.metadata`` (``["og"]``, ``["twitter"]``, ``["dc"]``, ``["meta"]``, ``["page"]``) that you read by key or
+through ``get_metadata``/``get_metadata_link`` with a namespace ``strategy``. Its extra weight is URL work: it fetches
+pages, follows redirects, and resolves relative URL-valued tags against the page URL to pick a single "discrete" URL for
+sharing.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the social-card ground with :meth:`~turbohtml.Document.opengraph`, which gathers the ``og:`` and
+``twitter:`` ``<meta>`` tags into one flat ``{key: value}`` mapping in a single C walk over the WHATWG-parsed tree, with
+no parser object to construct and no per-namespace accessor to pick. It parses the markup you already have rather than
+fetching, so it slots behind whatever downloader you use.
 
-:meth:`~turbohtml.Document.opengraph` returns the same social-card data as a flat ``{key: value}`` mapping, gathered in
-one walk over the parsed document with no parser object to construct and no per-namespace accessor to pick. ``og:`` and
-``twitter:`` tags share the one mapping because pages mix the ``property`` and ``name`` attributes freely, and the
-result is a plain dict that holds no reference back into the tree:
+******************************
+ turbohtml vs metadata_parser
+******************************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
 
-    from turbohtml import parse
+    - - Dimension
+      - turbohtml
+      - metadata_parser
+    - - Scope
+      - WHATWG HTML parser with metadata extraction on parsed trees
+      - Social-card metadata reader with URL fetching and normalization
+    - - Feature breadth
+      - Full DOM, selectors, serialization, ``opengraph()``, ``structured_data()``, ``base_url()``
+      - ``og``/``twitter``/``dc``/``meta``/``page`` namespaces, URL fetch, redirect and canonical-URL resolution
+    - - Performance
+      - One C walk over the parsed tree (see below)
+      - BeautifulSoup tree build and Python namespace mapping
+    - - Typing
+      - Fully typed, ships stubs
+      - No published type stubs
+    - - Dependencies
+      - Zero runtime dependencies (native C extension)
+      - requests, BeautifulSoup4, and helper libraries
+    - - Maintenance
+      - Actively maintained
+      - Actively maintained
 
-    doc = parse('<head><meta property="og:title" content="Widget"><meta name="twitter:card" content="summary"></head>')
-    print(doc.opengraph())
+Feature overlap
+===============
 
-.. testoutput::
+Port these 1:1:
 
-    {'og:title': 'Widget', 'twitter:card': 'summary'}
+- ``mp.parsed_result.metadata["og"]["title"]`` -> the ``og:title`` key of :meth:`~turbohtml.Document.opengraph`.
+- ``mp.parsed_result.get_metadatas("card", strategy=["twitter"])`` -> the ``twitter:card`` key of
+  :meth:`~turbohtml.Document.opengraph`.
+- ``mp.parsed_result.metadata["twitter"]["image"]`` -> the ``twitter:image`` key of the same mapping (``og:`` and
+  ``twitter:`` tags share the one dict).
+- ``MetadataParser(html=html)`` -> ``parse(html)`` (:func:`turbohtml.parse`), then read
+  :meth:`~turbohtml.Document.opengraph`.
+
+What turbohtml adds
+===================
+
+- A full WHATWG-conformant parser: the tree :meth:`~turbohtml.Document.opengraph` walks is the same DOM you query with
+  CSS selectors, serialize, or mutate, not a metadata-private intermediate.
+- Zero runtime dependencies. metadata_parser pulls in requests and BeautifulSoup4; turbohtml is a self-contained C
+  extension.
+- Full type coverage with shipped stubs, so ``opengraph()`` and its result check under a type checker.
+- Structured data beyond the social card: :meth:`~turbohtml.Document.structured_data` returns JSON-LD and Microdata in
+  the same walk, with :meth:`~turbohtml.Document.json_ld` and :meth:`~turbohtml.Document.microdata` beside
+  :meth:`~turbohtml.Document.opengraph`.
+- Document URL hints on the parsed tree: :meth:`~turbohtml.Document.base_url` resolves the effective ``<base>`` and
+  :meth:`~turbohtml.Document.meta_refresh` reads the refresh target.
+- A standalone string entry point :func:`turbohtml.extract.opengraph` that strips the ``og:`` prefix and adds
+  ``is_valid()`` for the Open Graph protocol's required properties.
+
+What metadata_parser has that turbohtml does not
+================================================
+
+- **URL fetching**: ``MetadataParser(url=...)`` downloads the page, follows redirects, and detects the response
+  encoding. turbohtml takes parsed HTML only, so pair it with ``urllib`` or ``httpx``.
+- **URL absolutization**: ``get_metadata_link`` and ``get_discrete_url`` resolve relative URL-valued tags against the
+  page URL. :meth:`~turbohtml.Document.opengraph` returns raw tag values; resolve them yourself against
+  :meth:`~turbohtml.Document.base_url`.
+- **Dublin Core (``dc``) and generic ``name``/``content`` namespaces**: metadata_parser groups these into
+  ``metadata["dc"]`` and ``metadata["meta"]``. :meth:`~turbohtml.Document.opengraph` gathers only ``og:`` and
+  ``twitter:`` tags; read any other ``<meta>`` by selecting it, e.g. ``parse(html).find_all("meta")``.
+- **Page-level links** (``canonical``, ``shortlink``) collected into ``metadata["page"]``. Read those with a selector,
+  e.g. ``parse(html).find('link[rel="canonical"]')``.
+- **Namespace ``strategy`` ordering**: ``get_metadata(field, strategy=[...])`` picks the first namespace that carries a
+  field. turbohtml keys tags by their full prefix (``og:title`` vs ``twitter:title``), so read the prefix you want
+  directly.
+
+Performance
+===========
 
 Both libraries start from the raw HTML string, so each parses before it reads the tags: ``metadata_parser`` builds its
 own tree and maps the meta block in Python, where :meth:`~turbohtml.Document.opengraph` parses to the WHATWG tree and
@@ -37,9 +105,13 @@ the single pass runs dozens of times faster:
 .. bench-table::
     :file: bench/metadata_parser.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the ``MetadataParser`` construction for a :func:`turbohtml.parse` call, then read
+:meth:`~turbohtml.Document.opengraph` by prefixed key instead of picking a namespace dict. Where metadata_parser fetched
+the URL for you, download the markup first and pass it to :func:`turbohtml.parse`.
 
 .. list-table::
     :header-rows: 1
@@ -55,10 +127,23 @@ the single pass runs dozens of times faster:
       - the ``twitter:card`` key of :meth:`~turbohtml.Document.opengraph`
     - - ``mp.get_metadata_link("image", strategy=["og"])``
       - the ``og:image`` key, absolutized yourself against :meth:`~turbohtml.Document.base_url`
+    - - ``mp.parsed_result.metadata["dc"]`` / ``["meta"]``
+      - ``doc.find_all("meta")``, read ``name``/``content`` off each tag
 
-**********
- Pitfalls
-**********
+.. testcode::
+
+    from turbohtml import parse
+
+    doc = parse('<head><meta property="og:title" content="Widget"><meta name="twitter:card" content="summary"></head>')
+    print(doc.opengraph())
+
+.. testoutput::
+
+    {'og:title': 'Widget', 'twitter:card': 'summary'}
+
+**********************
+ Gotchas and pitfalls
+**********************
 
 - metadata_parser groups tags into per-namespace dicts with unprefixed keys (``metadata["og"]["title"]``), while
   :meth:`~turbohtml.Document.opengraph` returns one flat mapping with prefixed keys (``og:title``, ``twitter:card``)
@@ -67,3 +152,7 @@ the single pass runs dozens of times faster:
   absolutizes URL-valued tags against the page URL. Resolve those yourself with :meth:`~turbohtml.Document.base_url`.
 - When a key repeats, the last occurrence wins in the flat mapping; read :meth:`~turbohtml.Document.structured_data`
   when you need every occurrence of a repeated key.
+- metadata_parser can fetch (``MetadataParser(url=...)``) and detect the response encoding; turbohtml takes parsed HTML,
+  so fetch the page yourself and pass the markup to :func:`turbohtml.parse`.
+- Only ``og:`` and ``twitter:`` tags land in :meth:`~turbohtml.Document.opengraph`. Dublin Core, generic
+  ``name``/``content`` pairs, and page-level ``<link>`` tags come back through selectors, not the metadata mapping.

--- a/docs/migration/microdata.rst
+++ b/docs/migration/microdata.rst
@@ -4,40 +4,133 @@
 
 .. package-meta:: microdata edsu/microdata
 
-`microdata <https://github.com/edsu/microdata>`_ pulls the HTML Microdata items a page embeds: ``get_items(html)``
-builds an html5lib tree, walks its ``itemscope`` elements, and returns ``Item`` objects you read with ``.itemtype``,
-``.get``/``.get_all``, and ``.json``. turbohtml serves that surface from :func:`turbohtml.extract.microdata` over the
-same C walk :meth:`turbohtml.Document.microdata` runs.
+`microdata <https://github.com/edsu/microdata>`_ is a small pure-Python library that pulls the HTML Microdata items a
+page embeds -- the WHATWG ``itemscope``/``itemprop`` vocabulary sites use to mark up schema.org products, recipes,
+people, and events. Its ``get_items`` entry point parses the page with html5lib, walks the ``itemscope`` elements in
+Python, and returns ``Item`` objects you read with ``.itemtype``, ``.itemid``, ``.props``, ``.get``/``.get_all``, and
+``.json``. It has long been the go-to dependency for scrapers that need schema.org markup off a page.
 
-***************
- Why turbohtml
-***************
+turbohtml serves that surface from :func:`turbohtml.extract.microdata`, backed by the same C walk that
+:meth:`turbohtml.Document.microdata` runs over the WHATWG tree. It returns the page's top-level items as frozen
+:class:`~turbohtml.MicrodataItem` records with the same accessors, so a scraper's item-reading code ports without a
+rewrite while the parse-and-walk runs in the C extension rather than in Python over an html5lib tree.
 
-:func:`turbohtml.extract.microdata` returns the page's top-level items as :class:`~turbohtml.MicrodataItem` records with
-the same accessors -- :meth:`~turbohtml.MicrodataItem.get`, :meth:`~turbohtml.MicrodataItem.get_all`, and
-:meth:`~turbohtml.MicrodataItem.json` -- so a nested property that is itself an ``itemscope`` comes back as a nested
-:class:`~turbohtml.MicrodataItem` rather than a flat string:
+************************
+ turbohtml vs microdata
+************************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
 
-    from turbohtml.extract import microdata
+    - - Dimension
+      - turbohtml
+      - microdata
+    - - Scope
+      - Full WHATWG HTML5 parser, serializer, and an extraction suite (Microdata, JSON-LD, OpenGraph, links, dates,
+        boilerplate)
+      - Microdata extraction only
+    - - Feature breadth
+      - Microdata, JSON-LD, and OpenGraph gathered in one walk; nested ``itemscope`` returns as a nested record
+      - ``get_items`` from a URL, file, or string; nested items; a mutable ``Item`` you can also build and edit
+    - - Performance
+      - One C walk over the parsed tree; 35 to 42x faster on the benchmark pages
+      - Python walk over an html5lib tree, built on each ``get_items`` call
+    - - Typing
+      - Fully typed; :class:`~turbohtml.MicrodataItem` is a frozen, slotted dataclass with shipped stubs
+      - Untyped
+    - - Dependencies
+      - C extension, no pure-Python runtime dependencies
+      - Requires html5lib
+    - - Maintenance
+      - Actively developed
+      - Minimal, low-activity single-maintainer project, stable for years
 
-    item = microdata(
-        '<div itemscope itemtype="https://schema.org/Person">'
-        '<span itemprop="name">Ada</span>'
-        '<span itemprop="name">Lovelace</span>'
-        '<div itemprop="address" itemscope><span itemprop="city">London</span></div>'
-        "</div>"
-    )[0]
-    print(item.type)
-    print(item.get("name"), item.get_all("name"))
-    print(item.get("address").get("city"))
+Feature overlap
+===============
 
-.. testoutput::
+The item-reading surface ports one-to-one:
 
-    https://schema.org/Person
-    Ada ['Ada', 'Lovelace']
-    London
+- ``microdata.get_items(html)`` -> :func:`turbohtml.extract.microdata`, both returning the page's top-level items in
+  document order.
+- ``item.itemid`` -> :attr:`item.id <turbohtml.MicrodataItem.id>`.
+- ``item.props`` -> :attr:`item.properties <turbohtml.MicrodataItem.properties>`, each ``itemprop`` name mapped to its
+  values in document order.
+- ``item.get(name)`` / ``item.get_all(name)`` -> :meth:`~turbohtml.MicrodataItem.get` /
+  :meth:`~turbohtml.MicrodataItem.get_all`, with the same first-value-or-``None`` and list-or-``[]`` contract.
+- ``item.json()`` -> :meth:`~turbohtml.MicrodataItem.json`, the same two-space-indented JSON of the tree below the item.
+- A property that is itself an ``itemscope`` comes back as a nested item in both libraries, not a flat string.
+
+What turbohtml adds
+===================
+
+- Nested items and multi-valued properties resolve directly off the record, so a property that is another ``itemscope``
+  is a nested :class:`~turbohtml.MicrodataItem`:
+
+  .. testcode::
+
+      from turbohtml.extract import microdata
+
+      item = microdata(
+          '<div itemscope itemtype="https://schema.org/Person">'
+          '<span itemprop="name">Ada</span>'
+          '<span itemprop="name">Lovelace</span>'
+          '<div itemprop="address" itemscope><span itemprop="city">London</span></div>'
+          "</div>"
+      )[0]
+      print(item.type)
+      print(item.get("name"), item.get_all("name"))
+      print(item.get("address").get("city"))
+
+  .. testoutput::
+
+      https://schema.org/Person
+      Ada ['Ada', 'Lovelace']
+      London
+
+- JSON-LD and OpenGraph off the same page in the same C walk: :meth:`turbohtml.Document.json_ld`,
+  :meth:`turbohtml.Document.opengraph`, and :meth:`turbohtml.Document.structured_data`, plus the string-input helpers
+  :func:`turbohtml.extract.opengraph` and the rest of the extraction suite. ``microdata`` covers Microdata alone.
+- :meth:`turbohtml.Document.microdata` extracts from an already-parsed :func:`turbohtml.parse` document, so pages you
+  hold for other work do not get reparsed.
+- The records are frozen and hold no reference back into the tree, so they outlive the document:
+
+  .. testcode::
+
+      item = microdata('<div itemscope itemid="urn:isbn:1"><span itemprop="name">B</span></div>')[0]
+      print(item.id, item.json())
+
+  .. testoutput::
+
+      urn:isbn:1 {
+        "id": "urn:isbn:1",
+        "properties": {
+          "name": [
+            "B"
+          ]
+        }
+      }
+
+- A text property's value follows the spec's ``textContent`` rule, so text nested in the property element is kept where
+  ``microdata`` drops it (see :ref:`microdata-divergences`).
+
+What microdata has that turbohtml does not
+==========================================
+
+- **Fetching from a URL or file.** ``get_items(location, encoding=None)`` accepts a URL or file-like object and reads it
+  for you. :func:`~turbohtml.extract.microdata` takes an HTML string only. Workaround: fetch the bytes yourself
+  (``urllib``/``requests``) and pass the decoded text, or feed the response to :func:`turbohtml.parse` and call
+  :meth:`~turbohtml.Document.microdata`.
+- **An explicit encoding argument.** ``get_items`` takes ``encoding`` to decode the fetched bytes. turbohtml handles
+  encoding at parse time on the byte input instead; there is no separate argument on the string helper.
+- **``itemtype`` as parsed URI objects.** ``item.itemtype`` is a list of ``URI`` objects (``item.itemtype[0].string``).
+  :attr:`~turbohtml.MicrodataItem.type` is the raw ``itemtype`` string; call ``.type.split()`` for the token list.
+- **A mutable, buildable item.** ``microdata``'s ``Item`` is an open object whose ``props`` dict you can edit and add
+  to. :class:`~turbohtml.MicrodataItem` is a frozen read-only record. No equivalent; build your own structure if you
+  need to synthesize or mutate items.
+
+Performance
+===========
 
 ``microdata`` starts from the raw HTML string, so it parses before it extracts: it builds an html5lib tree and walks the
 ``itemscope`` elements in Python, where :func:`~turbohtml.extract.microdata` parses to the WHATWG tree and gathers the
@@ -50,9 +143,21 @@ the same, the walk runs 35 to 42 times faster:
 Over the fixtures in ``microdata``'s own test suite the two libraries return byte-identical ``json()`` for every page
 but one, where turbohtml follows the spec more closely (see :ref:`microdata-divergences`).
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import and the entry point:
+
+.. code-block:: python
+
+    # before
+    from microdata import get_items
+
+    # after
+    from turbohtml.extract import microdata
+
+The call and item API map directly:
 
 .. list-table::
     :header-rows: 1
@@ -73,40 +178,54 @@ but one, where turbohtml follows the spec more closely (see :ref:`microdata-dive
     - - ``item.json()``
       - :meth:`~turbohtml.MicrodataItem.json`
 
-The items are frozen records that hold no reference back into the tree, so you can keep them after the document is gone:
+The item-reading code is the same shape on both sides; only the ``itemtype`` accessor changes:
 
-.. testcode::
+.. code-block:: python
 
-    item = microdata('<div itemscope itemid="urn:isbn:1"><span itemprop="name">B</span></div>')[0]
-    print(item.id, item.json())
+    # before
+    from microdata import get_items
 
-.. testoutput::
+    items = get_items(
+        '<div itemscope itemtype="https://schema.org/Person">'
+        '<span itemprop="name">Ada</span>'
+        '<div itemprop="address" itemscope><span itemprop="city">London</span></div>'
+        "</div>"
+    )
+    item = items[0]
+    print(item.itemtype[0].string)
+    print(item.get("name"))
+    print(item.get("address").get("city"))
 
-    urn:isbn:1 {
-      "id": "urn:isbn:1",
-      "properties": {
-        "name": [
-          "B"
-        ]
-      }
-    }
+    # after
+    from turbohtml.extract import microdata
+
+    item = microdata(
+        '<div itemscope itemtype="https://schema.org/Person">'
+        '<span itemprop="name">Ada</span>'
+        '<div itemprop="address" itemscope><span itemprop="city">London</span></div>'
+        "</div>"
+    )[0]
+    print(item.type)
+    print(item.get("name"))
+    print(item.get("address").get("city"))
 
 .. _microdata-divergences:
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
-- ``item.itemtype`` is a list of ``URI`` objects (``item.itemtype[0].string``); :attr:`~turbohtml.MicrodataItem.type` is
-  the raw ``itemtype`` string, which the `WHATWG spec <https://html.spec.whatwg.org/multipage/microdata.html>`_ treats
-  as a space-separated token set. Call ``.type.split()`` for the list, the form :meth:`~turbohtml.MicrodataItem.json`
-  emits.
+- ``item.itemtype`` is a list of ``URI`` objects, read via ``item.itemtype[0].string``.
+  :attr:`~turbohtml.MicrodataItem.type` is the raw ``itemtype`` string, which the `WHATWG spec
+  <https://html.spec.whatwg.org/multipage/microdata.html>`_ treats as a space-separated token set. Call
+  ``.type.split()`` for the list, the form :meth:`~turbohtml.MicrodataItem.json` emits.
 - A text property's value is the element's ``textContent`` per the spec, so a ``<script>`` or ``<style>`` nested inside
   a property element contributes its text; ``microdata`` drops that text. This is the one page in ``microdata``'s
   fixtures where the ``json()`` output differs.
 - :meth:`~turbohtml.MicrodataItem.get` returns the first value or ``None`` and :meth:`~turbohtml.MicrodataItem.get_all`
   returns the list or ``[]``, matching ``Item.get``/``Item.get_all``; a property that is itself an ``itemscope`` comes
   back as a nested :class:`~turbohtml.MicrodataItem`, not a string.
-- :func:`~turbohtml.extract.microdata` reparses the string on each call. Hold a :func:`turbohtml.parse` document and
-  call :meth:`~turbohtml.Document.microdata` when you also need :meth:`~turbohtml.Document.json_ld` or
-  :meth:`~turbohtml.Document.opengraph` off the same page.
+- :func:`~turbohtml.extract.microdata` takes an HTML string and reparses it on each call. To read a URL or file, fetch
+  the text yourself first. When you also need :meth:`~turbohtml.Document.json_ld` or
+  :meth:`~turbohtml.Document.opengraph` off the same page, hold a :func:`turbohtml.parse` document and call
+  :meth:`~turbohtml.Document.microdata` so the page is parsed once.

--- a/docs/migration/minify-html.rst
+++ b/docs/migration/minify-html.rst
@@ -4,26 +4,110 @@
 
 .. package-meta:: minify-html wilsonzlin/minify-html
 
-`minify-html <https://github.com/wilsonzlin/minify-html>`_ is a Rust HTML/CSS/JS minifier with a Python binding;
-``minify_html.minify(html, **flags)`` collapses whitespace, drops optional tags, and unquotes attributes, and can also
-minify embedded CSS and JavaScript.
+`minify-html <https://github.com/wilsonzlin/minify-html>`_ is a Rust HTML minifier with bindings for Python, Node, Deno,
+Ruby, Java, and a standalone CLI. ``minify_html.minify(html, **flags)`` collapses whitespace with a context-aware
+sensitivity model, drops the tags and attribute quotes the WHATWG rules make optional, strips comments, and can minify
+embedded CSS (via lightningcss) and JavaScript in the same pass. It targets maximum size reduction and is used to shrink
+HTML at build time and in response pipelines across those language ecosystems.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same HTML folds with :func:`turbohtml.clean.minify`, one call that minifies a document over the
+WHATWG tree turbohtml already builds, configured by the frozen :class:`~turbohtml.Minify` options object. It collapses
+insignificant whitespace, omits the optional tags, unquotes attributes, strips comments, and optionally rewrites inline
+JavaScript, running the work in a compiled C serializer over the parsed tree rather than as a separate Rust pass.
 
-:func:`turbohtml.clean.minify` minifies a document with one call over the WHATWG tree turbohtml already builds,
-configured by the frozen :class:`~turbohtml.Minify` options object. On the folds the two share (collapsing insignificant
-whitespace, omitting the tags the WHATWG rules make optional, dropping redundant attribute quotes, and stripping
-comments) it runs about twice as fast, parse included. It leaves embedded CSS and JavaScript untouched, which
-minify-html can also shrink.
+**************************
+ turbohtml vs minify-html
+**************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - minify-html
+    - - Scope
+      - Full WHATWG parser plus serializer; minify is one output layout of a queryable tree
+      - Standalone string-in/string-out HTML/CSS/JS minifier
+    - - Feature breadth
+      - Whitespace, comment, optional-tag, and attribute-quote folds plus opt-in inline JS minification
+      - The same HTML folds plus in-pass CSS and JS minification, template-syntax and SSI preservation flags, and more
+        aggressive whitespace and attribute rewrites
+    - - Performance
+      - C serializer over an already-built tree; about 2x faster, parse included (see below)
+      - Optimized Rust minifier, no tree retained
+    - - Typing
+      - Fully typed, frozen :class:`~turbohtml.Minify` options object
+      - Untyped ``**flags`` keyword arguments
+    - - Dependencies
+      - Self-contained C extension, no runtime dependencies
+      - Prebuilt Rust wheel, no runtime Python dependencies
+    - - Maintenance
+      - Actively maintained
+      - Actively maintained across multiple language bindings
+
+Feature overlap
+===============
+
+These HTML folds port one-to-one; each minify-html flag becomes a field on :class:`~turbohtml.Minify`:
+
+- Whitespace collapsing — on by default in both; maps to ``Minify(collapse_whitespace=True)`` (also the default).
+- Comment removal — ``keep_comments=False`` (the minify-html default) maps to ``Minify(strip_comments=True)`` (the
+  turbohtml default; comments go unless you opt out).
+- Optional-tag omission — ``keep_closing_tags`` and ``keep_html_and_head_opening_tags`` map to the single
+  ``Minify(omit_optional_tags=True)``, which drops the start and end tags the WHATWG rules make optional.
+- Attribute unquoting — on by default in both; maps to ``Minify(unquote_attributes=True)``.
+- Inline JavaScript minification — ``minify_js=True`` maps to ``Minify(minify_js=JSMinify())``, which rewrites
+  ``<script>`` bodies with turbohtml's shipped JS minifier.
+
+What turbohtml adds
+===================
+
+- A real parse and a tree — the input runs through the full WHATWG algorithm, so the same call site can select, mutate,
+  and re-serialize the document. minify-html is a one-shot string transform with no tree to query.
+- A typed, frozen options object — :class:`~turbohtml.Minify` validates configuration at construction and reuses one
+  instance across calls, versus untyped keyword flags.
+- Conservative, render-safe output — every fold is round-trip safe, so the output reparses to the input tree and
+  minifying twice changes nothing.
+- Self-contained C extension — no separate Rust minifier in the toolchain; minify shares the parser turbohtml already
+  ships.
+
+What minify-html has that turbohtml does not
+============================================
+
+- In-pass CSS minification — ``minify_css=True`` shrinks ``<style>`` bodies and ``style`` attributes with lightningcss
+  during the same call. turbohtml leaves ``<style>`` bodies verbatim. Workaround: run :func:`turbohtml.clean.minify_css`
+  over ``<style>`` bodies yourself (and :func:`turbohtml.clean.minify_css_inline` over ``style`` attribute values).
+- Aggressive whitespace removal — minify-html's context-aware model can delete inter-element whitespace outright where
+  its sensitivity rules judge it insignificant. turbohtml collapses each run to a single space and never deletes it, so
+  the output stays render-safe. No equivalent by design.
+- Boolean-attribute and entity shortening — minify-html rewrites ``checked="checked"`` to a bare ``checked`` and
+  shortens ``&amp;`` to ``&`` where safe. turbohtml writes boolean attributes in full and keeps ``&amp;``. No
+  equivalent.
+- Template and server-side markers — ``preserve_brace_template_syntax``, ``preserve_chevron_percent_template_syntax``,
+  ``keep_ssi_comments``, ``keep_input_type_text_attr``, ``ensure_spec_compliant_unquoted_attribute_values``,
+  ``remove_bangs``, and ``remove_processing_instructions`` tune edge cases turbohtml does not expose knobs for. No
+  equivalent; turbohtml applies the WHATWG-safe default in each case.
+- Non-Python bindings and a CLI — minify-html ships for Node, Deno, Ruby, Java, and as a standalone binary. turbohtml
+  exposes no minify CLI and is Python-only. Workaround: a two-line ``python -c`` invocation of
+  :func:`~turbohtml.clean.minify`.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/minify-html.json
 
-*************
- The renames
-*************
+On the folds the two share (collapsing insignificant whitespace, omitting the tags the WHATWG rules make optional,
+dropping redundant attribute quotes, and stripping comments) turbohtml runs about twice as fast, parse included.
+minify-html produces smaller output because it removes whitespace and shortens attributes more aggressively; turbohtml
+trades those bytes for output that stays valid and reparses to the same tree.
+
+****************
+ How to migrate
+****************
+
+Swap the import and drop the per-flag keywords for the options object:
 
 .. code-block:: python
 
@@ -36,16 +120,6 @@ minify-html can also shrink.
     from turbohtml.clean import minify
 
     minify(html)
-
-.. testcode::
-
-    from turbohtml.clean import minify
-
-    print(minify("<ul>  <li>  one  </li>  <li>  two  </li>  </ul>"))
-
-.. testoutput::
-
-    <ul> <li> one </li> <li> two </li> </ul>
 
 Each fold is a field on :class:`~turbohtml.Minify`, so a flag becomes one keyword on the options object:
 
@@ -61,30 +135,42 @@ Each fold is a field on :class:`~turbohtml.Minify`, so a flag becomes one keywor
       - ``Minify(strip_comments=...)`` (default ``True``)
     - - ``keep_closing_tags``, ``keep_html_and_head_opening_tags``
       - ``Minify(omit_optional_tags=...)`` (default ``True``; set ``False`` to keep every tag)
-    - - attribute unquoting
+    - - attribute unquoting (on by default)
       - ``Minify(unquote_attributes=...)`` (default ``True``)
     - - ``minify_js``
       - ``Minify(minify_js=JSMinify())`` rewrites inline ``<script>`` content (the default ``None`` leaves it verbatim)
     - - ``minify_css``
       - no inline hook -- run :func:`turbohtml.clean.minify_css` over ``<style>`` bodies yourself
-    - - ``minify_doctype``
+    - - ``minify_doctype`` / ``do_not_minify_doctype``
       - the doctype is always normalized to ``<!doctype html>``
     - - ``remove_processing_instructions``
       - the WHATWG algorithm has no processing instructions in the HTML namespace
 
-**********
- Pitfalls
-**********
+The default call minifies with every HTML fold engaged:
 
-- Every fold is round-trip safe, so minifying is idempotent and the output reparses to the input tree. The two minifiers
-  do not produce byte-for-byte identical output, though: turbohtml is the more conservative of the two, so port against
-  behavior rather than string equality.
-- turbohtml keeps attributes in source order; minify-html sorts them alphabetically.
+.. testcode::
+
+    from turbohtml.clean import minify
+
+    print(minify("<ul>  <li>  one  </li>  <li>  two  </li>  </ul>"))
+
+.. testoutput::
+
+    <ul> <li> one </li> <li> two </li> </ul>
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- The two minifiers do not produce byte-for-byte identical output. Every turbohtml fold is round-trip safe, so minifying
+  is idempotent and the output reparses to the input tree; turbohtml is the more conservative of the two, so port
+  against behavior rather than string equality.
+- turbohtml keeps attributes in source order; minify-html sorts them.
 - turbohtml collapses each whitespace run to one space and keeps a few optional end tags (``</body>``, ``</html>``,
   ``</li>``) that minify-html drops, so its output stays valid and render-safe while running a few bytes larger.
 - turbohtml writes boolean attributes in full (``checked="checked"``) and keeps ``&amp;`` where minify-html shortens to
   a bare ``checked`` and ``&``.
 - Embedded ``<style>`` bodies pass through unchanged (:func:`turbohtml.clean.minify_css` shrinks them separately), and
-  inline ``<script>`` minification is opt-in via ``Minify(minify_js=...)``.
+  inline ``<script>`` minification is opt-in via ``Minify(minify_js=...)``. minify-html folds both in the same call.
 - ``minify`` parses the input as a full document, so a bare fragment gains the ``<html>``/``<body>`` structure the
   WHATWG algorithm infers; call it on whole pages, not detached fragments.

--- a/docs/migration/news-please.rst
+++ b/docs/migration/news-please.rst
@@ -4,19 +4,85 @@
 
 .. package-meta:: news-please fhamborg/news-please
 
-`news-please <https://github.com/fhamborg/news-please>`_ is a news-crawling system: scrapy spiders discover pages, an
-extractor ensemble (newspaper, readability, a date extractor) pulls the article and metadata from each, and pipelines
-store the results in JSON, PostgreSQL, or Elasticsearch. Its in-library entry point, ``NewsPlease.from_html``, runs that
-ensemble on HTML you already have.
+`news-please <https://github.com/fhamborg/news-please>`_ is a news-crawling system. Scrapy spiders discover article
+pages, an extractor ensemble (newspaper, readability, and a dedicated date extractor) pulls the body and metadata from
+each page, and pipelines store the results in JSON, PostgreSQL, or Elasticsearch. It ships WARC and Common Crawl tooling
+for large-scale news archiving and is used in academic corpus building and news-monitoring pipelines. Its in-library
+entry point, ``NewsPlease.from_html``, runs the extraction ensemble on HTML you already hold.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the extraction step of that stack. :meth:`~turbohtml.Node.article` scores the parsed tree and harvests
+the article body and its metadata in one C pass, returning an :class:`~turbohtml.Article`. The crawling, scheduling, and
+storage layers stay whatever you build them into; turbohtml is the ``from_html`` in the middle, without the ensemble's
+dependency tree.
 
-:meth:`~turbohtml.Node.article` replaces the extraction step: one C pass over the parsed tree scores the content body
-and harvests the metadata the ensemble votes on, returning the :class:`~turbohtml.Article` record (``text``, ``title``,
-``byline``, ``date``, ``description``, ``lang``). The crawling, scheduling, and storage layers stay whatever you make
-them; turbohtml is the ``from_html`` in the middle, without the ensemble's dependency tree.
+**************************
+ turbohtml vs news-please
+**************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
+
+    - - Dimension
+      - turbohtml
+      - news-please
+    - - Scope
+      - HTML parser plus a one-call article extractor (``article()``)
+      - End-to-end news crawler: spiders, extraction ensemble, storage pipelines
+    - - Feature breadth
+      - Per-page body and metadata extraction from in-memory HTML
+      - Crawling, scheduling, WARC/Common Crawl ingestion, DB/Elasticsearch sinks, plus extraction
+    - - Performance
+      - One C pass over the parsed tree
+      - Several Python extractors whose votes are merged per page
+    - - Typing
+      - Typed :class:`~turbohtml.Article` NamedTuple, ships stubs
+      - ``NewsArticle`` / dict result, no bundled type stubs
+    - - Dependencies
+      - Self-contained C extension
+      - scrapy, newspaper, readability, date extractors, storage clients
+    - - Maintenance
+      - Active
+      - Active, research-driven
+
+Feature overlap
+===============
+
+The shared surface is single-page extraction. Everything ``NewsPlease.from_html`` returns for the body and core metadata
+has a direct :meth:`~turbohtml.Node.article` counterpart:
+
+- Article body text: ``maintext`` -> ``article().text``.
+- Title: ``title`` -> ``article().title`` (from the first ``<h1>``, then ``og:title``, then ``<title>``).
+- Author: ``authors`` -> ``article().byline`` (see the gotchas on the list-vs-string difference).
+- Publication date: ``date_publish`` -> ``article().date``.
+- Description: ``description`` -> ``article().description``.
+- Language: ``language`` -> ``article().lang``.
+
+What turbohtml adds
+===================
+
+- A full WHATWG HTML parser under the same object. ``parse(html)`` gives you the tree, CSS selectors, and serialization
+  alongside ``article()``, so extraction and DOM work share one parse.
+- A typed record. :class:`~turbohtml.Article` is a NamedTuple with stubs, so ``text``, ``title``, ``byline``, ``date``,
+  ``description``, and ``lang`` are statically known; news-please returns a ``NewsArticle`` / dict.
+- No ensemble dependency tree. The scoring and harvesting run in C with no scrapy, newspaper, or readability install.
+
+What news-please has that turbohtml does not
+============================================
+
+- Crawling and scheduling. The scrapy spiders that discover and fetch article pages have no turbohtml equivalent; fetch
+  pages yourself (``urllib``, ``httpx``) and pass the markup to ``parse``.
+- WARC and Common Crawl ingestion (``from_warc`` and the Common Crawl tooling). No equivalent; read WARC records with a
+  library such as ``warcio`` and hand each record's HTML to ``parse``.
+- Storage pipelines (JSON files, PostgreSQL, Elasticsearch). No equivalent; write the ``Article`` fields to your own
+  sink.
+- An extractor ensemble that merges several votes per page. turbohtml runs a single scoring pass. news-please's merge
+  can recover fields a single extractor misses, at the cost of running multiple Python extractors.
+- Inferred publication dates. news-please's date extractor derives a ``datetime`` even when the page declares none;
+  ``article().date`` reports only the declared string. Keep a date-inference library for pages that declare no date.
+
+Performance
+===========
 
 Extracting from a full page -- navigation, a scored article, and a footer. :meth:`~turbohtml.Node.article` scores and
 harvests in one C pass; news-please runs several Python extractors and merges their votes. Numbers vary with input and
@@ -25,9 +91,17 @@ hardware.
 .. bench-table::
     :file: bench/news-please.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Drop the ``NewsPlease`` import for ``parse``, and fetch pages yourself where you previously called ``from_url``:
+
+.. code-block:: python
+
+    from turbohtml import parse
+
+Map the calls:
 
 .. list-table::
     :header-rows: 1
@@ -72,9 +146,9 @@ hardware.
 
     Comets | Ada Lovelace | 2024-05-06 | en
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - news-please is a crawler; turbohtml replaces only the per-page extraction. The spider configuration, WARC ingestion
   (``from_warc``, the Common Crawl tooling), and the storage pipelines have no turbohtml equivalent.

--- a/docs/migration/newspaper3k.rst
+++ b/docs/migration/newspaper3k.rst
@@ -4,18 +4,85 @@
 
 .. package-meta:: newspaper3k codelucas/newspaper
 
-`newspaper3k <https://newspaper.readthedocs.io>`_ is a news-article scraper: an ``Article`` downloads a URL, then
-``parse()`` fills ``article.text``, ``article.title``, ``article.authors``, ``article.publish_date`` and the rest from
-the page, with optional NLP on top.
+`newspaper3k <https://newspaper.readthedocs.io>`_ is a news-article scraper built on ``requests`` and ``lxml``. An
+``Article`` downloads a URL, then ``parse()`` fills ``article.text``, ``article.title``, ``article.authors``,
+``article.publish_date``, ``article.meta_description`` and the rest by scoring the ``lxml`` tree and running
+regex-driven metadata scans. On top of extraction it bundles fetching, per-source article discovery, multi-language
+stopword lists, and NLP (``nlp()`` for keywords and a summary). It is widely used for one-shot "give me the body of this
+news page" scripts and small crawlers.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the extraction half of that surface. :meth:`~turbohtml.Node.article` scores the parsed tree and
+harvests the same metadata in one C pass over a WHATWG-conformant DOM, returning a typed :class:`~turbohtml.Article`
+record. It does not fetch URLs and has no NLP; you bring the markup and turbohtml gives back the content and metadata.
 
-:meth:`~turbohtml.Node.article` returns the same shape in one C pass: an :class:`~turbohtml.Article` record with the
-scored ``element`` and its ``text``, plus the harvested ``title``, ``byline``, ``date``, ``description`` and ``lang``.
-turbohtml does not fetch URLs, so download the page yourself and parse the markup; the keyword and summary NLP newspaper
-bundles has no equivalent and is out of scope.
+**************************
+ turbohtml vs newspaper3k
+**************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - newspaper3k
+    - - Scope
+      - Parse plus content and metadata extraction from markup you supply
+      - Fetch, extract, source discovery, and NLP end to end
+    - - Feature breadth
+      - Content body, ``title``, ``byline``, ``date``, ``description``, ``lang``; plus a full CSS/XPath DOM
+      - The same fields (authors as a list) plus downloading, keywords, and summarization
+    - - Performance
+      - One C pass over the arena; see the table below
+      - Builds an ``lxml`` tree, then regex metadata scans
+    - - Typing
+      - Typed API, :class:`~turbohtml.Article` is a ``NamedTuple`` with shipped stubs
+      - Untyped; attributes are populated after ``parse()``
+    - - Dependencies
+      - Self-contained C extension, no Python runtime deps
+      - ``requests``, ``lxml``, ``beautifulsoup4``, ``feedparser``, ``nltk``, ``Pillow`` and more
+    - - Maintenance
+      - Actively maintained
+      - Original ``newspaper3k`` is unmaintained; a community ``newspaper4k`` fork continues it
+
+Feature overlap
+===============
+
+The extraction fields map 1:1 onto the :class:`~turbohtml.Article` record from :meth:`~turbohtml.Node.article`:
+
+- ``article.text`` -> ``doc.article().text`` (or the :meth:`~turbohtml.Node.main_text` shortcut)
+- ``article.title`` -> ``doc.article().title``
+- ``article.authors`` -> ``doc.article().byline`` (one string, not a list)
+- ``article.publish_date`` -> ``doc.article().date``
+- ``article.meta_description`` -> ``doc.article().description``
+- ``article.meta_lang`` -> ``doc.article().lang``
+- ``article.top_node`` -> ``doc.article().element`` (the scored element, or ``None``)
+
+What turbohtml adds
+===================
+
+- A WHATWG-conformant parser, so malformed markup produces the same tree a browser would rather than lxml's recovery.
+- CSS selector and XPath querying over the parsed tree, so you can pull fields newspaper does not expose without a
+  second library.
+- A typed surface: :class:`~turbohtml.Article` is a ``NamedTuple`` with shipped stubs, so field access is checked.
+- No third-party dependency chain to install or pin; the extraction is a single C extension.
+
+What newspaper3k has that turbohtml does not
+============================================
+
+- URL downloading and caching. turbohtml takes parsed HTML; fetch the page yourself with ``urllib`` or ``httpx`` and
+  pass the markup to :func:`turbohtml.parse`.
+- Source-level article discovery (``newspaper.build(url)``, category and feed detection). No equivalent; drive your own
+  crawl and call :meth:`~turbohtml.Node.article` per page.
+- NLP: ``article.keywords`` and ``article.summary`` via ``nlp()``. No equivalent and out of scope; run an NLP library on
+  ``article().text`` if you need it.
+- ``authors`` as a full list of names. ``article().byline`` keeps only the first author source as one string; split it
+  yourself if you need the individual names.
+- Top-image and image-set extraction (``article.top_image``, ``article.images``). No equivalent; query the scored
+  ``element`` for ``<img>`` yourself.
+
+Performance
+===========
 
 Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
 :meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; newspaper3k builds an lxml tree
@@ -24,16 +91,21 @@ and runs its own regex-driven metadata scan. Numbers vary with input and hardwar
 .. bench-table::
     :file: bench/newspaper3k.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the download-then-parse dance for a fetch you own plus one :func:`turbohtml.parse` call. newspaper's ``Article``
+combines both; turbohtml only does the parse and extract, so the network call is yours.
 
 .. list-table::
     :header-rows: 1
     :widths: 50 50
 
-    - - `newspaper3k <https://github.com/codelucas/newspaper>`__
+    - - newspaper3k
       - turbohtml
+    - - ``Article(url); a.download(); a.parse()``
+      - fetch yourself, then ``doc = parse(html)``
     - - ``article.text``
       - ``doc.article().text`` (or :meth:`~turbohtml.Node.main_text`)
     - - ``article.title``
@@ -66,14 +138,16 @@ and runs its own regex-driven metadata scan. Numbers vary with input and hardwar
 
     Comets | Ada Lovelace | A short guide to comets. | en
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - newspaper3k downloads and caches URLs; :meth:`~turbohtml.Node.article` takes parsed HTML. Fetch the page yourself
   (``urllib`` or ``httpx``) and pass the markup to :func:`turbohtml.parse`.
 - ``article().byline`` is a single whitespace-folded string from the first author source, where newspaper's
   ``article.authors`` is a list; split it yourself if you need the individual names.
-- newspaper's keyword extraction, summarization, and other NLP have no turbohtml equivalent and are out of scope.
+- ``article().date`` is the harvested string; newspaper's ``publish_date`` is a ``datetime``. Parse it yourself if you
+  need a date object.
 - A page with no scoring article leaves ``element`` ``None`` and ``text`` empty while still filling the metadata, so
   branch on ``art.element`` rather than assuming a body.
+- newspaper's keyword extraction, summarization, and other NLP have no turbohtml equivalent and are out of scope.

--- a/docs/migration/nh3.rst
+++ b/docs/migration/nh3.rst
@@ -4,37 +4,108 @@
 
 .. package-meta:: nh3 messense/nh3
 
-`nh3 <https://nh3.readthedocs.io>`_ is the Python binding for the Rust `ammonia
-<https://github.com/rust-ammonia/ammonia>`_ HTML sanitizer, a common bleach refugee target. It is an allowlist
-sanitizer, but it declined bleach feature parity: no escape-instead-of-strip mode, no attribute-rewriting callable, and
-no linkifier.
+`nh3 <https://nh3.readthedocs.io>`_ is the Python binding (via PyO3/maturin) for the Rust `ammonia
+<https://github.com/rust-ammonia/ammonia>`_ HTML sanitizer, and a common landing spot for projects leaving the
+unmaintained bleach. It is an allowlist sanitizer: you declare the tags, attributes, URL schemes, and CSS properties you
+trust, and everything else is stripped or dropped. It ships as a single self-contained wheel with no Python runtime
+dependencies, plus two helpers -- ``nh3.clean_text`` to escape plain text and ``nh3.is_html`` for a quick content
+heuristic.
 
-***************
- Why turbohtml
-***************
+nh3 stays narrowly a sanitizer. It has no linkifier, and, unlike bleach, no escape-instead-of-strip mode: a disallowed
+tag is removed rather than rendered as visible text. ``turbohtml.clean`` covers the same allowlist surface behind a
+frozen :class:`~turbohtml.clean.Policy`, adds that escape mode and a companion linkifier, and lives inside a full
+WHATWG-conformant parser, so the same tree can be parsed, queried, sanitized, and minified without leaving the library.
 
-``turbohtml.clean`` stays in the same performance tier as the Rust binding while restoring the features nh3 dropped: an
-escape mode, a value-rewriting ``attribute_filter``, and a companion linkifier, all fully type annotated behind a frozen
-:class:`~turbohtml.clean.Policy`. It also leads nh3 on the benchmark:
+******************
+ turbohtml vs nh3
+******************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - nh3
+    - - Scope
+      - Full WHATWG parser with a sanitize/linkify/minify/CSS-minify suite
+      - HTML sanitization only, plus ``clean_text``/``is_html`` helpers
+    - - Feature breadth
+      - Escape/strip/remove modes, ``Policy`` presets, linkifier, HTML and CSS minifiers
+      - Allowlist sanitize with ``attribute_filter``, style-property filter, attribute-prefix and value allowlists
+    - - Performance
+      - Native C, leads on the corpus below
+      - Native Rust (ammonia core), same tier
+    - - Typing
+      - Fully annotated Python API with ``.pyi`` stubs
+      - Typed via bundled stubs
+    - - Dependencies
+      - Single C extension, no Python runtime deps
+      - Single Rust extension, no Python runtime deps
+    - - Maintenance
+      - Active, part of a broader HTML toolkit
+      - Active binding over the mature ammonia crate
+
+Feature overlap
+===============
+
+The allowlist surface ports one-to-one; only the call shape changes.
+
+- Tag allowlist: ``tags=`` -> :class:`Policy.tags <turbohtml.clean.Policy>`.
+- Per-tag attributes (with ``"*"`` wildcards): ``attributes=`` -> :class:`Policy.attributes <turbohtml.clean.Policy>`.
+- Drop a tag and its whole subtree: ``clean_content_tags=`` -> :class:`Policy.remove_with_content
+  <turbohtml.clean.Policy>`.
+- Forced ``rel`` tokens on kept links: ``link_rel=`` -> :class:`Policy.add_link_rel <turbohtml.clean.Policy>`.
+- URL scheme allowlist: ``url_schemes=`` -> :class:`Policy.url_schemes <turbohtml.clean.Policy>`.
+- Comment stripping: ``strip_comments=`` -> :class:`Policy.strip_comments <turbohtml.clean.Policy>`.
+- Per-attribute callable ``(tag, attr, value) -> str | None`` that drops or rewrites a value: ``attribute_filter=`` ->
+  :class:`Policy.attribute_filter <turbohtml.clean.Policy>`.
+- Values forced onto every kept instance of a tag: ``set_tag_attribute_values=`` -> :class:`Policy.set_attributes
+  <turbohtml.clean.Policy>`.
+- Inline-style property allowlist: ``filter_style_properties=`` -> :class:`Policy.css_properties
+  <turbohtml.clean.Policy>`.
+
+What turbohtml adds
+===================
+
+- An escape mode. :class:`~turbohtml.clean.OnDisallowed` is ``ESCAPE`` by default, so a disallowed tag becomes visible
+  text (``<x>`` renders as ``&lt;x&gt;``) instead of vanishing; nh3 only strips. ``STRIP`` (drop tag, keep children) and
+  ``REMOVE`` (drop the subtree) select nh3-style behavior from one enum.
+- Ready-made presets: :meth:`Policy.strict() <turbohtml.clean.Policy.strict>`, :meth:`Policy.basic()
+  <turbohtml.clean.Policy.basic>`, and :meth:`Policy.relaxed() <turbohtml.clean.Policy.relaxed>`.
+- A ``allow_relative_urls`` toggle to accept or reject scheme-less URLs independently of the scheme allowlist.
+- A reusable compiled :class:`~turbohtml.clean.Sanitizer`: build it once from a frozen :class:`~turbohtml.clean.Policy`
+  and call it from any thread.
+- A companion linkifier, :func:`turbohtml.clean.linkify`, for auto-linking plain URLs; nh3 has none.
+- HTML and CSS minifiers (:func:`~turbohtml.clean.minify`, :func:`~turbohtml.clean.minify_css`) in the same module, over
+  the same parse tree.
+
+What nh3 has that turbohtml does not
+====================================
+
+- ``generic_attribute_prefixes`` -- allow attributes whose name starts with a given prefix (e.g. every ``data-*``).
+  turbohtml matches attribute names exactly or with a ``"*"`` wildcard per tag, with no prefix matching. Workaround:
+  allow ``"*"`` and reject unwanted names in an ``attribute_filter``, or enumerate the concrete names.
+- ``tag_attribute_values`` -- restrict an attribute to a specific set of literal values. turbohtml has no dedicated
+  field. Workaround: an ``attribute_filter`` that returns ``None`` for values outside the set.
+- ``nh3.is_html(text)`` -- a heuristic bool for whether a string contains HTML. No turbohtml equivalent.
+- ``nh3.clean_text(text)`` -- escape a string for safe insertion as text. Workaround: ``sanitize(text,
+  Policy.strict())`` escapes all markup to text.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/nh3.json
 
-*************
- The renames
-*************
+``turbohtml.clean`` stays in the same native tier as the Rust binding and leads it on the benchmark corpus above.
 
-.. code-block:: python
+****************
+ How to migrate
+****************
 
-    # nh3
-    import nh3
-
-    nh3.clean(text, tags={"a"}, attributes={"a": {"href"}})
-
-    # turbohtml
-    from turbohtml.clean import sanitize, Policy
-
-    sanitize(text, Policy(tags=frozenset({"a"}), attributes={"a": frozenset({"href"})}))
+Swap the import and wrap the keyword arguments in a :class:`~turbohtml.clean.Policy`. nh3's flat keyword call becomes a
+frozen config object plus :func:`~turbohtml.clean.sanitize`.
 
 .. list-table::
     :header-rows: 1
@@ -46,13 +117,57 @@ escape mode, a value-rewriting ``attribute_filter``, and a companion linkifier, 
       - :func:`turbohtml.clean.sanitize` with a :class:`~turbohtml.clean.Policy`
     - - ``tags=``, ``attributes=``
       - ``Policy.tags``, ``Policy.attributes``
+    - - ``clean_content_tags=``
+      - ``Policy.remove_with_content``
     - - ``link_rel=``
       - ``Policy.add_link_rel``
     - - ``url_schemes=``
       - ``Policy.url_schemes``
+    - - ``strip_comments=``
+      - ``Policy.strip_comments``
     - - ``attribute_filter=``
-      - ``Policy.attribute_filter`` (may rewrite a value, not only drop it)
+      - ``Policy.attribute_filter``
     - - ``set_tag_attribute_values=``
       - ``Policy.set_attributes``
+    - - ``filter_style_properties=``
+      - ``Policy.css_properties``
     - - (drops disallowed tags)
       - :class:`~turbohtml.clean.OnDisallowed` (``ESCAPE`` by default; ``STRIP`` / ``REMOVE`` for nh3-style dropping)
+
+.. code-block:: python
+
+    # nh3
+    import nh3
+
+    nh3.clean(text, tags={"a"}, attributes={"a": {"href"}})
+
+    # turbohtml
+    from turbohtml.clean import sanitize, Policy, OnDisallowed
+
+    sanitize(text, Policy(tags=frozenset({"a"}), attributes={"a": frozenset({"href"})}))
+
+    # match nh3's default of dropping (not escaping) disallowed tags
+    sanitize(
+        text,
+        Policy(
+            tags=frozenset({"a"}),
+            attributes={"a": frozenset({"href"})},
+            on_disallowed_tag=OnDisallowed.STRIP,
+        ),
+    )
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- Disallowed-tag default differs. nh3 strips a disallowed tag and keeps its children; turbohtml escapes it to visible
+  text by default. Set ``on_disallowed_tag=OnDisallowed.STRIP`` to reproduce nh3's behavior exactly.
+- Set-typed fields must be sets. ``tags``, ``url_schemes``, ``remove_with_content``, and ``css_properties`` expect a
+  ``set``/``frozenset``; passing another type raises :class:`TypeError`. nh3 accepts any iterable for the equivalent
+  arguments.
+- Attribute allowlisting is by exact name or a per-tag ``"*"`` wildcard. There is no prefix rule, so ``data-*`` style
+  families need ``"*"`` plus an ``attribute_filter`` rather than nh3's ``generic_attribute_prefixes``.
+- ``sanitize`` takes an HTML fragment and returns a fragment; it does not add ``<html>``/``<body>`` scaffolding,
+  matching nh3's fragment-in, fragment-out contract.
+- Reuse the compiled :class:`~turbohtml.clean.Sanitizer` when sanitizing many inputs with one policy; each bare
+  :func:`~turbohtml.clean.sanitize` call recompiles the policy.

--- a/docs/migration/opengraph.rst
+++ b/docs/migration/opengraph.rst
@@ -5,19 +5,139 @@
 .. package-meta:: opengraph-py3 erikriver/opengraph
 
 `opengraph <https://pypi.org/project/opengraph-py3/>`_ (the ``opengraph_py3`` Python 3 fork of erikriver's
-``opengraph``) reads a page's Open Graph card: ``OpenGraph(html=...)`` builds a BeautifulSoup tree, scans the head for
-``og:``-prefixed ``<meta>`` tags, and returns a ``dict`` subclass keyed by the property name minus its ``og:`` prefix,
-with ``is_valid()`` reporting whether the required tags are present. turbohtml serves that shape from
-:func:`turbohtml.extract.opengraph` over :meth:`turbohtml.Document.opengraph`.
+``opengraph``) reads a page's Open Graph card. ``OpenGraph(html=...)`` builds a BeautifulSoup tree over html5lib, scans
+the head for ``og:``-prefixed ``<meta>`` tags, and returns a ``dict`` subclass keyed by the property name minus its
+``og:`` prefix, with ``is_valid()`` reporting whether the required tags are present. ``OpenGraph(url=...)`` fetches the
+page first; a ``scrape=True`` mode falls back to the ``<title>`` and body ``<img>`` when the og tags are missing.
 
-***************
- Why turbohtml
-***************
+It is a small, single-purpose scraping helper for lifting share-card metadata off a page. turbohtml serves that same
+shape from :func:`turbohtml.extract.opengraph`, a string entry point over :meth:`turbohtml.Document.opengraph`: the
+``og:`` ``<meta>`` tags are gathered in one C walk of the already parsed WHATWG tree, and the result is a frozen, fully
+typed :class:`~turbohtml.extract.OpenGraph` mapping with the same prefix-stripped keys and the same ``is_valid`` check.
 
-:func:`turbohtml.extract.opengraph` returns an :class:`~turbohtml.extract.OpenGraph` mapping with the same
-prefix-stripped keys, so ``og["title"]`` reads the ``og:title`` tag, and the same
-:meth:`~turbohtml.extract.OpenGraph.is_valid` check. It is a read-only mapping, so ``in``, ``.get``, iteration, and
-equality against a plain ``dict`` all work, and it holds no reference back into the tree:
+************************
+ turbohtml vs opengraph
+************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - opengraph
+    - - Scope
+      - Full WHATWG parser; Open Graph extraction is one feature of many
+      - Single-purpose Open Graph card reader
+    - - Feature breadth
+      - ``og:`` mapping via :func:`~turbohtml.extract.opengraph`, plus ``twitter:`` tags and full structured data
+        (JSON-LD, Microdata) off the same tree
+      - ``og:`` tags only, with an optional ``scrape`` fallback to ``<title>`` and body ``<img>``
+    - - Performance
+      - One C walk of the parsed tree; 94-133x faster on a social card
+      - BeautifulSoup tree over html5lib, scanned in Python
+    - - Typing
+      - Frozen, fully typed read-only :class:`~turbohtml.extract.OpenGraph` mapping, ``py.typed``
+      - Plain ``dict`` subclass, no shipped type hints
+    - - Dependencies
+      - Zero runtime deps (self-contained C extension)
+      - BeautifulSoup and html5lib, plus an HTTP client for ``url=`` mode
+    - - Maintenance
+      - Actively developed single extension
+      - Small community fork, low cadence
+
+Feature overlap
+===============
+
+The shared surface you can port one-to-one:
+
+- ``OpenGraph(html=html)`` -> :func:`turbohtml.extract.opengraph`, one call returning the ``og:`` card.
+- ``og["title"]`` / ``og.get("title")`` -> the same prefix-stripped keys on :class:`~turbohtml.extract.OpenGraph`;
+  ``og:title`` reads as ``og["title"]``.
+- ``og.is_valid()`` -> :meth:`turbohtml.extract.OpenGraph.is_valid`, the four-property presence check.
+- ``"title" in og``, iteration, and equality against a plain ``dict`` all work, since
+  :class:`~turbohtml.extract.OpenGraph` is a full :class:`~collections.abc.Mapping`.
+
+What turbohtml adds
+===================
+
+- The ``twitter:`` card, which ``opengraph`` never reads: :meth:`turbohtml.Document.opengraph` returns the ``og:`` and
+  ``twitter:`` tags together (with prefixes kept) off the same walk.
+- Every other structured-data format on the same tree: :meth:`~turbohtml.Document.json_ld`,
+  :meth:`~turbohtml.Document.microdata`, and :meth:`~turbohtml.Document.structured_data` for the whole set at once.
+- A read-only mapping that holds no reference back into the tree, so it outlives the document it came from.
+- One C walk under the per-tree critical section, 94-133x faster than the BeautifulSoup scan.
+- Zero third-party runtime dependencies: no BeautifulSoup, no html5lib to install or pin.
+- Full type coverage: :class:`~turbohtml.extract.OpenGraph` is annotated and shipped with ``py.typed``.
+
+What opengraph has that turbohtml does not
+==========================================
+
+- **URL fetching** (``OpenGraph(url=...)``): no equivalent. turbohtml does not fetch; run your own HTTP client and pass
+  the response body to :func:`~turbohtml.extract.opengraph`.
+- **Scrape fallback** (``scrape=True``, which falls back to ``<title>`` and body ``<img>`` when the og tags are
+  missing): no equivalent. Select those elements yourself with :meth:`turbohtml.Node.find` when the card is incomplete.
+- **``to_json()`` / ``to_html()`` serializers**: no equivalent. Build them from ``dict(og)`` yourself with :mod:`json`
+  or your own markup.
+
+Performance
+===========
+
+Both libraries start from the raw HTML string, so each parses before it reads the tags: ``opengraph`` builds a
+BeautifulSoup tree over html5lib and scans the head in Python, where :func:`~turbohtml.extract.opengraph` parses to the
+WHATWG tree and gathers the ``og:`` tags in one C walk. On a social-card head, and on an 8 KiB article carrying that
+head, the walk runs 94 to 133 times faster:
+
+.. bench-table::
+    :file: bench/opengraph.json
+
+Across hand-built cards covering the protocol's basic, structured-image, and required-tag shapes, the two libraries
+return byte-identical mappings.
+
+****************
+ How to migrate
+****************
+
+Swap the import and the constructor for a single function call on the HTML you already have.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `opengraph <https://pypi.org/project/opengraph-py3/>`__
+      - turbohtml
+    - - ``OpenGraph(html=html)``
+      - :func:`turbohtml.extract.opengraph`
+    - - ``OpenGraph(url=url)``
+      - :func:`~turbohtml.extract.opengraph` on the HTML you fetch yourself
+    - - ``og["title"]`` / ``og.get("title")``
+      - the same keys on :class:`~turbohtml.extract.OpenGraph`
+    - - ``og.is_valid()``
+      - :meth:`turbohtml.extract.OpenGraph.is_valid`
+    - - ``og.to_json()`` / ``og.to_html()``
+      - build these from ``dict(og)`` yourself
+
+Before, with ``opengraph``, the constructor parses and the dict subclass carries the prefix-stripped keys:
+
+.. code-block:: python
+
+    from opengraph import OpenGraph
+
+    og = OpenGraph(
+        html="<head>"
+        '<meta property="og:title" content="The Rock">'
+        '<meta property="og:type" content="video.movie">'
+        '<meta property="og:image" content="https://x/rock.jpg">'
+        '<meta property="og:url" content="https://x/tt0117500/">'
+        '<meta name="twitter:card" content="summary">'
+        "</head>"
+    )
+    print(og["title"])
+    print(dict(og))
+    print(og.is_valid())
+
+After, :func:`~turbohtml.extract.opengraph` returns the same shape from one C walk, as a read-only mapping that keeps no
+reference into the tree:
 
 .. testcode::
 
@@ -42,40 +162,8 @@ equality against a plain ``dict`` all work, and it holds no reference back into 
     {'title': 'The Rock', 'type': 'video.movie', 'image': 'https://x/rock.jpg', 'url': 'https://x/tt0117500/'}
     True
 
-Both libraries start from the raw HTML string, so each parses before it reads the tags: ``opengraph`` builds a
-BeautifulSoup tree (over html5lib) and scans the head in Python, where :func:`~turbohtml.extract.opengraph` parses to
-the WHATWG tree and gathers the ``og:`` tags in one C walk. On a social-card head, and on an 8 KiB article carrying that
-head, the walk runs 94 to 133 times faster:
-
-.. bench-table::
-    :file: bench/opengraph.json
-
-Across hand-built cards covering the protocol's basic, structured-image, and required-tag shapes, the two libraries
-return byte-identical mappings.
-
-*************
- The renames
-*************
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    - - `opengraph <https://pypi.org/project/opengraph-py3/>`__
-      - turbohtml
-    - - ``OpenGraph(html=html)``
-      - :func:`turbohtml.extract.opengraph`
-    - - ``OpenGraph(url=url)``
-      - :func:`~turbohtml.extract.opengraph` on the HTML you fetch yourself
-    - - ``og["title"]`` / ``og.get("title")``
-      - the same keys on :class:`~turbohtml.extract.OpenGraph`
-    - - ``og.is_valid()``
-      - :meth:`turbohtml.extract.OpenGraph.is_valid`
-    - - ``og.to_json()`` / ``og.to_html()``
-      - build these from ``dict(og)`` yourself
-
 turbohtml does not fetch URLs; ``OpenGraph(url=...)`` becomes your HTTP client plus :func:`~turbohtml.extract.opengraph`
-on the response body:
+on the response body. A card missing a required property reads back fine but fails the validity check:
 
 .. testcode::
 
@@ -86,9 +174,9 @@ on the response body:
 
     Only a title False
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - Keys drop the ``og:`` prefix (``og["title"]``, not ``og["og:title"]``), matching ``opengraph`` and diverging from the
   prefixed keys :meth:`turbohtml.Document.opengraph` returns. Structured sub-properties keep their tail, so
@@ -99,6 +187,9 @@ on the response body:
 - :meth:`~turbohtml.extract.OpenGraph.is_valid` requires the `Open Graph protocol <https://ogp.me/>`_'s four basic
   properties (``og:title``, ``og:type``, ``og:image``, ``og:url``). The ``opengraph_py3`` fork additionally requires
   ``og:description``, so a card with the four but no description is valid here and invalid there.
-- ``OpenGraph`` scraping mode (``scrape=True``, which falls back to ``<title>`` and body ``<img>`` when og tags are
-  missing) has no equivalent; select those elements yourself with :meth:`~turbohtml.Node.find` when the card is
-  incomplete.
+- The mapping is read-only. ``opengraph`` returns a mutable ``dict`` subclass you can assign into;
+  :class:`~turbohtml.extract.OpenGraph` supports only the read surface, so copy into ``dict(og)`` first if you need to
+  edit.
+- turbohtml takes an already-decoded ``str`` and applies the WHATWG encoding rules; ``opengraph`` in ``url=`` mode
+  decodes the fetched bytes itself. Decode the response body to ``str`` before handing it over rather than passing raw
+  bytes.

--- a/docs/migration/pandas.rst
+++ b/docs/migration/pandas.rst
@@ -4,18 +4,121 @@
 
 .. package-meta:: pandas pandas-dev/pandas
 
-`pandas <https://pandas.pydata.org>`_ is how scrapers turn ``<table>`` markup into rows: ``pandas.read_html`` parses
-every table on a page into a list of ``DataFrame`` objects. Only that one helper overlaps with turbohtml; the rest of
-pandas -- the ``DataFrame`` itself, its dtypes, and its analytics -- stays outside turbohtml's scope. ``read_html``
-pulls NumPy and pandas into a project that may need neither just to read a grid of strings.
+`pandas <https://pandas.pydata.org>`_ is the standard Python library for tabular data analysis: labeled columns, typed
+arrays, group-by, joins, and file I/O across CSV, Parquet, SQL, and more. Web scrapers reach for exactly one corner of
+it, `read_html <https://pandas.pydata.org/docs/reference/api/pandas.read_html.html>`_, which parses every ``<table>`` on
+a page into a list of ``DataFrame`` objects, resolving ``rowspan``/``colspan`` and optionally inferring headers and
+dtypes. To do that it needs a third-party HTML backend (``lxml``, ``html5lib``, or ``bs4``) plus pandas and NumPy
+themselves.
 
-***************
- Why turbohtml
-***************
+turbohtml covers only that table-reading slice, and covers it without the dependency stack.
+:meth:`~turbohtml.Element.rows` and :meth:`~turbohtml.Element.records` walk the cell grid in C and hand back plain lists
+and dicts, so a scraper that only needs a grid of strings never imports NumPy. Everything else pandas does -- the
+``DataFrame``, its dtypes, and its analytics -- stays outside turbohtml's scope; when you do want a frame, the records
+are the exact shape ``pandas.DataFrame`` takes, so pandas stays an optional last step rather than a hard parse-time
+dependency.
 
-:meth:`~turbohtml.Element.rows` and :meth:`~turbohtml.Element.records` resolve ``rowspan`` and ``colspan`` in C and
-return plain lists and dicts, so the conversion carries no dependency. When you do want a frame, the records are the
-exact shape ``pandas.DataFrame`` takes, so hand them over yourself and keep pandas optional:
+*********************
+ turbohtml vs pandas
+*********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 18 41 41
+
+    - - Dimension
+      - turbohtml
+      - pandas
+    - - Scope
+      - WHATWG HTML parse plus a C cell-grid reader that returns lists and dicts
+      - Full tabular analytics library; ``read_html`` is one I/O helper over a pluggable HTML backend
+    - - Feature breadth
+      - ``rows``, ``records``, and ``tables`` returning strings; full parse, query, mutate, and serialize around them
+      - Header inference, dtype coercion, ``NaN`` padding, URL fetch, backend flavors, link extraction, then the whole
+        analytics API
+    - - Performance
+      - C cell-grid walk into plain containers; roughly 12 to 90 times faster than ``read_html`` on tables
+      - Builds a NumPy-backed ``DataFrame`` per table, paying a fixed per-frame cost that dominates small tables
+    - - Typing
+      - Ships ``py.typed``; ``rows``/``records``/``tables`` return precise ``list`` types
+      - Ships ``py.typed``; ``read_html`` is typed as ``list[DataFrame]``
+    - - Dependencies
+      - Zero runtime dependencies (self-contained C extension)
+      - pandas and NumPy, plus ``lxml``/``html5lib``/``bs4`` for the HTML backend
+    - - Maintenance
+      - Actively developed, single-engine
+      - Mature, very widely deployed, long release history
+
+Feature overlap
+===============
+
+The shared surface is table reading; these port one-to-one (see the mapping under `How to migrate`_):
+
+- Parsing table markup you already hold into a rectangular grid.
+- Resolving ``rowspan`` and ``colspan`` into a filled grid of cells.
+- Reading one table's body rows as a list of lists (:meth:`~turbohtml.Element.rows` for ``read_html(...)[0]``).
+- Reading a table as header-keyed dicts (:meth:`~turbohtml.Element.records` for ``read_html(...,
+  header=0)[0].to_dict("records")``).
+- Reading every table in a document in one call (:meth:`~turbohtml.Node.tables` for the ``list[DataFrame]`` that
+  ``read_html`` returns).
+
+What turbohtml adds
+===================
+
+- **No NumPy or pandas import.** :meth:`~turbohtml.Element.rows` and :meth:`~turbohtml.Element.records` return built-in
+  ``list``/``dict``, so reading a grid of strings pulls in nothing. pandas keeps ``DataFrame`` optional and last.
+- **A C engine.** Parsing and the span-resolving grid walk both run in C, so small tables avoid the per-frame overhead
+  that dominates ``read_html``.
+- **A full document model.** The same parse gives you ``find``/``select``/XPath, mutation, and WHATWG serialization, so
+  table extraction lives inside a real DOM rather than a one-shot ``io`` helper.
+- **One deterministic algorithm.** turbohtml always runs the WHATWG parser; there is no backend flavor to pick or
+  install, and no behavioral drift between ``lxml`` and ``html5lib`` modes.
+
+What pandas has that turbohtml does not
+=======================================
+
+- **Dtype inference.** ``read_html`` coerces cells to ``int``/``float``/``NaN`` (and honors ``dtype``, ``converters``,
+  ``thousands``, ``decimal``, ``parse_dates``). turbohtml cells are always ``str``. Workaround: pass
+  :meth:`~turbohtml.Element.records` to ``pandas.DataFrame`` and let it infer, or convert columns yourself.
+- **Header and index inference.** ``header=``, ``index_col=``, and multi-row headers reshape the frame. turbohtml treats
+  the first row (typically the ``thead`` row) as the header for :meth:`~turbohtml.Element.records` and offers no index
+  concept. Workaround: read :meth:`~turbohtml.Element.rows` and slice the header rows yourself.
+- **Sparse span handling.** ``read_html`` can leave a spanned cell as a single value with ``NaN`` padding depending on
+  options; turbohtml copies a spanned cell's text into every slot it covers. No option toggles this.
+- **URL and file I/O with backend flavors.** ``read_html`` accepts a URL, path, or file object and picks an
+  ``lxml``/``html5lib``/``bs4`` parser. turbohtml parses markup you already hold. Workaround: fetch with
+  :mod:`urllib.request` (or ``requests``) and pass the bytes to :func:`turbohtml.parse`.
+- **Table matching and filtering.** ``read_html`` filters tables by ``match=`` regex, ``attrs=``, and
+  ``extract_links=``. turbohtml has no such filter on :meth:`~turbohtml.Node.tables`. Workaround:
+  :meth:`~turbohtml.Node.find`/ :meth:`~turbohtml.Node.select` the ``<table>`` you want first, then call
+  :meth:`~turbohtml.Element.rows`.
+
+Performance
+===========
+
+Reading a table with :meth:`~turbohtml.Element.rows` and :meth:`~turbohtml.Element.records` against
+``pandas.read_html``, both parsing the markup and resolving spans into a rectangular grid. turbohtml's C cell-grid walk
+returns plain lists and dicts where ``read_html`` builds a ``DataFrame`` (importing NumPy), so it runs roughly twelve to
+ninety times faster: the gap is widest on small tables, where pandas pays a fixed per-frame cost, and narrows as the row
+count grows. See :doc:`/development/performance` for the methodology.
+
+.. bench-table::
+    :file: bench/pandas.json
+
+****************
+ How to migrate
+****************
+
+Swap the ``read_html`` call for a parse plus a grid method. There is no backend flavor to pass, and no NumPy to install;
+if you still want a ``DataFrame``, feed :meth:`~turbohtml.Element.records` to ``pandas.DataFrame`` as the last step:
+
+.. code-block:: python
+
+    # pandas
+    import pandas as pd
+
+    frame = pd.read_html(html, header=0)[0]
+    records = frame.to_dict("records")
 
 .. testcode::
 
@@ -32,18 +135,8 @@ exact shape ``pandas.DataFrame`` takes, so hand them over yourself and keep pand
 
     [{'name': 'pen', 'qty': '3'}]
 
-Reading a four-column table with :meth:`~turbohtml.Element.rows` and :meth:`~turbohtml.Element.records` against
-``pandas.read_html``, both parsing the markup and resolving spans into a rectangular grid. turbohtml's C cell-grid walk
-returns plain lists and dicts where ``read_html`` builds a ``DataFrame`` (importing NumPy), so it runs roughly twelve to
-ninety times faster: the gap is widest on small tables, where pandas pays a fixed per-frame cost, and narrows as the row
-count grows. See :doc:`/development/performance` for the methodology.
-
-.. bench-table::
-    :file: bench/pandas.json
-
-*************
- The renames
-*************
+API mapping
+===========
 
 .. list-table::
     :header-rows: 1
@@ -72,9 +165,9 @@ so a whole document reads back without locating each ``<table>`` first:
 
     [[['a']], [['b', 'c']]]
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - Cells are strings, always. turbohtml does not infer ``int``/``float``/``NaN`` dtypes the way pandas does; convert
   columns yourself, or let ``pandas.DataFrame`` do it after :meth:`~turbohtml.Element.records`.

--- a/docs/migration/parsel.rst
+++ b/docs/migration/parsel.rst
@@ -4,31 +4,109 @@
 
 .. package-meta:: parsel scrapy/parsel
 
-`parsel <https://parsel.readthedocs.io>`_ is `Scrapy <https://scrapy.org>`_'s extraction-oriented selector library: a
-:class:`~parsel.selector.Selector` query returns a :class:`~parsel.selector.SelectorList` and you pull *strings* out of
-it with :meth:`~parsel.selector.SelectorList.get` / :meth:`~parsel.selector.SelectorList.getall`, using the ``::text``
-and ``::attr(name)`` pseudo-elements to reach text and attribute values.
+`parsel <https://parsel.readthedocs.io>`_ is `Scrapy <https://scrapy.org>`_'s extraction-oriented selector library. A
+:class:`~parsel.selector.Selector` wraps a document and every query returns a :class:`~parsel.selector.SelectorList`;
+you pull *strings* out of it with :meth:`~parsel.selector.SelectorList.get` /
+:meth:`~parsel.selector.SelectorList.getall`, reaching text and attribute values through the non-standard ``::text`` and
+``::attr(name)`` pseudo-elements. It layers cssselect (CSS-to-XPath translation), lxml/libxml2 (parsing and evaluation),
+w3lib, and jmespath into one façade, so a single object exposes CSS, XPath, JMESPath over embedded JSON, and regex
+extraction. It is the workhorse behind Scrapy spiders and is widely used standalone for scraping and data extraction.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same extraction ground with a native, spec-compliant HTML5 parser: :meth:`~turbohtml.Node.select`,
+:meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.re`, and attribute access return typed :class:`~turbohtml.Node`
+objects, and the string-shaping helpers (``.text``, ``.html``, :meth:`~turbohtml.Element.attr`) are ordinary members
+rather than pseudo-element syntax.
 
-turbohtml returns typed :class:`~turbohtml.Node` objects from :meth:`~turbohtml.Node.select` and
-:meth:`~turbohtml.Node.xpath`, so the non-standard ``::text`` / ``::attr()`` pseudo-elements become ordinary
-:attr:`~turbohtml.Node.text` and :meth:`~turbohtml.Element.attr` access. It compiles a selector against the tree once
-and matches by comparing interned integer atoms, where parsel translates every ``.css()`` to XPath with cssselect and
-re-evaluates it on libxml2 per call, so a reused query -- and pulling the values out of every match, parsel's whole
-point -- runs tens to hundreds of times faster:
+*********************
+ turbohtml vs parsel
+*********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - parsel
+    - - Scope
+      - Spec-compliant HTML5 parser plus native CSS/XPath selection, regex extraction, mutation, and serialization
+      - Extraction-only façade over lxml, cssselect, w3lib, and jmespath; no tree-construction of its own
+    - - Feature breadth
+      - CSS Selectors Level 4, XPath, regex, JMESPath (via stdlib), markdown/text/minify/sanitize output, DOM mutation
+      - CSS (translated to XPath), XPath, regex, JMESPath over JSON, XML/RSS parsing mode with namespaces
+    - - Performance
+      - Compiles a selector once and matches by interned integer atoms; see the table below
+      - Re-translates each ``.css()`` to XPath and re-evaluates on libxml2 per call
+    - - Typing
+      - Fully typed, ships ``.pyi`` stubs; queries return typed :class:`~turbohtml.Node`
+      - Returns :class:`~parsel.selector.SelectorList` of strings; typed but string-centric
+    - - Dependencies
+      - Self-contained C extension, no runtime dependencies
+      - Requires lxml, cssselect, w3lib, and jmespath
+    - - Maintenance
+      - Actively developed
+      - Actively maintained under the Scrapy project
+
+Feature overlap
+===============
+
+These map 1:1 and port with a rename:
+
+- CSS selection: :meth:`~parsel.selector.Selector.css` becomes :meth:`~turbohtml.Node.select` /
+  :meth:`~turbohtml.Node.select_one`.
+- XPath: :meth:`~parsel.selector.Selector.xpath` becomes :meth:`~turbohtml.Node.xpath`,
+  :meth:`~turbohtml.Node.xpath_one`, or :meth:`~turbohtml.Node.xpath_iter`, including the ``namespaces=`` keyword.
+- Regex extraction: :meth:`~parsel.selector.Selector.re` / :meth:`~parsel.selector.Selector.re_first` become
+  :meth:`~turbohtml.Node.re` / :meth:`~turbohtml.Node.re_first`, and the ``attr`` keyword runs the pattern over an
+  attribute value instead of the text.
+- Attribute access: :attr:`~parsel.selector.Selector.attrib` becomes :attr:`~turbohtml.Element.attrs`, and
+  ``::attr(name)`` becomes :meth:`~turbohtml.Element.attr`.
+- Text extraction: ``::text`` becomes :attr:`~turbohtml.Node.text`.
+- The underlying element: :attr:`sel.root <parsel.selector.Selector.root>` (an lxml element) becomes the
+  :class:`~turbohtml.Node` itself.
+
+What turbohtml adds
+===================
+
+- A WHATWG-conformant HTML5 tree builder. parsel parses through libxml2's HTML parser, which does not follow the spec's
+  tree-construction algorithm; turbohtml matches browser parsing on malformed markup.
+- CSS Selectors Level 4 evaluated by a native engine, not translated to XPath and handed to libxml2.
+- Tree mutation on the same object: :meth:`~turbohtml.Node.prune`, :meth:`~turbohtml.Node.remove`,
+  :meth:`~turbohtml.Node.strip_tags`, :meth:`~turbohtml.Element.set_text`,
+  :meth:`~turbohtml.Element.insert_adjacent_html`.
+- Output conversions built in: :meth:`~turbohtml.Node.serialize`, :meth:`~turbohtml.Node.to_markdown`,
+  :meth:`~turbohtml.Node.to_text`.
+- :meth:`~turbohtml.Node.matches` and :meth:`~turbohtml.Node.closest` for testing and walking without a fresh query.
+- No third-party runtime dependencies to install or pin.
+
+What parsel has that turbohtml does not
+=======================================
+
+- JMESPath / JSON selectors (:meth:`~parsel.selector.Selector.jmespath`): no equivalent. Parse the JSON payload with
+  :mod:`json` and query it with the ``jmespath`` package yourself.
+- An XML parsing mode (``Selector(type="xml")``) for RSS/Atom and other XML feeds, with namespace registration: no
+  equivalent, since turbohtml is an HTML parser. turbohtml's :meth:`~turbohtml.Node.xpath` accepts a ``namespaces=``
+  keyword for HTML documents, but it does not parse standalone XML.
+- The ``::text`` / ``::attr()`` pseudo-elements themselves: not CSS-standard and not parsed by turbohtml. Read
+  :attr:`~turbohtml.Node.text` and :meth:`~turbohtml.Element.attr` off the selected node instead.
+
+Performance
+===========
+
+turbohtml compiles a selector against the tree once and matches by comparing interned integer atoms, where parsel
+translates every ``.css()`` to XPath with cssselect and re-evaluates it on libxml2 per call, so a reused query -- and
+pulling the values out of every match, parsel's whole point -- runs tens to hundreds of times faster:
 
 .. bench-table::
     :file: bench/parsel.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
-The string-extraction helpers :meth:`~turbohtml.Node.re` and :meth:`~turbohtml.Node.re_first` carry over directly,
-including their ``attr`` keyword for running a pattern over an attribute value instead of the text.
+Replace ``Selector(text=html)`` with :func:`turbohtml.parse`, then swap the string-extraction calls for typed-node
+access. The regex helpers :meth:`~turbohtml.Node.re` and :meth:`~turbohtml.Node.re_first` carry over directly, including
+their ``attr`` keyword.
 
 .. list-table::
     :header-rows: 1
@@ -74,9 +152,9 @@ including their ``attr`` keyword for running a pattern over an attribute value i
     ['home', 'about']
     x
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - parsel's ``::text`` and ``::attr()`` pseudo-elements are not CSS standard and turbohtml does not parse them; read
   :attr:`~turbohtml.Node.text` and :meth:`~turbohtml.Element.attr` off the selected node instead.
@@ -88,3 +166,8 @@ including their ``attr`` keyword for running a pattern over an attribute value i
   ``SelectorList``; map them across :meth:`~turbohtml.Node.select` to cover every match.
 - parsel's JSON/JMESPath selectors (:meth:`~parsel.selector.Selector.jmespath`) are not ported; run
   :mod:`json`/``jmespath`` over parsed JSON yourself.
+- parsel returns ``None`` (via ``.get(default=None)``) or an empty ``SelectorList`` for a miss; turbohtml's
+  :meth:`~turbohtml.Node.select_one` returns ``None`` and :meth:`~turbohtml.Node.select` returns an empty list, so guard
+  the ``None`` before reading ``.text`` or :meth:`~turbohtml.Element.attr`.
+- parsel drives libxml2's non-spec HTML parser, so tree shape on malformed markup can differ from turbohtml's
+  WHATWG-conformant construction; re-check selectors that relied on libxml2's tolerant fixups.

--- a/docs/migration/pyquery.rst
+++ b/docs/migration/pyquery.rst
@@ -6,24 +6,97 @@
 
 `pyquery <https://github.com/gawel/pyquery>`_ puts a jQuery-style fluent, chainable wrapper over `lxml
 <https://lxml.de>`_/`cssselect <https://github.com/scrapy/cssselect>`_, so you select and mutate a document with method
-chains.
+chains. A single ``PyQuery`` object holds a matched set of nodes; calling it with a CSS selector, chaining ``.filter``,
+``.find``, ``.eq``, or ``.closest``, and reading or writing attributes, text, HTML, and classes all return either a new
+wrapper or a scalar. It is a common pick for scraping and templating code that wants the DOM-manipulation feel of jQuery
+without a browser.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that ground with :class:`turbohtml.query.Query`, a fully type-annotated fluent wrapper whose selector,
+attribute, and class primitives run in the C extension over a native tree, so the same chaining idiom ports across with
+almost no rename and a large speed margin.
 
-turbohtml ships the same chaining idiom as :class:`turbohtml.query.Query`, fully type annotated, with the selector and
-attribute primitives running in C. The wrapper skips a redundant de-duplication when a chain starts from one node, and
-edits its native tree in C where pyquery drives lxml under its jQuery-style wrapper, so the whole surface -- chaining a
-select/filter/read, setting content, bulk-editing tags, and reading a value off every match -- runs several to a hundred
-times faster:
+**********************
+ turbohtml vs pyquery
+**********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - pyquery
+    - - Scope
+      - WHATWG HTML parser plus a jQuery-style ``Query`` wrapper over a native tree
+      - jQuery-style wrapper only; parsing and the tree come from lxml
+    - - Feature breadth
+      - CSS select/filter/traverse, attr/text/html/class ops, node-level mutation and XPath 1.0
+      - CSS and XPath on the wrapper itself, broad jQuery method set, a network-fetching constructor
+    - - Performance
+      - Selector and attribute primitives in C over a native tree; several to ~100x faster on the shared surface
+      - Python wrapper delegating to lxml/cssselect
+    - - Typing
+      - Fully type annotated with shipped stubs
+      - No bundled type hints
+    - - Dependencies
+      - Self-contained C extension, no Python runtime deps
+      - Depends on lxml and cssselect
+    - - Maintenance
+      - Actively developed alongside the parser
+      - Mature, lightly maintained wrapper
+
+Feature overlap
+===============
+
+The shared surface ports one-to-one from a matched set built by calling the wrapper with a selector:
+
+- Construction and selection: ``PyQuery(html)`` -> :class:`Query(parse(html)) <turbohtml.query.Query>`, then
+  ``query("div.foo")`` and ``query("a").find("span")``.
+- Set narrowing and traversal: :meth:`~turbohtml.query.Query.filter`, :meth:`~turbohtml.query.Query.eq`,
+  :meth:`~turbohtml.query.Query.closest`, :meth:`~turbohtml.query.Query.parent`,
+  :meth:`~turbohtml.query.Query.children`, :meth:`~turbohtml.query.Query.siblings` keep the same names.
+- Reads and attribute writes: :meth:`~turbohtml.query.Query.attr`, :meth:`~turbohtml.query.Query.text`,
+  :meth:`~turbohtml.query.Query.html` keep the same names.
+- Class ops: :meth:`~turbohtml.Element.add_class`, :meth:`~turbohtml.Element.remove_class`,
+  :meth:`~turbohtml.Element.toggle_class`, :meth:`~turbohtml.Element.has_class`, available on both
+  :class:`~turbohtml.query.Query` and :class:`~turbohtml.Element`.
+- Iteration: ``for item in pq("a").items()`` -> :meth:`for item in query("a").items() <turbohtml.query.Query.items>`.
+
+What turbohtml adds
+===================
+
+- A full WHATWG HTML parser in the same package, so parsing and querying share one native tree instead of delegating to
+  lxml.
+- C-resident selector and attribute primitives, giving the large speed margin measured below.
+- Shipped type stubs for the whole surface, including ``Query`` and the node API.
+- No third-party runtime dependencies: the tree, selectors, and mutation all live in one self-contained C extension.
+
+What pyquery has that turbohtml does not
+========================================
+
+- **A network-fetching constructor.** ``PyQuery(url=...)`` fetches over HTTP for you. turbohtml has no equivalent; fetch
+  with `httpx <https://www.python-httpx.org>`_ (or any client) and hand the bytes to :func:`turbohtml.parse`.
+- **XPath on the fluent wrapper.** pyquery exposes lxml's ``.xpath(...)`` directly on a matched set. turbohtml's
+  ``Query`` is CSS-only; drop to the node-level :meth:`~turbohtml.Node.xpath` (XPath 1.0) or the
+  :meth:`~turbohtml.Node.find` grammar via :meth:`Query.items <turbohtml.query.Query.items>`.
+- **``.wrap_all`` over a non-contiguous set.** pyquery wraps any matched set in one container. turbohtml's node API
+  covers the tree-clean shapes (see below) but has no counterpart for an arbitrary scattered set;
+  :meth:`~turbohtml.Element.append` the nodes into a new element and place it yourself.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/pyquery.json
 
-*************
- The renames
-*************
+The whole shared surface -- chaining a select/filter/read, setting content, bulk-editing tags, and reading a value off
+every match -- runs several to a hundred times faster because the wrapper edits its native tree in C and skips a
+redundant de-duplication when a chain starts from a single node, where pyquery drives lxml under its jQuery-style
+wrapper.
+
+****************
+ How to migrate
+****************
 
 Build a :class:`~turbohtml.query.Query` from a parsed document and call it with a selector; the method chains port
 almost name for name:
@@ -107,9 +180,9 @@ one verbatim text node; and :meth:`~turbohtml.Element.insert_adjacent_html` spli
     - - ``pq(el).append(markup)``
       - :meth:`el.insert_adjacent_html("beforeend", markup) <turbohtml.Element.insert_adjacent_html>`
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``.wrap_all`` over an **arbitrary, non-contiguous** set of nodes has no single node-method counterpart (the set has no
   shared anchor to place the wrapper at); wrap the contiguous run, or :meth:`~turbohtml.Element.append` the scattered
@@ -119,3 +192,6 @@ one verbatim text node; and :meth:`~turbohtml.Element.insert_adjacent_html` spli
 - pyquery exposes lxml's ``.xpath(...)`` on the fluent wrapper itself; turbohtml's ``Query`` is CSS-only, so an XPath
   chain drops to the node-level :meth:`~turbohtml.Node.xpath` (XPath 1.0) or the :meth:`~turbohtml.Node.find` grammar
   via :meth:`Query.items <turbohtml.query.Query.items>`.
+- turbohtml parses to the **WHATWG spec**, so a malformed document is fixed up exactly as a browser would (implied
+  ``<tbody>``, reparented ``<head>`` content); pyquery's tree follows lxml's HTML parser, which can differ on the same
+  broken input.

--- a/docs/migration/rcssmin.rst
+++ b/docs/migration/rcssmin.rst
@@ -4,23 +4,102 @@
 
 .. package-meta:: rcssmin ndparker/rcssmin
 
-`rcssmin <https://github.com/ndparker/rcssmin>`_ is the most-used CSS minifier on PyPI, a fast C extension that is
-deliberately *non-destructive*: it strips comments and collapses whitespace and rewrites nothing else, so ``#ffffff``
-and ``0px`` survive untouched. ``rcssmin.cssmin`` maps to :func:`turbohtml.clean.minify_css`, which goes further --
-every value-safe rewrite as well -- so the result is smaller while still parsing to the same cascade.
+`rcssmin <https://github.com/ndparker/rcssmin>`_ is the most-used CSS minifier on PyPI, a fast C extension (with a
+pure-Python fallback) that is deliberately *non-destructive*. Its whole surface is one function, ``rcssmin.cssmin(style,
+keep_bang_comments=False)``: it strips comments, collapses insignificant whitespace, and rewrites nothing else, so
+``#ffffff`` and ``0px`` survive untouched. That verbatim-value guarantee is the point -- build pipelines reach for
+rcssmin when they want the bytes smaller without any value being touched, and its speed comes from doing strictly less
+work. It has no runtime dependencies.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that ground with :func:`turbohtml.clean.minify_css`, a value-rewriting minifier implemented in C. It
+does everything rcssmin does -- comment stripping and whitespace collapsing -- and then applies every rewrite that is
+provably value-safe, so the result is smaller while still parsing to the same cascade.
 
-turbohtml rewrites each value to its shortest equivalent form -- colors to their shortest hex or name, redundant zeros
-and units dropped, constant ``calc()`` folded, longhands merged into shorthands, equal rules combined -- where rcssmin
-leaves values verbatim. turbohtml's output is smaller on every framework except the custom-property-heavy ``bulma.css``,
-where rcssmin ends 0.1% ahead only by rewriting whitespace inside custom-property values. That rewrite is not
-value-safe: `CSS Variables 1 §2 <https://www.w3.org/TR/css-variables-1/#defining-variables>`_ keeps a custom property's
-value as its literal token stream, ``var()`` splices it verbatim and ``getPropertyValue()`` reads it back byte-exact, so
-a collapsed space is observable wherever the value is substituted or compared. rcssmin's whitespace-only pass is faster
-because it does strictly less work. Each ratio is against turbohtml:
+**********************
+ turbohtml vs rcssmin
+**********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - rcssmin
+    - - Scope
+      - Value-safe CSS minifier (``minify_css``), plus inline ``style``-attribute minification
+      - Non-destructive whitespace/comment stripper (``cssmin``)
+    - - Feature breadth
+      - Whitespace/comment removal, color and number shortening, constant ``calc()`` folding, box-longhand-to-shorthand
+        merging, adjacent equal-body rule merging, optional Baseline-year shorthands
+      - Whitespace/comment removal only; values left verbatim
+    - - Performance
+      - Native C, linear time; smaller output on every framework in the corpus below
+      - Native C, linear time; faster because it rewrites nothing
+    - - Typing
+      - Typed public API (:func:`~turbohtml.clean.minify_css`, :class:`~turbohtml.clean.CSSMinify`)
+      - Untyped
+    - - Dependencies
+      - None (ships the C extension)
+      - None (C extension with pure-Python fallback)
+    - - Maintenance
+      - Actively developed alongside the turbohtml serializer
+      - Maintained, stable, deliberately fixed scope
+
+Feature overlap
+===============
+
+The comment-and-whitespace path ports 1:1:
+
+- Minify a full stylesheet: ``rcssmin.cssmin(css)`` maps to :func:`turbohtml.clean.minify_css(css)
+  <turbohtml.clean.minify_css>`.
+- Both strip comments and collapse insignificant whitespace between tokens.
+- Both keep ``/*! ... */`` bang comments (license or copyright banners). turbohtml always preserves them; rcssmin
+  preserves them when called with ``keep_bang_comments=True``.
+- Both are idempotent and round-trip safe: the output parses to the same cascade as the input, and minifying it again is
+  a no-op.
+
+What turbohtml adds
+===================
+
+rcssmin rewrites no values, so everything below is turbohtml-only:
+
+- Color shortening: ``#ffffff`` to ``#fff``, ``rgb(255,0,0)`` to ``red``. rcssmin leaves colors verbatim.
+- Number and unit shortening: redundant leading and trailing zeros dropped, units removed on zero lengths (``0px`` to
+  ``0``). rcssmin leaves them.
+- Constant ``calc()`` folding: ``calc(2px + 3px)`` becomes ``5px``. rcssmin leaves the expression intact.
+- Box-longhand-to-shorthand merging (``margin``, ``padding``, and friends) and merging of adjacent rules with equal
+  bodies. rcssmin does neither, so the size gap widens on framework CSS that leans on those forms.
+- Opt-in Baseline-year shorthands via :class:`~turbohtml.clean.CSSMinify`: ``CSSMinify(baseline=2021)`` additionally
+  merges ``inset``, the flex ``gap``, and two-value ``overflow`` once they reached Baseline.
+- Inline ``style``-attribute minification via :func:`~turbohtml.clean.minify_css_inline` for bare declaration lists.
+- A typed surface: :func:`~turbohtml.clean.minify_css` and the frozen :class:`~turbohtml.clean.CSSMinify` options
+  object.
+
+What rcssmin has that turbohtml does not
+========================================
+
+- Verbatim value preservation. rcssmin's non-destructive contract guarantees every value survives byte-for-byte
+  (``#ffffff`` stays ``#ffffff``). If a downstream step needs the original literals unchanged, that guarantee has no
+  turbohtml equivalent: turbohtml rewrites to the shortest value-safe form, so the cascade is identical but the bytes
+  are not.
+- Dropping bang comments. rcssmin's default ``keep_bang_comments=False`` removes ``/*! ... */`` banners; passing
+  ``True`` keeps them. turbohtml always keeps them, so there is no way to strip a banner through the minifier -- remove
+  it from the source before minifying.
+- Bytes input. ``rcssmin.cssmin`` accepts and returns ``bytes`` as well as ``str``. turbohtml's
+  :func:`~turbohtml.clean.minify_css` takes ``str``; decode first if your source is bytes.
+- Raw speed. rcssmin only strips whitespace, so on cold input it is faster; reach for it when a larger result is
+  acceptable and speed matters more than size.
+
+Performance
+===========
+
+turbohtml's output is smaller on every framework except the custom-property-heavy ``bulma.css``, where rcssmin ends 0.1%
+ahead only by rewriting whitespace inside custom-property values. That rewrite is not value-safe: `CSS Variables 1 §2
+<https://www.w3.org/TR/css-variables-1/#defining-variables>`_ keeps a custom property's value as its literal token
+stream, ``var()`` splices it verbatim and ``getPropertyValue()`` reads it back byte-exact, so a collapsed space is
+observable wherever the value is substituted or compared. rcssmin's whitespace-only pass is faster because it does
+strictly less work. Each ratio is against turbohtml:
 
 .. bench-table::
     :file: bench/rcssmin.json
@@ -29,7 +108,7 @@ Both round-trip safely -- the output parses to the same cascade -- and both are 
 faster than every *other* value-rewriting minifier, which are pure-Python and turn quadratic on a large stylesheet.
 
 ****************
- rcssmin.cssmin
+ How to migrate
 ****************
 
 The import and the call name are the only change:
@@ -41,6 +120,21 @@ The import and the call name are the only change:
 
     # turbohtml
     from turbohtml.clean import minify_css
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - rcssmin
+      - turbohtml
+    - - ``from rcssmin import cssmin``
+      - ``from turbohtml.clean import minify_css``
+    - - ``cssmin(css)``
+      - ``minify_css(css)``
+    - - ``cssmin(css, keep_bang_comments=True)``
+      - ``minify_css(css)`` (bang comments always kept)
+    - - ``cssmin(css)`` on a ``style`` attribute value
+      - ``minify_css_inline(css)``
 
 .. testcode::
 
@@ -65,11 +159,19 @@ For the value of an HTML ``style`` attribute -- a bare declaration list with no 
 
     color:red;margin:.5px
 
-Pitfalls
-========
+**********************
+ Gotchas and pitfalls
+**********************
 
-- turbohtml has no options: every transform it applies is value-safe, so there is nothing to turn off for correctness.
-  rcssmin's ``keep_bang_comments`` flag has no turbohtml equivalent because turbohtml always keeps ``/*! ... */``
-  license comments and always drops the rest.
-- rcssmin is faster, because it only strips whitespace. Reach for it when a larger result is acceptable and raw speed
-  matters more than size; reach for turbohtml when you want the smallest round-trip-safe output.
+- Output size shifts. rcssmin leaves values verbatim; turbohtml shortens colors and numbers, folds ``calc()``, and
+  merges shorthands and equal-bodied rules, so its output is smaller than rcssmin's rather than byte-identical. Pin
+  tests to turbohtml's output, not to a stored rcssmin string.
+- turbohtml takes no per-call flags. rcssmin's ``keep_bang_comments`` argument has no counterpart because turbohtml
+  always keeps ``/*! ... */`` license comments and always drops the rest; the only knob is the frozen
+  :class:`~turbohtml.clean.CSSMinify` ``baseline`` year, which bounds output syntax, never the cascade.
+- Inline declarations need the inline entry point. A bare ``color:red;margin:0`` from a ``style`` attribute has no
+  selector or braces; pass it to :func:`~turbohtml.clean.minify_css_inline`, not :func:`~turbohtml.clean.minify_css`.
+- Custom-property values differ. rcssmin collapses whitespace inside a ``--var`` value; turbohtml keeps it byte-exact.
+  Byte-comparing the two minifiers on custom-property-heavy CSS will show a difference by design.
+- Input type. ``rcssmin.cssmin`` accepts ``bytes``; :func:`~turbohtml.clean.minify_css` takes ``str``. Decode a bytes
+  source before passing it.

--- a/docs/migration/readabilipy.rst
+++ b/docs/migration/readabilipy.rst
@@ -4,19 +4,87 @@
 
 .. package-meta:: readabilipy alan-turing-institute/ReadabiliPy
 
-`readabilipy <https://readabilipy.readthedocs.io>`_ wraps Mozilla's Readability.js: with Node.js available,
-``simple_json_from_html_string(html, use_readability=True)`` shells out to the reference article extractor and returns a
-JSON record (``title``, ``byline``, ``date``, ``content``, ``plain_text``); without Node it falls back to a pure-Python
-cleaner that keeps the whole page.
+`readabilipy <https://readabilipy.readthedocs.io>`_ is the Alan Turing Institute's article-extraction wrapper. Its fast
+path shells out to Mozilla's Readability.js: with Node.js on the machine, ``simple_json_from_html_string(html,
+use_readability=True)`` runs the reference extractor and returns a JSON record with ``title``, ``byline``, ``date``,
+``content`` (the scored article HTML), ``plain_content``, and ``plain_text`` (the body as a list of text blocks).
+Without Node it falls back to a pure-Python cleaner that parses the page with html5lib into BeautifulSoup, strips
+scripts and styling, and returns the *whole* cleaned page rather than a scored article. It is used in research pipelines
+that harvest readable text from crawled news and web pages.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with :meth:`~turbohtml.Node.article`, which runs readability-style content scoring and
+metadata harvesting in one C pass over the parsed tree, in-process and with no Node.js runtime in the pipeline.
 
-:meth:`~turbohtml.Node.article` runs the readability-style content scoring in-process, in one C pass over the parsed
-tree, so you get the extraction Readability.js provides without a Node.js runtime in the pipeline. The
-:class:`~turbohtml.Article` record carries the same fields the JSON does (``text``, ``title``, ``byline``, ``date``,
-plus ``description`` and ``lang``), and the scored ``element`` replaces the ``content`` HTML.
+**************************
+ turbohtml vs readabilipy
+**************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - readabilipy
+    - - Scope
+      - HTML5 parser, serializer, sanitizer, and content extraction in one library
+      - Article extraction only; delegates parsing to Readability.js or html5lib/BeautifulSoup
+    - - Feature breadth
+      - Scored article plus ``title``, ``byline``, ``date``, ``description``, ``lang``, and the scored ``element``
+      - Readability path yields the full JSON record; Python fallback does not score content at all
+    - - Performance
+      - One in-process C pass; no subprocess
+      - Readability path forks a Node.js process per document; Python path parses with html5lib
+    - - Typing
+      - Typed API; :class:`~turbohtml.Article` is a ``NamedTuple``
+      - Returns untyped ``dict`` records
+    - - Dependencies
+      - Self-contained C extension, no runtime dependencies
+      - Needs Node.js + Readability.js for the fast path; html5lib, BeautifulSoup, regex for the fallback
+    - - Maintenance
+      - Actively developed alongside the parser
+      - Thin wrapper tracking upstream Readability.js
+
+Feature overlap
+===============
+
+The scored-extraction surface ports one to one:
+
+- ``simple_json_from_html_string(html, use_readability=True)`` maps to :meth:`~turbohtml.Node.article` on a parsed
+  document.
+- ``result["title"]`` -> ``article().title``.
+- ``result["byline"]`` -> ``article().byline``.
+- ``result["date"]`` -> ``article().date``.
+- ``result["plain_text"]`` (the list of body text blocks) -> ``article().text``, the scored body as layout-aware plain
+  text.
+- ``result["content"]`` / ``result["plain_content"]`` -> ``article().element``, whose :attr:`~turbohtml.Node.html` is
+  the markup.
+- ``simple_tree_from_html_string(html)`` -> :func:`turbohtml.parse`.
+
+What turbohtml adds
+===================
+
+- No Node.js runtime and no subprocess: scoring runs in-process in C, so extraction works the same whether or not Node
+  is installed.
+- Two extra metadata fields beside the JSON's set: ``article().description`` and ``article().lang``.
+- The scored ``element`` is a live :class:`~turbohtml.Node`, so you can walk, query, or re-serialize it rather than
+  receive a fixed HTML string. Pair it with :class:`~turbohtml.clean.Sanitizer` when you need the markup scrubbed.
+- A full HTML5 parser, serializer, and CSS-selector engine in the same library, so extraction is one call inside a
+  document you already have parsed.
+- :func:`turbohtml.extract.boilerplate` returns one classified :class:`~turbohtml.extract.Paragraph` per block unit, a
+  closer analog to the JSON's per-block ``plain_text`` list than an unclassified text chunk.
+
+What readabilipy has that turbohtml does not
+============================================
+
+- **Bit-for-bit Readability.js output.** readabilipy's fast path is Mozilla's reference extractor, so its scoring
+  matches Firefox Reader View exactly. turbohtml scores independently and can disagree on borderline pages. If you must
+  reproduce Readability.js decisions, keep readabilipy for that path; there is no exact-parity mode in turbohtml.
+- **The article as a JSON dict.** readabilipy returns a plain ``dict`` ready to serialize. turbohtml returns a typed
+  :class:`~turbohtml.Article`; build the dict yourself with ``art._asdict()`` (dropping or serializing ``element``).
+
+Performance
+===========
 
 Extracting from a full page -- navigation, a scored article, and a footer. :meth:`~turbohtml.Node.article` scores and
 harvests in one C pass; readabilipy's Python mode parses with html5lib into BeautifulSoup and cleans the whole page
@@ -26,9 +94,21 @@ hardware.
 .. bench-table::
     :file: bench/readabilipy.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the module-level call for a parse-then-extract pair:
+
+.. code-block:: python
+
+    # before
+    from readabilipy import simple_json_from_html_string
+
+    # after
+    from turbohtml import parse
+
+The API mapping:
 
 .. list-table::
     :header-rows: 1
@@ -70,9 +150,9 @@ hardware.
 
     Comets | Ada Lovelace | article
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - readabilipy's pure-Python mode does not score content: its ``plain_text`` is the whole cleaned page, navigation and
   footer included. Ports that never had Node.js gain the actual article extraction by switching to
@@ -81,5 +161,7 @@ hardware.
   ``<title>`` tag and its separator splitting, so the two disagree on pages whose heading and title differ.
 - ``article().date`` reports the value the page declares; readabilipy normalizes what it finds toward ISO form, so
   compare parsed dates, not strings.
+- When nothing scores as content, ``article().element`` is ``None`` and ``article().text`` is empty; guard on it before
+  reading :attr:`~turbohtml.Node.html`. readabilipy's Python fallback instead hands back the cleaned full page.
 - The JSON's per-block ``plain_text`` list has a closer cousin in :func:`turbohtml.extract.boilerplate`, which returns
   one classified :class:`~turbohtml.extract.Paragraph` per block unit instead of unclassified text chunks.

--- a/docs/migration/readability-lxml.rst
+++ b/docs/migration/readability-lxml.rst
@@ -4,18 +4,85 @@
 
 .. package-meta:: readability-lxml buriy/python-readability
 
-`readability-lxml <https://github.com/buriy/python-readability>`_ is a Python port of Arc90's Readability: a
-``Document`` wraps the HTML, ``summary()`` returns the cleaned article markup, and ``short_title()`` the page title. It
-is the content-density heuristic turbohtml's :meth:`~turbohtml.Node.main_content` implements directly.
+`readability-lxml <https://github.com/buriy/python-readability>`_ is a Python port of Arc90's Readability. A
+``Document`` wraps the page HTML; ``summary()`` returns the cleaned article markup, ``short_title()`` the page title,
+and ``title()`` the raw ``<title>``. It scores candidate elements by text density and link ratio, strips navigation,
+sidebars, and footers, and rewrites the surviving content into a fresh cleaned fragment. Construction takes tuning knobs
+(``min_text_length``, ``retry_length``, ``positive_keywords``, ``negative_keywords``, ``url``), and it runs on lxml and
+cssselect. It is the content-extraction step behind readers, scrapers, and pipelines that want just the article body off
+a full page.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that same ground with :meth:`~turbohtml.Node.article`, which runs the identical content-density
+heuristic in C and returns an :class:`~turbohtml.Article` record. It selects the live scoring element unchanged rather
+than rewriting the DOM into a cleaned fragment, and it harvests the page metadata beside the body: byline, date,
+description, and language that readability-lxml leaves to you. Because the extraction sits on a full WHATWG parse, the
+same page is also a DOM you can query and serialize.
 
-:meth:`~turbohtml.Node.article` scores the content body the same way and returns it as an :class:`~turbohtml.Article`
-record, adding the byline, date, description and language readability-lxml leaves to you. It selects an existing element
-unchanged rather than rewriting the DOM into a cleaned fragment, so pair it with :class:`~turbohtml.clean.Sanitizer`
-when you need a scrubbed body.
+*******************************
+ turbohtml vs readability-lxml
+*******************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - readability-lxml
+    - - Scope
+      - Full WHATWG HTML parser with DOM, query, serialize, and content extraction on top
+      - Article extraction only, over an lxml parse of the page
+    - - Feature breadth
+      - One C scoring model plus article metadata (title, byline, date, description, lang)
+      - Cleaned article body and title, with keyword and length tuning
+    - - Performance
+      - C scoring pass over the parsed tree, selects the live element (see below)
+      - Python scoring over an lxml tree, then rewrites a cleaned fragment
+    - - Typing
+      - Fully annotated, ships PEP 561 stubs
+      - Untyped pure-Python source
+    - - Dependencies
+      - Compiled C extension
+      - lxml and cssselect
+    - - Maintenance
+      - Actively developed
+      - Maintained community port of Arc90 Readability
+
+Feature overlap
+===============
+
+The shared surface ports one call to one call:
+
+- ``Document(html).summary()`` -> ``parse(html).article().element`` (its markup via :attr:`~turbohtml.Node.html`).
+- ``Document(html).short_title()`` -> ``parse(html).article().title``.
+- the article's plain text -> ``parse(html).article().text`` (or :meth:`~turbohtml.Node.main_text`).
+- the scoring element itself -> :meth:`~turbohtml.Node.main_content`, the dominant content body or ``None``.
+
+What turbohtml adds
+===================
+
+- :meth:`~turbohtml.Node.article` returns the page metadata beside the body in the same record: ``byline``, ``date``,
+  ``description``, and ``lang``. readability-lxml exposes only the title.
+- It selects the live element unchanged, so the scored body stays part of the DOM you can keep querying, mutating, and
+  serializing. readability-lxml hands back a rewritten HTML string detached from the source tree.
+- The extraction rides on a full WHATWG parse, so the same document is available as a queryable, serializable DOM, not
+  only as an extracted fragment.
+- :func:`turbohtml.parse` follows the WHATWG recovery rules and never raises on malformed markup.
+
+What readability-lxml has that turbohtml does not
+=================================================
+
+- A cleaned, rewritten output fragment. ``summary()`` returns scrubbed markup with boilerplate elements removed;
+  ``article().element`` is the unmodified scoring element from the live tree. For a scrubbed body, pair it with
+  :class:`turbohtml.clean.Sanitizer`.
+- Scoring knobs: ``positive_keywords`` and ``negative_keywords`` bias candidate scoring, and ``min_text_length`` /
+  ``retry_length`` tune the retry pass. turbohtml's article scoring is not exposed as per-call keyword weights (the
+  related :class:`turbohtml.extract.Extraction` thresholds tune :func:`~turbohtml.extract.boilerplate`, not
+  :meth:`~turbohtml.Node.article`).
+- Pure-Python install with no compiled extension, which can matter on platforms without a prebuilt turbohtml wheel.
+
+Performance
+===========
 
 Scoring the content body of a full page -- navigation, a scored article, and a footer. :meth:`~turbohtml.Node.article`
 runs the same content-density heuristic in C and selects the live element; readability-lxml builds an lxml tree and
@@ -24,9 +91,18 @@ rewrites it into a cleaned summary fragment. Numbers vary with input and hardwar
 .. bench-table::
     :file: bench/readability-lxml.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the ``Document`` import for :func:`turbohtml.parse`, and pull the body, title, and metadata off one
+:class:`~turbohtml.Article` record:
+
+.. code-block:: python
+
+    from turbohtml import parse
+
+The call mapping:
 
 .. list-table::
     :header-rows: 1
@@ -35,15 +111,21 @@ rewrites it into a cleaned summary fragment. Numbers vary with input and hardwar
     - - `readability-lxml <https://github.com/buriy/python-readability>`__
       - turbohtml
     - - ``Document(html).summary()``
-      - ``doc.article().element`` (:attr:`~turbohtml.Node.html` for its markup, or ``None``)
+      - ``parse(html).article().element`` (:attr:`~turbohtml.Node.html` for its markup, or ``None``)
     - - ``Document(html).short_title()``
-      - ``doc.article().title``
+      - ``parse(html).article().title``
     - - the article's plain text
-      - ``doc.article().text`` (or :meth:`~turbohtml.Node.main_text`)
+      - ``parse(html).article().text`` (or :meth:`~turbohtml.Node.main_text`)
+    - - the scoring element only
+      - :meth:`~turbohtml.Node.main_content`
     - - (no equivalent)
-      - ``doc.article().byline``, ``.date``, ``.description``, ``.lang``
+      - ``parse(html).article().byline``, ``.date``, ``.description``, ``.lang``
+
+Before and after, scoring the article off a full page:
 
 .. testcode::
+
+    from turbohtml import parse
 
     doc = parse(
         "<html lang=en><head><title>Comets</title></head>"
@@ -60,13 +142,16 @@ rewrites it into a cleaned summary fragment. Numbers vary with input and hardwar
 
     Comets | article
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
-- ``Document.summary()`` returns cleaned HTML; ``doc.article().element`` is the scored element from the live tree,
-  unchanged. Read :attr:`~turbohtml.Node.html` for its markup, or sanitize it first for a scrubbed fragment.
-- readability-lxml extracts only the body and title; the byline, date, description and language come for free in the
+- ``summary()`` returns cleaned HTML; ``article().element`` is the scored element from the live tree, unchanged. Read
+  :attr:`~turbohtml.Node.html` for its markup, or sanitize it first with :class:`turbohtml.clean.Sanitizer` for a
+  scrubbed fragment.
+- readability-lxml extracts only the body and title; the byline, date, description, and language come for free in the
   same :class:`~turbohtml.Article` record.
-- A page with no scoring article leaves ``element`` ``None`` and ``text`` empty while still filling the metadata, so
-  branch on ``art.element`` rather than assuming a body.
+- A page with no scoring article leaves ``element`` as ``None`` and ``text`` empty while still filling the metadata, so
+  branch on ``art.element`` rather than assuming a body. readability-lxml raises instead of returning a partial result.
+- readability-lxml's ``positive_keywords`` / ``negative_keywords`` reweight candidate scoring per call; turbohtml's
+  article scoring has no per-call keyword bias, so pages you tuned by keyword may score differently.

--- a/docs/migration/resiliparse.rst
+++ b/docs/migration/resiliparse.rst
@@ -4,27 +4,140 @@
 
 .. package-meta:: resiliparse chatnoir-eu/chatnoir-resiliparse
 
-`resiliparse <https://github.com/chatnoir-eu/chatnoir-resiliparse>`_ is the web-crawl processing toolkit from ChatNoir.
-Its ``HTMLTree`` wraps the same `lexbor <https://lexbor.com>`_ engine selectolax does, building a WHATWG tree with real
-text nodes, and it ships boilerplate extraction, language detection, and WARC utilities alongside the parser.
+`resiliparse <https://github.com/chatnoir-eu/chatnoir-resiliparse>`_ is the web-crawl processing toolkit from the Webis
+group behind ChatNoir. It is built for large-scale corpus work: ``HTMLTree`` wraps the same `lexbor
+<https://lexbor.com>`_ engine selectolax does and builds a WHATWG tree with real text nodes, and alongside the parser it
+ships boilerplate-aware plain-text extraction, encoding detection, fast language detection, and process/memory guards
+for hardening crawl workers. WARC reading lives in its companion package FastWARC. It shows up wherever people process
+Common Crawl-scale archives in Python and need a fast, resilient HTML-to-text stage.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the DOM and text-extraction ground with one library: it parses the same WHATWG tree in its own C
+engine, then keeps you inside a fully typed, mutable :class:`~turbohtml.Document` where resiliparse's DOM traversal,
+``get_element_by_*`` lookups, and CSS ``query_selector`` methods collapse into one ``find``/``find_all``/``select``
+grammar. It does not try to be a crawl toolkit; language detection, process guards, and WARC handling stay resiliparse's
+job.
 
-resiliparse wraps lexbor's native parser; turbohtml has its own C engine and matches resiliparse's parse throughput,
-while returning a fully type annotated, mutable :class:`~turbohtml.Document` and folding resiliparse's DOM traversal,
-``get_element_by_*`` lookups, and CSS ``query_selector`` methods into one ``find``/``find_all``/``select`` grammar.
-Parsing is a dead heat; on text extraction (``extract_plain_text`` against :meth:`~turbohtml.Node.to_text`, and its
-``main_content=True`` mode against :meth:`~turbohtml.Node.main_text`) turbohtml walks the WHATWG tree once in C where
-resiliparse renders off the lexbor tree in a second pass:
+**************************
+ turbohtml vs resiliparse
+**************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 16 42 42
+
+    - - Dimension
+      - turbohtml
+      - resiliparse
+    - - Scope
+      - Parse, query, mutate, serialize, and extract text in one library
+      - Web-crawl processing toolkit: HTML parse and text extraction plus encoding/language detection and crawl guards
+    - - Feature breadth
+      - CSS :meth:`~turbohtml.Node.select`, XPath 1.0 :meth:`~turbohtml.Node.xpath`, the
+        :meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.find_all` grammar, a full edit surface, Markdown/plain-text
+        renderers, sanitizer, linkifier, structured-data extraction
+      - CSS ``query_selector`` plus ``get_element_by_*`` DOM lookups, boilerplate-aware ``extract_plain_text``, encoding
+        detection, fast language detection, process/memory guards
+    - - Performance
+      - Own C engine straight into the native tree; text extraction walks the WHATWG tree once in C
+      - lexbor parse (a dead heat with turbohtml); ``extract_plain_text`` renders off the lexbor tree in a second pass
+    - - Typing
+      - Fully type annotated with bundled stubs
+      - Cython extension; limited Python-level type surface
+    - - Dependencies
+      - Self-contained C extension
+      - Cython extension over lexbor; WARC handling needs the companion FastWARC package
+    - - Maintenance
+      - Actively developed
+      - Actively developed by the Webis research group
+
+Feature overlap
+===============
+
+Both are native WHATWG parsers with real text nodes, so the parse call, DOM walk, and text extraction port directly:
+
+- ``HTMLTree.parse(html)`` maps to :func:`turbohtml.parse`.
+- ``tree.body``, ``tree.head``, ``tree.title`` map to :meth:`doc.find("body") <turbohtml.Node.find>`,
+  ``doc.find("head")``, and ``doc.find("title").text``.
+- ``node.query_selector(sel)`` / ``node.query_selector_all(sel)`` map to :meth:`~turbohtml.Node.select_one` /
+  :meth:`~turbohtml.Node.select`.
+- ``node.get_element_by_id("main")`` maps to :meth:`node.find(id="main") <turbohtml.Node.find>`; the
+  ``get_elements_by_tag_name``/``get_elements_by_class_name`` pair maps to :meth:`~turbohtml.Node.find_all`
+  (``find_all("a")``, ``find_all(class_="x")``).
+- The ``getattr``/``hasattr``/``setattr``/``delattr`` attribute methods map onto the :attr:`~turbohtml.Element.attrs`
+  mapping (``attrs.get``, ``"href" in attrs``, ``attrs[...] = ...``, ``del attrs[...]``).
+- ``node.tag``, ``node.text``, ``node.html`` map to :attr:`~turbohtml.Element.tag`, :attr:`~turbohtml.Node.text`,
+  :attr:`~turbohtml.Node.html`; ``node.class_list`` maps to ``attrs["class"]``.
+- ``node.create_element``/``append_child``/``decompose`` map to :class:`~turbohtml.Element`,
+  :meth:`~turbohtml.Element.append`, :meth:`~turbohtml.Node.decompose`.
+- ``extract_plain_text(html)`` maps to :meth:`~turbohtml.Node.to_text` for laid-out text (or
+  :attr:`~turbohtml.Node.text` for the raw concatenation); ``extract_plain_text(html, main_content=True)`` maps to
+  :meth:`~turbohtml.Node.main_text`, and the boilerplate-stripped main node to :meth:`~turbohtml.Node.main_content`.
+
+What turbohtml adds
+===================
+
+- XPath 1.0 querying via :meth:`~turbohtml.Node.xpath`, which resiliparse has no equivalent for.
+- The :meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.find_all` filter grammar layered over CSS, so tag, id, class,
+  and attribute predicates compose in one call instead of chaining ``get_element_by_*`` methods.
+- Serialization and rendering in the same library: the :attr:`~turbohtml.Node.html` property,
+  :meth:`~turbohtml.Node.encode`, and the
+  :class:`~turbohtml.Markdown`/:class:`~turbohtml.PlainText`/:class:`~turbohtml.Html` renderers, including
+  :meth:`~turbohtml.Node.to_markdown`.
+- HTML sanitization against an allowlist (:func:`turbohtml.clean.sanitize` with a :class:`~turbohtml.clean.Policy`).
+- Link handling: :attr:`~turbohtml.Node.links`, :meth:`~turbohtml.Node.rewrite_links`,
+  :meth:`~turbohtml.Node.resolve_links`, and the :class:`~turbohtml.clean.Linkify` pass.
+- Structured-data extraction: :attr:`~turbohtml.Document.json_ld`, :attr:`~turbohtml.Document.opengraph`,
+  :attr:`~turbohtml.Document.microdata`.
+- Full static typing across the tree with bundled stubs.
+
+What resiliparse has that turbohtml does not
+============================================
+
+- **Fast language detection.** ``resiliparse.parse.lang`` (e.g. ``detect_fast``) classifies a document's language from
+  its text. turbohtml has no equivalent; reach for a dedicated language-ID library.
+- **Process and memory guards.** ``resiliparse.process_guard`` provides time and memory guards that kill a worker whose
+  parse or extraction runs away, which matters when processing adversarial crawl data at scale. turbohtml ships no such
+  guard; wrap calls in your own resource limits.
+- **WARC/archive processing.** resiliparse's ecosystem reads WARC records through the companion FastWARC package.
+  turbohtml is a tree library and has no archive support; keep FastWARC for the ingestion stage.
+- **Standalone MIME/encoding utilities.** ``resiliparse.parse.encoding`` exposes byte-to-str conversion and encoding
+  detection as free functions over raw bytes. turbohtml detects the encoding during :func:`~turbohtml.parse`
+  (``detect_encoding=True``) rather than as a standalone codec-inspection API.
+
+Performance
+===========
+
+Parsing is a dead heat: resiliparse runs lexbor and turbohtml runs its own C engine straight into the native tree. On
+text extraction (``extract_plain_text`` against :meth:`~turbohtml.Node.to_text`, and its ``main_content=True`` mode
+against :meth:`~turbohtml.Node.main_text`) turbohtml walks the WHATWG tree once in C where resiliparse renders off the
+lexbor tree in a second pass:
 
 .. bench-table::
     :file: bench/resiliparse.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap ``HTMLTree.parse`` for :func:`turbohtml.parse` and the ``resiliparse.extract`` import for the text methods on the
+returned node:
+
+.. code-block:: python
+
+    # resiliparse
+    from resiliparse.parse.html import HTMLTree
+    from resiliparse.extract.html2text import extract_plain_text
+
+    tree = HTMLTree.parse("<div id=main><p class=x>Hi <a href='/u'>link</a></p></div>")
+    href = tree.body.query_selector("#main a").getattr("href")
+    text = extract_plain_text(tree.document.html)
+
+    # turbohtml
+    from turbohtml import parse
+
+    doc = parse("<div id=main><p class=x>Hi <a href='/u'>link</a></p></div>")
+    href = doc.select_one("#main a").attrs["href"]
+    text = doc.to_text()
 
 .. list-table::
     :header-rows: 1
@@ -48,7 +161,7 @@ resiliparse renders off the lexbor tree in a second pass:
       - :attr:`~turbohtml.Element.tag`, :attr:`~turbohtml.Node.text`, :attr:`~turbohtml.Node.html`, ``attrs["class"]``
     - - ``node.parent``, ``node.next_element``, ``node.prev_element``, ``node.first_element_child``
       - :attr:`~turbohtml.Node.parent`, :attr:`~turbohtml.Node.next_sibling`, :attr:`~turbohtml.Node.previous_sibling`,
-        ``first_child``
+        ``node.children[0]``
     - - ``tree.create_element("div")``, ``node.append_child(...)``, ``node.decompose()``
       - :class:`~turbohtml.Element`, :meth:`~turbohtml.Element.append`, :meth:`~turbohtml.Node.decompose`
     - - ``extract_plain_text(html)`` (from ``resiliparse.extract``)
@@ -69,13 +182,20 @@ resiliparse renders off the lexbor tree in a second pass:
     /u
     Hi link
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
-- resiliparse's main-content extraction maps to :meth:`~turbohtml.Node.main_content` and
-  :meth:`~turbohtml.Node.main_text`, a content-density (readability) heuristic over the parsed tree. Its language
-  detection and the WARC/archive and crawl utilities it ships have no turbohtml equivalent and are out of scope; reach
-  for a dedicated tool there.
-- turbohtml compares nodes by identity over the underlying arena node, so two wrappers for the same element are equal
-  but two separately parsed trees with identical markup are not; compare serializations or walk the tree instead.
+- **Sibling traversal spans text nodes.** resiliparse's ``next_element``/``prev_element``/``first_element_child`` skip
+  to the next element; :attr:`~turbohtml.Node.next_sibling`/:attr:`~turbohtml.Node.previous_sibling` and
+  ``node.children`` are node-level and include :class:`~turbohtml.Text` nodes. Filter for elements, or use
+  :meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.select` when you want elements only.
+- **Main-content extraction is a heuristic.** :meth:`~turbohtml.Node.main_content` and :meth:`~turbohtml.Node.main_text`
+  run a content-density (readability) pass over the parsed tree. It approximates resiliparse's boilerplate removal but
+  will not match it token for token.
+- **Node identity, not markup identity.** turbohtml compares nodes by identity over the underlying arena node, so two
+  wrappers for the same element are equal, but two separately parsed trees with identical markup are not. Compare
+  serializations or walk the tree instead.
+- **The crawl toolkit stays behind.** Dropping resiliparse also drops its language detection, process guards, and the
+  FastWARC ingestion path. If a pipeline depends on those, keep resiliparse for that stage and hand turbohtml the HTML
+  string.

--- a/docs/migration/rjsmin.rst
+++ b/docs/migration/rjsmin.rst
@@ -6,19 +6,129 @@
     :alt: rjsmin monthly downloads
     :target: https://pepy.tech/project/rjsmin
 
-`rjsmin <https://github.com/ndparker/rjsmin>`_ minifies JavaScript with a single regular-expression substitution: it
-strips comments and insignificant whitespace and nothing else. That makes it very fast, but it never renames a variable
-or folds a constant, so its output stays close to the source size.
+`rjsmin <https://github.com/ndparker/rjsmin>`_ minifies JavaScript with a single regular-expression substitution: one
+pass strips comments and insignificant whitespace and nothing else. It ships a compiled ``_rjsmin`` speedup with a
+pure-Python fallback, so the regex runs fast even on large files, and it is a common build-step dependency where the
+only goal is to drop bytes the tokenizer proves are optional. Because a regex never renames a binding or folds a
+constant, the output stays close to the source size. Its whole surface is one function, ``jsmin(script,
+keep_bang_comments=False) -> str``, where ``keep_bang_comments`` preserves ``/*! ... */`` license blocks.
 
-***************
- Why turbohtml
-***************
+:func:`~turbohtml.minify_js` covers the same ground with a real front end: it lexes and parses to an arena AST in C,
+renames function-local bindings, folds constants, and prints the result. It always does at least what rjsmin does (strip
+whitespace and comments) and, with its optional passes on, shrinks well past what a whitespace-only substitution can
+reach. The HTML-embedded case rjsmin leaves to you — it only ever sees a script string you extract — is built in: pass a
+:class:`~turbohtml.JSMinify` as :class:`~turbohtml.Minify`'s ``minify_js`` and inline ``<script>`` content is minified
+during serialization.
 
-:func:`~turbohtml.minify_js` is a one-call replacement that does strictly more. It is a real front end — lex, parse,
-optimize, print — so on top of whitespace it renames function-local bindings and folds constants, and because it parses
-it can never mis-handle a regex-versus-division ``/`` the way a regex pass can. The HTML-embedded case rjsmin leaves to
-you (it only sees the script string) is built in: pass a :class:`~turbohtml.JSMinify` as :class:`~turbohtml.Minify`'s
-``minify_js`` and inline ``<script>`` content is minified during serialization.
+*********************
+ turbohtml vs rjsmin
+*********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - rjsmin
+    - - Scope
+      - Full HTML parser plus a standalone JS minifier and inline ``<script>`` minification
+      - JavaScript-only, whitespace and comment removal by one regex substitution
+    - - Feature breadth
+      - Whitespace, comment and number-literal folding always on; optional local-binding renaming and constant folding
+        with dead-code elimination
+      - Whitespace and comment removal only; no renaming, no folding; ``keep_bang_comments`` to retain ``/*! ... */``
+    - - Performance
+      - Parse-and-optimize front end in C; single-digit milliseconds on the library ladder
+      - One regex pass with a C speedup; a fraction of a millisecond, faster than a parse but shrinks far less
+    - - Typing
+      - Typed API with bundled stubs; ``JSMinify`` is a frozen dataclass
+      - Untyped ``jsmin(script, keep_bang_comments=False) -> str``
+    - - Dependencies
+      - Self-contained C extension
+      - Pure Python with an optional compiled ``_rjsmin`` speedup, no third-party dependencies
+    - - Maintenance
+      - Actively developed
+      - Stable and maintained, infrequent releases
+
+Feature overlap
+===============
+
+The shared surface ports 1:1 — a single call that takes a JavaScript string and returns a smaller one:
+
+- ``rjsmin.jsmin(source)`` maps directly to :func:`turbohtml.minify_js(source) <turbohtml.minify_js>`.
+- Whitespace and comment stripping is unconditional in both, so turbohtml is a drop-in for the plain call.
+- Neither tool needs a browser, DOM, or Node runtime; both operate on the string in-process.
+
+What turbohtml adds
+===================
+
+- **Local-binding renaming.** ``JSMinify(mangle=True)`` (the default) renames bindings local to a function to short
+  names, the bulk of the size win. rjsmin's regex never renames anything.
+- **Constant folding and dead-code elimination.** ``JSMinify(fold=True)`` (the default) evaluates constant expressions
+  and drops unreachable code. rjsmin does neither.
+- **Number-literal minification.** turbohtml rewrites numeric literals to their shortest form unconditionally; rjsmin
+  leaves them as written.
+- **A real parse, not a regex.** Because turbohtml tokenizes against ECMA-262 it distinguishes a regex literal from a
+  division operator by grammar rather than by regex heuristics, so no crafted ``/`` sequence can be misread.
+- **Inline ``<script>`` minification.** Pass a :class:`~turbohtml.JSMinify` as :class:`~turbohtml.Minify`'s
+  ``minify_js`` and ``<script>`` bodies are minified during HTML serialization. Only scripts whose ``type`` marks them
+  as JavaScript are rewritten; a ``type="application/json"`` or ``importmap`` payload is left byte-for-byte. rjsmin only
+  ever sees a bare script string you extract yourself.
+- **Typed surface.** A bundled stub and the frozen ``JSMinify`` dataclass give static checkers full signatures.
+
+What rjsmin has that turbohtml does not
+=======================================
+
+- **Preserving bang comments.** ``rjsmin.jsmin(source, keep_bang_comments=True)`` keeps ``/*! ... */`` blocks, the
+  convention for retaining a license header through minification. turbohtml strips every comment and has no equivalent
+  flag; if a required license notice must survive, prepend it to the minified output yourself or keep it in a separate
+  file the build concatenates.
+- **A cheaper whitespace-only pass.** rjsmin's single regex substitution is faster than a full parse and is the lighter
+  tool when the only requirement is stripping space as cheaply as possible. turbohtml parses, so it spends more time to
+  produce a smaller result.
+- **Guaranteed pass-through of any input.** rjsmin's regex emits *something* for every input. turbohtml parses, so a
+  construct its parser does not handle raises :class:`ValueError` for the standalone call. For the inline ``<script>``
+  path there is an equivalent to rjsmin's leniency: a script the parser cannot handle is emitted verbatim, so one bad
+  ``<script>`` never breaks the document. For the standalone call, wrap it in ``try/except ValueError`` and fall back to
+  the original source if you need the same never-fail behavior.
+- **Pure-Python-only install.** rjsmin runs from its pure-Python fallback with no compiled extension at all. turbohtml
+  ships a C extension; if a build must avoid compiled code entirely, rjsmin still fits where turbohtml cannot.
+
+Performance
+===========
+
+The trade is deliberate: rjsmin's regex is faster than a parse, but it shrinks far less. On the library ladder (``python
+-m bench minify-js``) turbohtml takes single-digit milliseconds where rjsmin takes a fraction of one, and in return its
+output is up to half the size: jQuery 3.7 minifies to 31% of source under turbohtml versus 51% under rjsmin, lodash 4.17
+to 13% versus 28%, because turbohtml renames and folds rather than only deleting space. Each ratio is against turbohtml:
+
+.. bench-table::
+    :file: bench/rjsmin.json
+
+When the cost that matters is bytes shipped rather than minify time, turbohtml wins; when you only need whitespace
+stripped as cheaply as possible, rjsmin is still the lighter tool.
+
+****************
+ How to migrate
+****************
+
+Swap the import and the call. rjsmin exposes one function; turbohtml exposes the same shape plus an options object.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - rjsmin
+      - turbohtml
+    - - ``import rjsmin``
+      - ``import turbohtml``
+    - - ``rjsmin.jsmin(source)``
+      - ``turbohtml.minify_js(source)``
+    - - ``rjsmin.jsmin(source)`` (whitespace/comments only)
+      - ``turbohtml.minify_js(source, JSMinify(mangle=False, fold=False))`` for the closest whitespace-only match
+    - - ``rjsmin.jsmin(source, keep_bang_comments=True)``
+      - no equivalent; turbohtml strips all comments (prepend the header to the output yourself)
 
 .. code-block:: python
 
@@ -32,13 +142,34 @@ you (it only sees the script string) is built in: pass a :class:`~turbohtml.JSMi
 
     turbohtml.minify_js(source)  # whitespace + rename locals + fold constants
 
-The trade is deliberate: rjsmin's regex is faster than a parse, but it shrinks far less. On the library ladder (``python
--m bench minify-js``) turbohtml takes single-digit milliseconds where rjsmin takes a fraction of one, and in return its
-output is up to half the size: jQuery 3.7 minifies to 31% of source under turbohtml versus 51% under rjsmin, lodash 4.17
-to 13% versus 28%, because turbohtml renames and folds rather than only deleting space. Each ratio is against turbohtml:
+To minify inline ``<script>`` content — which rjsmin leaves entirely to you — pass a :class:`~turbohtml.JSMinify` to the
+HTML serializer instead of extracting the script by hand:
 
-.. bench-table::
-    :file: bench/rjsmin.json
+.. code-block:: python
 
-When the cost that matters is bytes shipped rather than minify time, turbohtml wins; when you only need whitespace
-stripped as cheaply as possible, rjsmin is still the lighter tool.
+    import turbohtml
+    from turbohtml import Html, Minify, JSMinify
+
+    doc = turbohtml.parse("<p>hi<script>function plus(a, b) { return a + b; }</script>")
+    doc.serialize(Html(layout=Minify(minify_js=JSMinify())))
+
+**********************
+ Gotchas and pitfalls
+**********************
+
+- **Renaming is on by default.** ``turbohtml.minify_js(source)`` renames local bindings, which rjsmin never does. If a
+  consumer reflects on function-local variable names (rare), pass ``JSMinify(mangle=False)``. Top-level names are global
+  and are never renamed regardless of the setting.
+- **All comments are stripped.** turbohtml removes every comment unconditionally; there is no ``keep_bang_comments``
+  counterpart, so a ``/*! license */`` header that rjsmin would keep is dropped. Re-attach any required notice to the
+  minified output yourself.
+- **Unparsable input raises instead of passing through.** rjsmin emits something for any string; the standalone
+  :func:`~turbohtml.minify_js` raises :class:`ValueError` on a construct its parser does not handle. Catch it and fall
+  back to the source if you relied on rjsmin's never-fail behavior. The inline ``<script>`` path does not raise — it
+  emits the offending script verbatim.
+- **Number literals change form.** turbohtml rewrites numeric literals to their shortest equivalent; rjsmin leaves them
+  verbatim. The value is preserved, but a byte-for-byte diff against rjsmin output will differ here even with the
+  optional passes off.
+- **Script ``type`` gates the inline path.** Only scripts marked as JavaScript are rewritten during HTML serialization;
+  ``application/json`` and ``importmap`` payloads are left untouched. rjsmin has no such awareness because it never sees
+  the surrounding document.

--- a/docs/migration/selectolax.rst
+++ b/docs/migration/selectolax.rst
@@ -4,28 +4,112 @@
 
 .. package-meta:: selectolax rushter/selectolax
 
-`selectolax <https://github.com/rushter/selectolax>`_ is a fast CSS-only HTML parser that wraps the `lexbor
-<https://lexbor.com>`_ engine. It searches with CSS selectors and exposes ``text()`` as a method, with limited tree
-mutation.
+`selectolax <https://github.com/rushter/selectolax>`_ is a fast HTML parser that wraps a C engine and exposes CSS
+selection. It ships two backends: ``HTMLParser`` over Modest and ``LexborHTMLParser`` over `lexbor
+<https://lexbor.com>`_. You query with CSS selectors (``css`` / ``css_first``), read text through the ``text()``
+*method*, reach attributes via ``node.attributes``, and mutate the tree with a small set of operations (``decompose``,
+``unwrap``, ``strip_tags``, ``unwrap_tags``). It has no XPath and no regex extraction. Its niche is high-throughput web
+scraping and data extraction where CSS selection over a compiled C tree is the whole job.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground with a single native, spec-compliant HTML5 engine: :meth:`~turbohtml.Node.select` /
+:meth:`~turbohtml.Node.select_one` for CSS, :attr:`~turbohtml.Node.text` as a property, :attr:`~turbohtml.Element.attrs`
+for attributes, and the same drop/unwrap operations. On top of that surface it adds the ``find`` / ``find_all`` filter
+grammar, XPath, regex extraction, a full mutation surface, and markdown/text/minify output, all fully typed.
 
-turbohtml builds the same WHATWG tree but adds full static typing, the ``find``/``find_all`` filter grammar on top of
-CSS, a complete edit surface, and :attr:`~turbohtml.Node.text` as a property. Because selectolax wraps lexbor behind a
-heavier object layer, turbohtml's lighter native tree parses, selects, and serializes faster, drops a set of tags with
-their subtrees faster (:meth:`~turbohtml.Node.remove` against ``strip_tags``, over a 92 kB page of 839
-``<code>``/``<a>``/``<q>`` elements), and collects a node's visible text (:attr:`~turbohtml.Node.text` against
-selectolax's ``text()`` method) six to thirteen times faster, concatenating in one C pass where selectolax crosses the
-lexbor boundary per node:
+*************************
+ turbohtml vs selectolax
+*************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - selectolax
+    - - Scope
+      - Spec-compliant HTML5 parser plus native CSS/XPath selection, regex extraction, mutation, and serialization
+      - CSS-only selection and light tree editing over a bundled C engine (Modest or lexbor); no XPath, no regex
+    - - Feature breadth
+      - CSS Selectors Level 4, the ``find``/``find_all`` filter grammar, XPath, regex, DOM mutation, and
+        markdown/text/minify/sanitize output
+      - CSS selection, ``text()`` extraction, attribute access, and a handful of drop/unwrap/decompose operations
+    - - Performance
+      - Compiles a selector once and matches by interned integer atoms; collects text in one C pass; see the table below
+      - Fast CSS matching in C, but text collection and node access cross the C boundary per node
+    - - Typing
+      - Fully typed, ships ``.pyi`` stubs; queries return typed :class:`~turbohtml.Node`
+      - Typed API surface, but node access is string-centric and text is a method call
+    - - Dependencies
+      - Self-contained C extension, no runtime dependencies
+      - Self-contained C extension (Modest/lexbor bundled), no runtime dependencies
+    - - Maintenance
+      - Actively developed
+      - Actively maintained
+
+Feature overlap
+===============
+
+These map 1:1 and port with a rename:
+
+- CSS selection: ``node.css(sel)`` / ``node.css_first(sel)`` become :meth:`~turbohtml.Node.select` /
+  :meth:`~turbohtml.Node.select_one`.
+- Selector test: ``node.css_matches(sel)`` becomes :meth:`~turbohtml.Node.matches`.
+- Tag name: ``node.tag`` stays :attr:`~turbohtml.Element.tag`.
+- Attributes: ``node.attributes`` becomes :attr:`~turbohtml.Element.attrs`, and a single value reads through
+  :meth:`~turbohtml.Element.attr`.
+- Outer HTML: ``node.html`` stays :attr:`~turbohtml.Node.html`.
+- Node removal that keeps the children: ``node.unwrap()`` stays :meth:`~turbohtml.Node.unwrap`.
+- Node removal with its subtree: ``node.decompose()`` stays :meth:`~turbohtml.Node.decompose`.
+- Bulk tag stripping: ``parser.strip_tags([...])`` (drop tags *with* content) becomes :meth:`~turbohtml.Node.remove`,
+  and ``node.unwrap_tags([...])`` (keep content) becomes :meth:`~turbohtml.Node.strip_tags`. Both turbohtml methods take
+  a full CSS selector, not a tag-name list.
+
+What turbohtml adds
+===================
+
+- The ``find`` / ``find_all`` filter grammar layered on top of CSS, with axes and regex or callable filters, where
+  selectolax is CSS-only.
+- XPath: :meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.xpath_one`, :meth:`~turbohtml.Node.xpath_iter`.
+- Regex extraction over text or an attribute value: :meth:`~turbohtml.Node.re`, :meth:`~turbohtml.Node.re_first`.
+- Text as a property plus lazy iterators: :attr:`~turbohtml.Node.text`, :attr:`~turbohtml.Node.strings`,
+  :attr:`~turbohtml.Node.stripped_strings`, collected in one C pass instead of a per-node method call.
+- A full mutation surface on the same node: :meth:`~turbohtml.Node.prune`, :meth:`~turbohtml.Node.wrap`,
+  :meth:`~turbohtml.Node.insert_before`, :meth:`~turbohtml.Node.insert_after`, :meth:`~turbohtml.Node.replace_with`,
+  :meth:`~turbohtml.Element.set_text`, :meth:`~turbohtml.Element.insert_adjacent_html`.
+- Output conversions built in: :meth:`~turbohtml.Node.serialize`, :meth:`~turbohtml.Node.to_markdown`,
+  :meth:`~turbohtml.Node.to_text`.
+- :meth:`~turbohtml.Node.closest` for walking upward without a fresh query.
+
+What selectolax has that turbohtml does not
+===========================================
+
+- A choice of parser backends (``HTMLParser`` over Modest vs ``LexborHTMLParser`` over lexbor): no equivalent. turbohtml
+  is a single native engine; there is one tree builder and no backend switch.
+- ``text(deep=..., separator=..., strip=...)`` shaping text extraction in one call: no exact equivalent. Read
+  :attr:`~turbohtml.Node.text` for the flat string, iterate :attr:`~turbohtml.Node.stripped_strings` and ``join`` with
+  your own separator, or call :meth:`~turbohtml.Node.to_text` for a formatted rendering.
+- The bundled engine's raw C-level node handles and lexbor-specific knobs: not exposed. turbohtml's public surface is
+  the typed Python tree, not the underlying engine's C API.
+
+Performance
+===========
+
+turbohtml's lighter native tree parses, selects, and serializes faster than selectolax's heavier object layer over
+lexbor. It drops a set of tags with their subtrees faster (:meth:`~turbohtml.Node.remove` against ``strip_tags``, over a
+92 kB page of 839 ``<code>``/``<a>``/``<q>`` elements), and collects a node's visible text (:attr:`~turbohtml.Node.text`
+against selectolax's ``text()`` method) six to thirteen times faster, concatenating in one C pass where selectolax
+crosses the lexbor boundary per node:
 
 .. bench-table::
     :file: bench/selectolax.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Replace ``LexborHTMLParser(html)`` (or ``HTMLParser(html)``) with :func:`turbohtml.parse`, then swap ``css`` for
+:meth:`~turbohtml.Node.select` and drop the parentheses on ``text``.
 
 .. list-table::
     :header-rows: 1
@@ -39,10 +123,12 @@ lexbor boundary per node:
       - :attr:`doc.root <turbohtml.Document.root>`, :meth:`doc.find("body") <turbohtml.Node.find>`
     - - ``node.css("a")``, ``node.css_first("a")``
       - :meth:`~turbohtml.Node.select`, :meth:`~turbohtml.Node.select_one`
+    - - ``node.css_matches("a")``
+      - :meth:`~turbohtml.Node.matches`
     - - ``node.tag``
       - :attr:`~turbohtml.Element.tag` (same)
     - - ``node.attributes``
-      - :attr:`~turbohtml.Element.attrs`
+      - :attr:`~turbohtml.Element.attrs`, :meth:`~turbohtml.Element.attr`
     - - ``node.text()`` (a method)
       - :attr:`~turbohtml.Node.text` (a property), :attr:`~turbohtml.Node.strings`,
         :attr:`~turbohtml.Node.stripped_strings`
@@ -60,15 +146,21 @@ lexbor boundary per node:
 
     ['a', 'b']
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
-- selectolax queries are CSS-only; turbohtml adds the ``find``/``find_all`` filter grammar with axes and regex or
-  callable filters.
-- ``node.text`` is a property; drop the parentheses.
-- the bulk tag strippers are named the other way around: selectolax's ``strip_tags`` drops the tags *with* their content
+- ``node.text`` is a property in turbohtml; drop the parentheses. selectolax's ``text(deep=..., separator=...,
+  strip=...)`` keywords have no single-call equivalent: use :attr:`~turbohtml.Node.stripped_strings` with your own
+  ``join`` for a separator, or :meth:`~turbohtml.Node.to_text` for formatted output.
+- The bulk tag strippers are named the other way around: selectolax's ``strip_tags`` drops the tags *with* their content
   (turbohtml's :meth:`~turbohtml.Node.remove`), while its ``unwrap_tags`` keeps the content (turbohtml's
-  :meth:`~turbohtml.Node.strip_tags`). Both turbohtml methods take a full CSS selector, not just a tag-name list.
-- selectolax's lexbor-specific knobs and its raw C-level node handles are not exposed; turbohtml's public surface is the
-  typed Python tree, not the underlying engine's C API.
+  :meth:`~turbohtml.Node.strip_tags`). Both turbohtml methods take a full CSS selector, not a tag-name list.
+- selectolax queries are CSS-only; there is no ``xpath`` or ``re`` to port. Where you would have chained several ``css``
+  calls, turbohtml's ``find`` / ``find_all`` filter grammar, :meth:`~turbohtml.Node.xpath`, and
+  :meth:`~turbohtml.Node.re` cover the same intent in one call.
+- ``css_first`` returns ``None`` on a miss; so does :meth:`~turbohtml.Node.select_one`, and
+  :meth:`~turbohtml.Node.select` returns an empty list, so guard the ``None`` before reading ``.text`` or
+  :meth:`~turbohtml.Element.attr`.
+- selectolax's lexbor-specific knobs, its Modest-vs-lexbor backend choice, and its raw C-level node handles are not
+  exposed by turbohtml; the public surface is the typed Python tree, not the underlying engine's C API.

--- a/docs/migration/simple-html.rst
+++ b/docs/migration/simple-html.rst
@@ -4,31 +4,85 @@
 
 .. package-meta:: simple-html keithasaurus/simple_html
 
-`simple-html <https://github.com/keithasaurus/simple_html>`_ assembles HTML in Python from the other direction than a
-parser: each element is a tag called with an attribute dict first and children after (``div({"class": "card"},
-h1("Title"))``), and ``render`` walks the resulting tuples into a string. turbohtml replaces it with the terse
-:data:`turbohtml.build.E` builder.
+`simple-html <https://github.com/keithasaurus/simple_html>`_ is a pure-Python library for *generating* HTML from the
+inside out: each element is a tag object you call with a leading attribute mapping and then its children
+(``div({"class": "card"}, h1("Title"))``), and ``render`` walks the resulting tuples into a string. It carries no
+dependencies, is fully type-checked, and is scoped deliberately narrow -- it builds and escapes markup and nothing else,
+which makes it a common choice for server-rendered views and email templates where a full DOM would be overkill.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same construction ground with the terse :data:`turbohtml.build.E` builder, which keeps
+simple-html's call shape (attributes first, children after) but hands back a real :class:`~turbohtml.Element` tree
+instead of a string. That one difference in result type is the whole reason to move: the same call that builds your
+markup also leaves something you can query, edit, and re-serialize by exactly the rules that parse it back.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+**************************
+ turbohtml vs simple-html
+**************************
 
-.. testcode::
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
 
-    from turbohtml.build import E
+    - - Dimension
+      - turbohtml
+      - simple-html
+    - - Scope
+      - Full WHATWG parse, query, edit, and serialize; ``E`` is one builder over that tree
+      - HTML generation and escaping only; no parser, no queryable tree
+    - - Feature breadth
+      - Build, ``find``/``select``, mutate, ``to_markdown``, re-parse
+      - Build and ``render`` a string; the result is inert once produced
+    - - Performance
+      - Assembles in a C arena, serializes in C; ~3x slower than simple-html on raw string generation
+      - Concatenates tuples straight into a string, the faster path for one-shot rendering
+    - - Typing
+      - ``E.<tag>`` resolves dynamically via ``__getattr__``; the tree API is fully typed
+      - Every tag is an explicitly typed symbol, so a mistyped tag name fails at type-check time
+    - - Dependencies
+      - Requires the compiled C extension
+      - Zero dependencies, pure Python
+    - - Maintenance
+      - Active; ``E`` shares the parser's escape and serialize rules
+      - Small, stable, single-purpose
 
-    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
-    print(card.serialize())
+Feature overlap
+===============
 
-.. testoutput::
+The construction surface ports 1:1 -- both put attributes first and children after:
 
-    <div class="card"><h1>Title</h1><p>body</p></div>
+- ``div({"class": "card"}, h1("Title"))`` -> :data:`E.div({"class": "card"}, E.h1("Title")) <turbohtml.build.E>`.
+- A string child becomes escaped text in both.
+- A leading mapping sets attributes; everything after is a child in order.
+- Nested calls compose the same way, so an existing simple-html view tree maps node for node onto ``E`` calls.
+
+What turbohtml adds
+===================
+
+``E`` returns a real :class:`~turbohtml.Element`, so the entire tree surface is available on what you just built:
+
+- Query the fragment you constructed with :meth:`~turbohtml.Node.find` and :meth:`~turbohtml.Node.select`.
+- Mutate it with :meth:`~turbohtml.Element.append`, :meth:`~turbohtml.Element.extend`, and the rest of the edit API.
+- Convert it with :meth:`~turbohtml.Node.to_markdown`.
+- Serialize by the same C rules that parse HTML back, so round-tripping generated markup is exact.
+- A list-valued attribute joins on a space, so ``{"class": ["card", "lg"]}`` reads as a token list naturally.
+
+What simple-html has that turbohtml does not
+============================================
+
+- **Per-tag static typing.** simple-html exposes each tag as its own typed symbol, so a typo like ``dvi(...)`` is a
+  type-check error. ``E.dvi(...)`` resolves through ``__getattr__`` and would build a literal ``<dvi>`` element; the
+  builder cannot catch an unknown tag name statically. No equivalent -- rely on runtime output or tests.
+- **A pre-escaped-markup escape hatch.** simple-html's ``SafeString("<b>hi</b>")`` injects trusted raw markup. ``E`` has
+  no ``SafeString``; express the markup as child elements (:data:`E.b("hi") <turbohtml.build.E>`) or parse the string
+  into nodes first.
+- **A doctype constant.** simple-html ships ``DOCTYPE_HTML5`` to prepend a full-page doctype. ``E`` builds a fragment
+  with no ``<html>``/``<head>``/``<body>`` shell and no doctype; append the fragment under a parsed document when you
+  need the page frame.
+- **Zero dependencies / pure Python.** simple-html installs with no build step. turbohtml requires its compiled C
+  extension, which matters on locked-down or exotic targets.
+
+Performance
+===========
 
 ``E`` assembles the fragment in turbohtml's arena and serializes it in C; simple-html stays in Python. The same ``<ul>``
 of rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
@@ -41,12 +95,21 @@ string -- but the decisive difference is the result type: ``E`` hands back a rea
 string, so the call that builds the markup also leaves a tree you can query, edit, and
 re-:meth:`~turbohtml.Node.serialize`.
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
 
-simple-html and turbohtml share the call shape -- attributes lead, children follow -- so most calls port by swapping the
-import and the render step:
+Swap the import and the render step. simple-html and turbohtml share the call shape, so most calls port unchanged:
+
+.. code-block:: python
+
+    # before
+    from simple_html import div, h1, render
+
+    # after
+    from turbohtml.build import E
+
+The API mapping:
 
 .. list-table::
     :header-rows: 1
@@ -61,6 +124,21 @@ import and the render step:
       - :data:`E.li({"class": "item", "data-i": "1"}, "text") <turbohtml.build.E>`, unchanged
     - - ``SafeString("<b>hi</b>")`` for pre-escaped markup
       - build the markup as child elements instead: :data:`E.b("hi") <turbohtml.build.E>`
+    - - ``del_({}, "removed")`` (keyword-shadowing tag)
+      - :data:`E("del", {}, "removed") <turbohtml.build.E>` via the call form
+
+Before and after:
+
+.. testcode::
+
+    from turbohtml.build import E
+
+    card = E.div({"class": "card"}, E.h1("Title"), E.p("body"))
+    print(card.serialize())
+
+.. testoutput::
+
+    <div class="card"><h1>Title</h1><p>body</p></div>
 
 ``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
 attribute joins on a space so a class list reads naturally:
@@ -75,9 +153,9 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype,
   where simple-html ships a ``DOCTYPE_HTML5`` constant to prepend. Serialize the element you built, or append it under a
@@ -86,5 +164,8 @@ attribute joins on a space so a class list reads naturally:
   markup as child elements (or parse it into nodes first).
 - simple-html suffixes tags that shadow keywords (``del_``); ``E.del_`` would build a literal ``<del_>``, so use the
   call form ``E("del", ...)`` for those tags.
+- A mistyped tag on ``E`` silently builds that element rather than erroring, since ``E.<tag>`` resolves dynamically;
+  simple-html would flag the same typo at type-check time. Cover generated markup with a test.
+- A mapping argument is always read as attributes and must come first; passing one after a child raises ``TypeError``.
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.

--- a/docs/migration/soupsieve.rst
+++ b/docs/migration/soupsieve.rst
@@ -5,31 +5,116 @@
 .. package-meta:: soupsieve facelessuser/soupsieve
 
 `soupsieve <https://facelessuser.github.io/soupsieve/>`_ is BeautifulSoup's CSS selector engine and the library behind
-every ``Tag.select`` call: ``soupsieve.compile(selector)`` returns a reusable ``SoupSieve`` matcher, and the
+every ``Tag.select`` call. ``soupsieve.compile(selector)`` returns a reusable ``SoupSieve`` matcher, and the
 module-level ``select`` / ``select_one`` / ``iselect`` / ``match`` / ``filter`` / ``closest`` helpers run one-shot
-queries over bs4 tags.
+queries over bs4 tags. Its scope is deliberately narrow: it interprets a CSS selector against an already-parsed tree of
+BeautifulSoup ``Tag`` objects, one element at a time, in Python. It covers a broad slice of Selectors Level 3 and 4 and
+adds a few proprietary extensions (``:-soup-contains()``, ``[attr!=value]``, custom pseudo-class aliases). Because it is
+the default engine that ``bs4`` reaches for, it is installed on essentially every project that scrapes or queries HTML
+in Python.
 
-***************
- Why turbohtml
-***************
+:mod:`turbohtml.match` covers that same ground with the same call shapes over turbohtml's native selector engine. A port
+swaps ``import soupsieve`` for ``from turbohtml import match`` and keeps its structure: the matcher methods and module
+helpers keep soupsieve's names, and turbohtml parses the HTML itself rather than depending on a separate BeautifulSoup
+tree.
 
-:mod:`turbohtml.match` carries the same call shapes over turbohtml's native selector engine, so a port swaps ``import
-soupsieve`` for ``from turbohtml import match`` and keeps its structure. soupsieve interprets each selector in Python
-per element; turbohtml compiles it against the tree once and matches by comparing interned integer atoms in C, so a
-compiled ``select`` runs 195 to 1,126 times faster across real pages and per-element ``match`` 94 to 155 times faster:
+************************
+ turbohtml vs soupsieve
+************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
+
+    - - Dimension
+      - turbohtml
+      - soupsieve
+    - - Scope
+      - Full WHATWG HTML parser with a native CSS selector engine, an XPath engine, and serialization in one package.
+      - CSS selector engine only; relies on BeautifulSoup to parse and hold the tree it queries.
+    - - Feature breadth
+      - Selectors Level 4 subset over the native tree, plus :meth:`~turbohtml.Node.find_all` keyword filters and
+        :meth:`~turbohtml.Node.xpath`.
+      - Broad Selectors 3/4 support plus proprietary ``:-soup-contains()``, ``[attr!=value]``, ``custom=`` pseudo-class
+        aliases, and namespace discrimination.
+    - - Performance
+      - Selector compiled against the tree once, matched by comparing interned integer atoms in C.
+      - Each selector interpreted in Python per element on every call.
+    - - Typing
+      - Ships ``py.typed`` and full stubs; every public name is annotated.
+      - Ships ``py.typed`` and type hints.
+    - - Dependencies
+      - One self-contained package with a bundled C extension; the parser is built in.
+      - No hard runtime dependency, but it operates on BeautifulSoup trees, so bs4 is the practical runtime.
+    - - Maintenance
+      - Actively maintained.
+      - Actively maintained; the canonical selector engine shipped with BeautifulSoup.
+
+Feature overlap
+===============
+
+These port 1:1 -- same names, turbohtml nodes in place of bs4 tags:
+
+- :func:`~turbohtml.match.compile` returning a reusable :class:`~turbohtml.match.Matcher`, the analog of ``SoupSieve``.
+- The module helpers :func:`~turbohtml.match.select`, :func:`~turbohtml.match.select_one`,
+  :func:`~turbohtml.match.iselect`, :func:`~turbohtml.match.match`, :func:`~turbohtml.match.filter`, and
+  :func:`~turbohtml.match.closest`.
+- The same six methods on :class:`~turbohtml.match.Matcher`, plus its ``pattern`` / ``namespaces`` / ``flags``
+  properties.
+- ``limit=`` on ``select`` / ``iselect`` to cap the number of matches.
+- :func:`turbohtml.match.escape` for building a selector around untrusted class or id text.
+- :class:`turbohtml.match.SelectorSyntaxError` (a :class:`ValueError`) raised on a malformed selector.
+
+What turbohtml adds
+===================
+
+- A compiled matcher runs in C against interned atoms instead of interpreting the selector in Python per element (see
+  Performance).
+- Parsing is built in: :func:`turbohtml.parse` produces the tree the selector runs over, so there is no separate
+  BeautifulSoup dependency to install and keep in sync.
+- :func:`~turbohtml.match.css` is a readable alias of :func:`~turbohtml.match.compile` for call sites that read as
+  ``css(selector)``.
+- Beyond CSS, the same tree answers :meth:`~turbohtml.Node.find_all` keyword filters (``attrs=``, ``class_=``,
+  ``text=``) and :meth:`~turbohtml.Node.xpath` queries.
+- Spec-conformant matching where soupsieve 2.8 diverges: an only child matches a functional ``:nth-child(An+B)``, and
+  ``input[type=hidden]`` counts as ``:enabled`` (see Gotchas).
+- No global compile cache to manage, so ``soupsieve.purge()`` has no analog and needs none -- a
+  :class:`~turbohtml.match.Matcher` is the reusable artifact you hold yourself.
+
+What soupsieve has that turbohtml does not
+==========================================
+
+- ``:-soup-contains()`` / ``:-soup-contains-own()`` text selectors. No CSS equivalent; query text through
+  :meth:`~turbohtml.Node.find_all` with ``text=`` instead.
+- The proprietary ``[attr!=value]`` selector. Write ``:not([attr=value])``.
+- ``custom={":--name": "..."}`` pseudo-class aliases. No equivalent; inline the aliased selector, with ``:is(...)``
+  covering most uses.
+- Namespace discrimination: soupsieve honors the ``namespaces`` map for prefixed type selectors. turbohtml selects by
+  local name, so ``svg|rect`` matches every ``rect`` regardless of prefix; ``namespaces`` is carried for parity but
+  inert.
+- Three tracked selector gaps where the engines still disagree on real documents: `#349
+  <https://github.com/tox-dev/turbohtml/issues/349>`__, `#350 <https://github.com/tox-dev/turbohtml/issues/350>`__,
+  `#351 <https://github.com/tox-dev/turbohtml/issues/351>`__.
+
+Performance
+===========
+
+soupsieve interprets each selector in Python per element; turbohtml compiles it against the tree once and matches by
+comparing interned integer atoms in C, so a compiled ``select`` runs 195 to 1,126 times faster across real pages and
+per-element ``match`` 94 to 155 times faster:
 
 .. bench-table::
     :file: bench/soupsieve.json
 
 The engines agree on what they select: on a corpus of 247 selectors harvested from soupsieve's own test suite, both pick
-identical elements for every comparable selector over real documents, and the disagreements are three tracked turbohtml
-gaps (`#349 <https://github.com/tox-dev/turbohtml/issues/349>`__, `#350
-<https://github.com/tox-dev/turbohtml/issues/350>`__, `#351 <https://github.com/tox-dev/turbohtml/issues/351>`__) plus
-two spots where soupsieve itself strays from the spec (see the pitfalls).
+identical elements for every comparable selector over real documents, and the disagreements are the three tracked
+turbohtml gaps above plus two spots where soupsieve itself strays from the spec (see Gotchas).
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the import and parse with turbohtml; the matcher and helper names carry over:
 
 .. code-block:: python
 
@@ -48,20 +133,7 @@ two spots where soupsieve itself strays from the spec (see the pitfalls).
     matcher = match.compile("li.on a[href]")
     matcher.select(doc, limit=5)
 
-.. testcode::
-
-    from turbohtml import match, parse
-
-    doc = parse('<ul><li class="on"><a href="/a">a</a></li><li><a href="/b">b</a></li></ul>')
-    print([a.attr("href") for a in match.select("li.on a[href]", doc)])
-    print(match.match("li.on", match.compile("li").closest(match.select_one("a", doc))))
-
-.. testoutput::
-
-    ['/a']
-    True
-
-The matcher methods and module helpers keep soupsieve's names; only the trees and the keyword bundle differ.
+Only the trees and the keyword bundle differ; every call name stays.
 
 .. list-table::
     :header-rows: 1
@@ -87,20 +159,36 @@ The matcher methods and module helpers keep soupsieve's names; only the trees an
     - - ``custom={":--name": "..."}`` pseudo-class aliases
       - not supported; inline the aliased selector (``:is(...)`` covers most uses)
 
-**********
- Pitfalls
-**********
+A full round-trip, from parse to selection to matching:
+
+.. testcode::
+
+    from turbohtml import match, parse
+
+    doc = parse('<ul><li class="on"><a href="/a">a</a></li><li><a href="/b">b</a></li></ul>')
+    print([a.attr("href") for a in match.select("li.on a[href]", doc)])
+    print(match.match("li.on", match.compile("li").closest(match.select_one("a", doc))))
+
+.. testoutput::
+
+    ['/a']
+    True
+
+**********************
+ Gotchas and pitfalls
+**********************
 
 - The nodes are turbohtml's, so parse with :func:`turbohtml.parse` and pass the :class:`~turbohtml.Document` or an
-  :class:`~turbohtml.Element` where soupsieve took a bs4 ``Tag``; the matches come back as turbohtml elements with
-  :meth:`~turbohtml.Element.attr`/:attr:`~turbohtml.Node.text` instead of ``tag["attr"]``/``tag.get_text()``.
+  :class:`~turbohtml.Element` where soupsieve took a bs4 ``Tag``; matches come back as turbohtml elements with
+  :meth:`~turbohtml.Element.attr` / :attr:`~turbohtml.Node.text` instead of ``tag["attr"]`` / ``tag.get_text()``.
 - soupsieve's proprietary selectors raise :class:`~turbohtml.match.SelectorSyntaxError`: ``[attr!=value]`` (write
   ``:not([attr=value])``) and ``:-soup-contains()`` / ``:-soup-contains-own()`` (query text through
   :meth:`~turbohtml.Node.find_all` with ``text=`` instead).
 - ``namespaces`` and ``flags`` are carried for parity but never change which elements match: turbohtml selects by local
   name, so ``svg|rect`` matches every ``rect`` whatever the mapping says, and ``DEBUG`` prints nothing.
 - Two soupsieve 2.8 behaviors are off spec and not reproduced: an only child never matches a functional
-  ``:nth-child(An+B)`` (an only child sits at position 1, so ``:nth-child(-n+3)`` must match it), and
-  ``input[type=hidden]`` is excluded from ``:enabled`` (the current HTML spec no longer carves out hidden inputs).
+  ``:nth-child(An+B)`` in soupsieve (an only child sits at position 1, so ``:nth-child(-n+3)`` must match it here), and
+  ``input[type=hidden]`` is excluded from ``:enabled`` in soupsieve (the current HTML spec no longer carves out hidden
+  inputs).
 - Pseudo-classes soupsieve accepts and matches never (``:current``, ``:paused``, ``:local-link``, ``:host``, the removed
   ``:matches()``, ...) raise here instead, turning a selector that silently returned nothing into a loud error.

--- a/docs/migration/stdlib.rst
+++ b/docs/migration/stdlib.rst
@@ -2,57 +2,107 @@
  From the standard library
 ###########################
 
-Python's standard library ships HTML primitives in the :mod:`python:html` package: :func:`python:html.escape` and
-:func:`python:html.unescape` for entity handling, and :class:`python:html.parser.HTMLParser`, a SAX-style,
-non-WHATWG-conformant tokenizer you subclass with ``handle_*`` callbacks.
+Python's standard library ships HTML primitives in the :mod:`python:html` package. :func:`python:html.escape` and
+:func:`python:html.unescape` handle entity encoding and decoding, :mod:`python:html.entities` exposes the reference
+tables, and :class:`python:html.parser.HTMLParser` is a SAX-style tokenizer you subclass and drive with ``handle_*``
+callbacks. These are the zero-dependency, always-available building blocks that ship with CPython; countless scripts,
+templating helpers, and scrapers reach for them because they are already installed. The scope stops at tokenizing and
+entity work: ``html.parser`` does not build a document tree, does not implement WHATWG error recovery, and is explicitly
+documented as not fully HTML5-conformant.
 
-***************
- Why turbohtml
-***************
+turbohtml covers that same ground and extends past it. :func:`turbohtml.escape` and :func:`turbohtml.unescape` match the
+stdlib functions byte for byte, :func:`turbohtml.tokenize` and :class:`turbohtml.Tokenizer` replace the callback
+tokenizer, and :class:`turbohtml.migration.stdlib.HTMLParser` keeps your existing ``handle_*`` subclass working
+unchanged. Everything runs over a WHATWG-conformant C core that also builds a full parse tree, which ``html.parser`` has
+no equivalent for.
 
-:func:`turbohtml.escape` and :func:`turbohtml.unescape` reproduce the standard-library functions byte for byte, so they
-are drop-ins, but scan with SIMD and run several times faster. The tokenizer and :func:`turbohtml.parse` are
-WHATWG-conformant where ``html.parser`` is not, and the whole surface is fully type annotated:
+*********************
+ turbohtml vs stdlib
+*********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - stdlib (``html``)
+    - - Scope
+      - Escape/unescape, tokenizer, and full WHATWG tree construction
+      - Escape/unescape, entity tables, and a tokenizer only (no tree)
+    - - Feature breadth
+      - Tokens, tree, selectors, serialization, plus the callback shim
+      - ``escape``/``unescape``, ``html.entities`` tables, ``HTMLParser`` callbacks
+    - - Performance
+      - SIMD scanning, several times faster on escape/unescape
+      - Pure-Python entity scan and tokenizer
+    - - Typing
+      - Fully type annotated across the public surface
+      - Annotated in typeshed stubs, not conformant behavior
+    - - Dependencies
+      - Compiled C extension (wheels), installed from PyPI
+      - Built into CPython, zero install
+    - - Maintenance
+      - Actively developed, tracks the WHATWG spec
+      - Stable CPython module, ``html.parser`` frozen as non-conformant
+
+Feature overlap
+===============
+
+The shared surface ports one-to-one:
+
+- :func:`python:html.escape` → :func:`turbohtml.escape`, same signature and output.
+- :func:`python:html.unescape` → :func:`turbohtml.unescape`, same signature and output.
+- :class:`python:html.parser.HTMLParser` subclasses → :class:`turbohtml.migration.stdlib.HTMLParser`, same ``handle_*``
+  callbacks and ``feed``/``close``/``reset``/``getpos`` methods.
+
+What turbohtml adds
+===================
+
+- WHATWG-conformant tokenizing and tree construction via :func:`turbohtml.parse` and :func:`turbohtml.parse_fragment`;
+  ``html.parser`` tokenizes but never builds a tree and is documented as not HTML5-conformant.
+- A token stream you drive yourself through :func:`turbohtml.tokenize` and :class:`turbohtml.Tokenizer`, instead of
+  inverting control into callbacks.
+- Verbatim source capture per token (``capture_source=True`` → ``token.source``) and unresolved reference tokens
+  (``resolve_references=False`` → ``TokenType.CHARACTER_REFERENCE``).
+- SIMD-accelerated escape/unescape scanning.
+
+What stdlib has that turbohtml does not
+=======================================
+
+- ``html.parser`` and the ``html`` functions are built into CPython with no install step. turbohtml ships a compiled
+  extension from PyPI; in environments that cannot install wheels or build C, the stdlib remains the only option.
+- :mod:`python:html.entities` exposes the raw reference tables (``name2codepoint``, ``codepoint2name``, ``html5``) as
+  public data. turbohtml resolves references through ``escape``/``unescape`` and the tokenizer rather than exposing the
+  dicts; if you consume those tables directly, keep importing ``html.entities``.
+
+Performance
+===========
 
 .. bench-table::
     :file: bench/stdlib.json
 
-*********************
- Escape and unescape
-*********************
+:func:`turbohtml.escape` and :func:`turbohtml.unescape` reproduce the standard-library functions byte for byte, so they
+are drop-ins, but scan with SIMD and run several times faster.
 
-.. testcode::
+****************
+ How to migrate
+****************
 
-    import html
-    from turbohtml import escape, unescape
-
-    print(escape('<a href="x">') == html.escape('<a href="x">'))
-    print(unescape("caf&eacute; &#127881;") == html.unescape("caf&eacute; &#127881;"))
-
-.. testoutput::
-
-    True
-    True
-
-*********************
- html.parser adapter
-*********************
-
-To keep an existing :class:`python:html.parser.HTMLParser` subclass, swap its base class for
-:class:`turbohtml.migration.stdlib.HTMLParser`: the same ``handle_*`` callbacks and ``feed``/``close`` methods run over
-the WHATWG-conformant tokenizer. Or drop the subclass and take the token stream from :func:`turbohtml.tokenize` (or
-:meth:`turbohtml.Tokenizer.feed` for incremental input), or skip tokens entirely and :func:`turbohtml.parse` straight to
-a tree. All three are WHATWG-conformant, unlike ``html.parser``. The :doc:`/how-to/index` guide has a worked port.
-
-``HTMLParser`` is a SAX-style callback API; turbohtml gives you the events as a token stream you drive yourself, which
-inverts the control flow. Each ``handle_*`` override becomes a branch on :attr:`Token.type <turbohtml.Token.type>`:
+Swap the imports and, if you subclass the parser, swap the base class:
 
 .. list-table::
     :header-rows: 1
     :widths: 50 50
 
-    - - ``html.parser`` callback
-      - turbohtml token
+    - - stdlib call
+      - turbohtml call
+    - - ``html.escape(s)``
+      - ``turbohtml.escape(s)``
+    - - ``html.unescape(s)``
+      - ``turbohtml.unescape(s)``
+    - - ``class P(html.parser.HTMLParser)``
+      - ``class P(turbohtml.migration.stdlib.HTMLParser)``
     - - ``handle_starttag(tag, attrs)``
       - ``token.type is TokenType.START_TAG`` → ``token.tag``, ``token.attrs``
     - - ``handle_startendtag(tag, attrs)``
@@ -69,6 +119,30 @@ inverts the control flow. Each ``handle_*`` override becomes a branch on :attr:`
       - ``tokenize(..., resolve_references=False)`` → ``TokenType.CHARACTER_REFERENCE``, else resolved in ``token.data``
     - - ``get_starttag_text()``
       - ``tokenize(..., capture_source=True)`` → ``token.source``
+
+Escape and unescape are literal drop-ins:
+
+.. testcode::
+
+    import html
+    from turbohtml import escape, unescape
+
+    print(escape('<a href="x">') == html.escape('<a href="x">'))
+    print(unescape("caf&eacute; &#127881;") == html.unescape("caf&eacute; &#127881;"))
+
+.. testoutput::
+
+    True
+    True
+
+To keep an existing :class:`python:html.parser.HTMLParser` subclass, swap its base class for
+:class:`turbohtml.migration.stdlib.HTMLParser`: the same ``handle_*`` callbacks and ``feed``/``close`` methods run over
+the WHATWG-conformant tokenizer. Or drop the subclass and take the token stream from :func:`turbohtml.tokenize` (or
+:meth:`turbohtml.Tokenizer.feed` for incremental input), or skip tokens entirely and :func:`turbohtml.parse` straight to
+a tree. All three are WHATWG-conformant, unlike ``html.parser``. The :doc:`/how-to/index` guide has a worked port.
+
+``HTMLParser`` is a SAX-style callback API; turbohtml gives you the events as a token stream you drive yourself, which
+inverts the control flow. Each ``handle_*`` override becomes a branch on :attr:`Token.type <turbohtml.Token.type>`:
 
 .. testcode::
 
@@ -89,9 +163,9 @@ inverts the control flow. Each ``handle_*`` override becomes a branch on :attr:`
 
     [('start', 'p', [('class', 'x')]), ('data', 'Hi & bye'), ('end', 'p')]
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - The token stream inverts ``html.parser``'s callback control flow: you loop over tokens and branch on :attr:`Token.type
   <turbohtml.Token.type>` instead of overriding ``handle_*`` (unless you subclass
@@ -99,5 +173,12 @@ inverts the control flow. Each ``handle_*`` override becomes a branch on :attr:`
 - By default ``token.data`` already holds decoded text (the equivalent of ``convert_charrefs=True``). To recover the
   split stream ``convert_charrefs=False`` gives, pass ``resolve_references=False`` and handle
   ``TokenType.CHARACTER_REFERENCE`` tokens, whose ``token.source`` is the verbatim reference and ``token.data`` its
-  resolved value. The verbatim start-tag text ``get_starttag_text()`` returns is ``token.source`` once you pass
-  ``capture_source=True``.
+  resolved value. On :class:`turbohtml.migration.stdlib.HTMLParser` the ``convert_charrefs`` argument is accepted for
+  signature compatibility but ignored; references are always resolved.
+- The verbatim start-tag text ``get_starttag_text()`` returns is ``token.source`` once you pass ``capture_source=True``;
+  it is not captured by default.
+- ``html.parser`` is documented as not fully HTML5-conformant, so tricky recovery cases (malformed tags, misnested
+  elements, foreign content) can tokenize differently. turbohtml follows the WHATWG spec, so output may diverge from a
+  legacy ``html.parser`` run on the same broken input; the turbohtml result is the conformant one.
+- If your code imports the reference tables from :mod:`python:html.entities` directly, keep that import: turbohtml does
+  not re-export ``name2codepoint``/``codepoint2name``/``html5``.

--- a/docs/migration/trafilatura.rst
+++ b/docs/migration/trafilatura.rst
@@ -5,30 +5,110 @@
 .. package-meta:: trafilatura adbar/trafilatura
 
 `trafilatura <https://trafilatura.readthedocs.io>`_ extracts the main text and metadata from a web page: it downloads
-the URL, scores the content body, and returns the article alongside its title, author, date, and description. It also
-layers in optional language detection and precision-tuned publication-date inference, the latter from the `htmldate
-<https://htmldate.readthedocs.io>`_ library it builds on.
+the URL, scores the content body against navigation and boilerplate, and returns the article alongside its title,
+author, date, description, and site name. It serializes to plain text, Markdown, XML/TEI, JSON, or CSV, and layers in
+optional comment extraction, table and link handling, deduplication across a crawl, language detection, and
+precision-tuned publication-date inference (the last from the `htmldate <https://htmldate.readthedocs.io>`_ library it
+builds on). It is a common front end for building text corpora for NLP and search indexing.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the extraction core of that: :meth:`~turbohtml.Node.article` scores a parsed page and harvests its
+*declared* metadata in one C pass, returning an :class:`~turbohtml.Article` record. It works on HTML you already have,
+so pair it with your own downloader and, when you need trafilatura's heavier heuristics (inferred dates, detected
+language, Markdown/XML output), keep those alongside it.
 
-:meth:`~turbohtml.Node.article` answers the same question -- *given a cluttered page, what is the article and its
-metadata* -- in one C pass over the parsed tree. It returns an :class:`~turbohtml.Article` record (``element``,
-``text``, ``title``, ``byline``, ``date``, ``description``, ``lang``), harvesting the *declared* metadata rather than
-inferring it. turbohtml works on HTML you already have, so pair it with a downloader (``urllib`` or ``httpx``) and, when
-you need them, trafilatura's heavier language and date heuristics.
+**************************
+ turbohtml vs trafilatura
+**************************
 
-Extracting the content body and metadata from a full page -- navigation, a scored article, and a footer.
+.. list-table::
+    :header-rows: 1
+    :widths: 20 40 40
+
+    - - Dimension
+      - turbohtml
+      - trafilatura
+    - - Scope
+      - Full WHATWG HTML parser with DOM, query, serialize, and content extraction on top
+      - Content-and-metadata extraction plus fetching, crawling, and multi-format output
+    - - Feature breadth
+      - One C scoring pass yielding a body element and declared metadata (:class:`~turbohtml.Article`)
+      - Extraction with comments, tables, links, images, dedup, language ID, and inferred dates
+    - - Performance
+      - C scoring pass over the parsed tree (see below)
+      - Python scoring over an lxml tree, with optional readability/justext fallbacks
+    - - Typing
+      - Fully annotated, ships PEP 561 stubs
+      - Annotated pure-Python source
+    - - Dependencies
+      - Compiled C extension
+      - lxml plus courlan, htmldate, and charset-normalizer
+    - - Maintenance
+      - Actively developed
+      - Actively developed and widely used
+
+Feature overlap
+===============
+
+The shared surface ports one call to one call:
+
+- ``trafilatura.extract(html)`` -> ``parse(html).article().text`` (or :meth:`~turbohtml.Node.main_text`), the scored
+  body as plain text.
+- ``extract_metadata(html).title`` -> ``article().title``.
+- ``extract_metadata(html).author`` -> ``article().byline``.
+- ``extract_metadata(html).date`` -> ``article().date`` (as declared, see the date pitfall below).
+- ``extract_metadata(html).description`` -> ``article().description``.
+- the extracted content body -> ``article().element``, the scored element (:attr:`~turbohtml.Node.html` for its markup),
+  or ``None`` when nothing reads as content.
+
+What turbohtml adds
+===================
+
+- The extraction rides on a full WHATWG parse, so the scored body comes back as a DOM element you can query, mutate, and
+  serialize, not only as text. :meth:`~turbohtml.Node.main_content` returns that element directly.
+- Metadata is harvested from what the page *declares* (``<html lang>``, ``article:published_time``, ``rel=author``,
+  ``og:*``, ``<title>``) in the same C pass as the body, with no second Python analysis stage.
+- :func:`turbohtml.parse` follows the WHATWG recovery rules and never raises on malformed markup, and the parsed tree is
+  reusable for anything else you need from the page.
+
+What trafilatura has that turbohtml does not
+============================================
+
+- Fetching and crawling: ``fetch_url(url)``, ``fetch_response``, plus sitemap, feed, and spider helpers. turbohtml has
+  no fetcher; read the page with ``urllib`` or ``httpx`` and pass the markup to :func:`~turbohtml.parse`.
+- Output formats. ``extract(html, output_format="markdown" | "xml" | "xmltei" | "json" | "csv")`` serializes the result;
+  turbohtml returns plain text and the DOM element, so build Markdown or JSON from ``article()`` yourself.
+- Comment, table, link, and image extraction toggles (``include_comments``, ``include_tables``, ``include_links``,
+  ``include_images``). turbohtml scores one prose body; extract those regions from the DOM by hand.
+- ``favor_precision`` / ``favor_recall`` tuning and the readability-lxml / justext fallbacks. turbohtml has a single
+  scoring model with no drop-in aggressiveness switch.
+- Cross-document deduplication (the LRU cache that drops repeated segments across a crawl). No equivalent.
+- Inferred publication dates via htmldate and prose language detection. ``article().date`` returns the declared date
+  string and ``article().lang`` reports ``<html lang>``; neither infers. Keep htmldate and a language detector for pages
+  where those are only inferable.
+- Richer metadata fields (site name, categories, tags, license, canonical URL, hostname, lead image). turbohtml exposes
+  ``title``, ``byline``, ``date``, ``description``, and ``lang``.
+
+Performance
+===========
+
 :meth:`~turbohtml.Node.article` scores and harvests in one C pass over the parsed tree; trafilatura builds an lxml tree
-in Python first. Numbers vary with input and hardware.
+in Python first and scores it there. Numbers vary with input and hardware.
 
 .. bench-table::
     :file: bench/trafilatura.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the trafilatura import for :func:`turbohtml.parse` and read the fields off one :meth:`~turbohtml.Node.article`
+call:
+
+.. code-block:: python
+
+    from turbohtml import parse
+
+The call mapping:
 
 .. list-table::
     :header-rows: 1
@@ -48,6 +128,10 @@ in Python first. Numbers vary with input and hardware.
       - ``doc.article().description``
     - - the extracted content body
       - ``doc.article().element`` (the scored element; :attr:`~turbohtml.Node.html` for its markup, or ``None``)
+    - - ``trafilatura.fetch_url(url)``
+      - fetch the page yourself (``urllib`` or ``httpx``), then parse the markup
+
+Before and after, harvesting the body and metadata from a full page:
 
 .. testcode::
 
@@ -66,24 +150,19 @@ in Python first. Numbers vary with input and hardware.
 
     Comets | Ada Lovelace | 2024-05-06 | en
 
-******************************
- Publication dates (htmldate)
-******************************
-
-trafilatura's date support comes from `htmldate <https://htmldate.readthedocs.io>`_, whose ``find_date(html)`` scans
-many patterns and validates the result against a range. ``doc.article().date`` is the lightweight counterpart: it
-returns the first of a ``<time>``, an ``article:published_time`` meta, and a common date meta (``date``, ``pubdate``,
-``dc.date``) exactly as the page declares it, without parsing or normalizing the value. Wrap it in
-``datetime.date.fromisoformat`` or ``dateutil`` when you need a real date object, and keep htmldate for pages whose date
-is only inferable.
-
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - trafilatura downloads URLs; :meth:`~turbohtml.Node.article` takes parsed HTML. Fetch the page yourself (``urllib`` or
   ``httpx``) and pass the markup to :func:`turbohtml.parse`.
+- ``article().date`` returns the date exactly as the page declares it (the first of a ``<time>``, an
+  ``article:published_time`` meta, or a common date meta such as ``date``, ``pubdate``, ``dc.date``) without parsing or
+  normalizing it. Wrap it in ``datetime.date.fromisoformat`` or ``dateutil`` for a real date object, and keep htmldate
+  for pages whose date is only inferable.
 - ``article().lang`` reports the document's ``<html lang>`` attribute, not a language *detected* from the prose the way
   trafilatura's optional language filter does; that inference is out of scope.
 - A page with no scoring article leaves ``element`` ``None`` and ``text`` empty while still filling the metadata, so
   branch on ``art.element`` rather than assuming a body.
+- turbohtml returns plain text only. For the Markdown, XML, or JSON that ``extract(..., output_format=...)`` produces,
+  serialize the ``article()`` fields (and the ``element`` subtree) yourself.

--- a/docs/migration/w3lib.rst
+++ b/docs/migration/w3lib.rst
@@ -4,31 +4,116 @@
 
 .. package-meta:: w3lib scrapy/w3lib
 
-`w3lib <https://w3lib.readthedocs.io>`_ collects low-level web utilities: entity resolution, tag/comment stripping, URL
-canonicalization, and response-encoding helpers. Its ``w3lib.html`` text/entity subset maps onto the WHATWG tree, and
-its ``w3lib.url`` canonicalization surface maps onto the :mod:`turbohtml.extract` URL helpers; only the HTTP-header and
-file/data-URI helpers stay outside turbohtml's scope.
+`w3lib <https://w3lib.readthedocs.io>`_ is the Scrapy project's grab-bag of stateless web utilities: character-reference
+resolution, regex tag/comment stripping, URL canonicalization and query cleaning, and response-encoding detection. It
+carries no parser and no tree; every helper is a pure-Python function over a string, ``bytes``, or ``urllib`` split
+result, which is why it ships as Scrapy's low-level layer and shows up in scrapers that need one canonical URL form or a
+quick entity decode without pulling in a full DOM.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same ground from the other direction. The ``w3lib.html`` text and entity helpers map onto the
+WHATWG tree turbohtml already builds, so a regex tag strip becomes a real parse plus a text read; the ``w3lib.url``
+canonicalization surface maps onto the :mod:`turbohtml.extract` URL helpers, whose canonical form is the `WHATWG URL
+standard <https://url.spec.whatwg.org/>`_ serialization instead of w3lib's urllib re-encoding. Only w3lib's HTTP-header
+and file/data-URI plumbing stays outside turbohtml's scope.
 
-:func:`turbohtml.unescape` resolves the same character references w3lib's regex-based ``replace_entities`` does, fully
-type annotated and running the scan in C, so it is a drop-in that runs several times faster on entity-heavy input. Two
-more ``w3lib.html`` helpers map onto the WHATWG tree: stripping a set of tags while keeping their text
-(:meth:`~turbohtml.Node.strip_tags` against the regex ``remove_tags``, over a 92 kB page of 839
-``<code>``/``<a>``/``<q>`` elements) and reading a document's own URL hints (:meth:`~turbohtml.Document.base_url` and
-:meth:`~turbohtml.Document.meta_refresh` against ``get_base_url`` and ``get_meta_refresh``), each a structure-aware pass
-that still beats the regex. The URL surface maps onto :mod:`turbohtml.extract`, whose canonical form is the `WHATWG URL
-standard <https://url.spec.whatwg.org/>`_ serialization rather than w3lib's urllib re-encoding, 2x-6x faster over a
-shared 100-URL batch:
+********************
+ turbohtml vs w3lib
+********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 18 41 41
+
+    - - Dimension
+      - turbohtml
+      - w3lib
+    - - Scope
+      - WHATWG HTML parser, DOM tree, selectors, serializer, URL/extract and encoding detection
+      - Stateless string, URL, and encoding utilities for scraping, no parser or tree
+    - - Feature breadth
+      - Broader on HTML: real tree, ``strip_tags``, ``remove``, document URL hints, sanitizing ``clean``
+      - Broader on transport: HTTP headers, file/data URIs, in-place query-parameter mutation
+    - - Performance
+      - C extension; 2x-6x on the shared URL batch, several times faster on entity-heavy text
+      - Pure-Python regex and ``urllib`` re-encoding
+    - - Typing
+      - Fully annotated with bundled ``.pyi`` stubs for the C extension
+      - Typed, ``py.typed``
+    - - Dependencies
+      - Compiled C extension, no Python runtime dependencies
+      - Pure Python, standard library only
+    - - Maintenance
+      - Actively developed
+      - Mature and stable under the Scrapy org
+
+Feature overlap
+===============
+
+These map 1:1 and port directly:
+
+- :func:`w3lib.html.replace_entities` -> :func:`turbohtml.unescape` (same character-reference resolution).
+- :func:`w3lib.html.remove_tags` -> :func:`turbohtml.parse` then :attr:`~turbohtml.Node.text`, or
+  :meth:`~turbohtml.Node.strip_tags` to unwrap only a chosen set while keeping the rest of the document.
+- :func:`w3lib.html.remove_comments` -> :attr:`~turbohtml.Node.text` (comments never appear in text).
+- :func:`w3lib.html.remove_tags_with_content` -> :meth:`~turbohtml.Node.remove` (drops the tag and its subtree).
+- :func:`w3lib.html.get_base_url` -> :meth:`~turbohtml.Document.base_url`.
+- :func:`w3lib.html.get_meta_refresh` -> :meth:`~turbohtml.Document.meta_refresh`.
+- :func:`w3lib.url.canonicalize_url` -> :func:`turbohtml.extract.normalize_url` with ``UrlCleaning.w3lib()``.
+- :func:`w3lib.url.url_query_cleaner` -> ``UrlCleaning(query_allow=...)`` / ``UrlCleaning(query_deny=...)``.
+- :func:`w3lib.url.safe_url_string` -> :func:`turbohtml.extract.clean_url` (also validates) or
+  :func:`~turbohtml.extract.normalize_url`.
+- ``w3lib.url.is_url`` -> ``turbohtml.extract.clean_url(text) is not None``.
+
+What turbohtml adds
+===================
+
+- A real WHATWG tree behind every text operation: nested and malformed markup is parsed the way a browser does, not
+  matched as ``<...>`` spans, and ``text`` returns decoded characters rather than leaving entities encoded.
+- Selector-based tree editing (:meth:`~turbohtml.Node.remove`, :meth:`~turbohtml.Node.strip_tags`) that reshapes the
+  document in place, where w3lib only returns strings.
+- Sanitizing output via ``turbohtml.clean`` when the goal is safe HTML rather than reshaping a tree, which w3lib has no
+  concept of.
+- WHATWG-standard URL serialization from :mod:`turbohtml.extract`, including default-port stripping, ``..`` segment
+  resolution, and automatic removal of known tracking parameters (``utm_*``, ``gclid``, ...) that ``canonicalize_url``
+  never drops.
+- Encoding detection from bytes through :func:`turbohtml.detect.detect`.
+
+What w3lib has that turbohtml does not
+======================================
+
+- ``w3lib.url.add_or_replace_parameter`` / ``add_or_replace_parameters`` — building a URL by setting a query value. No
+  equivalent; turbohtml's ``UrlCleaning`` filters parameters but does not add or rewrite them.
+- ``w3lib.url.url_query_parameter`` — reading a single query value out of a URL. No equivalent; use ``urllib.parse`` for
+  extraction.
+- File and data URI helpers (``file_uri_to_path``, ``path_to_file_uri``, ``any_to_uri``, ``parse_data_uri``). No
+  equivalent, these are outside turbohtml's scope.
+- HTTP-header helpers (``basic_auth_header``, ``headers_dict_to_raw``). No equivalent.
+- ``w3lib.encoding``'s full decode chain (``html_to_unicode``, ``http_content_type_encoding``,
+  ``html_body_declared_encoding``, ``read_bom``) that returns decoded text. :func:`turbohtml.detect.detect` answers the
+  encoding-label question from bytes but does not chain an HTTP ``Content-Type`` header into the decision or hand back
+  the decoded string.
+
+Performance
+===========
+
+The URL surface is 2x-6x faster over a shared 100-URL batch, and the entity and tag helpers each run a structure-aware C
+pass that still beats w3lib's regex on entity-heavy input:
 
 .. bench-table::
     :file: bench/w3lib.json
 
-*************
- The renames
-*************
+****************
+ How to migrate
+****************
+
+Swap the imports for the turbohtml entry points:
+
+.. code-block:: python
+
+    from turbohtml import parse, unescape
+    from turbohtml.extract import UrlCleaning, clean_url, normalize_url
+
+Then map each call:
 
 .. list-table::
     :header-rows: 1
@@ -108,10 +193,6 @@ The two helpers that read a document's own URL hints map to the :meth:`~turbohtm
     http://site.com/sub/
     (5.0, 'http://site.com/next.html')
 
-**********************
- URL canonicalization
-**********************
-
 ``canonicalize_url`` becomes :func:`turbohtml.extract.normalize_url` with the ``UrlCleaning.w3lib()`` preset, which
 mirrors w3lib's fragment dropping; ``url_query_cleaner``'s keep/remove parameter lists become the ``query_allow`` and
 ``query_deny`` fields on the same config:
@@ -130,16 +211,9 @@ mirrors w3lib's fragment dropping; ``url_query_cleaner``'s keep/remove parameter
     http://www.example.com/do?a=50&b=2&b=5&c=3
     http://x.example/product.html?id=200
 
-Over the 253 URLs in w3lib's own test suite the two canonicalizers return identical output for 88% of inputs; every
-divergence is the URL standard's form winning over a urllib legacy form. turbohtml keeps a valueless parameter as ``?q``
-where w3lib appends ``?q=``, percent-encodes a query space as ``%20`` where w3lib emits ``+``, leaves ``,`` ``(`` ``)``
-raw in queries (outside the WHATWG query percent-encode set) where w3lib escapes them, splits parameters on ``&`` only
-(w3lib also splits the legacy ``;``), strips a default ``:80``/``:443`` port and resolves ``..`` segments where w3lib
-keeps both, and drops known tracking parameters, which w3lib never does.
-
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``remove_tags`` strips angle brackets with a regular expression and leaves entities encoded (``Tom &amp; Jerry``),
   while :attr:`~turbohtml.Node.text` runs the WHATWG tree builder and returns decoded characters (``Tom & Jerry``).
@@ -148,7 +222,14 @@ keeps both, and drops known tracking parameters, which w3lib never does.
 - ``remove_tags_with_content`` edits the tree rather than returning a string: :meth:`~turbohtml.Node.remove` drops the
   matches in place, and :meth:`~turbohtml.Node.text` then reads what is left, so a one-line w3lib call becomes a
   parse-edit-read sequence.
+- Over the 253 URLs in w3lib's own test suite the two canonicalizers return identical output for 88% of inputs; every
+  divergence is the URL standard's form winning over a urllib legacy form. turbohtml keeps a valueless parameter as
+  ``?q`` where w3lib appends ``?q=``, percent-encodes a query space as ``%20`` where w3lib emits ``+``, leaves ``,``
+  ``(`` ``)`` raw in queries (outside the WHATWG query percent-encode set) where w3lib escapes them, splits parameters
+  on ``&`` only (w3lib also splits the legacy ``;``), strips a default ``:80``/``:443`` port and resolves ``..``
+  segments where w3lib keeps both.
 - :func:`~turbohtml.extract.normalize_url` always removes known tracking parameters (``utm_*``, ``gclid``, ...);
   ``canonicalize_url`` keeps them. List one in ``UrlCleaning(query_allow=...)`` when it must survive.
-- ``add_or_replace_parameter``, the response-encoding helpers (:func:`turbohtml.detect.detect` answers the encoding
-  question from bytes), and the HTTP-header and file/data-URI helpers have no equivalent here.
+- ``add_or_replace_parameter``, the response-encoding decode chain (:func:`turbohtml.detect.detect` answers the encoding
+  question from bytes but does not return decoded text), and the HTTP-header and file/data-URI helpers have no
+  equivalent here.

--- a/docs/migration/yattag.rst
+++ b/docs/migration/yattag.rst
@@ -4,20 +4,153 @@
 
 .. package-meta:: yattag leforestier/yattag
 
-`yattag <https://www.yattag.org>`_ assembles HTML in Python from the other direction than a parser: you unpack ``doc,
-tag, text = Doc().tagtext()`` and open each element as a ``with tag(...)`` block, calling ``text(...)`` for content,
-then read the string back with ``doc.getvalue()``. turbohtml replaces it with the terse :data:`turbohtml.build.E`
-builder.
+`yattag <https://www.yattag.org>`_ assembles HTML in Python from the other direction than a parser. You unpack ``doc,
+tag, text = Doc().tagtext()``, open each element as a ``with tag(...)`` block, call ``text(...)`` for escaped content
+and ``line(...)`` for an open-text-close shorthand, then read the string back with ``doc.getvalue()``. Attributes are
+keyword arguments (``klass`` for ``class``) or ``("data-i", "1")`` tuples for names that are not Python identifiers.
+Beyond plain generation it scaffolds forms: ``Doc(defaults=..., errors=...)`` with
+``doc.input``/``doc.textarea``/``doc.select`` fills field values from a defaults dict and wraps invalid fields with
+error text, which makes it a common pick for server-rendered pages and form redisplay in Flask and similar stacks
+without a template language.
 
-***************
- Why turbohtml
-***************
+turbohtml covers the same generation ground with the terse :data:`turbohtml.build.E` builder, but the value it hands
+back is a real :class:`~turbohtml.Element` in a parsed tree rather than an accumulated string, so the whole query, edit,
+and serialize surface stays available on what you just built and the markup serializes by exactly the WHATWG rules that
+parse it back.
 
-turbohtml builds HTML with :class:`~turbohtml.Element` plus :meth:`~turbohtml.Node.serialize`, and
-:data:`turbohtml.build.E` is a terse front end for it: ``E.<tag>(attrs, *children)``, where a leading mapping is the
-attributes and each child is a node or a string that becomes text. The result is a real turbohtml tree, so the whole
-edit, query, and serialize surface stays available and the markup you generate serializes by exactly the rules that
-parse it back:
+*********************
+ turbohtml vs yattag
+*********************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
+
+    - - Dimension
+      - turbohtml
+      - yattag
+    - - Scope
+      - Full WHATWG parser, serializer, builder, selectors, sanitizer, converters
+      - HTML/XML generation only, from Python
+    - - Feature breadth
+      - ``E`` builder over a real tree: CSS/XPath query, edit, ``to_markdown``, compact/indent/minify layouts
+      - Context-manager nesting, ``line``/``stag``/``asis`` helpers, ``indent`` pretty-printer, form fill and error
+        wrapping
+    - - Performance
+      - Builds and serializes in C
+      - Pure Python
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - Untyped
+    - - Dependencies
+      - None (self-contained C extension)
+      - None (pure Python)
+    - - Maintenance
+      - Active
+      - Stable, infrequent releases
+
+Feature overlap
+===============
+
+The shared surface ports one-to-one:
+
+- ``with tag("div", klass="card"): ...`` -> :data:`E.div({"class": "card"}, ...) <turbohtml.build.E>`; the attribute
+  mapping leads, the children follow in the same call instead of a context-manager block.
+- ``line("h1", "Title", klass="t")`` -> :data:`E.h1({"class": "t"}, "Title") <turbohtml.build.E>`; the open-text-close
+  shorthand is the default builder call.
+- ``text("body")`` -> a plain string child, which ``E`` escapes into a :class:`~turbohtml.Text` node just as ``text``
+  escapes into the buffer.
+- ``doc.stag("img", src="a.png")`` -> :data:`E.img({"src": "a.png"}) <turbohtml.build.E>`; the serializer omits the
+  close tag for a void element by the WHATWG rules, so no explicit self-closing call is needed.
+- A non-identifier attribute name such as ``("data-i", "1")`` -> the plain dict key ``{"data-i": "1"}``, with no
+  ``klass`` alias or tuple form to remember.
+- A non-identifier tag name -> :data:`E("my-card", ...) <turbohtml.build.E>`, the call form.
+- A class token list joins on a space: ``klass="card lg"`` -> ``E.div({"class": ["card", "lg"]})``.
+
+What turbohtml adds
+===================
+
+- The result is an ordinary :class:`~turbohtml.Element`, so :meth:`~turbohtml.Node.select`,
+  :meth:`~turbohtml.Node.xpath`, :meth:`~turbohtml.Node.find`, :meth:`~turbohtml.Node.to_markdown`, and the full edit
+  API are available on what you built. yattag hands back only a string from ``doc.getvalue()``.
+- The markup serializes by exactly the WHATWG rules that parse it back, so a fragment round-trips through
+  :func:`turbohtml.parse` unchanged; yattag hand-assembles its own string.
+- ``E`` assembles the fragment in turbohtml's arena and serializes it in C, where yattag stays in Python.
+- Layout control beyond yattag's ``indent``: a compact default, an :class:`~turbohtml.Indent` pretty-print, and a
+  :class:`~turbohtml.Minify` layout (whitespace collapse, optional-tag omission, JS/CSS minify), all through one
+  :meth:`~turbohtml.Node.serialize` call.
+- Full type annotations with a ``py.typed`` marker.
+- You can :func:`turbohtml.parse` real markup and append an ``E`` fragment under it, mixing parsing and building in one
+  tree.
+
+What yattag has that turbohtml does not
+=======================================
+
+- Context-manager nesting: ``with tag("div"): text("hi")`` collects everything written inside the block. ``E`` has no
+  context-manager form. Workaround: pass children as positional arguments, or build bottom-up and
+  :meth:`~turbohtml.Element.append`.
+- Form fill and validation: ``Doc(defaults=..., errors=...)`` with ``doc.input``/``doc.textarea``/``doc.select`` fills a
+  field's value from the defaults dict and wraps an invalid field with its error text. ``E`` has no form-aware builder.
+  Workaround: set the ``value``/``checked`` attributes yourself from the dict, and build the error markup as ordinary
+  elements.
+- ``doc.asis("<b>x</b>")`` injects unescaped HTML into the buffer. ``E`` always escapes a string into a
+  :class:`~turbohtml.Text` node. Workaround: :func:`turbohtml.parse` the raw markup and append the resulting nodes,
+  since turbohtml is a real parser.
+- ``doc.attr(...)`` adds attributes to the currently open tag from inside its block. ``E`` sets every attribute in the
+  leading mapping at construction, so there is no open-tag-to-mutate. Workaround: assemble the full attribute dict
+  before the ``E`` call, or set attributes on the returned :class:`~turbohtml.Element` afterward.
+- ``Doc`` also builds XML with arbitrary tags and no void-element or HTML-serialization rules. ``E`` builds an HTML tree
+  and serializes by WHATWG rules. Workaround: for XML output, build the tree and serialize it as HTML, accepting the
+  HTML void-element and escaping conventions.
+
+Performance
+===========
+
+``E`` runs on par with yattag. The same ``<ul>`` of rows -- a class, a ``data`` attribute, and a text child apiece --
+built both ways:
+
+.. bench-table::
+    :file: bench/yattag.json
+
+The decisive difference is the result type: ``E`` hands back a real :class:`~turbohtml.Element`, not a string, so the
+call that builds the markup also leaves a tree you can query, edit, and re-:meth:`~turbohtml.Node.serialize`.
+
+****************
+ How to migrate
+****************
+
+Swap the ``Doc().tagtext()`` unpacking for the single ``E`` builder:
+
+.. code-block:: python
+
+    # yattag
+    from yattag import Doc
+
+    doc, tag, text = Doc().tagtext()
+
+    # turbohtml
+    from turbohtml.build import E
+
+.. list-table::
+    :header-rows: 1
+    :widths: 50 50
+
+    - - `yattag <https://www.yattag.org/>`__
+      - turbohtml
+    - - ``with tag("div", klass="card"): ...`` and ``text("x")``
+      - :data:`E.div({"class": "card"}, "x") <turbohtml.build.E>`; build children inline instead of opening a tag scope
+    - - ``line("h1", "Title", klass="t")``
+      - :data:`E.h1({"class": "t"}, "Title") <turbohtml.build.E>`
+    - - ``doc.stag("img", src="a.png")``
+      - :data:`E.img({"src": "a.png"}) <turbohtml.build.E>`
+    - - ``("data-i", "1")`` tuple attribute
+      - the plain dict key :data:`E.li({"data-i": "1"}) <turbohtml.build.E>`
+    - - ``tag(...)`` for a non-identifier tag name
+      - :data:`E("tag", ...) <turbohtml.build.E>`, the call form
+    - - ``doc.getvalue()`` / ``indent(doc.getvalue())``
+      - :meth:`~turbohtml.Node.serialize` (compact) or ``serialize(Html(layout=Indent()))``
+
+A ``with``-block tree becomes one nested call, attributes leading and children following:
 
 .. testcode::
 
@@ -29,33 +162,6 @@ parse it back:
 .. testoutput::
 
     <div class="card"><h1>Title</h1><p>body</p></div>
-
-``E`` assembles the fragment in turbohtml's arena and serializes it in C; yattag stays in Python. The same ``<ul>`` of
-rows -- a class, a ``data`` attribute, and a text child apiece -- built both ways:
-
-.. bench-table::
-    :file: bench/yattag.json
-
-``E`` runs on par with yattag, and the decisive difference is the result type: ``E`` hands back a real
-:class:`~turbohtml.Element`, not a string, so the call that builds the markup also leaves a tree you can query, edit,
-and re-:meth:`~turbohtml.Node.serialize`.
-
-*************
- The renames
-*************
-
-yattag opens a tag scope with a context manager; turbohtml builds children inline:
-
-.. list-table::
-    :header-rows: 1
-    :widths: 50 50
-
-    - - `yattag <https://www.yattag.org/>`__
-      - turbohtml
-    - - ``doc, tag, text`` with ``with tag("div"):`` and ``text("x")``
-      - :data:`E.div("x") <turbohtml.build.E>` returns the element; build children inline instead of opening a tag scope
-    - - ``with tag("div", ("class", "card")):``
-      - :data:`E.div({"class": "card"}, ...) <turbohtml.build.E>`; attributes are a leading mapping
 
 ``E("tag", ...)`` is the call form for a tag that is not a Python identifier (a custom element, say), and a list-valued
 attribute joins on a space so a class list reads naturally:
@@ -70,13 +176,19 @@ attribute joins on a space so a class list reads naturally:
 
     <my-card class="card lg">hi</my-card>
 
-**********
- Pitfalls
-**********
+**********************
+ Gotchas and pitfalls
+**********************
 
 - ``E`` builds a fragment, not a document: there is no implicit ``<html>``/``<head>``/``<body>`` wrapper and no doctype.
   Serialize the element you built, or append it under a parsed document when you need the full page shell.
 - A leading mapping is always read as attributes; to start an element with literal text, pass the string first
   (``E.p("text", E.b("bold"))``).
+- ``E`` escapes strings into text nodes, so ``E.div("<b>")`` serializes as ``&lt;b&gt;``. yattag's ``asis()`` did no
+  escaping; to inject real markup, :func:`turbohtml.parse` it and append the nodes.
+- turbohtml serializes compact by default, where yattag's ``indent()`` pretty-prints. Pass ``Html(layout=Indent())`` to
+  :meth:`~turbohtml.Node.serialize` for indented output.
+- Write attribute names as plain dict keys (``{"class": "card", "data-i": "1"}``), not yattag's ``klass`` keyword or
+  ``("name", "value")`` tuple conventions.
 - The result is an ordinary :class:`~turbohtml.Element`, so the whole edit and query surface (``append``, ``find``,
   ``select``, ``serialize``, ``to_markdown``) is available -- the builder only saves the construction boilerplate.


### PR DESCRIPTION
The 57 migration guides had drifted apart. One opened with a code sample, the next with a feature list, another buried the turbohtml-versus-library tradeoff several screens down, so a reader comparing turbohtml against a library they already use hunted for the same facts in a different place each time. 📚 This standardizes every guide on one structure, so the comparison reads the same way whichever library you arrive from.

Each guide now opens with an expanded description of the source library and where turbohtml overlaps it, followed by an at-a-glance head-to-head table covering scope, feature breadth, performance, typing, dependencies, and maintenance. Three sections below the table split the surface: feature overlap that ports one-to-one, what turbohtml adds, and what the library has that turbohtml does not. A performance section holds the benchmark table, a how-to-migrate section gives the import-and-call mapping with before/after snippets, and a closing gotchas-and-pitfalls section lists the behavioral differences worth catching before a port.

The change is documentation only, limited to the 57 files under `docs/migration/`. 🔎 Cross-references now point at the classes that carry each method (the query and edit methods resolve to `Node`, `append` and `extend` to `Element`), the embedded snippets pass the repo `ruff-docs` lint, and the full `tox -e docs` build of doctest plus HTML under warnings-as-errors is clean.
