### PR TITLE
🧹 refactor(api): actionable errors, correct types, :raises: docstrings

### DIFF
--- a/docs/changelog/434.bugfix.rst
+++ b/docs/changelog/434.bugfix.rst
@@ -1,3 +1,12 @@
 :meth:`~turbohtml.Node.xpath` now raises a :exc:`ValueError` naming an unknown function, a :exc:`TypeError` when a query
 puts a value where the grammar requires a node-set, and a parse error that carries the offending token and its source
 offset, in place of the previous ``NotImplementedError``.
+
+More failure paths across the public API now raise a precise, actionable error instead of silently returning the wrong
+result or leaking a low-level type. :func:`~turbohtml.parse_fragment` rejects an unknown context tag with a
+:exc:`ValueError` rather than parsing under a garbage root; :func:`~turbohtml.parse` raises :exc:`LookupError` on an
+unknown ``encoding`` label instead of falling back to windows-1252, matching :meth:`~turbohtml.Node.encode`;
+:class:`~turbohtml.Element` reports a non-``str`` tag as ``TypeError: tag must be a str`` and rejects ``=``, ``"``, and
+``'`` in a tag name; :meth:`~turbohtml.Node.find_all` rejects a negative ``limit`` with a :exc:`ValueError`; and feeding
+a closed :class:`~turbohtml.Tokenizer` raises a :exc:`ValueError` instead of quietly resuming. Every public callable's
+docstring now documents the exceptions it raises with a ``:raises:`` block.

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -15,13 +15,15 @@ PyDoc_STRVAR(escape_doc, "escape(s, quote=True)\n--\n\n"
                          ":param s: text to escape.\n"
                          ":param quote: also translate the double (\") and single (') quotation marks,\n"
                          "    so the result is safe inside an attribute value.\n"
-                         ":returns: the escaped text.");
+                         ":returns: the escaped text.\n"
+                         ":raises TypeError: if s is not a str.");
 
 PyDoc_STRVAR(unescape_doc, "unescape(s, /)\n--\n\n"
                            "Convert all named and numeric character references in s to the\n"
                            "corresponding Unicode characters, following the HTML5 rules.\n\n"
                            ":param s: text containing character references.\n"
-                           ":returns: the text with every reference resolved.");
+                           ":returns: the text with every reference resolved.\n"
+                           ":raises TypeError: if s is not a str.");
 
 PyDoc_STRVAR(markup_escape_doc, "escape(s, /)\n--\n\n"
                                 "Replace &, <, >, ', and \" with HTML-safe sequences and return a Markup.\n\n"
@@ -49,7 +51,8 @@ PyDoc_STRVAR(tokenize_doc, "tokenize(s, /, *, resolve_references=True, capture_s
                            "    run; when False each one becomes its own CHARACTER_REFERENCE token.\n"
                            ":param capture_source: record each markup token's verbatim source on\n"
                            "    Token.source.\n"
-                           ":returns: an iterator of Token objects in document order.");
+                           ":returns: an iterator of Token objects in document order.\n"
+                           ":raises TypeError: if s is not a str.");
 
 PyDoc_STRVAR(parse_doc, "parse(markup, *, encoding=None, strict=False, detect_encoding=False, positions=True)\n--\n\n"
                         "Parse a whole HTML document with the WHATWG tree-construction algorithm and\n"
@@ -64,7 +67,11 @@ PyDoc_STRVAR(parse_doc, "parse(markup, *, encoding=None, strict=False, detect_en
                         "    used only when the spec's encoding steps yield nothing.\n"
                         ":param positions: record each element's source_line/source_col; pass False to\n"
                         "    skip it when memory or speed matters more than source locations.\n"
-                        ":returns: the parsed Document.");
+                        ":returns: the parsed Document.\n"
+                        ":raises TypeError: if markup is neither a str nor a bytes-like object.\n"
+                        ":raises LookupError: if encoding names a codec Python does not know.\n"
+                        ":raises HTMLParseError: under strict=True, on the first recovered parse error;\n"
+                        "    its error attribute carries the ParseError (code, line, col).");
 
 PyDoc_STRVAR(parse_fragment_doc, "parse_fragment(html, context='div', *, positions=True)\n--\n\n"
                                  "Parse an HTML fragment as the innerHTML of a context element.\n\n"
@@ -73,7 +80,9 @@ PyDoc_STRVAR(parse_fragment_doc, "parse_fragment(html, context='div', *, positio
                                  "    (e.g. 'td', 'svg path').\n"
                                  ":param positions: record each element's source_line/source_col; pass\n"
                                  "    False to skip it.\n"
-                                 ":returns: the context Element with the parsed nodes as its children.");
+                                 ":returns: the context Element with the parsed nodes as its children.\n"
+                                 ":raises TypeError: if html or context is not a str.\n"
+                                 ":raises ValueError: if context is not a known element tag.");
 
 PyDoc_STRVAR(annotation_surface_doc, "annotation_surface(text, spans, /)\n--\n\n"
                                      "Group the annotated substrings by label, the inscriptis surface-form\n"

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -666,8 +666,18 @@ static PyObject *parse_bytes(module_state *state, PyObject *markup, const char *
     Py_ssize_t len = view.len;
     const th_encoding_entry *entry = NULL;
     Py_ssize_t skip = th_encoding_bom(bytes, len, &entry);
-    if (entry == NULL && enc_arg != NULL) {
-        entry = th_encoding_lookup(enc_arg, enc_len);
+    if (enc_arg != NULL) {
+        /* validate the label even when a BOM already won, so a bogus encoding is an
+           error rather than a silent fallback, matching Document.encode's LookupError */
+        const th_encoding_entry *labeled = th_encoding_lookup(enc_arg, enc_len);
+        if (labeled == NULL) {
+            PyBuffer_Release(&view);
+            PyErr_Format(PyExc_LookupError, "unknown encoding: %s", enc_arg);
+            return NULL;
+        }
+        if (entry == NULL) {
+            entry = labeled;
+        }
     }
     if (entry == NULL) {
         entry = th_encoding_prescan(bytes, len);
@@ -819,6 +829,12 @@ PyObject *turbohtml_tree_parse_fragment(PyObject *module, PyObject *args, PyObje
         if (context == NULL) { /* a lone-surrogate context has no UTF-8 form */
             return NULL;
         }
+        if (!th_tree_fragment_context_known(context, context_len)) {
+            PyErr_Format(PyExc_ValueError,
+                         "context must be a known element tag (optionally namespaced, e.g. 'svg path'), not %R",
+                         context_obj);
+            return NULL;
+        }
     }
     th_tree *tree = th_tree_parse_fragment(PyUnicode_KIND(text), PyUnicode_DATA(text), PyUnicode_GET_LENGTH(text),
                                            context, context_len, positions);
@@ -936,7 +952,11 @@ PyDoc_STRVAR(stream_feed_doc, "feed(data)\n--\n\n"
                               "Raises ValueError once the parser is closed.\n\n"
                               ":param data: str (fed as code points) or a bytes-like object decoded with\n"
                               "    the parser's encoding, an incomplete trailing multi-byte sequence held\n"
-                              "    back until the next chunk.");
+                              "    back until the next chunk.\n"
+                              ":raises TypeError: if data is neither a str nor a bytes-like object.\n"
+                              ":raises ValueError: if the parser is already closed.\n"
+                              ":raises LookupError: if the parser's encoding names a codec Python does not\n"
+                              "    know (raised on the first bytes chunk).");
 
 static PyObject *stream_feed(PyObject *self, PyObject *data) {
     PyObject *result;

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -2608,6 +2608,8 @@ PyDoc_STRVAR(element_doc, "An element node: a tag, a namespace, attributes, and 
                           ":param attrs: initial attributes; a list value sets a token-list attribute and\n"
                           "    None a valueless one.\n"
                           ":param children: initial child nodes, appended in order.\n"
+                          ":raises TypeError: if tag or an attribute name is not a str, an attribute value\n"
+                          "    is not a str, a list of str, or None, or a child is not a node.\n"
                           ":raises ValueError: if the tag or an attribute name carries a character HTML\n"
                           "    forbids there, or if children are given for a void element.");
 
@@ -2636,18 +2638,29 @@ static PyObject *element_insert_adjacent_html(PyObject *self, PyObject *args);
 PyDoc_STRVAR(append_doc, "append(child, /)\n--\n\n"
                          "Add child as the last child of this element. A node already in a tree is\n"
                          "moved; a node from another tree is adopted by copy.\n\n"
-                         ":param child: the node to append.");
+                         ":param child: the node to append.\n"
+                         ":raises TypeError: if child is not a node, or is a Document.\n"
+                         ":raises ValueError: if child is an ancestor of this element (which would form a\n"
+                         "    cycle).");
 
 PyDoc_STRVAR(extend_doc, "extend(children, /)\n--\n\n"
                          "Append every node from the iterable in order, each one moved or adopted\n"
                          "like append().\n\n"
-                         ":param children: the nodes to append.");
+                         ":param children: the nodes to append.\n"
+                         ":raises TypeError: if children is not iterable, or a member is not a node or is\n"
+                         "    a Document.\n"
+                         ":raises ValueError: if a member is an ancestor of this element (which would form\n"
+                         "    a cycle).");
 
 PyDoc_STRVAR(insert_doc, "insert(index, child, /)\n--\n\n"
                          "Insert child among this element's children, counted and clamped like\n"
                          "list.insert.\n\n"
                          ":param index: position among the existing children.\n"
-                         ":param child: the node to insert.");
+                         ":param child: the node to insert.\n"
+                         ":raises TypeError: if index is not an int, or child is not a node or is a\n"
+                         "    Document.\n"
+                         ":raises ValueError: if child is an ancestor of this element (which would form a\n"
+                         "    cycle).");
 
 PyDoc_STRVAR(clear_doc, "clear()\n--\n\n"
                         "Detach every child of this element, leaving it empty.");
@@ -2661,7 +2674,8 @@ PyDoc_STRVAR(wrap_children_doc, "wrap_children(wrapper, /)\n--\n\n"
                                 "and return it. The bulk form of wrap() for a container's whole content; an\n"
                                 "empty element gains an empty wrapper.\n\n"
                                 ":param wrapper: the element to move the children into.\n"
-                                ":returns: wrapper, now holding the moved children.");
+                                ":returns: wrapper, now holding the moved children.\n"
+                                ":raises TypeError: if wrapper is not an element.");
 
 /* --- classList: the space-separated class token set ------------------------ */
 
@@ -2819,7 +2833,9 @@ static PyObject *class_mutate(PyObject *self, PyObject *arg, enum class_op op) {
 PyDoc_STRVAR(add_class_doc, "add_class(name, /)\n--\n\n"
                             "Add name to this element's class tokens when absent and return the element.\n"
                             "Existing tokens keep their order; on a change the class value is rewritten\n"
-                            "with single-space separators.");
+                            "with single-space separators.\n\n"
+                            ":raises TypeError: if name is not a str.\n"
+                            ":raises ValueError: if name is empty or contains whitespace.");
 
 static PyObject *element_add_class(PyObject *self, PyObject *arg) {
     return class_mutate(self, arg, CLASS_ADD);
@@ -2827,7 +2843,9 @@ static PyObject *element_add_class(PyObject *self, PyObject *arg) {
 
 PyDoc_STRVAR(remove_class_doc, "remove_class(name, /)\n--\n\n"
                                "Remove every occurrence of name from this element's class tokens and return\n"
-                               "the element. Removing the last token leaves an empty class attribute.");
+                               "the element. Removing the last token leaves an empty class attribute.\n\n"
+                               ":raises TypeError: if name is not a str.\n"
+                               ":raises ValueError: if name is empty or contains whitespace.");
 
 static PyObject *element_remove_class(PyObject *self, PyObject *arg) {
     return class_mutate(self, arg, CLASS_REMOVE);
@@ -2835,7 +2853,9 @@ static PyObject *element_remove_class(PyObject *self, PyObject *arg) {
 
 PyDoc_STRVAR(toggle_class_doc, "toggle_class(name, /)\n--\n\n"
                                "Remove name from this element's class tokens when present, add it when\n"
-                               "absent, and return the element.");
+                               "absent, and return the element.\n\n"
+                               ":raises TypeError: if name is not a str.\n"
+                               ":raises ValueError: if name is empty or contains whitespace.");
 
 static PyObject *element_toggle_class(PyObject *self, PyObject *arg) {
     return class_mutate(self, arg, CLASS_TOGGLE);
@@ -2845,12 +2865,14 @@ PyDoc_STRVAR(set_inner_html_doc, "set_inner_html(html, /)\n--\n\n"
                                  "Replace this element's children with the nodes parsed from html, a fragment\n"
                                  "parsed in this element's own context (the DOM innerHTML= setter). The\n"
                                  "string is run through the same HTML parser as parse(), so malformed markup\n"
-                                 "is repaired the same way.");
+                                 "is repaired the same way.\n\n"
+                                 ":raises TypeError: if html is not a str.");
 
 PyDoc_STRVAR(set_text_doc, "set_text(text, /)\n--\n\n"
                            "Replace this element's children with a single Text node holding text\n"
                            "verbatim (the DOM textContent= setter). text is never parsed, so any markup\n"
-                           "in it is escaped on serialization. The Element.text= setter is equivalent.");
+                           "in it is escaped on serialization. The Element.text= setter is equivalent.\n\n"
+                           ":raises TypeError: if text is not a str.");
 
 PyDoc_STRVAR(insert_adjacent_html_doc, "insert_adjacent_html(position, html, /)\n--\n\n"
                                        "Parse html as a fragment and insert it relative to this element at position,\n"
@@ -2858,7 +2880,10 @@ PyDoc_STRVAR(insert_adjacent_html_doc, "insert_adjacent_html(position, html, /)\
                                        "insertAdjacentHTML, matched case-insensitively). 'beforebegin' and 'afterend'\n"
                                        "place the nodes among this element's siblings, so they require an element\n"
                                        "parent; 'afterbegin' and 'beforeend' add them as the first or last children.\n"
-                                       "The fragment parses in the context of the element that will hold it.");
+                                       "The fragment parses in the context of the element that will hold it.\n\n"
+                                       ":raises TypeError: if position or html is not a str.\n"
+                                       ":raises ValueError: if position is not one of the four keywords, or a\n"
+                                       "    sibling-relative position is used on a node without an element parent.");
 
 /* ---- css_path() / xpath_path(): the unique locator for a node ---- */
 
@@ -3212,8 +3237,10 @@ static int validate_name(PyObject *name, int is_attr) {
     const void *data = PyUnicode_DATA(name);
     for (Py_ssize_t index = 0; index < len; index++) {
         Py_UCS4 character = PyUnicode_READ(kind, data, index);
-        int bad = character <= ' ' || character == '/' || character == '>' || character == '<' ||
-                  (is_attr && (character == '=' || character == '"' || character == '\''));
+        /* =, ", and ' break a tag name's serialization just as they do an attribute
+           name's, so both reject them (a tag <a"b> would round-trip as malformed markup) */
+        int bad = character <= ' ' || character == '/' || character == '>' || character == '<' || character == '=' ||
+                  character == '"' || character == '\'';
         if (bad) {
             PyObject *ch = PyUnicode_FromOrdinal((int)character);
             if (ch != NULL) { /* GCOVR_EXCL_BR_LINE: a forbidden character is ASCII and always builds */
@@ -3382,7 +3409,11 @@ static PyObject *element_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *tag;
     PyObject *attrs = NULL;
     PyObject *children = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "U|OO", keywords, &tag, &attrs, &children)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OO", keywords, &tag, &attrs, &children)) {
+        return NULL;
+    }
+    if (!PyUnicode_Check(tag)) {
+        PyErr_Format(PyExc_TypeError, "tag must be a str, not %.80s", Py_TYPE(tag)->tp_name);
         return NULL;
     }
     if (validate_name(tag, 0) < 0) {

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -1290,14 +1290,19 @@ PyDoc_STRVAR(serialize_doc, "serialize(options=None)\n--\n\n"
                             "Serialize this node and its subtree to a str.\n\n"
                             ":param options: an Html configuration object (formatter, layout, attribute\n"
                             "    ordering, and meta-charset handling), or None for the defaults.\n"
-                            ":returns: the serialized markup.");
+                            ":returns: the serialized markup.\n"
+                            ":raises TypeError: if options is not an Html configuration object.");
 
 PyDoc_STRVAR(encode_doc, "encode(encoding='utf-8', options=None)\n--\n\n"
                          "Serialize this node and its subtree to bytes, with the same formatting controls\n"
                          "as serialize().\n\n"
                          ":param encoding: the codec to encode the markup with.\n"
                          ":param options: an Html configuration object, or None for the defaults.\n"
-                         ":returns: the serialized markup encoded as bytes.");
+                         ":returns: the serialized markup encoded as bytes.\n"
+                         ":raises TypeError: if options is not an Html configuration object.\n"
+                         ":raises LookupError: if encoding names a codec Python does not know.\n"
+                         ":raises UnicodeEncodeError: if the markup has characters the encoding cannot\n"
+                         "    represent.");
 
 PyDoc_STRVAR(find_doc,
              "find(tag=None, /, *, axis=Axis.DESCENDANTS, attrs=None, class_=None, text=None, **filters)\n--\n\n"
@@ -1310,7 +1315,9 @@ PyDoc_STRVAR(find_doc,
              ":param text: match the element's collected text (an exact str, a regex search, or a callable\n"
              "    predicate); filter a literal text attribute through attrs={'text': ...}.\n"
              ":param filters: further attribute filters given as keyword arguments.\n"
-             ":returns: the first matching Element, or None.");
+             ":returns: the first matching Element, or None.\n"
+             ":raises TypeError: if axis is not an Axis, or a filter is not a str, bool, regex,\n"
+             "    callable, or a list of those.");
 
 PyDoc_STRVAR(find_all_doc,
              "find_all(tag=None, /, *, axis=Axis.DESCENDANTS, attrs=None, class_=None, text=None, limit=None, "
@@ -1325,28 +1332,41 @@ PyDoc_STRVAR(find_all_doc,
              "    predicate).\n"
              ":param limit: stop after this many matches; None collects them all.\n"
              ":param filters: further attribute filters given as keyword arguments.\n"
-             ":returns: the matching Elements in document order.");
+             ":returns: the matching Elements in document order.\n"
+             ":raises TypeError: if axis is not an Axis, limit is not an int or None, or a\n"
+             "    filter is not a str, bool, regex, callable, or a list of those.\n"
+             ":raises ValueError: if limit is negative.");
 
 PyDoc_STRVAR(insert_before_doc, "insert_before(*nodes)\n--\n\n"
                                 "Insert each node into this node's parent right before this node, in order. A\n"
                                 "node already in a tree is moved; a node from another tree is adopted by copy.\n\n"
-                                ":param nodes: the nodes to insert.");
+                                ":param nodes: the nodes to insert.\n"
+                                ":raises TypeError: if an argument is not a node, or is a Document.\n"
+                                ":raises ValueError: if this node has no parent, or a node is an ancestor of\n"
+                                "    the insertion point (which would form a cycle).");
 
 PyDoc_STRVAR(insert_after_doc, "insert_after(*nodes)\n--\n\n"
                                "Insert each node into this node's parent right after this node, in order,\n"
                                "with the same move-or-adopt rule as insert_before().\n\n"
-                               ":param nodes: the nodes to insert.");
+                               ":param nodes: the nodes to insert.\n"
+                               ":raises TypeError: if an argument is not a node, or is a Document.\n"
+                               ":raises ValueError: if this node has no parent, or a node is an ancestor of\n"
+                               "    the insertion point (which would form a cycle).");
 
 PyDoc_STRVAR(replace_with_doc, "replace_with(*nodes)\n--\n\n"
                                "Put nodes where this node is, in order, and detach this node, which becomes a\n"
                                "standalone root the caller still holds. With no nodes this just removes this\n"
                                "node.\n\n"
-                               ":param nodes: the nodes to put in this node's place.");
+                               ":param nodes: the nodes to put in this node's place.\n"
+                               ":raises TypeError: if an argument is not a node, or is a Document.\n"
+                               ":raises ValueError: if this node has no parent, or a node is an ancestor of\n"
+                               "    this node (which would form a cycle).");
 
 PyDoc_STRVAR(wrap_doc, "wrap(wrapper, /)\n--\n\n"
                        "Put this node inside wrapper, in this node's place.\n\n"
                        ":param wrapper: the element to wrap this node in.\n"
-                       ":returns: wrapper, now holding this node.");
+                       ":returns: wrapper, now holding this node.\n"
+                       ":raises TypeError: if wrapper is not an element.");
 
 PyDoc_STRVAR(wrap_siblings_doc, "wrap_siblings(wrapper, /, *, until=None)\n--\n\n"
                                 "Wrap this node and the siblings that follow it in wrapper in one move; the\n"
@@ -1354,11 +1374,15 @@ PyDoc_STRVAR(wrap_siblings_doc, "wrap_siblings(wrapper, /, *, until=None)\n--\n\
                                 ":param wrapper: the element to wrap the run in.\n"
                                 ":param until: the last sibling to include (this node or a later one);\n"
                                 "    None reaches to the last sibling.\n"
-                                ":returns: wrapper, now holding the run.");
+                                ":returns: wrapper, now holding the run.\n"
+                                ":raises TypeError: if wrapper is not an element, or until is not a node.\n"
+                                ":raises ValueError: if this node has no parent, or until is not this node or\n"
+                                "    a following sibling.");
 
 PyDoc_STRVAR(unwrap_doc, "unwrap()\n--\n\n"
                          "Replace this node with its children, the inverse of wrap().\n\n"
-                         ":returns: this node, detached.");
+                         ":returns: this node, detached.\n"
+                         ":raises ValueError: if this node has no parent.");
 
 PyDoc_STRVAR(extract_doc, "extract()\n--\n\n"
                           "Detach this node from its parent, leaving a standalone node the caller can\n"

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -3650,6 +3650,26 @@ th_tree *th_tree_parse_fragment(int kind, const void *data, Py_ssize_t length, c
     return tree;
 }
 
+/* Whether a public parse_fragment() context names a real element. A bare name must
+   intern to a known HTML atom: an unknown one (a typo like "zzz") would otherwise
+   parse in "in body" mode under a garbage root, silently yielding the wrong tree.
+   An explicitly namespaced foreign context (svg/math) is always accepted, since
+   those element registries are open-ended. */
+int th_tree_fragment_context_known(const char *context, Py_ssize_t context_len) {
+    if ((context_len > 4 && memcmp(context, "svg ", 4) == 0) || (context_len > 5 && memcmp(context, "math ", 5) == 0)) {
+        return 1;
+    }
+    char lower[MAX_CONTEXT_NAME];
+    Py_ssize_t lower_len = context_len < (Py_ssize_t)sizeof(lower) ? context_len : (Py_ssize_t)sizeof(lower);
+    for (Py_ssize_t index = 0; index < lower_len; index++) {
+        char character = context[index];
+        lower[index] = character >= 'A' && character <= 'Z' ? (char)(character + 32) : character;
+    }
+    th_buf ctx_name = {lower, lower_len, 0, PyUnicode_1BYTE_KIND};
+    uint8_t ctx_flags;
+    return intern_atom(&ctx_name, &ctx_flags) != TH_TAG_UNKNOWN;
+}
+
 void th_tree_free(th_tree *tree) {
     arena_block *block = tree->arena;
     while (block != NULL) {

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -171,6 +171,10 @@ void th_node_normalize(th_tree *tree, th_node *root);
 th_tree *th_tree_parse_fragment(int kind, const void *data, Py_ssize_t length, const char *context,
                                 Py_ssize_t context_len, int positions);
 
+/* Whether context names a real element the public parse_fragment() accepts: a known
+   HTML tag, or any explicitly namespaced (svg/math) foreign element. */
+int th_tree_fragment_context_known(const char *context, Py_ssize_t context_len);
+
 void th_tree_free(th_tree *tree);
 
 /* --- streaming (push) parse --- */

--- a/src/turbohtml/_c/query/find/find.c
+++ b/src/turbohtml/_c/query/find/find.c
@@ -483,6 +483,10 @@ static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_
                 if (PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: an overflowing limit cannot be forced from a test */
                     return -1;          /* GCOVR_EXCL_LINE: overflow path */
                 }
+                if (query->limit < 0) {
+                    PyErr_Format(PyExc_ValueError, "limit must be non-negative, not %R", value);
+                    return -1;
+                }
             } else {
                 PyErr_SetString(PyExc_TypeError, "limit must be an int or None");
                 return -1;

--- a/src/turbohtml/_c/tokenizer/tokenizer.c
+++ b/src/turbohtml/_c/tokenizer/tokenizer.c
@@ -18,6 +18,7 @@
 typedef struct {
     PyObject_HEAD th_tokenizer *sm;
     PyObject *source; /* borrowed-input owner for one-shot tokenize(), else NULL */
+    int closed;       /* set by close()/__exit__; feed() after it is an error until reset() */
 } TokenizerObject;
 
 typedef struct {
@@ -160,6 +161,7 @@ static PyObject *tokenizer_new(PyTypeObject *type, PyObject *args, PyObject *kwd
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     self->source = NULL;
+    self->closed = 0;
     self->sm = th_tok_new();
     if (self->sm == NULL) {      /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         Py_DECREF(self);         /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -198,9 +200,15 @@ PyDoc_STRVAR(tokenizer_feed_doc, "feed(data)\n--\n\n"
                                  "Append a chunk of markup. Text before an unfinished tag stays buffered until\n"
                                  "more is fed or close() is called.\n\n"
                                  ":param data: the next chunk of markup.\n"
-                                 ":returns: an iterator over the tokens that are now complete.");
+                                 ":returns: an iterator over the tokens that are now complete.\n"
+                                 ":raises TypeError: if data is not a str.\n"
+                                 ":raises ValueError: if the tokenizer is closed; call reset() to reuse it.");
 
 static PyObject *tokenizer_feed(PyObject *self, PyObject *data) {
+    if (((TokenizerObject *)self)->closed) {
+        PyErr_SetString(PyExc_ValueError, "cannot feed a closed Tokenizer; call reset() to reuse it");
+        return NULL;
+    }
     th_tokenizer *sm = ((TokenizerObject *)self)->sm;
     int rc;
     Py_BEGIN_CRITICAL_SECTION(self); /* th_tok_feed mutates the shared state machine */
@@ -220,6 +228,7 @@ static PyObject *tokenizer_close(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     th_tokenizer *sm = ((TokenizerObject *)self)->sm;
     Py_BEGIN_CRITICAL_SECTION(self); /* th_tok_close mutates the shared state machine */
     th_tok_close(sm);
+    ((TokenizerObject *)self)->closed = 1;
     Py_END_CRITICAL_SECTION();
     return iter_new(state_of(self), self);
 }
@@ -230,6 +239,7 @@ PyDoc_STRVAR(tokenizer_reset_doc, "reset()\n--\n\n"
 static PyObject *tokenizer_reset(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     Py_BEGIN_CRITICAL_SECTION(self); /* th_tok_reset mutates the shared state machine */
     th_tok_reset(((TokenizerObject *)self)->sm);
+    ((TokenizerObject *)self)->closed = 0;
     Py_END_CRITICAL_SECTION();
     Py_RETURN_NONE;
 }
@@ -247,6 +257,7 @@ PyDoc_STRVAR(tokenizer_exit_doc, "__exit__(*exc)\n--\n\n"
 static PyObject *tokenizer_exit(PyObject *self, PyObject *Py_UNUSED(args)) {
     Py_BEGIN_CRITICAL_SECTION(self); /* th_tok_close mutates the shared state machine */
     th_tok_close(((TokenizerObject *)self)->sm);
+    ((TokenizerObject *)self)->closed = 1;
     Py_END_CRITICAL_SECTION();
     Py_RETURN_NONE;
 }

--- a/src/turbohtml/_render.py
+++ b/src/turbohtml/_render.py
@@ -51,6 +51,7 @@ class Markdown:
     :param convert: the only tags to render as Markdown, every other tag dropped to text; mutually exclusive with
         ``strip``.
     :param converters: per-tag overrides, each a callable receiving the element and its rendered child Markdown.
+    :raises ValueError: if both ``strip`` and ``convert`` are given, since they are mutually exclusive.
     """
 
     @dataclass(frozen=True)

--- a/tests/dom/test_tree_api.py
+++ b/tests/dom/test_tree_api.py
@@ -71,6 +71,30 @@ def test_parse_fragment_context_with_lone_surrogate_is_rejected() -> None:
 
 
 @pytest.mark.parametrize(
+    "context",
+    ["zzznotatag", "my-widget", "z" * 40],
+    ids=["typo", "custom-element", "overlong"],
+)
+def test_parse_fragment_rejects_unknown_context(context: str) -> None:
+    # an unknown context would silently parse in "in body" mode under a garbage root
+    with pytest.raises(ValueError, match="context must be a known element tag"):
+        parse_fragment("<p>", context)
+
+
+@pytest.mark.parametrize(
+    ("context", "tag"),
+    [
+        pytest.param("svg circle", "circle", id="svg-open-registry"),
+        pytest.param("math mrow", "mrow", id="math-open-registry"),
+        pytest.param("TABLE", "table", id="uppercase-known-tag"),
+    ],
+)
+def test_parse_fragment_accepts_context(context: str, tag: str) -> None:
+    # a namespaced foreign registry is open-ended; a known tag matches case-insensitively
+    assert parse_fragment("<p/>", context).tag == tag
+
+
+@pytest.mark.parametrize(
     ("html", "context", "tag", "child_tags", "text"),
     [
         pytest.param("<td>a<td>b", "tr", "tr", ["td", "td"], "ab", id="table-row-context"),

--- a/tests/dom/test_tree_construct.py
+++ b/tests/dom/test_tree_construct.py
@@ -122,11 +122,19 @@ def test_element_attribute_name_is_lowercased() -> None:
         pytest.param("a/b", id="slash"),
         pytest.param("a>b", id="gt"),
         pytest.param("a<b", id="lt"),
+        pytest.param("a=b", id="eq"),
+        pytest.param('a"b', id="dquote"),
+        pytest.param("a'b", id="squote"),
     ],
 )
 def test_element_tag_is_rejected(tag: str) -> None:
     with pytest.raises(ValueError, match=r"empty|invalid character"):
         Element(tag)
+
+
+def test_element_tag_must_be_a_str() -> None:
+    with pytest.raises(TypeError, match="tag must be a str, not int"):
+        Element(5)  # ty: ignore[invalid-argument-type]  # tag must be a str
 
 
 @pytest.mark.parametrize(

--- a/tests/encoding/test_encoding.py
+++ b/tests/encoding/test_encoding.py
@@ -46,15 +46,32 @@ def test_bom_is_detected_and_stripped(data: bytes, encoding: str) -> None:
         pytest.param(b"\xef\xbb\xbf<p>x", "iso-8859-2", "UTF-8", id="bom-overrides-argument"),
         # the argument outranks a <meta>; a <meta> is used only without an argument
         pytest.param(b'<meta charset="utf-8"><p>x', "iso-8859-2", "ISO-8859-2", id="argument-outranks-meta"),
-        pytest.param(b"<p>x", "not-a-real-encoding", "windows-1252", id="unknown-label-falls-through"),
         pytest.param(b"<p>x", "  ISO-8859-2  ", "ISO-8859-2", id="whitespace-and-case-insensitive"),
-        pytest.param(b"<p>x", "", "windows-1252", id="empty-label"),
-        pytest.param(b"<p>x", "   ", "windows-1252", id="whitespace-label"),
-        pytest.param(b"<p>x", "x" * 80, "windows-1252", id="overlong-label"),
     ],
 )
 def test_encoding_argument(data: bytes, encoding_arg: str, expected: str) -> None:
     assert parse(data, encoding=encoding_arg).encoding == expected
+
+
+@pytest.mark.parametrize(
+    "encoding_arg",
+    [
+        pytest.param("not-a-real-encoding", id="unknown-label"),
+        pytest.param("", id="empty-label"),
+        pytest.param("   ", id="whitespace-label"),
+        pytest.param("x" * 80, id="overlong-label"),
+    ],
+)
+def test_unknown_encoding_argument_raises(encoding_arg: str) -> None:
+    # an unknown label is an error, not a silent windows-1252 fallback, matching Document.encode
+    with pytest.raises(LookupError, match="unknown encoding"):
+        parse(b"<p>x", encoding=encoding_arg)
+
+
+def test_unknown_encoding_argument_raises_even_with_bom() -> None:
+    # the label is validated before a BOM can win, so a bogus one is never silently ignored
+    with pytest.raises(LookupError, match="unknown encoding"):
+        parse(b"\xef\xbb\xbf<p>x", encoding="not-a-real-encoding")
 
 
 @pytest.mark.parametrize(

--- a/tests/query/find/test_tree_find.py
+++ b/tests/query/find/test_tree_find.py
@@ -251,11 +251,15 @@ def test_axis_preceding_excludes_ancestors() -> None:
         pytest.param(None, 2, id="none"),
         pytest.param(1, 1, id="one"),
         pytest.param(0, 0, id="zero"),
-        pytest.param(-1, 2, id="negative-is-unlimited"),
     ],
 )
 def test_limit(limit: int | None, count: int) -> None:
     assert len(parse(_DOC).find_all("p", limit=limit)) == count
+
+
+def test_negative_limit_is_rejected() -> None:
+    with pytest.raises(ValueError, match="limit must be non-negative"):
+        parse(_DOC).find_all("p", limit=-1)
 
 
 def test_limit_on_the_general_path() -> None:

--- a/tests/tokenizer/test_tokenizer.py
+++ b/tests/tokenizer/test_tokenizer.py
@@ -293,6 +293,21 @@ def test_streaming_crlf_across_feeds() -> None:
     assert [token.data for token in tokenizer.close()] == ["a\nb"]
 
 
+def test_feed_after_close_is_rejected() -> None:
+    tokenizer = Tokenizer()
+    list(tokenizer.feed("<p>"))
+    list(tokenizer.close())
+    with pytest.raises(ValueError, match="closed Tokenizer"):
+        tokenizer.feed("<b>")
+
+
+def test_reset_reopens_a_closed_tokenizer() -> None:
+    tokenizer = Tokenizer()
+    list(tokenizer.close())
+    tokenizer.reset()
+    assert [token.type for token in tokenizer.feed("<b>")] == [TokenType.START_TAG]
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [


### PR DESCRIPTION
Issue #434 audited error handling across the public API and found failure paths that crash, leak a low-level type, or return the wrong result without complaint, plus zero `:raises:` blocks in the C docstrings. This is the closing sweep, covering the entry points earlier PRs left.

`parse_fragment` interned an unknown context tag verbatim and built the fragment in `in body` mode under a garbage root; it now raises `ValueError` naming the tag, while a namespaced `svg`/`math` context stays accepted since those registries are open-ended. `parse` fell back to windows-1252 on an unknown `encoding` label even though `Document.encode` raises `LookupError`; the two now agree. `Element` reported a non-`str` tag with a generic `argument 1 must be str, not int` and accepted `=`, `"`, and `'` in a tag name that could not round-trip, so it now says `tag must be a str, not <type>` and rejects those characters. `find_all` treated a negative `limit` as unlimited and now rejects it with `ValueError`. Feeding a closed `Tokenizer` resumed tokenizing; it now raises `ValueError`, and `reset` reopens it.

Every raise stays in the C extension. Alongside the type and message fixes, the parse family, tokenizer, `IncrementalParser`, `find`/`find_all`, `serialize`/`encode`, the node and element mutation methods, the classList operations, and the `Markdown` config each gained a `:raises:` block naming what they raise and when.

closes #434
