### PR TITLE
✨ feat(clean): sanitizer attribute-prefix, value-allowlist, and host-allowlist policy

### DIFF
--- a/docs/changelog/461.feature.rst
+++ b/docs/changelog/461.feature.rst
@@ -1,0 +1,6 @@
+Give :class:`turbohtml.clean.Policy` three sanitizer knobs that previously needed an ``attribute_filter`` workaround:
+``attribute_prefixes`` keeps any attribute whose name starts with an allowlisted prefix (nh3
+``generic_attribute_prefixes``, the ``data-*`` case), ``attribute_values`` restricts a kept ``(tag, attribute)`` to a
+set of literal values (nh3 ``tag_attribute_values``), and ``media_hosts`` keeps an ``audio``/``video``/``source``/
+``track`` ``src`` only when its URL host is on the allowlist (lxml-html-clean ``host_whitelist``). All three run in the
+C sanitize walk and cost nothing when unset - by :user:`gaborbernat`.

--- a/docs/migration/lxml-html-clean.rst
+++ b/docs/migration/lxml-html-clean.rst
@@ -31,8 +31,9 @@ the filtering walk in C.
       - Allowlist HTML sanitizer, plus linkify and HTML/CSS minify in one module
       - Blocklist ``Cleaner`` extracted from ``lxml.html.clean``; sanitization only
     - - Feature breadth
-      - Policy presets (``strict``/``basic``/``relaxed``), per-tag attribute allowlists, ``style`` scrubbing, link
-        ``rel`` injection, attribute-filter hook
+      - Policy presets (``strict``/``basic``/``relaxed``), per-tag attribute allowlists, attribute-prefix/value
+        allowlists, embedded-media ``host_whitelist``, ``style`` scrubbing, link ``rel`` injection, attribute-filter
+        hook
       - ~20 category toggles, ``host_whitelist`` for embedded media, ``safe_attrs``, ``add_nofollow``, in-place tree
         mutation
     - - Performance
@@ -63,6 +64,9 @@ The shared surface ports directly:
   ``frozenset({"nofollow"})``).
 - Remove forms, frames, and embedded media: leave those tags out of ``Policy.tags`` instead of toggling ``forms``,
   ``frames``, ``embedded``.
+- Restrict embedded media to named hosts: ``host_whitelist=`` maps to :class:`Policy.media_hosts
+  <turbohtml.clean.Policy>`, which drops an ``audio``/``video``/``source``/``track`` ``src`` whose URL host is not on
+  the allowlist.
 
 What turbohtml adds
 ===================
@@ -83,9 +87,6 @@ What turbohtml adds
 What lxml-html-clean has that turbohtml does not
 ================================================
 
-- ``host_whitelist``: allow embedded media (``iframe``, ``embed``) only from named hosts. turbohtml has no built-in host
-  allowlist; implement one in a ``Policy.attribute_filter`` that parses the ``src`` host and returns ``None`` to drop a
-  disallowed value.
 - In-place cleaning of an existing lxml element or subtree: ``Cleaner`` mutates the tree you already hold.
   :func:`~turbohtml.clean.sanitize` takes an HTML string and returns an HTML string, so there is no in-tree equivalent.
 - ``annoying_tags``: a named toggle for presentational cruft (``blink``, ``marquee``). turbohtml has no dedicated flag;
@@ -132,7 +133,7 @@ Swap the import and invert the model: instead of switching dangerous categories 
     - - ``add_nofollow=True``
       - ``Policy.add_link_rel``
     - - ``host_whitelist=``
-      - ``Policy.attribute_filter`` (no built-in host allowlist)
+      - ``Policy.media_hosts``
 
 .. testcode::
 
@@ -156,6 +157,9 @@ The ``javascript:`` URL is gone because ``http``/``https``/``mailto`` are the on
  Gotchas and pitfalls
 **********************
 
+- ``host_whitelist`` in ``Cleaner`` gates ``iframe``/``embed``; turbohtml escapes those framing elements outright (they
+  are never kept), so ``Policy.media_hosts`` instead gates the ``src`` of the media elements turbohtml can keep --
+  ``audio``, ``video``, ``source``, ``track`` -- dropping a ``src`` whose host is not on the lowercase allowlist.
 - turbohtml scrubs a kept ``style`` attribute against ``Policy.css_properties`` but drops ``<style>`` elements, where
   ``Cleaner`` scrubs their text and keeps the element.
 - ``Cleaner`` rewrites a disallowed scheme to an empty ``href``; turbohtml drops the attribute outright.

--- a/docs/migration/nh3.rst
+++ b/docs/migration/nh3.rst
@@ -31,7 +31,8 @@ WHATWG-conformant parser, so the same tree can be parsed, queried, sanitized, an
       - Full WHATWG parser with a sanitize/linkify/minify/CSS-minify suite
       - HTML sanitization only, plus ``clean_text``/``is_html`` helpers
     - - Feature breadth
-      - Escape/strip/remove modes, ``Policy`` presets, linkifier, HTML and CSS minifiers
+      - Escape/strip/remove modes, ``Policy`` presets, linkifier, attribute-prefix/value allowlists, embedded-media host
+        allowlist, HTML and CSS minifiers
       - Allowlist sanitize with ``attribute_filter``, style-property filter, attribute-prefix and value allowlists
     - - Performance
       - Native C, leads on the corpus below
@@ -64,6 +65,10 @@ The allowlist surface ports one-to-one; only the call shape changes.
   <turbohtml.clean.Policy>`.
 - Inline-style property allowlist: ``filter_style_properties=`` -> :class:`Policy.css_properties
   <turbohtml.clean.Policy>`.
+- Attribute-name prefix allowlist (the ``data-*`` family): ``generic_attribute_prefixes=`` ->
+  :class:`Policy.attribute_prefixes <turbohtml.clean.Policy>`.
+- Restrict an attribute to literal values: ``tag_attribute_values=`` -> :class:`Policy.attribute_values
+  <turbohtml.clean.Policy>` (narrows an attribute already admitted by ``attributes``; it cannot admit a new one).
 
 What turbohtml adds
 ===================
@@ -83,11 +88,6 @@ What turbohtml adds
 What nh3 has that turbohtml does not
 ====================================
 
-- ``generic_attribute_prefixes`` -- allow attributes whose name starts with a given prefix (e.g. every ``data-*``).
-  turbohtml matches attribute names exactly or with a ``"*"`` wildcard per tag, with no prefix matching. Workaround:
-  allow ``"*"`` and reject unwanted names in an ``attribute_filter``, or enumerate the concrete names.
-- ``tag_attribute_values`` -- restrict an attribute to a specific set of literal values. turbohtml has no dedicated
-  field. Workaround: an ``attribute_filter`` that returns ``None`` for values outside the set.
 - ``nh3.is_html(text)`` -- a heuristic bool for whether a string contains HTML. No turbohtml equivalent.
 - ``nh3.clean_text(text)`` -- escape a string for safe insertion as text. Workaround: ``sanitize(text,
   Policy.strict())`` escapes all markup to text.
@@ -131,6 +131,10 @@ frozen config object plus :func:`~turbohtml.clean.sanitize`.
       - ``Policy.set_attributes``
     - - ``filter_style_properties=``
       - ``Policy.css_properties``
+    - - ``generic_attribute_prefixes=``
+      - ``Policy.attribute_prefixes``
+    - - ``tag_attribute_values=``
+      - ``Policy.attribute_values``
     - - (drops disallowed tags)
       - :class:`~turbohtml.clean.OnDisallowed` (``ESCAPE`` by default; ``STRIP`` / ``REMOVE`` for nh3-style dropping)
 
@@ -165,8 +169,9 @@ frozen config object plus :func:`~turbohtml.clean.sanitize`.
 - Set-typed fields must be sets. ``tags``, ``url_schemes``, ``remove_with_content``, and ``css_properties`` expect a
   ``set``/``frozenset``; passing another type raises :class:`TypeError`. nh3 accepts any iterable for the equivalent
   arguments.
-- Attribute allowlisting is by exact name or a per-tag ``"*"`` wildcard. There is no prefix rule, so ``data-*`` style
-  families need ``"*"`` plus an ``attribute_filter`` rather than nh3's ``generic_attribute_prefixes``.
+- Attribute allowlisting is by exact name, a per-tag ``"*"`` wildcard, or a name prefix in ``attribute_prefixes`` (nh3's
+  ``generic_attribute_prefixes``, e.g. ``"data-"`` for every ``data-*``). ``attribute_values`` restricts a kept
+  attribute to literal values; it narrows an attribute ``attributes`` already admits and cannot admit a new one.
 - ``sanitize`` takes an HTML fragment and returns a fragment; it does not add ``<html>``/``<body>`` scaffolding,
   matching nh3's fragment-in, fragment-out contract.
 - Reuse the compiled :class:`~turbohtml.clean.Sanitizer` when sanitizing many inputs with one policy; each bare

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -28,6 +28,9 @@ typedef struct {
     PyObject *set_attributes;   /* dict[str, dict[str, str]]: per-tag attribute values to force-set on kept elements */
     PyObject *remove_with_content; /* frozenset[str]: disallowed tags whose whole subtree is dropped, not escaped */
     PyObject *css_properties;      /* frozenset[str]: CSS property names kept when scrubbing a `style` attribute */
+    PyObject *attribute_prefixes;  /* frozenset[str]: allow any attribute whose name starts with one of these */
+    PyObject *attribute_values;    /* dict[str, dict[str, frozenset[str]]]: per (tag, attr) literal value allowlist */
+    PyObject *media_hosts; /* frozenset[str]: allowed hosts for an embedded-media (audio/video/source/track) src */
     int allow_relative;
     int on_disallowed;
     int strip_comments;
@@ -188,8 +191,36 @@ static int is_srcset_attr(const char *name, Py_ssize_t len) {
     return 0;
 }
 
-/* Is `name` allowed on element `tag` by the policy? A "*" inside an attribute set allows every attribute name.
-   Returns 1 allow, 0 drop, -1 error. */
+/* Does `name` begin with any allowlisted attribute-name prefix (nh3's generic_attribute_prefixes, the `data-*` case)?
+   The prefixes are validated as non-empty str at setup, so each check is a byte-prefix compare. Returns 1 match, 0
+   none, -1 error. Only reached when the prefix set is non-empty, so a policy without prefixes never iterates. */
+static int name_has_allowed_prefix(sanitizer *s, const char *name, Py_ssize_t len) {
+    PyObject *iterator = PyObject_GetIter(s->attribute_prefixes);
+    if (iterator == NULL) { /* GCOVR_EXCL_BR_LINE: getting an iterator over a set cannot fail */
+        return -1;          /* GCOVR_EXCL_LINE: error path */
+    }
+    int matched = 0;
+    PyObject *prefix;
+    while (!matched && (prefix = PyIter_Next(iterator)) != NULL) {
+        Py_ssize_t prefix_len = 0;
+        const char *prefix_bytes = PyUnicode_AsUTF8AndSize(prefix, &prefix_len);
+        if (prefix_bytes == NULL) { /* GCOVR_EXCL_BR_LINE: prefixes are validated as str at setup */
+            Py_DECREF(prefix);      /* GCOVR_EXCL_LINE: error path */
+            Py_DECREF(iterator);    /* GCOVR_EXCL_LINE */
+            return -1;              /* GCOVR_EXCL_LINE */
+        }
+        matched = len >= prefix_len && memcmp(name, prefix_bytes, (size_t)prefix_len) == 0;
+        Py_DECREF(prefix);
+    }
+    Py_DECREF(iterator);
+    if (PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: set iteration raises no error of its own */
+        return -1;          /* GCOVR_EXCL_LINE: error path */
+    }
+    return matched;
+}
+
+/* Is `name` allowed on element `tag` by the policy? A "*" inside an attribute set allows every attribute name, and an
+   allowlisted name prefix allows a whole family. Returns 1 allow, 0 drop, -1 error. */
 static int attr_allowed(sanitizer *s, PyObject *tag, const char *name, Py_ssize_t len) {
     PyObject *attr = PyUnicode_FromStringAndSize(name, len);
     if (attr == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -203,6 +234,129 @@ static int attr_allowed(sanitizer *s, PyObject *tag, const char *name, Py_ssize_
         }
     }
     Py_DECREF(attr);
+    if (!allowed && PySet_GET_SIZE(s->attribute_prefixes) > 0) {
+        allowed = name_has_allowed_prefix(s, name, len);
+    }
+    return allowed;
+}
+
+/* Restrict a surviving (tag, attribute) to its literal value allowlist (nh3's tag_attribute_values), if the policy set
+   one for it. An attribute with no per-(tag, attr) entry is unrestricted. Returns 1 keep, 0 drop, -1 error. Only
+   reached when the value map is non-empty. */
+static int value_allowed(sanitizer *s, PyObject *tag, const char *name, Py_ssize_t name_len, const Py_UCS4 *value,
+                         Py_ssize_t value_len) {
+    PyObject *per_tag = PyDict_GetItemWithError(s->attribute_values, tag);
+    if (per_tag == NULL) {
+        if (PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: PyDict_GetItemWithError only errors on a non-hashable key */
+            return -1;          /* GCOVR_EXCL_LINE: error path */
+        }
+        return 1; /* no value allowlist for this tag */
+    }
+    PyObject *attr = PyUnicode_FromStringAndSize(name, name_len);
+    if (attr == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *allowed_values = PyDict_GetItemWithError(per_tag, attr);
+    Py_DECREF(attr);
+    if (allowed_values == NULL) {
+        if (PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: the key is a freshly built str, always hashable */
+            return -1;          /* GCOVR_EXCL_LINE: error path */
+        }
+        return 1; /* this attribute is unrestricted */
+    }
+    PyObject *text = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, value, value_len);
+    if (text == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int keep = PySet_Contains(allowed_values, text);
+    Py_DECREF(text);
+    return keep;
+}
+
+/* The embedded-media elements whose `src` a host allowlist governs. iframe/embed/object are absent because the safety
+   baseline escapes them outright (is_unsafe_tag), so they never reach a kept element's attributes; these media elements
+   a policy can allowlist and keep. */
+static int is_media_host_tag(uint16_t atom) {
+    switch (atom) {
+    case TH_TAG_AUDIO:
+    case TH_TAG_VIDEO:
+    case TH_TAG_SOURCE:
+    case TH_TAG_TRACK:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/* The authority marker bytes that end a URL host: a path, query, or fragment. */
+static int ends_authority(Py_UCS4 c) {
+    switch (c) {
+    case '/':
+    case '?':
+    case '#':
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/* Locate the authority host of a URL value: the reg-name after "scheme://" or a protocol-relative "//", after any
+   "userinfo@" and before a ":port" or the path/query/fragment -- the same split urllib.parse.urlsplit makes, without
+   re-parsing the whole URL. Sets *start,*end to the host span and returns 0, or returns -1 when the URL carries no
+   authority (a relative or opaque src, which has no host to match). */
+static int url_host_span(const Py_UCS4 *value, Py_ssize_t len, Py_ssize_t *start, Py_ssize_t *end) {
+    Py_ssize_t authority = -1;
+    if (len >= 2 && value[0] == '/' && value[1] == '/') {
+        authority = 2; /* protocol-relative //host/path */
+    }
+    for (Py_ssize_t index = 0; authority < 0 && index + 2 < len; index++) {
+        if (value[index] == ':' && value[index + 1] == '/' && value[index + 2] == '/') {
+            authority = index + 3; /* scheme://host */
+        }
+    }
+    if (authority < 0) {
+        return -1;
+    }
+    Py_ssize_t host_start = authority;
+    Py_ssize_t pos = authority;
+    while (pos < len && !ends_authority(value[pos])) {
+        if (value[pos] == '@') {
+            host_start = pos + 1; /* userinfo precedes the host; the last '@' before the path wins */
+        }
+        pos++;
+    }
+    Py_ssize_t host_end = host_start;
+    while (host_end < pos && value[host_end] != ':') {
+        host_end++; /* stop at a ":port" */
+    }
+    *start = host_start;
+    *end = host_end;
+    return 0;
+}
+
+/* Keep an embedded-media `src` only when its URL host is on the allowlist, compared case-insensitively against the
+   lowercase entries. Returns 1 allow, 0 drop, -1 error. */
+static int host_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t len) {
+    Py_ssize_t host_start = 0;
+    Py_ssize_t host_end = 0;
+    if (url_host_span(value, len, &host_start, &host_end) < 0) {
+        return 0; /* a relative or opaque src has no host, so no allowlisted host can admit it */
+    }
+    Py_UCS4 host[256];
+    Py_ssize_t host_len = host_end - host_start;
+    if (host_len >= (Py_ssize_t)(sizeof(host) / sizeof(host[0]))) {
+        return 0; /* longer than any real DNS host (max 253), so it cannot be on the allowlist */
+    }
+    for (Py_ssize_t index = 0; index < host_len; index++) {
+        Py_UCS4 c = value[host_start + index];
+        host[index] = (c >= 'A' && c <= 'Z') ? (c | 0x20) : c;
+    }
+    PyObject *key = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, host, host_len);
+    if (key == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int allowed = PySet_Contains(s->media_hosts, key);
+    Py_DECREF(key);
     return allowed;
 }
 
@@ -531,6 +685,13 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             }
             drop = !allowed;
         }
+        if (!drop && PyDict_GET_SIZE(s->attribute_values) > 0) {
+            int keep = value_allowed(s, tag, name, name_len, attr->value, attr->value_len);
+            if (keep < 0) { /* GCOVR_EXCL_BR_LINE: value_allowed only fails on allocation failure */
+                return -1;  /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            drop = !keep;
+        }
         int url_disallowed = 0;
         if (!drop && is_url_attr(name, name_len)) {
             int ok = scheme_allowed(s, attr->value, attr->value_len);
@@ -545,6 +706,14 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
                 return -1; /* GCOVR_EXCL_LINE */
             }
             url_disallowed = !ok;
+        }
+        if (!drop && !url_disallowed && PySet_GET_SIZE(s->media_hosts) > 0 && is_media_host_tag(element->atom) &&
+            name_len == 3 && memcmp(name, "src", 3) == 0) {
+            int ok = host_allowed(s, attr->value, attr->value_len);
+            if (ok < 0) {  /* GCOVR_EXCL_BR_LINE: host_allowed only fails on allocation failure */
+                return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            url_disallowed = !ok; /* a disallowed host drops every src occurrence, like a disallowed scheme */
         }
         if (url_disallowed) {
             /* A duplicate URL attribute desyncs the per-value scheme check from the
@@ -787,20 +956,51 @@ static int require_anyset(PyObject *value, const char *field) {
     return 0;
 }
 
+/* Every attribute-name prefix must be a non-empty str: a non-string cannot be a name prefix, and an empty prefix would
+   match every name and quietly defeat the allowlist. Checked once at setup so the per-attribute test stays a compare.
+ */
+static int require_prefixes(PyObject *prefixes) {
+    PyObject *iterator = PyObject_GetIter(prefixes);
+    if (iterator == NULL) { /* GCOVR_EXCL_BR_LINE: getting an iterator over a set cannot fail */
+        return -1;          /* GCOVR_EXCL_LINE: error path */
+    }
+    int status = 0;
+    PyObject *prefix;
+    while (status == 0 && (prefix = PyIter_Next(iterator)) != NULL) {
+        if (!PyUnicode_Check(prefix)) {
+            PyErr_Format(PyExc_TypeError, "Policy.attribute_prefixes must contain only str, got %.100s",
+                         Py_TYPE(prefix)->tp_name);
+            status = -1;
+        } else if (PyUnicode_GET_LENGTH(prefix) == 0) {
+            PyErr_SetString(PyExc_ValueError, "Policy.attribute_prefixes must not contain an empty prefix");
+            status = -1;
+        }
+        Py_DECREF(prefix);
+    }
+    Py_DECREF(iterator);
+    if (status == 0 && PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: set iteration raises no error of its own */
+        return -1;                         /* GCOVR_EXCL_LINE: error path */
+    }
+    return status;
+}
+
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
-   attribute_filter, set_attributes, remove_with_content, css_properties) -> None. Filters the fragment in place;
-   sanitizer.py serializes it. */
+   attribute_filter, set_attributes, remove_with_content, css_properties, attribute_prefixes, attribute_values,
+   media_hosts) -> None. Filters the fragment in place; sanitizer.py serializes it. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOOOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
-                          &s.set_attributes, &s.remove_with_content, &s.css_properties)) {
+                          &s.set_attributes, &s.remove_with_content, &s.css_properties, &s.attribute_prefixes,
+                          &s.attribute_values, &s.media_hosts)) {
         return NULL;
     }
     if (require_anyset(s.tags, "tags") < 0 || require_anyset(s.url_schemes, "url_schemes") < 0 ||
         require_anyset(s.remove_with_content, "remove_with_content") < 0 ||
-        require_anyset(s.css_properties, "css_properties") < 0) {
+        require_anyset(s.css_properties, "css_properties") < 0 ||
+        require_anyset(s.attribute_prefixes, "attribute_prefixes") < 0 ||
+        require_anyset(s.media_hosts, "media_hosts") < 0 || require_prefixes(s.attribute_prefixes) < 0) {
         return NULL;
     }
     th_node *root;

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -101,6 +101,13 @@ class Policy:
         escaped or stripped, so their text never leaks into the output.
     :param css_properties: when ``style`` is allowed, its value is scrubbed against this set and any declaration whose
         property name is not in it is dropped, so dangerous CSS cannot ride in on a kept ``style``.
+    :param attribute_prefixes: allow any attribute whose name starts with one of these prefixes (e.g. ``"data-"`` for
+        every ``data-*``), on top of the exact-name and ``"*"`` matches in ``attributes``.
+    :param attribute_values: restrict a kept attribute to literal values, keyed ``{tag: {attribute: allowed_values}}``;
+        a surviving attribute whose value is outside its set is dropped. This narrows an attribute ``attributes``
+        already admits and cannot admit a new one.
+    :param media_hosts: allowed hosts for an embedded-media ``src`` (``audio``, ``video``, ``source``, ``track``); a
+        ``src`` whose URL host is not one of these lowercase entries is dropped. Empty means no host restriction.
     """
 
     tags: frozenset[str] = DEFAULT_TAGS
@@ -115,6 +122,9 @@ class Policy:
     set_attributes: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
     remove_with_content: frozenset[str] = frozenset()
     css_properties: frozenset[str] = DEFAULT_CSS_PROPERTIES
+    attribute_prefixes: frozenset[str] = frozenset()
+    attribute_values: Mapping[str, Mapping[str, frozenset[str]]] = field(default_factory=dict)
+    media_hosts: frozenset[str] = frozenset()
 
     @classmethod
     def strict(cls) -> Policy:
@@ -161,6 +171,10 @@ class Sanitizer:
         self._attributes = dict(self.policy.attributes)
         self._link_rel = " ".join(sorted(self.policy.add_link_rel)) or None
         self._set_attributes = {tag: dict(values) for tag, values in self.policy.set_attributes.items()}
+        self._attribute_values = {
+            tag: {attr: frozenset(values) for attr, values in attrs.items()}
+            for tag, attrs in self.policy.attribute_values.items()
+        }
 
     def sanitize(self, html: str) -> str:
         """
@@ -169,7 +183,9 @@ class Sanitizer:
         :param html: the untrusted HTML fragment.
         :returns: the sanitized, safe HTML.
         :raises TypeError: if a set-typed policy field (``tags``, ``url_schemes``, ``remove_with_content``,
-            ``css_properties``) holds a value that is not a set or frozenset.
+            ``css_properties``, ``attribute_prefixes``, ``media_hosts``) holds a value that is not a set or frozenset,
+            or ``attribute_prefixes`` contains a non-string.
+        :raises ValueError: if ``attribute_prefixes`` contains an empty string, which would match every attribute.
         """
         policy = self.policy
         root = parse_fragment(html)
@@ -186,6 +202,9 @@ class Sanitizer:
             self._set_attributes,
             policy.remove_with_content,
             policy.css_properties,
+            policy.attribute_prefixes,
+            self._attribute_values,
+            policy.media_hosts,
         )
         return root.inner_html
 
@@ -198,7 +217,9 @@ def sanitize(html: str, policy: Policy | None = None) -> str:
     :param policy: the policy to enforce; None uses bleach's default allowlist.
     :returns: the sanitized, safe HTML.
     :raises TypeError: if a set-typed policy field (``tags``, ``url_schemes``, ``remove_with_content``,
-        ``css_properties``) holds a value that is not a set or frozenset.
+        ``css_properties``, ``attribute_prefixes``, ``media_hosts``) holds a value that is not a set or frozenset, or
+        ``attribute_prefixes`` contains a non-string.
+    :raises ValueError: if ``attribute_prefixes`` contains an empty string, which would match every attribute.
     """
     return Sanitizer(policy).sanitize(html)
 

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -44,6 +44,9 @@ def _sanitize(
     set_attributes: Mapping[str, Mapping[str, str]],
     remove_with_content: frozenset[str],
     css_properties: frozenset[str],
+    attribute_prefixes: frozenset[str],
+    attribute_values: Mapping[str, Mapping[str, frozenset[str]]],
+    media_hosts: frozenset[str],
     /,
 ) -> None: ...
 def annotation_surface(text: str, spans: Iterable[tuple[int, int, str]], /) -> dict[str, list[str]]: ...

--- a/tests/features/test_sanitizer.py
+++ b/tests/features/test_sanitizer.py
@@ -581,6 +581,8 @@ def test_sanitizer_is_reusable() -> None:
         pytest.param("url_schemes", ["http"], "list", id="url_schemes"),
         pytest.param("remove_with_content", ["x"], "list", id="remove_with_content"),
         pytest.param("css_properties", "color", "str", id="css_properties"),
+        pytest.param("attribute_prefixes", ["data-"], "list", id="attribute_prefixes"),
+        pytest.param("media_hosts", ["x.com"], "list", id="media_hosts"),
     ],
 )
 def test_non_set_policy_field_raises_typeerror(field: str, value: list[str] | str, type_name: str) -> None:
@@ -634,8 +636,11 @@ def test_strip_propagates_a_child_filter_error() -> None:
 def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
-    # the eleven policy arguments after the element; only the non-element first argument matters to this guard
-    policy_args = (frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset(), frozenset())
+    # the fourteen policy arguments after the element; only the non-element first argument matters to this guard
+    policy_args = (
+        frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset(), frozenset(), frozenset(), {},
+        frozenset(),
+    )  # fmt: skip
     with pytest.raises(TypeError):
         _sanitize("not an element", *policy_args)  # ty: ignore[invalid-argument-type]
 
@@ -671,3 +676,165 @@ def test_module_constants_match_bleach_defaults() -> None:
         "acronym": frozenset({"title"}),
     }
     assert frozenset({"http", "https", "mailto"}) == DEFAULT_SCHEMES
+
+
+def _prefix_policy(prefixes: frozenset[str]) -> Policy:
+    """Allow <a href> plus any attribute matching one of the given name prefixes."""
+    return Policy(tags=frozenset({"a"}), attributes={"a": frozenset({"href"})}, attribute_prefixes=prefixes)
+
+
+def test_attribute_prefix_allows_matching_family() -> None:
+    out = sanitize(
+        '<a href="http://x" data-id="1" data-role="nav" class="c">y</a>', _prefix_policy(frozenset({"data-"}))
+    )
+    assert out == '<a href="http://x" data-id="1" data-role="nav">y</a>'
+
+
+def test_attribute_prefix_multiple_prefixes_each_allow() -> None:
+    policy = _prefix_policy(frozenset({"data-", "aria-"}))
+    assert sanitize('<a href="http://x" aria-label="l" data-x="1">y</a>', policy) == (
+        '<a href="http://x" aria-label="l" data-x="1">y</a>'
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("dat", id="shorter-than-prefix"),
+        pytest.param("datax", id="same-length-mismatch"),
+        pytest.param("role", id="unrelated"),
+    ],
+)
+def test_attribute_prefix_non_matching_name_dropped(name: str) -> None:
+    # a name shorter than the prefix, or the prefix length but a different byte, is not a prefix match
+    assert sanitize(f'<a href="http://x" {name}="1">y</a>', _prefix_policy(frozenset({"data-"}))) == (
+        '<a href="http://x">y</a>'
+    )
+
+
+def test_attribute_prefix_default_policy_drops_data_attributes() -> None:
+    # without a configured prefix set, prefix matching pays nothing and data-* is not admitted
+    assert sanitize('<a href="http://x" data-id="1">y</a>') == '<a href="http://x">y</a>'
+
+
+def test_attribute_prefix_empty_string_raises_valueerror() -> None:
+    with pytest.raises(ValueError, match="attribute_prefixes must not contain an empty prefix"):
+        sanitize("<a>y</a>", _prefix_policy(frozenset({""})))
+
+
+def test_attribute_prefix_non_string_raises_typeerror() -> None:
+    policy = _prefix_policy(frozenset({123}))  # ty: ignore[invalid-argument-type]  # a non-str prefix is rejected
+    with pytest.raises(TypeError, match="attribute_prefixes must contain only str, got int"):
+        sanitize("<a>y</a>", policy)
+
+
+def _value_policy() -> Policy:
+    """Allow <a href target> and <b>, restricting <a target> to two literal values."""
+    return Policy(
+        tags=frozenset({"a", "b"}),
+        attributes={"a": frozenset({"href", "target"}), "b": frozenset({"target"})},
+        attribute_values={"a": {"target": frozenset({"_blank", "_self"})}},
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "kept"),
+    [pytest.param("_blank", True, id="allowed"), pytest.param("_top", False, id="disallowed")],
+)
+def test_attribute_value_allowlist_restricts_target(value: str, kept: bool) -> None:  # noqa: FBT001
+    out = sanitize(f'<a href="http://x" target="{value}">y</a>', _value_policy())
+    assert (f'target="{value}"' in out) is kept
+
+
+def test_attribute_value_allowlist_leaves_unrestricted_attribute() -> None:
+    # href has no value entry, so its value is not constrained
+    assert sanitize('<a href="http://weird" target="_self">y</a>', _value_policy()) == (
+        '<a href="http://weird" target="_self">y</a>'
+    )
+
+
+def test_attribute_value_allowlist_leaves_unrestricted_tag() -> None:
+    # <b> is not keyed in attribute_values, so its target is unrestricted
+    assert sanitize('<b target="_top">y</b>', _value_policy()) == '<b target="_top">y</b>'
+
+
+def test_attribute_value_allowlist_only_narrows_never_allows() -> None:
+    # target is absent from <a>'s attribute allowlist, so a value entry cannot resurrect it
+    policy = Policy(
+        tags=frozenset({"a"}),
+        attributes={"a": frozenset({"href"})},
+        attribute_values={"a": {"target": frozenset({"_blank"})}},
+    )
+    assert sanitize('<a href="http://x" target="_blank">y</a>', policy) == '<a href="http://x">y</a>'
+
+
+def _media_policy(hosts: frozenset[str], *, extra_attrs: frozenset[str] = frozenset()) -> Policy:
+    """Allow the embedded-media elements plus <img>, gating their src by host allowlist."""
+    return Policy(
+        tags=frozenset({"video", "audio", "source", "track", "img"}),
+        attributes={"*": frozenset({"src"}) | extra_attrs},
+        media_hosts=hosts,
+    )
+
+
+@pytest.mark.parametrize("tag", ["video", "audio", "source", "track"])
+def test_media_host_allowlist_keeps_allowed_host(tag: str) -> None:
+    policy = _media_policy(frozenset({"youtube.com"}))
+    assert f'<{tag} src="https://youtube.com/e/x">' in sanitize(f'<{tag} src="https://youtube.com/e/x">', policy)
+
+
+@pytest.mark.parametrize(
+    ("src", "kept"),
+    [
+        pytest.param("https://youtube.com/e/x", True, id="scheme-host-path"),
+        pytest.param("https://youtube.com", True, id="host-no-path"),
+        pytest.param("https://youtube.com?q=1", True, id="host-query"),
+        pytest.param("https://youtube.com#f", True, id="host-fragment"),
+        pytest.param("https://youtube.com:8080/x", True, id="host-port"),
+        pytest.param("https://user@youtube.com/x", True, id="host-userinfo"),
+        pytest.param("//youtube.com/x", True, id="protocol-relative"),
+        pytest.param("https://evil.com/x", False, id="disallowed-host"),
+        pytest.param("https:///x", False, id="empty-host"),
+        pytest.param("local.mp4", False, id="relative-no-authority"),
+        pytest.param("/local.mp4", False, id="rooted-relative"),
+        pytest.param("x", False, id="single-char"),
+        pytest.param("https:ab", False, id="allowed-scheme-opaque"),
+        pytest.param("https:/x", False, id="allowed-scheme-one-slash"),
+    ],
+)
+def test_media_host_allowlist_gates_src(src: str, kept: bool) -> None:  # noqa: FBT001
+    out = sanitize(f'<video src="{src}">', _media_policy(frozenset({"youtube.com"})))
+    assert ("src=" in out) is kept
+
+
+def test_media_host_allowlist_matches_host_case_insensitively() -> None:
+    assert 'src="https://YouTube.COM/x"' in sanitize(
+        '<video src="https://YouTube.COM/x">', _media_policy(frozenset({"youtube.com"}))
+    )
+
+
+def test_media_host_allowlist_rejects_overlong_host() -> None:
+    host = "a" * 300 + ".com"
+    assert "src=" not in sanitize(f'<video src="https://{host}/x">', _media_policy(frozenset({"youtube.com"})))
+
+
+def test_media_host_allowlist_does_not_touch_non_media_src() -> None:
+    # <img> is not an embedded-media element, so its src is not host-gated
+    assert sanitize('<img src="https://evil.com/x">', _media_policy(frozenset({"youtube.com"}))) == (
+        '<img src="https://evil.com/x">'
+    )
+
+
+def test_media_host_allowlist_skips_non_src_media_attributes() -> None:
+    # only src is host-gated; a sibling attribute on the same media element is untouched
+    policy = _media_policy(frozenset({"youtube.com"}), extra_attrs=frozenset({"alt", "width"}))
+    out = sanitize('<video src="https://youtube.com/x" alt="a" width="10">', policy)
+    assert 'src="https://youtube.com/x"' in out
+    assert 'alt="a"' in out
+    assert 'width="10"' in out
+
+
+def test_media_host_default_policy_leaves_src_unrestricted() -> None:
+    # with no media_hosts configured, the host check pays nothing and any allowed-scheme src survives
+    policy = Policy(tags=frozenset({"video"}), attributes={"*": frozenset({"src"})})
+    assert 'src="https://evil.com/x"' in sanitize('<video src="https://evil.com/x">', policy)


### PR DESCRIPTION
Three sanitizer policies that competitors ship and `turbohtml.clean` forced into an `attribute_filter` workaround now have first-class `Policy` fields, closing gaps the migration audit flagged against nh3 and lxml-html-clean. 🧹

`attribute_prefixes` keeps any attribute whose name starts with an allowlisted prefix, so `data-*` no longer needs a `"*"` wildcard plus a hand-written filter (nh3 `generic_attribute_prefixes`). `attribute_values` restricts a kept `(tag, attribute)` to a set of literal values and drops anything outside it, narrowing an attribute that `attributes` already admits (nh3 `tag_attribute_values`). `media_hosts` keeps an `audio`/`video`/`source`/`track` `src` only when its URL host is on the allowlist, matching lxml-html-clean `host_whitelist` for the media elements turbohtml can keep (`iframe`/`embed` stay dropped by the safety baseline).

All three live in the C sanitize walk, with the Python layer only compiling the policy and calling in. Each check sits behind a size guard on its policy field, so the default no-config policy runs no extra work. The host lookup reuses the URL split the rest of the sanitizer relies on rather than a second parser, and bad config (a non-set field, a non-string or empty prefix) raises `TypeError`/`ValueError` naming the offending `Policy` field. The nh3 and lxml-html-clean guides drop the closed gaps.

part of #459
