### PR TITLE
✨ feat(serialize): preserve license/bang comments in minify_js

### DIFF
--- a/docs/changelog/462.feature.rst
+++ b/docs/changelog/462.feature.rst
@@ -1,0 +1,3 @@
+Keep ``/*! ... */`` bang comments and any comment carrying an ``@license`` or ``@preserve`` annotation through
+:func:`~turbohtml.minify_js`, emitted byte-exact as a leading banner so a license header survives minification; every
+other comment is still dropped. The rule matches the CSS minifier and applies to inline ``<script>`` minification too.

--- a/docs/how-to/serializing.rst
+++ b/docs/how-to/serializing.rst
@@ -83,10 +83,11 @@ When the input is a string rather than a built tree -- the ``minify-html`` and `
 *******************
 
 :func:`~turbohtml.minify_js` minifies a JavaScript string on its own. It always folds whitespace, comments and number
-literals; a :class:`~turbohtml.JSMinify` toggles the two heavier passes — ``mangle`` renames local bindings to short
-names and ``fold`` runs constant folding and dead-code elimination. Top-level names are global, so they are never
-renamed; only bindings local to a function are. A construct the parser does not handle raises :class:`ValueError` rather
-than passing through silently.
+literals — ``/*! ... */`` bang comments and any ``@license`` / ``@preserve`` comment are the exception, kept byte-exact
+as a leading banner so a license header survives, exactly as the CSS minifier keeps them. A :class:`~turbohtml.JSMinify`
+toggles the two heavier passes — ``mangle`` renames local bindings to short names and ``fold`` runs constant folding and
+dead-code elimination. Top-level names are global, so they are never renamed; only bindings local to a function are. A
+construct the parser does not handle raises :class:`ValueError` rather than passing through silently.
 
 .. testcode::
 

--- a/docs/migration/rjsmin.rst
+++ b/docs/migration/rjsmin.rst
@@ -57,7 +57,8 @@ Feature overlap
 The shared surface ports 1:1 — a single call that takes a JavaScript string and returns a smaller one:
 
 - ``rjsmin.jsmin(source)`` maps directly to :func:`turbohtml.minify_js(source) <turbohtml.minify_js>`.
-- Whitespace and comment stripping is unconditional in both, so turbohtml is a drop-in for the plain call.
+- Whitespace and ordinary-comment stripping is unconditional in both; the one difference is that turbohtml keeps ``/*!
+  ... */`` license banners by default (see below), where the plain rjsmin call drops them.
 - Neither tool needs a browser, DOM, or Node runtime; both operate on the string in-process.
 
 What turbohtml adds
@@ -75,15 +76,15 @@ What turbohtml adds
   ``minify_js`` and ``<script>`` bodies are minified during HTML serialization. Only scripts whose ``type`` marks them
   as JavaScript are rewritten; a ``type="application/json"`` or ``importmap`` payload is left byte-for-byte. rjsmin only
   ever sees a bare script string you extract yourself.
+- **License-comment preservation, on by default.** turbohtml keeps ``/*! ... */`` bang comments and any comment carrying
+  an ``@license`` or ``@preserve`` annotation, emitting them byte-exact as a leading banner so a copyright or license
+  header survives minification; every other comment is dropped. rjsmin keeps bang comments only when called with
+  ``keep_bang_comments=True``, and this matches turbohtml's CSS minifier, which keeps ``/*! ... */`` the same way.
 - **Typed surface.** A bundled stub and the frozen ``JSMinify`` dataclass give static checkers full signatures.
 
 What rjsmin has that turbohtml does not
 =======================================
 
-- **Preserving bang comments.** ``rjsmin.jsmin(source, keep_bang_comments=True)`` keeps ``/*! ... */`` blocks, the
-  convention for retaining a license header through minification. turbohtml strips every comment and has no equivalent
-  flag; if a required license notice must survive, prepend it to the minified output yourself or keep it in a separate
-  file the build concatenates.
 - **A cheaper whitespace-only pass.** rjsmin's single regex substitution is faster than a full parse and is the lighter
   tool when the only requirement is stripping space as cheaply as possible. turbohtml parses, so it spends more time to
   produce a smaller result.
@@ -128,7 +129,7 @@ Swap the import and the call. rjsmin exposes one function; turbohtml exposes the
     - - ``rjsmin.jsmin(source)`` (whitespace/comments only)
       - ``turbohtml.minify_js(source, JSMinify(mangle=False, fold=False))`` for the closest whitespace-only match
     - - ``rjsmin.jsmin(source, keep_bang_comments=True)``
-      - no equivalent; turbohtml strips all comments (prepend the header to the output yourself)
+      - ``turbohtml.minify_js(source)`` keeps ``/*! ... */`` and ``@license`` / ``@preserve`` banners by default
 
 .. code-block:: python
 
@@ -160,9 +161,10 @@ HTML serializer instead of extracting the script by hand:
 - **Renaming is on by default.** ``turbohtml.minify_js(source)`` renames local bindings, which rjsmin never does. If a
   consumer reflects on function-local variable names (rare), pass ``JSMinify(mangle=False)``. Top-level names are global
   and are never renamed regardless of the setting.
-- **All comments are stripped.** turbohtml removes every comment unconditionally; there is no ``keep_bang_comments``
-  counterpart, so a ``/*! license */`` header that rjsmin would keep is dropped. Re-attach any required notice to the
-  minified output yourself.
+- **License banners are kept, not stripped, and hoisted to the top.** turbohtml keeps ``/*! ... */`` and ``@license`` /
+  ``@preserve`` comments byte-exact and emits them as a leading banner in source order, while dropping every other
+  comment. rjsmin only keeps them under ``keep_bang_comments=True`` and leaves them in place, so a diff against rjsmin
+  output differs when a bang comment sits mid-script.
 - **Unparsable input raises instead of passing through.** rjsmin emits something for any string; the standalone
   :func:`~turbohtml.minify_js` raises :class:`ValueError` on a construct its parser does not handle. Catch it and fall
   back to the source if you relied on rjsmin's never-fail behavior. The inline ``<script>`` path does not raise — it

--- a/src/turbohtml/_c/serialize/js/ast.c
+++ b/src/turbohtml/_c/serialize/js/ast.c
@@ -336,6 +336,7 @@ void jm_program_free(jm_program *prog) {
         jm_free(prog->owned[index]);
     }
     jm_free(prog->owned);
+    jm_free(prog->comments);
     jm_free(prog->nodes);
     jm_free(prog->syms);
     jm_free(prog->scopes);

--- a/src/turbohtml/_c/serialize/js/internal.h
+++ b/src/turbohtml/_c/serialize/js/internal.h
@@ -95,6 +95,19 @@ typedef enum {
     JT_NULLISH_ASSIGN, /* ??= */
 } jm_tok;
 
+/* ----------------------------------------------------------------- comments */
+
+/* A license/banner comment kept through minification: a bang block comment (its body opens with `!`, the
+   marker the CSS minifier also keeps) or one whose body carries an @license or @preserve annotation. text
+   borrows the source span including the surrounding block-comment delimiters, so the printer re-emits it
+   byte-exact; every other comment is discarded as trivia. */
+typedef struct {
+    const Py_UCS4 *text;
+    Py_ssize_t len;
+} jm_comment;
+
+struct jm_program; /* the lexer accrues kept comments into the program's list (defined below) */
+
 /* ----------------------------------------------------------------- lexer */
 
 typedef struct {
@@ -107,6 +120,9 @@ typedef struct {
     const Py_UCS4 *text; /* lexeme of a value-bearing token (into src) */
     Py_ssize_t text_len;
     int newline_before; /* a line terminator (or a block comment with one) preceded this token */
+
+    struct jm_program *sink; /* kept comments accrue here; NULL discards every comment (the token-dump path) */
+    int32_t comment_count;   /* kept-comment count so far, rewound with the lexer on a speculative backtrack */
 
     int error; /* a lexical error was hit; kind is JT_ERROR */
 } jm_lexer;
@@ -278,7 +294,7 @@ typedef struct {
 
 /* A parsed program: the node arena, the symbol and scope tables, the root node, and
    the borrowed source. Owned by one minify call and freed with jm_program_free. */
-typedef struct {
+typedef struct jm_program {
     jm_node *nodes;
     int32_t node_count;
     int32_t node_cap;
@@ -300,6 +316,15 @@ typedef struct {
     Py_UCS4 **owned;
     int32_t owned_count;
     int32_t owned_cap;
+
+    /* license/banner comments kept through minification, in source order; the printer emits them as a
+       leading block. Each borrows its source span (the source outlives the program), so only the array
+       itself is owned. jm_comment_count is the committed count the parser copies from the lexer once the
+       whole program is scanned, so a comment seen only on a backtracked branch never lands here. */
+    jm_comment *comments;
+    int32_t comment_count;
+    int32_t comment_cap;
+
     int failed; /* allocation failure */
 } jm_program;
 

--- a/src/turbohtml/_c/serialize/js/lexer.c
+++ b/src/turbohtml/_c/serialize/js/lexer.c
@@ -86,6 +86,8 @@ void jm_lex_init(jm_lexer *lx, const Py_UCS4 *src, Py_ssize_t len) {
     lx->text = src;
     lx->text_len = 0;
     lx->newline_before = 0;
+    lx->sink = NULL;
+    lx->comment_count = 0;
     lx->error = 0;
 }
 
@@ -97,6 +99,59 @@ int jm_text_eq(const jm_lexer *lx, const char *keyword) {
         }
     }
     return index == lx->text_len;
+}
+
+/* ----------------------------------------------------------- kept comments */
+
+/* Whether body[0..body_len) contains needle (an ASCII literal) as a substring. */
+static int jm_body_has(const Py_UCS4 *body, Py_ssize_t body_len, const char *needle) {
+    Py_ssize_t needle_len = (Py_ssize_t)strlen(needle);
+    for (Py_ssize_t index = 0; index + needle_len <= body_len; index++) {
+        Py_ssize_t match = 0;
+        while (match < needle_len && body[index + match] == (Py_UCS4)(unsigned char)needle[match]) {
+            match++;
+        }
+        if (match == needle_len) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Whether a closed block comment (text spans the whole comment including both delimiters, so len >= 4 and
+   text[2] is the first body code point) is a license/banner comment kept through minification: a body that
+   opens with `!` -- the bang marker the CSS minifier keeps byte-exact -- or an @license / @preserve
+   annotation anywhere in the body. */
+static int jm_comment_is_kept(const Py_UCS4 *text, Py_ssize_t len) {
+    if (text[2] == '!') {
+        return 1;
+    }
+    const Py_UCS4 *body = text + 2;
+    Py_ssize_t body_len = len - 4; /* strip the two-code-point delimiters at each end */
+    return jm_body_has(body, body_len, "@license") || jm_body_has(body, body_len, "@preserve");
+}
+
+/* Record a kept comment into the program sink so the printer can re-emit it. Discards ordinary comments
+   and does nothing on the token-dump path (sink == NULL). The count lives on the lexer so a speculative
+   backtrack rewinds it, and a re-scan overwrites the same slots -- the committed run is left correct. */
+static void jm_capture_comment(jm_lexer *lx, const Py_UCS4 *text, Py_ssize_t len) {
+    if (lx->sink == NULL || !jm_comment_is_kept(text, len)) {
+        return;
+    }
+    struct jm_program *prog = lx->sink;
+    if (lx->comment_count == prog->comment_cap) {
+        int32_t cap = prog->comment_cap ? prog->comment_cap * 2 : 4;
+        jm_comment *grown = jm_realloc(prog->comments, (size_t)cap * sizeof(jm_comment));
+        if (grown == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation-failure path */
+            prog->failed = 1; /* GCOVR_EXCL_LINE */
+            return;           /* GCOVR_EXCL_LINE */
+        }
+        prog->comments = grown;
+        prog->comment_cap = cap;
+    }
+    prog->comments[lx->comment_count].text = text;
+    prog->comments[lx->comment_count].len = len;
+    lx->comment_count++;
 }
 
 /* ----------------------------------------------------------- skipping */
@@ -119,6 +174,7 @@ static void jm_skip_trivia(jm_lexer *lx) {
                 lx->pos++;
             }
         } else if (ch == '/' && lx->pos + 1 < lx->len && lx->src[lx->pos + 1] == '*') {
+            Py_ssize_t comment_start = lx->pos;
             lx->pos += 2;
             while (lx->pos < lx->len &&
                    !(lx->src[lx->pos] == '*' && lx->pos + 1 < lx->len && lx->src[lx->pos + 1] == '/')) {
@@ -129,6 +185,7 @@ static void jm_skip_trivia(jm_lexer *lx) {
             }
             if (lx->pos < lx->len) {
                 lx->pos += 2; /* past the closing star-slash */
+                jm_capture_comment(lx, lx->src + comment_start, lx->pos - comment_start);
             } else {
                 lx->error = 1; /* unterminated block comment */
                 return;

--- a/src/turbohtml/_c/serialize/js/parser.c
+++ b/src/turbohtml/_c/serialize/js/parser.c
@@ -1525,6 +1525,7 @@ jm_program *jm_parse(const Py_UCS4 *src, Py_ssize_t len, char *errbuf, size_t er
         errbuf[0] = '\0';
     }
     jm_lex_init(&parser.lx, src, len);
+    parser.lx.sink = prog; /* accrue kept license/banner comments before the first token is read */
     advance(&parser);
 
     int32_t root = jm_node_new(prog, JN_PROGRAM);
@@ -1542,6 +1543,7 @@ jm_program *jm_parse(const Py_UCS4 *src, Py_ssize_t len, char *errbuf, size_t er
         tail = stmt;
     }
     prog->root = root;
+    prog->comment_count = parser.lx.comment_count; /* commit the run scanned on the real parse path */
 
     if (parser.err || prog->failed) {     /* GCOVR_EXCL_BR_LINE: prog->failed is only set on allocation failure */
         if (prog->failed && errlen > 0) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */

--- a/src/turbohtml/_c/serialize/js/printer.c
+++ b/src/turbohtml/_c/serialize/js/printer.c
@@ -1311,6 +1311,13 @@ Py_UCS4 *jm_print(const jm_program *prog, Py_ssize_t *out_len) {
     if (st.failed) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
         return NULL; /* GCOVR_EXCL_LINE */
     }
+    /* Kept license/banner comments lead the output in source order. They carry no semantics, so hoisting
+       them to the top keeps a license header first and visible and stays byte-exact and idempotent,
+       without threading source offsets through the fold/compress/mangle passes. put_run's adjacency guard
+       spaces the comment's closing delimiter from a following token where a merge would change the run. */
+    for (int32_t index = 0; index < prog->comment_count; index++) {
+        put_run(&st, prog->comments[index].text, prog->comments[index].len);
+    }
     const jm_node *root = &prog->nodes[prog->root];
     int pending = 0;
     for (int32_t stmt = root->a; stmt >= 0; stmt = prog->nodes[stmt].next) {

--- a/src/turbohtml/_jsminify.py
+++ b/src/turbohtml/_jsminify.py
@@ -24,10 +24,13 @@ class JSMinify:
     """
     Which optional JavaScript-minifier passes to run.
 
-    Whitespace, comment and numeric-literal minification is unconditional. ``mangle``
-    renames local bindings to short names (the bulk of the size win) and ``fold`` runs
-    constant folding and dead-code elimination; turning either off keeps that aspect of
-    the source readable (e.g. ``mangle=False`` for debuggable output).
+    Whitespace and numeric-literal minification is unconditional, as is comment removal
+    -- except ``/*! ... */`` bang comments and any comment carrying an ``@license`` or
+    ``@preserve`` annotation, which are kept byte-exact as a leading banner so a license
+    header survives (the same rule the CSS minifier applies). ``mangle`` renames local
+    bindings to short names (the bulk of the size win) and ``fold`` runs constant folding
+    and dead-code elimination; turning either off keeps that aspect of the source readable
+    (e.g. ``mangle=False`` for debuggable output).
 
     :param mangle: rename local bindings to short names.
     :param fold: constant-fold and eliminate dead code.

--- a/tests/serialize/js/test_minify.py
+++ b/tests/serialize/js/test_minify.py
@@ -26,6 +26,8 @@ def minify(source: str) -> str:
         pytest.param("a = 1 ; b = 2 ;", "a=1;b=2", id="statement-semicolons"),
         pytest.param("// line\nx = 1", "x=1", id="line-comment"),
         pytest.param("/* block */ x = 1", "x=1", id="block-comment"),
+        # a `//!` line comment is not a banner: only block bang comments are kept (see test_bang_comments_kept)
+        pytest.param("//! not a banner\nx = 1", "x=1", id="bang-line-comment-stripped"),
         pytest.param("function f ( a , b ) { return a + b }", "function f(a,b){return a+b}", id="function"),
         pytest.param("x = 1 + 2 * 3", "x=1+2*3", id="precedence-no-parens"),
         pytest.param("x = ( 1 + 2 ) * 3", "x=(1+2)*3", id="precedence-needs-parens"),
@@ -307,6 +309,47 @@ def test_operators_and_structural(source: str, expected: str) -> None:
 )
 def test_statement_position_parens_preserved(source: str, expected: str) -> None:
     assert minify(source) == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        # a bang block comment is a license/banner header kept byte-exact, the way the CSS minifier keeps
+        # `/*! ... */`; every other comment is still stripped
+        pytest.param("/*! (c) 2026 Me */\nvar x = 1", "/*! (c) 2026 Me */var x=1", id="bang-kept"),
+        pytest.param("/* @license MIT */\na = 1", "/* @license MIT */a=1", id="license-kept"),
+        pytest.param("/* @preserve keep */ a = 1", "/* @preserve keep */a=1", id="preserve-kept"),
+        # the body survives verbatim: internal stars, newlines and alignment are not touched
+        pytest.param("/*!\n * line\n */\na = 1", "/*!\n * line\n */a=1", id="bang-body-verbatim"),
+        pytest.param("/* plain */ a = 1", "a=1", id="plain-block-stripped"),
+        # a bang comment anywhere is hoisted into a leading banner, in source order
+        pytest.param("a = 1;/*! trailing */", "/*! trailing */a=1", id="trailing-bang-hoisted"),
+        pytest.param("/*! one */b = 1;/*! two */", "/*! one */ /*! two */b=1", id="two-bangs-source-order"),
+        # a program that is nothing but a banner still emits it
+        pytest.param("/*! banner only */", "/*! banner only */", id="banner-only"),
+        # more banners than the initial capacity, to exercise the growth of the kept-comment list
+        pytest.param(
+            "/*!1*//*!2*//*!3*//*!4*//*!5*/x = 1",
+            "/*!1*/ /*!2*/ /*!3*/ /*!4*/ /*!5*/x=1",
+            id="many-bangs-grow",
+        ),
+    ],
+)
+def test_bang_comments_kept(source: str, expected: str) -> None:
+    assert minify(source) == expected
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("/*! keep */\nfunction f(longName){return longName*2}", id="mangle-fold"),
+        pytest.param("/* @license MIT */ const value = 1 + 2; use(value)", id="license-through-compress"),
+    ],
+)
+def test_bang_comment_survives_full_minify_and_is_idempotent(source: str) -> None:
+    once = minify_js(source)
+    assert once.startswith("/*")  # the banner leads the output even with mangle and fold on
+    assert minify_js(once) == once
 
 
 def test_unparseable_input_raises() -> None:

--- a/tests/serialize/js/test_public_api.py
+++ b/tests/serialize/js/test_public_api.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import pytest
 
-from turbohtml import JSMinify, _html, minify_js
+import turbohtml
+from turbohtml import Html, JSMinify, Minify, _html, minify_js
 
 _SOURCE = "function f(){var longName=true;return longName}"
 
@@ -47,6 +48,22 @@ def test_low_level_binding_requires_three_arguments() -> None:
     # the public wrapper always passes (source, fold, mangle); the seam rejects a short call
     with pytest.raises(TypeError):
         _html._minify_js("x")  # ty: ignore[missing-argument]  # too few args on purpose
+
+
+def _serialize_script(html: str) -> str:
+    return turbohtml.parse(html).serialize(Html(layout=Minify(minify_js=JSMinify())))
+
+
+def test_inline_script_keeps_bang_comment() -> None:
+    # the license header survives minification of an inline <script>, as it does for the standalone call
+    out = _serialize_script("<script>/*! lib v1 */\nfunction plus(a,b){return a+b}</script>")
+    assert out == "<script>/*! lib v1 */function plus(b,a){return b+a}</script>"
+
+
+def test_inline_script_unparsable_falls_back_verbatim() -> None:
+    # a script the parser cannot handle is emitted unchanged (the errlen==0 opt-out), so one bad
+    # <script> never breaks document serialization the way the standalone call's ValueError would
+    assert _serialize_script("<script>function (</script>") == "<script>function (</script>"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Three sanitizer policies that competitors ship and `turbohtml.clean` forced into an `attribute_filter` workaround now have first-class `Policy` fields, closing gaps the migration audit flagged against nh3 and lxml-html-clean. 🧹

`attribute_prefixes` keeps any attribute whose name starts with an allowlisted prefix, so `data-*` no longer needs a `"*"` wildcard plus a hand-written filter (nh3 `generic_attribute_prefixes`). `attribute_values` restricts a kept `(tag, attribute)` to a set of literal values and drops anything outside it, narrowing an attribute that `attributes` already admits (nh3 `tag_attribute_values`). `media_hosts` keeps an `audio`/`video`/`source`/`track` `src` only when its URL host is on the allowlist, matching lxml-html-clean `host_whitelist` for the media elements turbohtml can keep (`iframe`/`embed` stay dropped by the safety baseline).

All three live in the C sanitize walk, with the Python layer only compiling the policy and calling in. Each check sits behind a size guard on its policy field, so the default no-config policy runs no extra work. The host lookup reuses the URL split the rest of the sanitizer relies on rather than a second parser, and bad config (a non-set field, a non-string or empty prefix) raises `TypeError`/`ValueError` naming the offending `Policy` field. The nh3 and lxml-html-clean guides drop the closed gaps.

part of #459
