### PR TITLE
✨ feat(clean): minify boolean-attribute collapse and optional end-tag omission

### DIFF
--- a/docs/changelog/465.feature.rst
+++ b/docs/changelog/465.feature.rst
@@ -1,0 +1,4 @@
+Shrink two more render-safe forms in :func:`turbohtml.clean.minify`, both under existing :class:`~turbohtml.Minify`
+flags. ``unquote_attributes`` collapses a WHATWG boolean attribute whose value repeats its name (``checked="checked"``)
+to the bare ``checked``, and ``omit_optional_tags`` now also drops the optional ``</caption>`` and ``</colgroup>`` end
+tags. Both stay round-trip safe, so the output reparses to the same tree and re-minifying is a fixpoint.

--- a/docs/migration/html5lib.rst
+++ b/docs/migration/html5lib.rst
@@ -88,7 +88,9 @@ What html5lib has that turbohtml does not
 - **Serializer filters.** html5lib's serializer chains filters for optional-tag omission, alphabetical attribute order,
   meta-charset injection, and whitespace. turbohtml serializes WHATWG-conformant output selected by
   :class:`~turbohtml.Formatter`; it does not expose that filter registry. Workaround: pick the closest ``Formatter`` and
-  layout; for optional-tag omission there is no equivalent.
+  layout. Optional-tag omission and boolean-attribute collapse have a direct equivalent in :class:`~turbohtml.Minify`
+  (``omit_optional_tags`` drops the start/end tags the WHATWG rules make optional; ``unquote_attributes`` rewrites
+  ``checked="checked"`` to a bare ``checked``).
 - **A (deprecated) sanitizer.** html5lib ships ``html5lib.filters.sanitizer``, deprecated since 1.1. turbohtml has no
   sanitizer. Workaround: use a dedicated sanitizer such as ``nh3`` or ``bleach`` (see :doc:`nh3` and :doc:`bleach`).
 - **Optional statistical encoding detection.** With ``chardet`` installed, html5lib's input stream can guess an encoding
@@ -196,5 +198,6 @@ Because turbohtml returns a queryable tree, the walk-the-etree step after parsin
   prescan, then a ``windows-1252`` fallback. html5lib with ``chardet`` installed can additionally guess from byte
   frequency; where that matters, detect the encoding first and hand turbohtml the decoded ``str``.
 - **No serializer object or filter chain.** html5lib builds a serializer and threads filters through it; turbohtml
-  serializes directly with :meth:`~turbohtml.Node.serialize` and a :class:`~turbohtml.Formatter`, and does not offer
-  optional-tag omission or attribute reordering.
+  serializes directly with :meth:`~turbohtml.Node.serialize` and a :class:`~turbohtml.Formatter`. The common filters
+  have direct equivalents -- optional-tag omission and boolean-attribute collapse through :class:`~turbohtml.Minify`,
+  and attribute sorting through the ``sort_attributes`` serialize option -- but there is no chainable filter registry.

--- a/docs/migration/htmlmin.rst
+++ b/docs/migration/htmlmin.rst
@@ -57,9 +57,10 @@ These folds port one-to-one; each htmlmin flag becomes a field on :class:`~turbo
   the default).
 - Comment removal — ``remove_comments=True`` maps to ``Minify(strip_comments=True)`` (the turbohtml default; comments go
   unless you opt out).
-- Attribute-quote removal and empty-attribute reduction — ``remove_optional_attribute_quotes`` and
-  ``reduce_empty_attributes`` map to the single ``Minify(unquote_attributes=True)``, which also collapses an empty value
-  to a bare attribute name.
+- Attribute-quote removal, empty-attribute reduction, and boolean-attribute reduction —
+  ``remove_optional_attribute_quotes``, ``reduce_empty_attributes``, and ``reduce_boolean_attributes`` map to the single
+  ``Minify(unquote_attributes=True)``, which drops redundant quotes, collapses an empty value to a bare attribute name,
+  and rewrites a boolean attribute whose value repeats its name (``checked="checked"``) to the bare ``checked``.
 
 What turbohtml adds
 ===================
@@ -81,8 +82,6 @@ What htmlmin has that turbohtml does not
 - ``remove_empty_space`` / ``remove_all_empty_space`` — htmlmin can delete inter-element whitespace outright. turbohtml
   has no equivalent by design: dropping that whitespace can change rendering, so every run collapses to a single space
   and the output reparses to the same tree. No equivalent.
-- ``reduce_boolean_attributes`` — htmlmin can rewrite ``checked="checked"`` to ``checked``. turbohtml leaves boolean
-  attributes written in full. No equivalent.
 - ``keep_pre`` / ``pre_tags`` / ``pre_attr`` — htmlmin lets you configure which tags and per-attribute markers preserve
   whitespace. turbohtml always preserves whitespace inside ``<pre>`` and ``<textarea>`` (significant per WHATWG) and
   offers no per-attribute opt-out. Workaround: none needed for the common case; the preservation is automatic and
@@ -138,15 +137,14 @@ Each fold is a field on :class:`~turbohtml.Minify`, so a flag becomes one keywor
       - ``Minify(collapse_whitespace=...)`` (default ``True``)
     - - ``remove_comments`` (default ``False``)
       - ``Minify(strip_comments=...)`` (default ``True``; comments go unless you opt out)
-    - - ``remove_optional_attribute_quotes``, ``reduce_empty_attributes``
-      - ``Minify(unquote_attributes=...)`` (default ``True``; an empty value becomes a bare attribute name)
+    - - ``remove_optional_attribute_quotes``, ``reduce_empty_attributes``, ``reduce_boolean_attributes``
+      - ``Minify(unquote_attributes=...)`` (default ``True``; an empty value becomes a bare attribute name, and a
+        boolean attribute whose value repeats its name -- ``checked="checked"`` -- collapses to bare ``checked``)
     - - no equivalent -- htmlmin keeps every tag
       - ``Minify(omit_optional_tags=...)`` (default ``True``) drops the tags the WHATWG rules make optional
     - - ``remove_empty_space``, ``remove_all_empty_space``
       - not supported -- deleting inter-element whitespace outright can change rendering, so every run collapses to one
         space and the output reparses to the same tree
-    - - ``reduce_boolean_attributes``
-      - not supported -- boolean attributes stay written in full (``checked="checked"``)
     - - ``keep_pre``, ``pre_tags``, ``pre_attr``
       - whitespace inside ``<pre>`` and ``<textarea>`` is significant per WHATWG and always survives; there is no
         per-attribute opt-out

--- a/docs/migration/minify-html.rst
+++ b/docs/migration/minify-html.rst
@@ -57,7 +57,9 @@ These HTML folds port one-to-one; each minify-html flag becomes a field on :clas
   turbohtml default; comments go unless you opt out).
 - Optional-tag omission — ``keep_closing_tags`` and ``keep_html_and_head_opening_tags`` map to the single
   ``Minify(omit_optional_tags=True)``, which drops the start and end tags the WHATWG rules make optional.
-- Attribute unquoting — on by default in both; maps to ``Minify(unquote_attributes=True)``.
+- Attribute unquoting and boolean-attribute collapse — on by default in both; maps to
+  ``Minify(unquote_attributes=True)``, which drops redundant quotes and rewrites a boolean attribute whose value repeats
+  its name (``checked="checked"``) to the bare ``checked``.
 - Inline JavaScript minification — ``minify_js=True`` maps to ``Minify(minify_js=JSMinify())``, which rewrites
   ``<script>`` bodies with turbohtml's shipped JS minifier.
 - Inline CSS minification — ``minify_css=True`` maps to ``Minify(minify_css=True)``, which shrinks ``<style>`` bodies
@@ -81,9 +83,9 @@ What minify-html has that turbohtml does not
 - Aggressive whitespace removal — minify-html's context-aware model can delete inter-element whitespace outright where
   its sensitivity rules judge it insignificant. turbohtml collapses each run to a single space and never deletes it, so
   the output stays render-safe. No equivalent by design.
-- Boolean-attribute and entity shortening — minify-html rewrites ``checked="checked"`` to a bare ``checked`` and
-  shortens ``&amp;`` to ``&`` where safe. turbohtml writes boolean attributes in full and keeps ``&amp;``. No
-  equivalent.
+- Entity shortening — minify-html shortens ``&amp;`` to ``&`` where safe; turbohtml keeps ``&amp;``. No equivalent.
+  (Boolean-attribute collapse now matches: ``Minify(unquote_attributes=True)`` rewrites ``checked="checked"`` to a bare
+  ``checked``.)
 - Template and server-side markers — ``preserve_brace_template_syntax``, ``preserve_chevron_percent_template_syntax``,
   ``keep_ssi_comments``, ``keep_input_type_text_attr``, ``ensure_spec_compliant_unquoted_attribute_values``,
   ``remove_bangs``, and ``remove_processing_instructions`` tune edge cases turbohtml does not expose knobs for. No
@@ -135,8 +137,8 @@ Each fold is a field on :class:`~turbohtml.Minify`, so a flag becomes one keywor
       - ``Minify(strip_comments=...)`` (default ``True``)
     - - ``keep_closing_tags``, ``keep_html_and_head_opening_tags``
       - ``Minify(omit_optional_tags=...)`` (default ``True``; set ``False`` to keep every tag)
-    - - attribute unquoting (on by default)
-      - ``Minify(unquote_attributes=...)`` (default ``True``)
+    - - attribute unquoting and boolean-attribute collapse (on by default)
+      - ``Minify(unquote_attributes=...)`` (default ``True``; also collapses ``checked="checked"`` to bare ``checked``)
     - - ``minify_js``
       - ``Minify(minify_js=JSMinify())`` rewrites inline ``<script>`` content (the default ``None`` leaves it verbatim)
     - - ``minify_css``
@@ -166,10 +168,9 @@ The default call minifies with every HTML fold engaged:
   is idempotent and the output reparses to the input tree; turbohtml is the more conservative of the two, so port
   against behavior rather than string equality.
 - turbohtml keeps attributes in source order; minify-html sorts them.
-- turbohtml collapses each whitespace run to one space and keeps a few optional end tags (``</body>``, ``</html>``,
-  ``</li>``) that minify-html drops, so its output stays valid and render-safe while running a few bytes larger.
-- turbohtml writes boolean attributes in full (``checked="checked"``) and keeps ``&amp;`` where minify-html shortens to
-  a bare ``checked`` and ``&``.
+- turbohtml collapses each whitespace run to one space rather than deleting it, so its output stays render-safe while
+  running a few bytes larger; it also keeps the optional start tags (``<colgroup>``, ``<tbody>``) minify-html can drop.
+- turbohtml keeps ``&amp;`` where minify-html shortens it to a bare ``&``.
 - Embedded CSS and JavaScript minification is opt-in: ``Minify(minify_css=True)`` shrinks ``<style>`` bodies and
   ``style`` attribute values, and ``Minify(minify_js=...)`` rewrites inline ``<script>`` content. minify-html folds both
   in the same call and turbohtml leaves them verbatim unless asked.

--- a/src/turbohtml/_c/dom/formatters.c
+++ b/src/turbohtml/_c/dom/formatters.c
@@ -109,7 +109,8 @@ static PyObject *minify_get_minify_css(PyObject *self, void *Py_UNUSED(closure))
 static PyGetSetDef minify_getset[] = {
     {"collapse_whitespace", minify_get_collapse, NULL, "fold insignificant whitespace runs to a single space", NULL},
     {"omit_optional_tags", minify_get_omit, NULL, "drop the start/end tags the WHATWG rules make optional", NULL},
-    {"unquote_attributes", minify_get_unquote, NULL, "drop redundant attribute quotes and empty values", NULL},
+    {"unquote_attributes", minify_get_unquote, NULL,
+     "drop redundant attribute quotes, empty values, and boolean values that repeat the name", NULL},
     {"strip_comments", minify_get_strip, NULL, "remove comment nodes", NULL},
     {"minify_js", minify_get_minify_js, NULL, "the JSMinify config for inline <script>, or None when off", NULL},
     {"minify_css", minify_get_minify_css, NULL, "minify <style> bodies and style attributes", NULL},
@@ -175,7 +176,9 @@ PyDoc_STRVAR(minify_doc, "Minify(*, collapse_whitespace=True, omit_optional_tags
                          "reparses to the same tree.\n\n"
                          ":param collapse_whitespace: collapse runs of insignificant whitespace.\n"
                          ":param omit_optional_tags: drop start/end tags the parser can infer.\n"
-                         ":param unquote_attributes: remove quotes around attribute values that allow it.\n"
+                         ":param unquote_attributes: remove quotes around attribute values that allow it, drop\n"
+                         "    an empty value to a bare name, and collapse a boolean attribute whose value repeats\n"
+                         "    its name (checked=\"checked\") to the bare name.\n"
                          ":param strip_comments: remove comments.\n"
                          ":param minify_js: a JSMinify to also minify inline <script> JavaScript, or None\n"
                          "    (the default) to leave scripts untouched. A script that fails to parse is\n"

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -281,12 +281,12 @@ Py_UCS4 *th_node_serialize(th_tree *tree, th_node *node, const th_serialize_opts
 typedef struct {
     int collapse_whitespace; /* fold ASCII-whitespace runs to a single space outside pre/textarea/listing */
     int omit_optional_tags;  /* drop the start/end tags the WHATWG optional-tag rules allow */
-    int unquote_attributes;  /* drop redundant attribute quotes and write empty values as bare names */
-    int strip_comments;      /* skip comment nodes */
-    int minify_js;           /* minify inline <script> JavaScript (a parse failure falls back to verbatim) */
-    int minify_js_fold;      /* run the JS constant-folding / dead-code pass */
-    int minify_js_mangle;    /* run the JS identifier-renaming pass */
-    int minify_css;          /* minify <style> bodies and style="" values through the CSS minifier */
+    int unquote_attributes; /* drop redundant attribute quotes, empty values, and boolean values that repeat the name */
+    int strip_comments;     /* skip comment nodes */
+    int minify_js;          /* minify inline <script> JavaScript (a parse failure falls back to verbatim) */
+    int minify_js_fold;     /* run the JS constant-folding / dead-code pass */
+    int minify_js_mangle;   /* run the JS identifier-renaming pass */
+    int minify_css;         /* minify <style> bodies and style="" values through the CSS minifier */
 } th_minify_opts;
 
 /* Serialize node and its subtree minified under minify and the output options.

--- a/src/turbohtml/_c/serialize/minify.c
+++ b/src/turbohtml/_c/serialize/minify.c
@@ -118,6 +118,66 @@ static int mini_attr_unquotable(const Py_UCS4 *value, Py_ssize_t len) {
     return value[len - 1] != '/';
 }
 
+/* The WHATWG boolean attributes: presence alone sets them, so the parser and every renderer
+   ignore the value. Rewriting one whose value repeats the name (or is empty) to the bare name
+   is render-identical, and the empty value the reparse then carries re-minifies to the same
+   bare form -- a fixpoint. Several of these names (allowfullscreen, playsinline, ...) have no
+   attribute atom, and the value-repeats-name coincidence that gates this scan is off every hot
+   attribute, so it matches on name bytes rather than an atom switch. */
+static int mini_is_boolean_attr(const char *name, Py_ssize_t name_len) {
+    static const struct {
+        const char *name;
+        Py_ssize_t len;
+    } booleans[] = {
+        {"allowfullscreen", 15},
+        {"async", 5},
+        {"autofocus", 9},
+        {"autoplay", 8},
+        {"checked", 7},
+        {"controls", 8},
+        {"default", 7},
+        {"defer", 5},
+        {"disabled", 8},
+        {"formnovalidate", 14},
+        {"inert", 5},
+        {"ismap", 5},
+        {"itemscope", 9},
+        {"loop", 4},
+        {"multiple", 8},
+        {"muted", 5},
+        {"nomodule", 8},
+        {"novalidate", 10},
+        {"open", 4},
+        {"playsinline", 11},
+        {"readonly", 8},
+        {"required", 8},
+        {"reversed", 8},
+        {"selected", 8},
+    };
+    for (size_t index = 0; index < sizeof(booleans) / sizeof(booleans[0]); index++) {
+        if (booleans[index].len == name_len && memcmp(booleans[index].name, name, (size_t)name_len) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* ASCII case-insensitive equality of a UCS-4 attribute value against the (lowercase) attribute
+   name bytes, over an already length-matched span: a boolean attribute reduces to its bare name
+   only when its value repeats the name (case-folded), like checked="Checked". */
+static int mini_value_matches_name(const Py_UCS4 *value, const char *name, Py_ssize_t len) {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 character = value[index];
+        if (character >= 'A' && character <= 'Z') {
+            character += 'a' - 'A';
+        }
+        if (character != (Py_UCS4)(unsigned char)name[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 /* Encode text[0..len) as UTF-8 into a freshly PyMem-allocated buffer (caller frees); *out_len
    receives the byte count. The CSS engine works over UTF-8 bytes while the tree stores code
    points, so the <style>/style= paths transcode through here. Tree text is well-formed code
@@ -212,6 +272,10 @@ static void mini_open_tag(sbuf *out, th_tree *tree, th_node *node, const th_seri
         if (minify_css && value_len > 0 && name_len == 5 && memcmp(name, "style", 5) == 0) {
             /* NULL with value_len 0 when the declarations minified to empty, rendered as an empty value below */
             value = minified = mini_style_attr_css(value, value_len, &value_len);
+        }
+        if (unquote && value_len == name_len && mini_value_matches_name(value, name, value_len) &&
+            mini_is_boolean_attr(name, name_len)) {
+            continue; /* a boolean attribute whose value repeats its name renders as the bare name */
         }
         if (unquote && value_len == 0) {
             continue; /* an empty value reparses identically as a bare attribute name */
@@ -388,6 +452,12 @@ static int mini_end_tag_rule(th_tree *tree, th_node *node, th_node *next) {
     case TH_TAG_P:
         return mini_is_p_follow(na) ||
                (last && node->parent->ns == TH_NS_HTML && !mini_p_parent_excluded(node->parent->atom));
+    case TH_TAG_CAPTION:
+    case TH_TAG_COLGROUP:
+        /* caption/colgroup exist only inside a table (a stray one is dropped at parse), so a
+           following table section or the table's own close reconstructs the element; only an
+           inserted whitespace text node or a comment would reattach inside it */
+        return next == NULL || (next->type != TH_NODE_COMMENT && !mini_starts_with_ws(tree, next));
     case TH_TAG_HTML:
     case TH_TAG_BODY:
         return next == NULL || next->type != TH_NODE_COMMENT; /* not immediately followed by a comment */

--- a/tests/serialize/test_minify.py
+++ b/tests/serialize/test_minify.py
@@ -274,6 +274,26 @@ def test_keep_comment_when_off() -> None:
             "<table><tbody><tr><td>a<th>b</table>",
             id="td-before-th",
         ),
+        pytest.param(
+            "<table><caption>c</caption><tbody><tr><td>a</td></tr></tbody></table>",
+            "<table><caption>c<tbody><tr><td>a</table>",
+            id="caption-before-section",
+        ),
+        pytest.param(
+            "<table><caption>c</caption></table>",
+            "<table><caption>c</table>",
+            id="caption-last",
+        ),
+        pytest.param(
+            "<table><colgroup><col></colgroup><tbody><tr><td>a</td></tr></tbody></table>",
+            "<table><colgroup><col><tbody><tr><td>a</table>",
+            id="colgroup-before-section",
+        ),
+        pytest.param(
+            "<table><colgroup><col></colgroup><colgroup><col></colgroup><tr><td>a</td></tr></table>",
+            "<table><colgroup><col><colgroup><col><tbody><tr><td>a</table>",
+            id="colgroup-before-colgroup",
+        ),
         pytest.param("<p>a</p><p>b</p>", "<p>a<p>b", id="p-before-p"),
         pytest.param("<p>a</p><ul><li>x</li></ul>", "<p>a<ul><li>x</ul>", id="p-before-ul"),
         pytest.param("<ol><li><p>a</p></li></ol>", "<ol><li><p>a</ol>", id="p-last-in-li"),
@@ -384,6 +404,94 @@ def test_html_body_end_kept_before_comment() -> None:
 def test_head_end_kept_before_whitespace() -> None:
     out = parse("<html><head><title>t</title></head> <body>x</body></html>").serialize(Html(layout=Minify()))
     assert "</head>" in out
+
+
+@pytest.mark.parametrize(
+    ("element", "follow"),
+    [
+        pytest.param("caption", " ", id="caption-before-whitespace"),
+        pytest.param("caption", "<!--c-->", id="caption-before-comment"),
+        pytest.param("colgroup", " ", id="colgroup-before-whitespace"),
+        pytest.param("colgroup", "<!--c-->", id="colgroup-before-comment"),
+    ],
+)
+def test_caption_colgroup_end_kept_before_whitespace_or_comment(element: str, follow: str) -> None:
+    # an inserted whitespace text node or a comment after the element would reattach
+    # inside it on reparse, so the end tag must survive; every other following node is a
+    # table section the parser's own close reconstructs
+    inner = "<col>" if element == "colgroup" else "c"
+    source = f"<table><{element}>{inner}</{element}>{follow}<tbody><tr><td>a</table>"
+    once = parse(source).serialize(Html(layout=Minify(strip_comments=False)))
+    assert f"</{element}>" in once
+    assert parse(once).html == parse(source).html
+    assert parse(once).serialize(Html(layout=Minify(strip_comments=False))) == once
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "allowfullscreen",
+        "async",
+        "autofocus",
+        "autoplay",
+        "checked",
+        "controls",
+        "default",
+        "defer",
+        "disabled",
+        "formnovalidate",
+        "inert",
+        "ismap",
+        "itemscope",
+        "loop",
+        "multiple",
+        "muted",
+        "nomodule",
+        "novalidate",
+        "open",
+        "playsinline",
+        "readonly",
+        "required",
+        "reversed",
+        "selected",
+    ],
+)
+def test_boolean_attribute_value_collapses_to_bare_name(name: str) -> None:
+    # a boolean attribute renders on presence alone, so a value that repeats the name is
+    # redundant; the bare form reparses to an empty value that re-minifies to itself
+    source = f'<div {name}="{name}">t</div>'
+    out = frag(source, omit_optional_tags=False)
+    assert out == f"<div {name}>t</div>"
+    assert frag(out, omit_optional_tags=False) == out  # the bare form is a re-minify fixpoint
+
+
+def test_boolean_attribute_value_collapse_is_case_insensitive() -> None:
+    assert frag('<input checked="CHECKED">', omit_optional_tags=False) == "<input checked>"
+
+
+def test_boolean_attribute_empty_value_collapses_to_bare_name() -> None:
+    assert frag('<input disabled="">', omit_optional_tags=False) == "<input disabled>"
+
+
+def test_boolean_attribute_keeps_value_when_it_differs_from_name() -> None:
+    # only a value repeating the name (or empty) is redundant; any other value is preserved
+    assert frag('<input disabled="true">', omit_optional_tags=False) == "<input disabled=true>"
+
+
+def test_non_boolean_attribute_value_matching_name_is_kept() -> None:
+    # title is not a boolean attribute, so title="title" carries a real value and stays
+    assert frag('<a title="title">t</a>', omit_optional_tags=False) == "<a title=title>t</a>"
+
+
+def test_attribute_value_same_length_as_name_but_different_is_kept() -> None:
+    # a value the same length as the name but not repeating it is a real value: no collapse
+    assert frag('<a class="claYY">t</a>', omit_optional_tags=False) == "<a class=claYY>t</a>"
+
+
+def test_boolean_attribute_collapse_needs_unquote() -> None:
+    assert frag('<input checked="checked">', omit_optional_tags=False, unquote_attributes=False) == (
+        '<input checked="checked">'
+    )
 
 
 def test_head_start_omitted_when_empty() -> None:


### PR DESCRIPTION
Migrating a minifier off `htmlmin` or `minify-html` left two render-safe size wins unused: those tools rewrite `checked="checked"` to a bare `checked` and drop the `</caption>`/`</colgroup>` end tags the WHATWG rules make optional, while turbohtml kept both written out in full. This closes both gaps from the migration audit, so `turbohtml.clean.minify` shrinks the same forms the competitors do.

Both reuse existing flags instead of new API. `unquote_attributes` already dropped an empty value to a bare attribute name; it now also collapses a WHATWG boolean attribute whose value repeats its name, since the value carries presence only and the parser ignores it. 🎯 `omit_optional_tags` already omitted the rest of the §13.1.2.4 optional-end-tag set; it now extends to `</caption>` and `</colgroup>` under the same following-node condition the table sections use. The end tag survives before an inserted whitespace text node or a comment, which would reattach inside the element on reparse, and drops otherwise, because a caption or colgroup lives only inside a table where the next section or the table close reconstructs it.

Every fold stays round-trip safe: `minify(x)` reparses to the same tree and re-minifying is a fixpoint. The bare boolean attribute reparses to an empty value that re-minifies to the same bare form, so idempotence holds even though the DOM attribute string changes. The html5lib tree-construction corpus runs through minify with zero non-idempotent cases, and the `htmlmin`, `minify-html`, and `html5lib` migration guides record the closed gaps.

part of #459
