### PR TITLE
✨ feat(clean): sanitize <style> element contents against the CSS policy

### DIFF
--- a/docs/changelog/469.feature.rst
+++ b/docs/changelog/469.feature.rst
@@ -1,0 +1,6 @@
+Scrub the CSS inside a kept ``<style>`` element in :func:`turbohtml.clean.sanitize`, closing the last gap left by
+bleach's ``css_sanitizer``. When ``style`` is in ``Policy.tags`` the element is kept and its stylesheet body is vetted
+against ``Policy.css_properties``, the same allowlist a ``style`` attribute already uses: a declaration survives only
+when its property is allowlisted and its value carries no ``expression()`` or ``url()`` with a disallowed scheme, while
+selectors and block nesting are preserved. A ``<style>`` the policy does not allow is still neutralized - by
+:user:`gaborbernat`.

--- a/docs/migration/bleach.rst
+++ b/docs/migration/bleach.rst
@@ -77,10 +77,6 @@ What turbohtml adds
 What bleach has that turbohtml does not
 =======================================
 
-- ``css_sanitizer`` (bleach's tinycss2-backed CSS cleaner) scrubbed both the ``style`` attribute and ``<style>`` element
-  contents. turbohtml's native sanitizer scrubs a kept ``style`` *attribute* against ``Policy.css_properties`` but drops
-  ``<style>`` element contents rather than cleaning them; the compat shim rejects a ``css_sanitizer`` argument with
-  ``NotImplementedError``. Workaround: pre-scrub or strip ``<style>`` before sanitizing.
 - A pluggable html5lib filter pipeline (``bleach.sanitizer.Cleaner(filters=[...])``) let you insert arbitrary html5lib
   ``Filter`` classes into the clean pass. turbohtml has no equivalent filter chain; express the transform through
   ``attribute_filter``, ``set_attributes``, or a post-parse walk over the tree instead.
@@ -127,7 +123,8 @@ The bleach-compatible shim keeps ``clean``'s signature, so the import is the onl
     - - ``strip_comments=``
       - ``Policy.strip_comments``
     - - ``css_sanitizer=``
-      - ``Policy.css_properties`` (style attribute only)
+      - ``Policy.css_properties`` (scrubs both the ``style`` attribute and, when ``style`` is allowed, the ``<style>``
+        element body)
 
 ``clean(text, tags=..., attributes=..., protocols=..., strip=..., strip_comments=...)`` maps onto a
 :class:`~turbohtml.clean.Policy`. ``attributes`` accepts bleach's list, per-tag dict, or callable forms; ``strip``
@@ -218,9 +215,11 @@ bleach shipped a frozen list. A bare domain such as ``example.com`` still links 
 
 - turbohtml's safety baseline (``<script>``, ``on*`` handlers, ``javascript:`` URLs) is not configurable, so even a
   permissive ``attributes`` callable cannot re-admit them, where bleach faithfully kept whatever you allowed.
-- The bleach-compatible ``clean`` shim does not take a ``css_sanitizer`` argument; passing one raises
-  ``NotImplementedError``. ``<style>`` element contents are dropped rather than scrubbed. The native sanitizer scrubs a
-  kept ``style`` *attribute* against ``Policy.css_properties`` but leaves ``<style>`` contents out.
+- The bleach-compatible ``clean`` shim does not take a ``css_sanitizer`` object; passing one raises
+  ``NotImplementedError``. Configure CSS scrubbing through ``Policy.css_properties`` on the native
+  :func:`~turbohtml.clean.sanitize` instead: it vets a kept ``style`` attribute and, when ``style`` is in
+  ``Policy.tags``, the ``<style>`` element body against the same property allowlist, dropping unsafe declarations while
+  keeping selectors and block nesting.
 - turbohtml leaves an existing ``<a>`` untouched so linkifying is idempotent, where bleach always reprocessed present
   links. Opt back in with the ``Linkify.process_existing`` field to run the callbacks over author-written anchors too
   (the callback reads ``Link.existing`` to branch).

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -543,10 +543,13 @@ static int css_value_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t star
     return 1;
 }
 
-/* Append the declaration `value[start:end)` to `out` if the property name (the part before `colon`) is allowlisted,
-   trimming surrounding whitespace and joining kept declarations with "; ". Returns 0, or -1 on error. */
-static int css_flush_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_ssize_t colon,
-                                 Py_UCS4 *out, Py_ssize_t *out_len) {
+/* Decide whether the declaration `value[start:end)`, split at `colon` into property and value, survives the policy:
+   its property name must be allowlisted and its value free of expression()/url(disallowed-scheme). On a keep, the
+   trimmed declaration span (property start through the value's last non-whitespace byte) is returned in *name_start
+   and *decl_end. Returns 1 keep, 0 drop, -1 error. Shared by the `style` attribute and `<style>` body scrubbers so the
+   safety rules stay identical across both. */
+static int css_declaration_kept(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_ssize_t colon,
+                                Py_ssize_t *name_start_out, Py_ssize_t *decl_end_out) {
     if (colon < start) {
         return 0; /* no property:value split in this declaration, so drop it */
     }
@@ -572,11 +575,24 @@ static int css_flush_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t 
     if (!value_ok) {
         return 0; /* an allowlisted property carrying expression()/url(disallowed-scheme) is still dropped */
     }
-    /* output from the trimmed name start to the value's last non-whitespace byte (the leading whitespace was already
-       trimmed into name_start, so a kept declaration is emitted without its surrounding whitespace) */
     Py_ssize_t decl_end = end;
     while (decl_end > colon + 1 && is_ascii_ws(value[decl_end - 1])) {
         decl_end--;
+    }
+    *name_start_out = name_start;
+    *decl_end_out = decl_end;
+    return 1;
+}
+
+/* Append the declaration `value[start:end)` to `out` if it survives the policy, trimming surrounding whitespace and
+   joining kept declarations with "; " (the `style` attribute's declaration-list form). Returns 0, or -1 on error. */
+static int css_flush_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_ssize_t colon,
+                                 Py_UCS4 *out, Py_ssize_t *out_len) {
+    Py_ssize_t name_start = 0;
+    Py_ssize_t decl_end = 0;
+    int kept = css_declaration_kept(s, value, start, end, colon, &name_start, &decl_end);
+    if (kept <= 0) { /* GCOVR_EXCL_BR_LINE: the -1 half is css_declaration_kept's allocation-failure path */
+        return kept;
     }
     if (*out_len > 0) {
         out[(*out_len)++] = ';';
@@ -669,6 +685,170 @@ static int sanitize_style(sanitizer *s, th_node *element, th_node_attr *attr) {
     int result = th_node_attr_set(s->tree, element, "style", 5, out, out_len, 1);
     PyMem_Free(out);
     return result;
+}
+
+/* Copy the rule prelude (a selector or at-rule head) `value[start:end)` to `out`, trimmed of surrounding whitespace.
+   A prelude carries no declarations, so it is kept verbatim: CSS selectors cannot run script, and the value-level
+   dangers (expression(), url(disallowed-scheme)) live in declaration values, which css_declaration_kept still vets. */
+static void css_emit_prelude(const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_UCS4 *out,
+                             Py_ssize_t *out_len) {
+    while (start < end && is_ascii_ws(value[start])) {
+        start++;
+    }
+    while (end > start && is_ascii_ws(value[end - 1])) {
+        end--;
+    }
+    for (Py_ssize_t index = start; index < end; index++) {
+        out[(*out_len)++] = value[index];
+    }
+}
+
+/* Append the declaration `value[start:end)` to `out` if it survives the policy, terminated with ';' (the stylesheet's
+   block form, so `p{color:red}` re-serializes to `p{color:red;}` and re-scrubbing is a fixpoint). Returns 0, or -1 on
+   error. */
+static int css_emit_block_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end,
+                                      Py_ssize_t colon, Py_UCS4 *out, Py_ssize_t *out_len) {
+    Py_ssize_t name_start = 0;
+    Py_ssize_t decl_end = 0;
+    int kept = css_declaration_kept(s, value, start, end, colon, &name_start, &decl_end);
+    if (kept <= 0) { /* GCOVR_EXCL_BR_LINE: the -1 half is css_declaration_kept's allocation-failure path */
+        return kept;
+    }
+    for (Py_ssize_t index = name_start; index < decl_end; index++) {
+        out[(*out_len)++] = value[index];
+    }
+    out[(*out_len)++] = ';';
+    return 0;
+}
+
+/* Scrub a `<style>` body: a stylesheet is a sequence of rules, each a prelude (selector or at-rule head) and a `{...}`
+   block. A block's declarations are vetted like a `style` attribute -- only allowlisted, expression()/url-safe
+   declarations survive -- while preludes and block nesting are kept, so `p{color:red;position:fixed}` becomes
+   `p{color:red;}`. Segmentation runs a single pass whose terminator classifies each run: a `{` makes the run a prelude
+   (open a block), a `;`/`}` a declaration. An at-rule statement (`@import ...;`, `@charset ...`) has no property:value
+   split, so css_declaration_kept drops it, and a `url()`/quoted/commented `;`, `:`, `{`, or `}` is skipped so it is
+   never mistaken for a separator. brace_depth is an int counter, not recursion, so a pathologically nested body cannot
+   overflow the C stack. Writes the scrubbed body length to *out_len_out. Returns 0, or -1 on error. */
+static int scrub_stylesheet(sanitizer *s, const Py_UCS4 *value, Py_ssize_t len, Py_UCS4 *out, Py_ssize_t *out_len_out) {
+    Py_ssize_t out_len = 0;
+    Py_ssize_t seg_start = 0;
+    Py_ssize_t colon = -1;
+    int mode = 0; /* 0 normal, 1 string, 2 comment */
+    Py_UCS4 quote = 0;
+    int depth = 0; /* parenthesis nesting, so a separator inside url(...) is not a separator */
+    int brace_depth = 0;
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_UCS4 c = value[index];
+        if (mode == 2) {
+            if (c == '*' && index + 1 < len && value[index + 1] == '/') {
+                mode = 0;
+                index++;
+            }
+            continue;
+        }
+        if (mode == 1) {
+            if (c == '\\') {
+                index++; /* a backslash escapes the next byte, even a quote */
+            } else if (c == quote) {
+                mode = 0;
+            }
+            continue;
+        }
+        if (c == '/' && index + 1 < len && value[index + 1] == '*') {
+            mode = 2;
+            index++;
+            continue;
+        }
+        if (c == '"' || c == '\'') {
+            mode = 1;
+            quote = c;
+            continue;
+        }
+        if (c == '(') {
+            depth++;
+            continue;
+        }
+        if (c == ')') {
+            depth -= depth > 0;
+            continue;
+        }
+        if (depth > 0) {
+            continue;
+        }
+        if (c == '{') {
+            css_emit_prelude(value, seg_start, index, out, &out_len);
+            out[out_len++] = '{';
+            brace_depth++;
+            seg_start = index + 1;
+            colon = -1;
+            continue;
+        }
+        if (c == '}') {
+            if (brace_depth > 0) { /* a stray '}' outside any block is dropped, carrying no declaration to flush */
+                int flushed = css_emit_block_declaration(s, value, seg_start, index, colon, out, &out_len);
+                if (flushed < 0) { /* GCOVR_EXCL_BR_LINE: css_emit_block_declaration only fails on allocation failure */
+                    return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+                }
+                out[out_len++] = '}';
+                brace_depth--;
+            }
+            seg_start = index + 1;
+            colon = -1;
+            continue;
+        }
+        if (c == ';') {
+            if (brace_depth > 0) { /* a run ended by ';' outside a block is an at-statement, dropped with its body */
+                int flushed = css_emit_block_declaration(s, value, seg_start, index, colon, out, &out_len);
+                if (flushed < 0) { /* GCOVR_EXCL_BR_LINE: css_emit_block_declaration only fails on allocation failure */
+                    return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+                }
+            }
+            seg_start = index + 1;
+            colon = -1;
+            continue;
+        }
+        if (c == ':' && colon < 0) {
+            colon = index;
+        }
+    }
+    if (brace_depth > 0) { /* an unclosed block: flush its trailing declaration and balance the missing braces */
+        int flushed = css_emit_block_declaration(s, value, seg_start, len, colon, out, &out_len);
+        if (flushed < 0) { /* GCOVR_EXCL_BR_LINE: css_emit_block_declaration only fails on allocation failure */
+            return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        while (brace_depth-- > 0) {
+            out[out_len++] = '}';
+        }
+    }
+    *out_len_out = out_len;
+    return 0;
+}
+
+/* Scrub the CSS a kept `<style>` element holds: a raw-text element carries its stylesheet as one text child (or none
+   when empty), so rewrite that child's data in place with the policy-safe subset. Returns 0, or -1 on error. */
+static int sanitize_style_body(sanitizer *s, th_node *element) {
+    th_node *text = element->first_child;
+    if (text == NULL) {
+        return 0; /* an empty <style></style> has no body to scrub */
+    }
+    Py_ssize_t len = 0;
+    Py_UCS4 *body = th_node_data(s->tree, text, &len); /* a parsed text node is a source slice, so materialize it */
+    if (body == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    Py_UCS4 *out = PyMem_Malloc((size_t)(2 * len + 16) * sizeof(Py_UCS4));
+    if (out == NULL) {    /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        PyMem_Free(body); /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;        /* GCOVR_EXCL_LINE */
+    }
+    Py_ssize_t out_len = 0;
+    int status = scrub_stylesheet(s, body, len, out, &out_len);
+    if (status == 0) { /* GCOVR_EXCL_BR_LINE: scrub_stylesheet's non-zero return is its allocation-failure path */
+        status = th_node_set_data(s->tree, text, out, out_len);
+    }
+    PyMem_Free(out);
+    PyMem_Free(body);
+    return status;
 }
 
 static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
@@ -896,8 +1076,11 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
     /* an allowlisted element matches by its serialized name (a foreign element by
        e.g. "svg"/"foreignObject"); the unsafe-tag set still escapes scripting and
        raw-text elements in any namespace, and a foreign element also needs kept
-       context so it stays inside real foreign markup */
-    int allowed = is_unsafe_tag(element->atom) ? 0 : PySet_Contains(s->tags, tag);
+       context so it stays inside real foreign markup. An HTML <style> is exempt from
+       the unsafe-tag block: a policy that allowlists it keeps it with its body scrubbed
+       against css_properties (like a `style` attribute), rather than dropping its CSS. */
+    int style_element = element->atom == TH_TAG_STYLE && is_html;
+    int allowed = (is_unsafe_tag(element->atom) && !style_element) ? 0 : PySet_Contains(s->tags, tag);
     if (allowed > 0 && !is_html && !parent_kept) {
         allowed = 0;
     }
@@ -906,6 +1089,9 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
     int status = 0;
     if (allowed < 0 || remove_content < 0) { /* GCOVR_EXCL_BR_LINE: PySet_Contains never fails on a str key */
         status = -1;                         /* GCOVR_EXCL_LINE */
+    } else if (allowed && style_element) {
+        /* a kept <style> holds raw CSS, not child elements, so scrub its stylesheet body instead of walking children */
+        status = sanitize_attributes(s, element, tag) < 0 ? -1 : sanitize_style_body(s, element);
     } else if (allowed) {
         status = sanitize_attributes(s, element, tag) < 0 ? -1 : sanitize_children(s, element, 1);
     } else if (remove_content || s->on_disallowed == ON_REMOVE || (s->on_disallowed == ON_STRIP && !is_html)) {

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -99,8 +99,10 @@ class Policy:
         present); unlike ``attribute_filter``, this can add attributes that were not there.
     :param remove_with_content: disallowed tags whose whole subtree is dropped (e.g. ``script``/``style``) rather than
         escaped or stripped, so their text never leaks into the output.
-    :param css_properties: when ``style`` is allowed, its value is scrubbed against this set and any declaration whose
-        property name is not in it is dropped, so dangerous CSS cannot ride in on a kept ``style``.
+    :param css_properties: the CSS property allowlist. A kept ``style`` attribute and, when ``style`` is in ``tags``,
+        the ``<style>`` element's stylesheet body are both scrubbed against it: any declaration whose property name is
+        not in the set (or whose value smuggles ``expression()`` or a ``url()`` with a disallowed scheme) is dropped,
+        while selectors and block nesting are kept, so dangerous CSS cannot ride in on a kept ``style``.
     :param attribute_prefixes: allow any attribute whose name starts with one of these prefixes (e.g. ``"data-"`` for
         every ``data-*``), on top of the exact-name and ``"*"`` matches in ``attributes``.
     :param attribute_values: restrict a kept attribute to literal values, keyed ``{tag: {attribute: allowed_values}}``;

--- a/tests/features/test_sanitizer.py
+++ b/tests/features/test_sanitizer.py
@@ -34,8 +34,10 @@ def _style_policy(
 
 
 # frame and frameset are absent: the parser drops them outside a frameset document, so a fragment never contains one.
+# style is absent too: unlike the others, allowlisting it keeps the element with its CSS scrubbed (see the style-body
+# tests), rather than neutralizing it.
 _UNSAFE_TAGS = [
-    "script", "style", "iframe", "embed", "object", "noscript",
+    "script", "iframe", "embed", "object", "noscript",
     "noembed", "noframes", "base", "basefont", "title", "xmp", "template",
 ]  # fmt: skip
 # (tag, markup that yields it) -- col and area need a table/map context to parse as an element.
@@ -352,6 +354,99 @@ def test_style_value_rejects_expression_and_bad_url_scheme(style: str, kept: boo
 def test_style_double_quoted_url_scheme_is_stripped() -> None:
     # a double-quoted url() (in a single-quoted attribute) cannot smuggle a disallowed scheme past the value scan
     assert "style=" not in sanitize("""<p style='color: url("javascript:x")'>y</p>""", _style_policy())
+
+
+def _style_element_policy(*, css_properties: frozenset[str] = DEFAULT_CSS_PROPERTIES) -> Policy:
+    """A policy that allowlists the <style> element, so its stylesheet body is scrubbed rather than dropped."""
+    return Policy(tags=frozenset({"style"}), attributes={}, css_properties=css_properties)
+
+
+@pytest.mark.parametrize(
+    ("css", "expected_body"),
+    [
+        pytest.param("p{color:red;position:fixed}", "p{color:red;}", id="keep-one-drop-one"),
+        pytest.param("p{position:fixed}", "p{}", id="drop-all-keeps-empty-rule"),
+        pytest.param("a{color:red}b{width:5px}", "a{color:red;}b{width:5px;}", id="two-rules"),
+        pytest.param("@media screen{p{color:red;position:fixed}}", "@media screen{p{color:red;}}", id="nested-at-rule"),
+        pytest.param('@import "evil";p{color:red}', "p{color:red;}", id="at-statement-dropped"),
+        pytest.param("p{color:expression(a)}", "p{}", id="expression-value-dropped"),
+        pytest.param("p{color:url(javascript:x)}", "p{}", id="url-bad-scheme-dropped"),
+        pytest.param("p{color:url(http://ok)}", "p{color:url(http://ok);}", id="url-allowed-scheme-kept"),
+        pytest.param("p{color:rgb(1,2,3)}", "p{color:rgb(1,2,3);}", id="parenthesised-value-kept"),
+        pytest.param("p{color:red", "p{color:red;}", id="unclosed-block-balanced"),
+        pytest.param("}p{color:red}", "p{color:red;}", id="stray-close-brace-dropped"),
+        pytest.param('p{content:"a{b};c";color:red}', "p{color:red;}", id="string-holds-separators"),
+        pytest.param(
+            "p{color:red/* ; : */;width:5px}", "p{color:red/* ; : */;width:5px;}", id="comment-holds-separators"
+        ),
+        pytest.param(r'p{font-family:"a\";b";color:red}', r'p{font-family:"a\";b";color:red;}', id="string-escape"),
+        pytest.param("p{color:red}/", "p{color:red;}", id="trailing-slash-not-comment"),
+        pytest.param("p{color:red}/* unterminated", "p{color:red;}", id="unterminated-comment"),
+        pytest.param("p{color:red}/* x*", "p{color:red;}", id="comment-trailing-asterisk"),
+        pytest.param("p{color:red}/* a*b */", "p{color:red;}", id="comment-lone-asterisk"),
+        pytest.param("p{color:1/2}", "p{color:1/2;}", id="slash-not-comment-in-value"),
+        pytest.param("p{color:red)}", "p{color:red);}", id="stray-close-paren"),
+        pytest.param("p{color:a:b}", "p{color:a:b;}", id="value-has-second-colon"),
+        pytest.param("  p  {color:red}", "p{color:red;}", id="prelude-whitespace-trimmed"),
+        pytest.param("   {color:red}", "{color:red;}", id="whitespace-only-prelude"),
+        pytest.param("p{content:'a;b';color:red}", "p{color:red;}", id="single-quoted-string"),
+        pytest.param("p{novalue;color:red}", "p{color:red;}", id="declaration-without-colon-dropped"),
+    ],
+)
+def test_style_element_body_scrubbed(css: str, expected_body: str) -> None:
+    # an allowlisted <style> keeps its element and structure; each declaration is vetted like a style attribute
+    assert sanitize(f"<style>{css}</style>", _style_element_policy()) == f"<style>{expected_body}</style>"
+
+
+@pytest.mark.parametrize("css", ["", "  "], ids=["no-text-child", "whitespace-only"])
+def test_style_element_kept_when_body_empty(css: str) -> None:
+    # keeping the element is the point: an empty body leaves <style></style> standing, never escaped or dropped
+    assert sanitize(f"<style>{css}</style>", _style_element_policy()) == "<style></style>"
+
+
+def test_style_element_body_is_idempotent() -> None:
+    # re-sanitizing the scrubbed output is a fixpoint, the correctness gate for a value-safe transform
+    once = sanitize(
+        "<style>a{color:red;position:fixed}@media(min-width:1px){p{width:5px;top:0}}</style>", _style_element_policy()
+    )
+    assert sanitize(once, _style_element_policy()) == once
+
+
+def test_style_element_empty_property_set_drops_all_css() -> None:
+    # an empty css_properties set means no declaration is allowlisted, so every rule scrubs to an empty block
+    assert (
+        sanitize("<style>p{color:red}</style>", _style_element_policy(css_properties=frozenset()))
+        == "<style>p{}</style>"
+    )
+
+
+def test_style_element_attributes_still_scrubbed() -> None:
+    # a kept <style> is a normal allowed element for attributes: a disallowed one is dropped, the body still scrubbed
+    out = sanitize('<style bad="x">p{color:red;position:fixed}</style>', _style_element_policy())
+    assert out == "<style>p{color:red;}</style>"
+
+
+def test_style_element_attribute_filter_error_propagates() -> None:
+    # a kept <style> runs its surviving attributes through the filter like any element, so a filter error surfaces
+    def boom(_tag: str, name: str, _value: str) -> str:
+        raise ValueError(name)
+
+    policy = Policy(tags=frozenset({"style"}), attributes={"style": frozenset({"foo"})}, attribute_filter=boom)
+    with pytest.raises(ValueError, match="foo"):
+        sanitize('<style foo="x">p{color:red}</style>', policy)
+
+
+def test_style_element_dropped_when_not_allowed() -> None:
+    # the baseline is unchanged: a <style> the policy does not allowlist is escaped, never kept as live CSS
+    out = sanitize("<style>p{color:red}</style>")
+    assert "<style>" not in out
+    assert "&lt;style&gt;" in out
+
+
+def test_style_element_removed_with_content_when_named() -> None:
+    # naming style in remove_with_content still drops the whole element, even though the tag is otherwise unsafe-exempt
+    policy = Policy(tags=frozenset({"b"}), remove_with_content=frozenset({"style"}))
+    assert sanitize("<b>ok</b><style>p{color:red}</style>", policy) == "<b>ok</b>"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
bleach's `css_sanitizer` cleaned CSS in two places: a `style` attribute and a `<style>` element body. turbohtml's sanitizer scrubbed the attribute against `Policy.css_properties` but had no answer for the element, so a `<style>` was escaped or dropped even where a policy allowlisted it. 🎨 That left a real gap for anyone porting a bleach setup that kept trusted stylesheets.

This exempts an HTML `<style>` from the unsafe-tag baseline: when `style` is in `Policy.tags`, the element is kept and its stylesheet body is scrubbed against the same `Policy.css_properties` allowlist the attribute path uses. A declaration survives only when its property is allowlisted and its value carries no `expression()` or `url()` with a disallowed scheme; selectors and block nesting (including `@media` and other nested at-rules) are preserved, while at-rule statements such as `@import` are dropped. The body is walked in a single pass that classifies each run by its terminator, where a `{` opens a rule prelude and a `;` or `}` closes a declaration, with strings, comments, and `url()` parentheses masked so a separator inside them is never mistaken for one. Brace depth is an integer counter rather than recursion, so a pathologically nested body cannot overflow the stack, and the property and value checks are shared with the attribute scrubber so both enforce identical rules. The transform is a fixpoint: re-sanitizing scrubbed output returns it unchanged.

Cleaning is always on when `style` is allowlisted, matching bleach's model where keeping `<style>` means its contents are scrubbed. A `<style>` the policy does not allow is still neutralized as before, and naming it in `remove_with_content` still drops the whole element. The bleach migration guide drops the now-closed gap.

part of #459
