### PR TITLE
✨ feat: python -m turbohtml command-line interface

### DIFF
--- a/docs/changelog/470.feature.rst
+++ b/docs/changelog/470.feature.rst
@@ -1,0 +1,4 @@
+Add a thin command line, ``python -m turbohtml`` (installed as the ``turbohtml`` console script), wrapping the public
+API: ``minify``, ``minify-css``, ``minify-js``, ``detect``, ``to-markdown``, ``to-text``, and ``sanitize``. Each
+subcommand reads a file argument or stdin and writes to stdout or ``-o FILE``, giving the toolkit the shell entry point
+``html2text``, ``markdownify``, ``htmlmin``, ``inscriptis``, ``minify-html``, and ``charset-normalizer`` each ship.

--- a/docs/how-to/cli.rst
+++ b/docs/how-to/cli.rst
@@ -44,6 +44,6 @@ is omitted or ``-``) and writes to stdout, or to the ``-o FILE`` given:
     $ curl -s https://example.com | python -m turbohtml detect
     UTF-8
 
-A subcommand exits ``0`` on success and ``1`` with a message on stderr when the library rejects the input (an
-unparsable script, an empty byte stream to ``detect``) or the input file cannot be read; argument errors exit ``2``.
-For policies, renderer options, or streaming, call the API from Python.
+A subcommand exits ``0`` on success and ``1`` with a message on stderr when the library rejects the input (an unparsable
+script, an empty byte stream to ``detect``) or the input file cannot be read; argument errors exit ``2``. For policies,
+renderer options, or streaming, call the API from Python.

--- a/docs/how-to/cli.rst
+++ b/docs/how-to/cli.rst
@@ -1,0 +1,49 @@
+############################
+ Run turbohtml from a shell
+############################
+
+***************************
+ The ``turbohtml`` command
+***************************
+
+``python -m turbohtml`` (installed as the ``turbohtml`` console script) is a thin front end over the public API, for the
+same one-off jobs ``html2text``, ``markdownify``, ``htmlmin``, ``inscriptis``, ``minify-html``, ``charset-normalizer``,
+and ``courlan`` expose on the command line. Each subcommand reads one input (a file argument, or stdin when the argument
+is omitted or ``-``) and writes to stdout, or to the ``-o FILE`` given:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 78
+
+    - - Subcommand
+      - Calls
+    - - ``minify``
+      - :func:`turbohtml.clean.minify`; ``--minify-css`` also minifies ``<style>`` bodies and ``style`` attributes.
+    - - ``minify-css``
+      - :func:`turbohtml.clean.minify_css`
+    - - ``minify-js``
+      - :func:`turbohtml.minify_js`
+    - - ``detect``
+      - :func:`turbohtml.detect.detect`, printing the encoding name of the input bytes.
+    - - ``to-markdown``
+      - :meth:`turbohtml.Node.to_markdown` on the parsed input.
+    - - ``to-text``
+      - :meth:`turbohtml.Node.to_text` on the parsed input.
+    - - ``sanitize``
+      - :func:`turbohtml.clean.sanitize` against the default policy.
+
+.. code-block:: console
+
+    $ echo '<h1>Title</h1><p>Body</p>' | python -m turbohtml to-markdown
+    # Title
+
+    Body
+
+    $ python -m turbohtml minify --minify-css page.html -o page.min.html
+
+    $ curl -s https://example.com | python -m turbohtml detect
+    UTF-8
+
+A subcommand exits ``0`` on success and ``1`` with a message on stderr when the library rejects the input (an
+unparsable script, an empty byte stream to ``detect``) or the input file cannot be read; argument errors exit ``2``.
+For policies, renderer options, or streaming, call the API from Python.

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -3,8 +3,9 @@
 ###############
 
 Task-focused recipes for the common jobs: escaping text, parsing markup into a tree, querying, matching, and editing
-that tree, serializing it back to HTML, Markdown, or plain text, and the tokenizer, link, encoding, and sanitizer
-helpers. Each page is a short, self-contained walkthrough you can lift straight into your own code.
+that tree, serializing it back to HTML, Markdown, or plain text, the tokenizer, link, encoding, and sanitizer helpers,
+and running the toolkit from a shell. Each page is a short, self-contained walkthrough you can lift straight into your
+own code.
 
 .. toctree::
     :maxdepth: 1
@@ -22,3 +23,4 @@ helpers. Each page is a short, self-contained walkthrough you can lift straight 
     links
     structured-data
     sanitizing
+    cli

--- a/docs/migration/charset-normalizer.rst
+++ b/docs/migration/charset-normalizer.rst
@@ -81,6 +81,8 @@ What turbohtml adds
   that mirrors chardet's ``UniversalDetector`` and always agrees with :func:`~turbohtml.detect.detect` of the
   concatenated bytes.
 - A ``Detection.chardet()`` preset that reproduces chardet's 0.2 minimum-confidence behavior.
+- A shell entry point: ``python -m turbohtml detect`` (installed as the ``turbohtml`` console script) prints the
+  encoding of a file or stdin, covering the ``normalizer`` command's core job.
 
 What charset-normalizer has that turbohtml does not
 ===================================================
@@ -88,8 +90,9 @@ What charset-normalizer has that turbohtml does not
 - Arbitrary CPython codecs: charset-normalizer can propose any codec the interpreter ships (``big5hkscs``,
   ``shift_jis_2004``, and other exotic encodings). turbohtml detects only ``chardetng``'s web-focused set (UTF-8,
   ISO-2022-JP, five CJK encodings, 19 single-byte encodings). No equivalent for encodings outside that set.
-- A CLI: the ``normalizer`` command has no turbohtml counterpart. Workaround: call :func:`~turbohtml.detect.detect` from
-  a short script.
+- ``normalizer``'s richer report: its command tabulates chaos, coherence, and alphabets, where ``python -m turbohtml
+  detect`` prints only the winning encoding name. Workaround: :func:`~turbohtml.detect.detect_all` from a script for the
+  ranked candidates.
 - ``explain=True`` verbose logging of the scoring decision. Workaround: :func:`~turbohtml.detect.detect_all` exposes the
   ranked candidates and their confidences as the introspection surface.
 - File and stream helpers ``from_path`` / ``from_fp``. Workaround: read the bytes yourself and pass them to

--- a/docs/migration/courlan.rst
+++ b/docs/migration/courlan.rst
@@ -96,7 +96,9 @@ What courlan has that turbohtml does not
   anchor's ``hreflang``, and in strict mode a language subdomain). No equivalent for the content-scoring path.
 - **Punycode-to-Unicode and slash collapsing.** courlan decodes punycode hosts to Unicode and collapses repeated
   slashes; turbohtml keeps the WHATWG forms (ASCII host, empty segments preserved). No flag toggles this.
-- **A command-line interface.** courlan ships a CLI; turbohtml exposes the Python API only.
+- **A URL-cleaning command line.** courlan ships a CLI for its URL operations. turbohtml now ships ``python -m
+  turbohtml`` (minify, convert, sanitize, detect), but none of its subcommands clean URLs; run the extract API from a
+  short script for that job.
 
 Performance
 ===========

--- a/docs/migration/html2text.rst
+++ b/docs/migration/html2text.rst
@@ -72,12 +72,12 @@ What turbohtml adds
   before it is rendered to Markdown.
 - Grouped, frozen-dataclass config (``Markdown.Links``, ``Markdown.Images``, ``Markdown.Tables`` ...) is fully typed and
   discoverable, versus html2text's flat set of untyped instance attributes.
+- A shell entry point: ``python -m turbohtml to-markdown`` (installed as the ``turbohtml`` console script) reads a file
+  or stdin, covering html2text's command-line converter.
 
 What html2text has that turbohtml does not
 ==========================================
 
-- A command-line converter and ``python -m html2text`` entry point. turbohtml exposes Markdown as a library method only;
-  wrap ``turbohtml.parse(open(path).read()).to_markdown()`` in a short script for equivalent shell use.
 - Pure-Python install with no compiled extension. html2text runs anywhere a Python interpreter does; turbohtml needs a
   prebuilt wheel (or a C toolchain to build from source) for the target platform.
 - ``baseurl`` in html2text and ``Markdown.Links(base_url=...)`` both prefix rather than fully resolve; neither does

--- a/docs/migration/htmlmin.rst
+++ b/docs/migration/htmlmin.rst
@@ -74,6 +74,8 @@ What turbohtml adds
   stylesheets. htmlmin never touches ``<style>`` bodies.
 - A real parse — the input runs through the full WHATWG algorithm, so malformed markup is repaired to the same tree a
   browser builds before it is serialized.
+- A shell entry point — ``python -m turbohtml minify`` (installed as the ``turbohtml`` console script, with a
+  ``--minify-css`` flag) reads a file or stdin, covering htmlmin's command-line tool.
 
 What htmlmin has that turbohtml does not
 ========================================
@@ -92,8 +94,6 @@ What htmlmin has that turbohtml does not
 - WSGI middleware and framework decorator — htmlmin ships ``htmlmin.middleware.HTMLMinMiddleware`` and a decorator to
   minify HTTP responses in place. turbohtml has no built-in web-framework integration. Workaround: call
   :func:`~turbohtml.clean.minify` on the rendered response body in your own middleware or view wrapper.
-- ``htmlmin`` command-line tool — htmlmin installs a console script. turbohtml exposes no minify CLI. Workaround: a
-  two-line ``python -c`` invocation of :func:`~turbohtml.clean.minify`.
 
 Performance
 ===========

--- a/docs/migration/inscriptis.rst
+++ b/docs/migration/inscriptis.rst
@@ -76,6 +76,8 @@ What turbohtml adds
 - **Other output modes** on the same node: :meth:`~turbohtml.Node.to_markdown`, :meth:`~turbohtml.Node.serialize`, and
   the raw :attr:`~turbohtml.Node.text` concatenation with no layout at all.
 - **No lxml dependency** and a native C layout pass, which is where the speedup comes from.
+- **A shell entry point.** ``python -m turbohtml to-text`` (installed as the ``turbohtml`` console script) reads a file
+  or stdin, covering inscriptis's ``inscript`` command-line tool.
 
 What inscriptis has that turbohtml does not
 ===========================================
@@ -84,8 +86,6 @@ What inscriptis has that turbohtml does not
   ``padding``, ``white-space`` rules) through ``ParserConfig(css=...)``. turbohtml exposes only the fixed
   ``layout="strict"`` / ``layout="extended"`` profiles, not per-tag overrides. Workaround: pick the closest profile and
   post-process, or mutate the tree before ``to_text``.
-- **The ``inscript`` command-line tool.** turbohtml has no shipped CLI for text conversion; call
-  ``turbohtml.parse(...).to_text()`` from a short script.
 - **Anchor and caption toggles.** inscriptis's ``display_anchors`` (render ``id`` targets) and ``deduplicate_captions``
   have no direct :class:`~turbohtml.PlainText` equivalent. Workaround: strip or dedupe the relevant nodes on the tree
   before rendering.

--- a/docs/migration/markdownify.rst
+++ b/docs/migration/markdownify.rst
@@ -79,13 +79,12 @@ What turbohtml adds
   discoverable, versus markdownify's flat set of untyped keyword options.
 - Reference-style links, image-render modes, transliteration, and a Google Docs inline-CSS mode
   (``Markdown.google_doc()``) that markdownify does not expose.
+- A shell entry point: ``python -m turbohtml to-markdown`` (installed as the ``turbohtml`` console script) reads a file
+  or stdin, covering markdownify's command-line converter.
 
 What markdownify has that turbohtml does not
 ============================================
 
-- A command-line converter (``python -m markdownify`` / the ``markdownify`` console script). turbohtml exposes Markdown
-  as a library method only; wrap ``turbohtml.parse(open(path).read()).to_markdown()`` in a short script for equivalent
-  shell use.
 - Subclass-based extension: markdownify lets a ``MarkdownConverter`` subclass override any ``convert_<tag>`` method and
   call the parent implementation with ``super()``. turbohtml's ``Markdown(converters=...)`` maps a tag name to a
   callable receiving the element and its already-rendered child Markdown, which covers per-tag replacement but not

--- a/docs/migration/minify-html.rst
+++ b/docs/migration/minify-html.rst
@@ -74,6 +74,8 @@ What turbohtml adds
   minifying twice changes nothing.
 - Self-contained C extension — no separate Rust minifier in the toolchain; minify shares the parser turbohtml already
   ships.
+- A shell entry point — ``python -m turbohtml minify`` (installed as the ``turbohtml`` console script, with a
+  ``--minify-css`` flag) reads a file or stdin, covering minify-html's standalone CLI on Python.
 
 What minify-html has that turbohtml does not
 ============================================
@@ -88,9 +90,8 @@ What minify-html has that turbohtml does not
   ``keep_ssi_comments``, ``keep_input_type_text_attr``, ``ensure_spec_compliant_unquoted_attribute_values``,
   ``remove_bangs``, and ``remove_processing_instructions`` tune edge cases turbohtml does not expose knobs for. No
   equivalent; turbohtml applies the WHATWG-safe default in each case.
-- Non-Python bindings and a CLI — minify-html ships for Node, Deno, Ruby, Java, and as a standalone binary. turbohtml
-  exposes no minify CLI and is Python-only. Workaround: a two-line ``python -c`` invocation of
-  :func:`~turbohtml.clean.minify`.
+- Non-Python bindings — minify-html ships for Node, Deno, Ruby, and Java; turbohtml is Python-only (the standalone
+  binary's job is covered by ``python -m turbohtml minify``).
 
 Performance
 ===========

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,7 @@ py.extension_module(
 py.install_sources(
     [
         'src/turbohtml/__init__.py',
+        'src/turbohtml/__main__.py',
         'src/turbohtml/_article.py',
         'src/turbohtml/_cssmin.py',
         'src/turbohtml/_dates.py',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ urls.Documentation = "https://turbohtml.readthedocs.io"
 urls.Homepage = "https://github.com/tox-dev/turbohtml"
 urls.Source = "https://github.com/tox-dev/turbohtml"
 urls.Tracker = "https://github.com/tox-dev/turbohtml/issues"
+scripts.turbohtml = "turbohtml.__main__:main"
 
 [dependency-groups]
 dev = [
@@ -284,6 +285,8 @@ paths.source = [
 ]
 html.show_contexts = true
 html.skip_covered = false
+# covdefaults omits */__main__.py by default; the CLI lives there, so gate it like the rest
+covdefaults.subtract_omit = "*/__main__.py"
 
 [tool.towncrier]
 name = "turbohtml"

--- a/src/turbohtml/__main__.py
+++ b/src/turbohtml/__main__.py
@@ -1,0 +1,139 @@
+"""
+turbohtml.__main__: a thin ``python -m turbohtml`` front end over the public API.
+
+Every subcommand parses argv, reads one input (a file argument or stdin), calls the matching public function, and
+writes the result (stdout or ``-o``); the transforms themselves live in the C core, so this module only wires argv to
+them. It gives the toolkit the command-line surface ``html2text``, ``markdownify``, ``htmlmin``, ``inscriptis``,
+``minify-html``, ``charset-normalizer``, and ``courlan`` each ship and turbohtml lacked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from . import minify_js, parse
+from ._html import Minify
+from .clean import minify, minify_css, sanitize
+from .detect import detect
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = ["main"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """
+    Run the ``python -m turbohtml`` command line.
+
+    :param argv: the argument vector, excluding the program name; ``None`` reads ``sys.argv``.
+    :returns: the process exit code -- 0 on success, 1 when the library rejects the input or the file cannot be read.
+    """
+    args = _parser().parse_args(argv)
+    try:
+        return args.handler(args)
+    except (OSError, ValueError, LookupError) as error:
+        sys.stderr.write(f"turbohtml {args.command}: {error}\n")
+        return 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the argument parser: one subcommand per public entry point, each sharing the input/output arguments."""
+    parser = argparse.ArgumentParser(prog="python -m turbohtml", description="Command-line front end for turbohtml.")
+    shared = argparse.ArgumentParser(add_help=False)
+    shared.add_argument("file", nargs="?", help="input file; omit or pass - to read stdin")
+    shared.add_argument("-o", "--output", metavar="FILE", help="write to this file instead of stdout")
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    minify_parser = commands.add_parser("minify", parents=[shared], help="minify an HTML document")
+    minify_parser.add_argument(
+        "--minify-css", action="store_true", help="also minify <style> bodies and style attributes"
+    )
+    minify_parser.set_defaults(handler=_run_minify)
+
+    commands.add_parser("minify-css", parents=[shared], help="minify a CSS stylesheet").set_defaults(
+        handler=_run_minify_css
+    )
+    commands.add_parser("minify-js", parents=[shared], help="minify a JavaScript source").set_defaults(
+        handler=_run_minify_js
+    )
+    commands.add_parser("detect", parents=[shared], help="report the character encoding of bytes").set_defaults(
+        handler=_run_detect
+    )
+    commands.add_parser("to-markdown", parents=[shared], help="render HTML as Markdown").set_defaults(
+        handler=_run_to_markdown
+    )
+    commands.add_parser("to-text", parents=[shared], help="render HTML as layout-aware plain text").set_defaults(
+        handler=_run_to_text
+    )
+    commands.add_parser("sanitize", parents=[shared], help="sanitize HTML against the default policy").set_defaults(
+        handler=_run_sanitize
+    )
+    return parser
+
+
+def _run_minify(args: argparse.Namespace) -> int:
+    _write(minify(_read_text(args.file), Minify(minify_css=args.minify_css)), args.output)
+    return 0
+
+
+def _run_minify_css(args: argparse.Namespace) -> int:
+    _write(minify_css(_read_text(args.file)), args.output)
+    return 0
+
+
+def _run_minify_js(args: argparse.Namespace) -> int:
+    _write(minify_js(_read_text(args.file)), args.output)
+    return 0
+
+
+def _run_detect(args: argparse.Namespace) -> int:
+    if (match := detect(_read_bytes(args.file))).encoding is None:
+        sys.stderr.write("turbohtml detect: no encoding detected\n")
+        return 1
+    _write(f"{match.encoding}\n", args.output)
+    return 0
+
+
+def _run_to_markdown(args: argparse.Namespace) -> int:
+    _write(parse(_read_text(args.file)).to_markdown(), args.output)
+    return 0
+
+
+def _run_to_text(args: argparse.Namespace) -> int:
+    _write(parse(_read_text(args.file)).to_text(), args.output)
+    return 0
+
+
+def _run_sanitize(args: argparse.Namespace) -> int:
+    _write(sanitize(_read_text(args.file)), args.output)
+    return 0
+
+
+def _read_text(path: str | None) -> str:
+    """Read text input from ``path``, or stdin when it is ``None`` or ``-``."""
+    if path is None or path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def _read_bytes(path: str | None) -> bytes:
+    """Read binary input from ``path``, or stdin when it is ``None`` or ``-``."""
+    if path is None or path == "-":
+        return sys.stdin.buffer.read()
+    return Path(path).read_bytes()
+
+
+def _write(text: str, output: str | None) -> None:
+    """Write ``text`` to ``output``, or stdout when it is ``None`` or ``-``."""
+    if output is None or output == "-":
+        sys.stdout.write(text)
+    else:
+        Path(output).write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,111 @@
+"""End-to-end tests for the ``python -m turbohtml`` command-line interface."""
+
+from __future__ import annotations
+
+import io
+import subprocess  # noqa: S404  # the entry-point test runs turbohtml in a clean interpreter; the command is fixed, not input
+import sys
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from turbohtml.__main__ import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    ("argv", "stdin", "expected"),
+    [
+        pytest.param(["minify"], "<p>a  b</p><!-- c -->", "<p>a b", id="minify"),
+        pytest.param(
+            ["minify", "--minify-css"],
+            "<style>a { color : red }</style>",
+            "<style>a{color:red}</style>",
+            id="minify-css-flag",
+        ),
+        pytest.param(["minify-css"], "a { color: #ffffff }", "a{color:#fff}", id="minify-css"),
+        pytest.param(["minify-js"], "const  x = 1 ;", "const x=1", id="minify-js"),
+        pytest.param(["to-markdown"], "<h1>T</h1><p>b</p>", "# T\n\nb", id="to-markdown"),
+        pytest.param(["to-text"], "<h1>T</h1><p>b</p>", "T\n\nb", id="to-text"),
+        pytest.param(
+            ["sanitize"], "<b>hi</b><script>x()</script>", "<b>hi</b>&lt;script&gt;x()&lt;/script&gt;", id="sanitize"
+        ),
+        pytest.param(["detect"], "café èè", "UTF-8\n", id="detect"),
+    ],
+)
+def test_cli_subcommand_stdin_to_stdout(
+    argv: list[str], stdin: str, expected: str, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(read=io.StringIO(stdin).read, buffer=io.BytesIO(stdin.encode())))
+    assert main(argv) == 0
+    assert capsys.readouterr().out == expected
+
+
+def test_cli_reads_file_argument(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    source = tmp_path / "in.html"
+    source.write_text("<p>a  b</p>", encoding="utf-8")
+    assert main(["minify", str(source)]) == 0
+    assert capsys.readouterr().out == "<p>a b"
+
+
+def test_cli_dash_reads_stdin(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("<p>a  b</p>"))
+    assert main(["minify", "-"]) == 0
+    assert capsys.readouterr().out == "<p>a b"
+
+
+def test_cli_detect_reads_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    source = tmp_path / "in.txt"
+    source.write_bytes("café èè".encode())
+    assert main(["detect", str(source)]) == 0
+    assert capsys.readouterr().out == "UTF-8\n"
+
+
+def test_cli_writes_output_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("<p>a  b</p>"))
+    destination = tmp_path / "out.html"
+    assert main(["minify", "-o", str(destination)]) == 0
+    assert destination.read_text(encoding="utf-8") == "<p>a b"
+
+
+def test_cli_detect_empty_input_fails(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(buffer=io.BytesIO(b"")))
+    assert main(["detect"]) == 1
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert captured.err == "turbohtml detect: no encoding detected\n"
+
+
+def test_cli_library_error_maps_to_exit_code(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("const ="))
+    assert main(["minify-js"]) == 1
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert captured.err.startswith("turbohtml minify-js: ")
+
+
+def test_cli_missing_file_maps_to_exit_code(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["minify", "does-not-exist.html"]) == 1
+    assert capsys.readouterr().err.startswith("turbohtml minify: ")
+
+
+def test_cli_requires_a_subcommand() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main([])
+    assert excinfo.value.code == 2
+
+
+def test_cli_module_entry_point() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "turbohtml", "minify-css"],
+        input="a { color: #ffffff }",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout == "a{color:#fff}"


### PR DESCRIPTION
`dominate`, `markyp`, and `simple-html` each ship a one-call helper that emits a whole HTML5 document, and the migration guides listed that as a gap: `turbohtml.build.E` builds only a fragment, with no `<html>`/`<head>`/`<body>` shell and no doctype. 📄 This adds the missing helper so generating a full page takes one call instead of a hand-assembled skeleton.

`turbohtml.build.document(title=..., lang=..., charset=..., head=..., body=...)` returns a `Document` that serializes to `<!DOCTYPE html>` wrapping `<html>` (with an optional `lang`), a `<head>` that leads with `<meta charset>` and an optional `<title>`, and `<body>`. ✨ The C extension builds the whole skeleton through a new `th_tree_build_shell` in `dom/mutate.c` behind the private `_build_document` binding; `build.py` only marshals the arguments and maps head and body strings to `Text` nodes, then fills the two sections through the same node-adoption path `extend()` uses. Pass `charset=None` to drop the meta (say, when an HTTP header sets it) and `title=None` to omit the title.

The result is an ordinary parsed `Document`, so the query, edit, and serialize surface stays available on the page you just built, and re-parsing its serialization round-trips. The dominate, markyp, and simple-html migration guides drop the page-shell gap and point at the new function.

part of #459
