### PR TITLE
⚡ perf(extract): skip the RDFa walk when a document has no typeof

### DIFF
--- a/docs/changelog/475.misc.rst
+++ b/docs/changelog/475.misc.rst
@@ -1,0 +1,3 @@
+Skip the RDFa tree walk in :meth:`~turbohtml.Document.rdfa` and :meth:`~turbohtml.Document.structured_data` when the
+document interns no ``typeof`` attribute, restoring ``structured_data()`` to its pre-RDFa cost on pages that carry no
+RDFa.

--- a/src/turbohtml/_c/features/structured_data.c
+++ b/src/turbohtml/_c/features/structured_data.c
@@ -1180,20 +1180,23 @@ static PyObject *gather_rdfa(PyObject *self, PyObject *base) {
     if (items == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    PyObject *prefixes = build_default_prefixes();
-    if (prefixes == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        Py_DECREF(items);   /* GCOVR_EXCL_LINE: allocation-failure path */
-        return NULL;        /* GCOVR_EXCL_LINE */
-    }
     th_tree *tree = tree_of(self);
     module_state *state = state_of(self);
     th_node *root = ((NodeObject *)self)->node;
-    rdfa_ctx ctx = {NULL, prefixes, base};
     int failed = 0;
     Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
-    failed = walk_rdfa(tree, state, root, ctx, items) < 0;
+    /* A document that never interns a typeof attribute carries no RDFa resource, so skip the walk and the prefix map it
+       would need -- this is the whole cost of the RDFa pass on the pages (most of them) that use no RDFa. */
+    if (th_attr_lookup(tree, "typeof", 6) != UINT32_MAX) {
+        PyObject *prefixes = build_default_prefixes();
+        failed = prefixes == NULL; /* the build fails only on unforceable allocation */
+        if (prefixes != NULL) {    /* GCOVR_EXCL_BR_LINE: the build fails only on unforceable allocation */
+            rdfa_ctx ctx = {NULL, prefixes, base};
+            failed = walk_rdfa(tree, state, root, ctx, items) < 0;
+            Py_DECREF(prefixes);
+        }
+    }
     Py_END_CRITICAL_SECTION();
-    Py_DECREF(prefixes);
     if (failed) {         /* GCOVR_EXCL_BR_LINE: allocation-failure path */
         Py_DECREF(items); /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;      /* GCOVR_EXCL_LINE */

--- a/tests/features/test_structured_data_microdata.py
+++ b/tests/features/test_structured_data_microdata.py
@@ -552,6 +552,11 @@ def test_rdfa_get_and_get_all() -> None:
     assert item.get_all("missing") == []
 
 
+def test_rdfa_typeof_only_in_text_is_not_a_resource() -> None:
+    # the no-typeof-attribute fast path keys on the attribute, not the word: prose mentioning typeof yields nothing
+    assert parse("<p>the typeof operator and vocab of JS</p>").rdfa() == []
+
+
 def test_rdfa_resolves_iri_objects_and_subject() -> None:
     html = (
         '<div typeof="T" resource="/me">'


### PR DESCRIPTION
The RDFa extraction that landed in #472 walks the whole tree to find `typeof` resources, and for correctness it resolves each element's inherited `@vocab`/`@prefix` context as it descends. That cost is paid on every document, including the majority that carry no RDFa at all, and it shows up on the `structured_data()` benchmark over the WHATWG spec (which mentions the word `typeof` only in prose, never as an attribute). ⚡

The fix guards the walk on one atom-table lookup: a document that never interned a `typeof` attribute has no RDFa resource, so `gather_rdfa` returns the empty list without walking the tree or building the RDFa 1.1 prefix map. Pages that do use RDFa take the same path as before.

Behavior is unchanged. The existing RDFa tests already exercise both the walked path (documents with `typeof`) and the skipped path (documents without), and a new test pins that a document mentioning `typeof` only in text yields no resources.
