### PR TITLE
✨ feat(extract): canonical, site_name, tags, and lead-image metadata

### DIFF
--- a/docs/changelog/476.feature.rst
+++ b/docs/changelog/476.feature.rst
@@ -1,0 +1,5 @@
+Harvest four more metadata fields alongside the content body in :meth:`~turbohtml.Node.article`: ``canonical`` (the
+``<link rel=canonical>`` URL, then ``og:url``), ``site_name`` (``og:site_name``, then a ``<meta
+name=application-name>``), ``tags`` (every ``<meta name=keywords>`` value, comma-split, plus each ``article:tag``, in
+document order), and ``image`` (``og:image``, then ``twitter:image``). The existing fields keep their positions, so only
+code that reads past ``lang`` sees the new tail.

--- a/docs/migration/metadata_parser.rst
+++ b/docs/migration/metadata_parser.rst
@@ -88,8 +88,10 @@ What metadata_parser has that turbohtml does not
   ``metadata["meta"]``. :meth:`~turbohtml.Document.opengraph` gathers only ``og:``/``twitter:`` tags and
   :meth:`~turbohtml.Document.dublin_core` the ``dc.*``/``dcterms.*`` ones; read any other ``<meta>`` by selecting it,
   e.g. ``parse(html).find_all("meta")``.
-- **Page-level links** (``canonical``, ``shortlink``) collected into ``metadata["page"]``. Read those with a selector,
-  e.g. ``parse(html).find('link[rel="canonical"]')``.
+- **Page-level links** collected into ``metadata["page"]``. The canonical URL comes back through
+  :meth:`~turbohtml.Node.article` as ``article().canonical`` (the ``<link rel="canonical">`` href, falling back to
+  ``og:url``); read any other page link, such as ``shortlink``, with a selector, e.g.
+  ``parse(html).find('link[rel="shortlink"]')``.
 - **Namespace ``strategy`` ordering**: ``get_metadata(field, strategy=[...])`` picks the first namespace that carries a
   field. turbohtml keys tags by their full prefix (``og:title`` vs ``twitter:title``), so read the prefix you want
   directly.

--- a/docs/migration/trafilatura.rst
+++ b/docs/migration/trafilatura.rst
@@ -87,8 +87,9 @@ What trafilatura has that turbohtml does not
   htmldate for pages where the date is only inferable. Prose language, by contrast, turbohtml now infers:
   :func:`turbohtml.detect.detect_language` classifies the extracted text (``article().lang`` still only reports the
   declared ``<html lang>``).
-- Richer metadata fields (site name, categories, tags, license, canonical URL, hostname, lead image). turbohtml exposes
-  ``title``, ``byline``, ``date``, ``description``, and ``lang``.
+- License and hostname metadata fields. :meth:`~turbohtml.Node.article` exposes ``title``, ``byline``, ``date``,
+  ``description``, ``lang``, ``canonical``, ``site_name``, ``tags``, and ``image`` (the lead image); derive the hostname
+  from ``canonical`` with :func:`urllib.parse.urlsplit` and read a license ``<link rel="license">`` with a selector.
 
 Performance
 ===========

--- a/src/turbohtml/_article.py
+++ b/src/turbohtml/_article.py
@@ -18,9 +18,12 @@ class Article(NamedTuple):
     The dominant content of a document and the metadata harvested beside it.
 
     ``element`` is the scored content body (``None`` when nothing reads as content) and ``text`` its layout-aware plain
-    text (empty then). ``title``, ``byline``, ``date``, ``description`` and ``lang`` are the page metadata, each
-    whitespace-normalized or ``None`` when the source is absent. This makes :meth:`~turbohtml.Node.article` a one-call
-    replacement for trafilatura and newspaper3k.
+    text (empty then). ``title``, ``byline``, ``date``, ``description``, ``lang``, ``canonical`` (the ``<link
+    rel=canonical>`` URL or ``og:url``), ``site_name`` (``og:site_name`` or ``<meta name=application-name>``) and
+    ``image`` (the ``og:image`` or ``twitter:image`` lead image) are single-valued page metadata, each
+    whitespace-normalized or ``None`` when the source is absent. ``tags`` collects every ``<meta name=keywords>`` value
+    (comma-split) and ``article:tag`` in document order, an empty tuple when none appear. This makes
+    :meth:`~turbohtml.Node.article` a one-call replacement for trafilatura and newspaper3k.
     """
 
     element: Element | None
@@ -30,6 +33,10 @@ class Article(NamedTuple):
     date: str | None
     description: str | None
     lang: str | None
+    canonical: str | None
+    site_name: str | None
+    tags: tuple[str, ...]
+    image: str | None
 
 
 _register_article(Article)

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -1103,16 +1103,38 @@ static PyObject *article_field(const Py_UCS4 *data, Py_ssize_t len) {
     return ucs4_to_str(data, len);
 }
 
+/* Materialize the harvested tags as a tuple of str, empty when none were found. */
+static PyObject *article_tags(const th_article_tag *tags, Py_ssize_t count) {
+    PyObject *tuple = PyTuple_New(count);
+    if (tuple == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    for (Py_ssize_t index = 0; index < count; index++) {
+        PyObject *item = ucs4_to_str(tags[index].data, tags[index].len);
+        if (item == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            Py_DECREF(tuple); /* GCOVR_EXCL_LINE: allocation-failure path */
+            return NULL;      /* GCOVR_EXCL_LINE */
+        }
+        PyTuple_SET_ITEM(tuple, index, item);
+    }
+    return tuple;
+}
+
 PyDoc_STRVAR(article_doc, "article()\n--\n\n"
                           "Return an Article record for the dominant content under this node: the\n"
                           "scored content body (element), its layout-aware plain text (text, as\n"
                           "main_text()), and the page metadata harvested from the document -- title,\n"
-                          "byline, date, description and lang. element is None and text is empty when\n"
-                          "nothing reads as content; each metadata field is None when absent. Title\n"
-                          "comes from <h1>, then og:title, then <title>; byline from a rel=author\n"
-                          "link, then a meta author, then article:author; date from <time>, then\n"
-                          "article:published_time, then a common date meta; description from\n"
-                          "og:description, then a meta description; lang from <html lang>. Pure C.");
+                          "byline, date, description, lang, canonical, site_name, tags and image.\n"
+                          "element is None and text is empty when nothing reads as content; each\n"
+                          "single-valued metadata field is None when absent and tags is an empty\n"
+                          "tuple. Title comes from <h1>, then og:title, then <title>; byline from a\n"
+                          "rel=author link, then a meta author, then article:author; date from\n"
+                          "<time>, then article:published_time, then a common date meta; description\n"
+                          "from og:description, then a meta description; lang from <html lang>;\n"
+                          "canonical from <link rel=canonical>, then og:url; site_name from\n"
+                          "og:site_name, then a meta application-name; tags from every <meta\n"
+                          "name=keywords> (comma-split) and article:tag; image from og:image, then\n"
+                          "twitter:image. Pure C.");
 
 static PyObject *node_article(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     th_tree *tree = tree_of(self);
@@ -1139,11 +1161,16 @@ static PyObject *node_article(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     PyObject *date = article_field(meta.date, meta.date_len);
     PyObject *description = article_field(meta.description, meta.description_len);
     PyObject *lang = article_field(meta.lang, meta.lang_len);
+    PyObject *canonical = article_field(meta.canonical, meta.canonical_len);
+    PyObject *site_name = article_field(meta.site_name, meta.site_name_len);
+    PyObject *image = article_field(meta.image, meta.image_len);
+    PyObject *tags = article_tags(meta.tags, meta.tags_count);
     th_article_meta_clear(&meta);
 
     /* Py_BuildValue("(N...)") steals each reference and, if any field is NULL from
        an (unforceable) allocation failure, propagates the error and frees the rest. */
-    PyObject *args = Py_BuildValue("(NNNNNNN)", element, text, title, byline, date, description, lang);
+    PyObject *args = Py_BuildValue("(NNNNNNNNNNN)", element, text, title, byline, date, description, lang, canonical,
+                                   site_name, tags, image);
     if (args == NULL) { /* GCOVR_EXCL_BR_LINE: a field is NULL only on an unforceable allocation failure */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -440,15 +440,26 @@ Py_UCS4 *th_node_layout_text(th_tree *tree, th_node *node, const text_opts *opt,
    th_node_layout_text) afterwards. The engine for Node.main_content()/main_text(). */
 th_node *th_node_main_content(th_tree *tree, th_node *root);
 
+/* One harvested tag/keyword: a freshly PyMem-allocated, whitespace-normalized
+   code-point buffer and its length. */
+typedef struct {
+    Py_UCS4 *data;
+    Py_ssize_t len;
+} th_article_tag;
+
 /* The page-level article metadata Node.article() returns beside the content body:
-   each field is a freshly PyMem-allocated, whitespace-normalized code-point buffer
-   (NULL with a zero length when the source is absent), harvested in pure C from the
-   document the content sits in -- title from <h1> / og:title / <title>, byline from
-   a rel=author link / meta author / article:author, date from <time> / article:
-   published_time / a common date meta, description from og:description / meta
-   description, and lang from <html lang>. The caller holds the per-tree critical
-   section, materializes each buffer into a str (or None), then th_article_meta_clear
-   frees them. */
+   each single-valued field is a freshly PyMem-allocated, whitespace-normalized
+   code-point buffer (NULL with a zero length when the source is absent), harvested in
+   pure C from the document the content sits in -- title from <h1> / og:title /
+   <title>, byline from a rel=author link / meta author / article:author, date from
+   <time> / article:published_time / a common date meta, description from
+   og:description / meta description, lang from <html lang>, canonical from
+   <link rel=canonical> / og:url, site_name from og:site_name / meta application-name,
+   and image from og:image / twitter:image. tags holds each <meta name=keywords>
+   value (comma-split) and each article:tag in document order, tags_count of them (an
+   empty run when none appear). The caller holds the per-tree critical section,
+   materializes each buffer into a str (or None) and tags into a tuple, then
+   th_article_meta_clear frees them. */
 typedef struct {
     Py_UCS4 *title;
     Py_ssize_t title_len;
@@ -460,6 +471,14 @@ typedef struct {
     Py_ssize_t description_len;
     Py_UCS4 *lang;
     Py_ssize_t lang_len;
+    Py_UCS4 *canonical;
+    Py_ssize_t canonical_len;
+    Py_UCS4 *site_name;
+    Py_ssize_t site_name_len;
+    Py_UCS4 *image;
+    Py_ssize_t image_len;
+    th_article_tag *tags;
+    Py_ssize_t tags_count;
 } th_article_meta;
 
 /* Fill meta by harvesting the article metadata fields from root (the document the

--- a/src/turbohtml/_c/serialize/readability.c
+++ b/src/turbohtml/_c/serialize/readability.c
@@ -490,19 +490,10 @@ static int read_is_meta(th_tree *tree, th_node *node, const void *ctx) {
     return 0;
 }
 
-/* Whether node is an <a> whose rel attribute carries the "author" token. */
-static int read_is_author_link(th_tree *tree, th_node *node, const void *Py_UNUSED(ctx)) {
-    if (node->ns != TH_NS_HTML || node->atom != TH_TAG_A) {
-        return 0;
-    }
-    Py_ssize_t found = th_node_attr_find(tree, node, "rel", 3);
-    if (found < 0) {
-        return 0;
-    }
-    /* a valueless rel carries value_len 0 (a NULL pointer if hand-built, an empty
-       string if parsed), so the token scan below simply yields no tokens */
-    const Py_UCS4 *value = node->attrs[found].value;
-    Py_ssize_t value_len = node->attrs[found].value_len;
+/* Whether a rel attribute run carries token as one of its whitespace-separated
+   values, compared case-insensitively. A valueless rel carries value_len 0 (a NULL
+   pointer if hand-built, an empty string if parsed), so the scan yields no tokens. */
+static int read_rel_has_token(const Py_UCS4 *value, Py_ssize_t value_len, const char *token) {
     Py_ssize_t index = 0;
     while (index < value_len) {
         while (index < value_len && read_is_ws(value[index])) {
@@ -512,11 +503,35 @@ static int read_is_author_link(th_tree *tree, th_node *node, const void *Py_UNUS
         while (index < value_len && !read_is_ws(value[index])) {
             index++;
         }
-        if (index > start && ser_value_iequals(value + start, index - start, "author")) {
+        if (index > start && ser_value_iequals(value + start, index - start, token)) {
             return 1;
         }
     }
     return 0;
+}
+
+/* Whether node is an <a> whose rel attribute carries the "author" token. */
+static int read_is_author_link(th_tree *tree, th_node *node, const void *Py_UNUSED(ctx)) {
+    if (node->ns != TH_NS_HTML || node->atom != TH_TAG_A) {
+        return 0;
+    }
+    Py_ssize_t found = th_node_attr_find(tree, node, "rel", 3);
+    if (found < 0) {
+        return 0;
+    }
+    return read_rel_has_token(node->attrs[found].value, node->attrs[found].value_len, "author");
+}
+
+/* Whether node is a <link> whose rel attribute carries the "canonical" token. */
+static int read_is_canonical_link(th_tree *tree, th_node *node, const void *Py_UNUSED(ctx)) {
+    if (node->ns != TH_NS_HTML || node->atom != TH_TAG_LINK) {
+        return 0;
+    }
+    Py_ssize_t found = th_node_attr_find(tree, node, "rel", 3);
+    if (found < 0) {
+        return 0;
+    }
+    return read_rel_has_token(node->attrs[found].value, node->attrs[found].value_len, "canonical");
 }
 
 /* The normalized content of the first <meta> matching key, or NULL when absent. */
@@ -632,6 +647,136 @@ static Py_UCS4 *read_harvest_lang(th_tree *tree, th_node *root, Py_ssize_t *out_
     return read_attr_value(tree, html, "lang", 4, out_len);
 }
 
+/* Canonical URL: the first <link rel=canonical>'s href, else the og:url meta. */
+static Py_UCS4 *read_harvest_canonical(th_tree *tree, th_node *root, Py_ssize_t *out_len) {
+    th_node *link = read_find(tree, root, read_is_canonical_link, NULL);
+    if (link != NULL) {
+        Py_UCS4 *href = read_attr_value(tree, link, "href", 4, out_len);
+        if (href != NULL) {
+            return href;
+        }
+    }
+    return read_meta_content(tree, root, "og:url", out_len);
+}
+
+/* Site name: the og:site_name meta, else the application-name meta. */
+static Py_UCS4 *read_harvest_site_name(th_tree *tree, th_node *root, Py_ssize_t *out_len) {
+    Py_UCS4 *og = read_meta_content(tree, root, "og:site_name", out_len);
+    if (og != NULL) {
+        return og;
+    }
+    return read_meta_content(tree, root, "application-name", out_len);
+}
+
+/* Lead image: the og:image meta, else the twitter:image meta. */
+static Py_UCS4 *read_harvest_image(th_tree *tree, th_node *root, Py_ssize_t *out_len) {
+    Py_UCS4 *og = read_meta_content(tree, root, "og:image", out_len);
+    if (og != NULL) {
+        return og;
+    }
+    return read_meta_content(tree, root, "twitter:image", out_len);
+}
+
+/* Append the normalized [text, text+len) run to the tags array, growing it as needed.
+   A run that normalizes to empty is skipped so a blank keyword reads as no tag. Returns
+   -1 only on the excluded allocation-failure path. */
+static int read_tags_append(th_article_tag **items, Py_ssize_t *count, Py_ssize_t *cap, const Py_UCS4 *text,
+                            Py_ssize_t len) {
+    Py_ssize_t norm_len = 0;
+    Py_UCS4 *norm = read_normalize(text, len, &norm_len);
+    if (norm == NULL) {
+        return 0;
+    }
+    if (*count == *cap) {
+        Py_ssize_t grown_cap = *cap < 4 ? 4 : *cap * 2;
+        th_article_tag *grown = PyMem_Realloc(*items, (size_t)grown_cap * sizeof(th_article_tag));
+        if (grown == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            PyMem_Free(norm); /* GCOVR_EXCL_LINE: allocation-failure path */
+            return -1;        /* GCOVR_EXCL_LINE */
+        }
+        *items = grown;
+        *cap = grown_cap;
+    }
+    (*items)[*count].data = norm;
+    (*items)[*count].len = norm_len;
+    (*count)++;
+    return 0;
+}
+
+/* Append each comma-separated segment of a keywords content run as its own tag.
+   Returns -1 only on the excluded allocation-failure path. */
+static int read_tags_split(th_article_tag **items, Py_ssize_t *count, Py_ssize_t *cap, const Py_UCS4 *value,
+                           Py_ssize_t value_len) {
+    Py_ssize_t start = 0;
+    for (Py_ssize_t index = 0; index <= value_len; index++) {
+        if (index == value_len || value[index] == (Py_UCS4)',') {
+            if (read_tags_append(items, count, cap, value + start, index - start) < 0) { /* GCOVR_EXCL_BR_LINE:
+                                                                                        allocation-failure path */
+                return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            start = index + 1;
+        }
+    }
+    return 0;
+}
+
+/* One <meta>'s tag contribution: comma-split when it names keywords, the whole content
+   when it is an article:tag, nothing otherwise. Returns -1 only on the excluded
+   allocation-failure path. */
+static int read_tags_from_meta(th_tree *tree, th_node *meta, th_article_tag **items, Py_ssize_t *count,
+                               Py_ssize_t *cap) {
+    Py_ssize_t content = th_node_attr_find(tree, meta, "content", 7);
+    if (content < 0 || meta->attrs[content].value == NULL) {
+        return 0;
+    }
+    const Py_UCS4 *value = meta->attrs[content].value;
+    Py_ssize_t value_len = meta->attrs[content].value_len;
+    if (read_is_meta(tree, meta, "keywords")) {
+        return read_tags_split(items, count, cap, value, value_len);
+    }
+    if (read_is_meta(tree, meta, "article:tag")) {
+        return read_tags_append(items, count, cap, value, value_len);
+    }
+    return 0;
+}
+
+/* Gather every <meta name=keywords> value (comma-split) and every article:tag under
+   root into the tags array, in document order. Returns -1 only on the excluded
+   allocation-failure path. */
+static int read_collect_tags(th_tree *tree, th_node *root, th_article_tag **items, Py_ssize_t *count, Py_ssize_t *cap) {
+    for (th_node *child = root->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type != TH_NODE_ELEMENT) {
+            continue;
+        }
+        if (child->ns == TH_NS_HTML && child->atom == TH_TAG_META) {
+            if (read_tags_from_meta(tree, child, items, count, cap) < 0) { /* GCOVR_EXCL_BR_LINE: alloc-failure path */
+                return -1;                                                 /* GCOVR_EXCL_LINE: allocation-failure */
+            }
+        }
+        if (read_collect_tags(tree, child, items, count, cap) < 0) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
+            return -1;                                               /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    return 0;
+}
+
+/* Tags: the keyword and article:tag values harvested by read_collect_tags. On the
+   excluded allocation-failure path the partial run is freed and the field stays
+   empty, the way an absent source reads. */
+static void read_harvest_tags(th_tree *tree, th_node *root, th_article_tag **out, Py_ssize_t *out_count) {
+    *out = NULL;
+    *out_count = 0;
+    Py_ssize_t cap = 0;
+    if (read_collect_tags(tree, root, out, out_count, &cap) < 0) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
+        for (Py_ssize_t index = 0; index < *out_count; index++) {  /* GCOVR_EXCL_LINE: allocation-failure path */
+            PyMem_Free((*out)[index].data);                        /* GCOVR_EXCL_LINE */
+        } /* GCOVR_EXCL_LINE */
+        PyMem_Free(*out); /* GCOVR_EXCL_LINE */
+        *out = NULL;      /* GCOVR_EXCL_LINE */
+        *out_count = 0;   /* GCOVR_EXCL_LINE */
+    } /* GCOVR_EXCL_LINE: llvm-cov flags this fall-through brace of the allocation-failure block */
+}
+
 void th_article_metadata(th_tree *tree, th_node *root, th_article_meta *meta) {
     if (root == NULL) {
         /* a node built by hand (Element(...)) owns a tree with no document root, so
@@ -643,6 +788,10 @@ void th_article_metadata(th_tree *tree, th_node *root, th_article_meta *meta) {
     meta->date = read_harvest_date(tree, root, &meta->date_len);
     meta->description = read_harvest_description(tree, root, &meta->description_len);
     meta->lang = read_harvest_lang(tree, root, &meta->lang_len);
+    meta->canonical = read_harvest_canonical(tree, root, &meta->canonical_len);
+    meta->site_name = read_harvest_site_name(tree, root, &meta->site_name_len);
+    meta->image = read_harvest_image(tree, root, &meta->image_len);
+    read_harvest_tags(tree, root, &meta->tags, &meta->tags_count);
 }
 
 void th_article_meta_clear(th_article_meta *meta) {
@@ -651,4 +800,11 @@ void th_article_meta_clear(th_article_meta *meta) {
     PyMem_Free(meta->date);
     PyMem_Free(meta->description);
     PyMem_Free(meta->lang);
+    PyMem_Free(meta->canonical);
+    PyMem_Free(meta->site_name);
+    PyMem_Free(meta->image);
+    for (Py_ssize_t index = 0; index < meta->tags_count; index++) {
+        PyMem_Free(meta->tags[index].data);
+    }
+    PyMem_Free(meta->tags);
 }

--- a/tests/serialize/test_tree_main_content.py
+++ b/tests/serialize/test_tree_main_content.py
@@ -6,8 +6,9 @@ record. The readability content-density heuristic is pure C in
 ``treebuilder_readability.h``. These cases drive every scoring branch with
 article-shaped fixtures (tag and class/id weighting, boilerplate prunings,
 link-density discounting, candidate-array regrow, empty-result guards) and every
-metadata field beside it (title, byline, date, description and lang, each in its
-present, absent, and multiple-source-precedence form).
+metadata field beside it (title, byline, date, description, lang, canonical,
+site_name, tags and image, each in its present, absent, and
+multiple-source-precedence form).
 """
 
 from __future__ import annotations
@@ -325,6 +326,10 @@ def test_article_all_fields_absent_are_none() -> None:
     assert art.byline is None
     assert art.date is None
     assert art.description is None
+    assert art.canonical is None
+    assert art.site_name is None
+    assert art.image is None
+    assert art.tags == ()
 
 
 def test_article_available_on_element() -> None:
@@ -546,17 +551,129 @@ def test_article_meta_with_valueless_content_is_skipped() -> None:
     assert parse(html).article().title == "Fallback"
 
 
+@pytest.mark.parametrize(
+    ("head", "expected"),
+    [
+        pytest.param(
+            "<link rel=canonical href='https://ex.com/a'><meta property=og:url content='https://ex.com/og'>",
+            "https://ex.com/a",
+            id="canonical-link-wins",
+        ),
+        pytest.param("<meta property=og:url content='https://ex.com/og'>", "https://ex.com/og", id="og-url-fallback"),
+        pytest.param(
+            "<link rel=stylesheet href='/s.css'><meta property=og:url content='https://ex.com/og'>",
+            "https://ex.com/og",
+            id="non-canonical-link-ignored",
+        ),
+        pytest.param(
+            "<link rel=canonical><meta property=og:url content='https://ex.com/og'>",
+            "https://ex.com/og",
+            id="valueless-canonical-link-falls-through",
+        ),
+        pytest.param(
+            "<link href='/x'><meta property=og:url content='https://ex.com/og'>",
+            "https://ex.com/og",
+            id="link-without-rel-ignored",
+        ),
+    ],
+)
+def test_article_canonical_precedence(head: str, expected: str) -> None:
+    art = parse(f"<html><head>{head}</head><body>{BODY}</body></html>").article()
+    assert art.canonical == expected
+
+
+def test_article_canonical_absent_is_none() -> None:
+    assert parse(f"<body>{BODY}</body>").article().canonical is None
+
+
+@pytest.mark.parametrize(
+    ("head", "expected"),
+    [
+        pytest.param(
+            "<meta name=application-name content='App'><meta property=og:site_name content='Example News'>",
+            "Example News",
+            id="og-site-name-wins",
+        ),
+        pytest.param("<meta name=application-name content='App'>", "App", id="application-name-fallback"),
+    ],
+)
+def test_article_site_name_precedence(head: str, expected: str) -> None:
+    art = parse(f"<html><head>{head}</head><body>{BODY}</body></html>").article()
+    assert art.site_name == expected
+
+
+def test_article_site_name_absent_is_none() -> None:
+    assert parse(f"<body>{BODY}</body>").article().site_name is None
+
+
+@pytest.mark.parametrize(
+    ("head", "expected"),
+    [
+        pytest.param(
+            "<meta name=twitter:image content='https://ex.com/t.png'>"
+            "<meta property=og:image content='https://ex.com/o.png'>",
+            "https://ex.com/o.png",
+            id="og-image-wins",
+        ),
+        pytest.param(
+            "<meta name=twitter:image content='https://ex.com/t.png'>",
+            "https://ex.com/t.png",
+            id="twitter-image-fallback",
+        ),
+    ],
+)
+def test_article_image_precedence(head: str, expected: str) -> None:
+    art = parse(f"<html><head>{head}</head><body>{BODY}</body></html>").article()
+    assert art.image == expected
+
+
+def test_article_image_absent_is_none() -> None:
+    assert parse(f"<body>{BODY}</body>").article().image is None
+
+
+def test_article_tags_split_keywords_and_collect_article_tags() -> None:
+    head = (
+        "<meta name=keywords content='space,  comets , tails'>"
+        "<meta property=article:tag content='astronomy'>"
+        "<meta property=article:tag content='science'>"
+    )
+    # keywords are comma-split and each article:tag appended, all in document order.
+    art = parse(f"<html><head>{head}</head><body>{BODY}</body></html>").article()
+    assert art.tags == ("space", "comets", "tails", "astronomy", "science")
+
+
+def test_article_tags_skip_blank_keyword_segments() -> None:
+    # empty segments (leading/trailing comma, whitespace-only) leave no tag behind.
+    art = parse(f"<head><meta name=keywords content=' , solo ,, '></head><body>{BODY}</body>").article()
+    assert art.tags == ("solo",)
+
+
+def test_article_tags_ignore_valueless_content() -> None:
+    head = "<meta name=keywords><meta property=article:tag>"
+    assert parse(f"<html><head>{head}</head><body>{BODY}</body></html>").article().tags == ()
+
+
+def test_article_tags_grow_past_initial_capacity() -> None:
+    keywords = ",".join(f"t{index}" for index in range(9))
+    art = parse(f"<head><meta name=keywords content='{keywords}'></head><body>{BODY}</body>").article()
+    assert art.tags == tuple(f"t{index}" for index in range(9))
+
+
 def test_article_fields_unpack_in_order() -> None:
     art = parse(f"<html lang=en><body>{BODY}</body></html>").article()
-    element, text, title, byline, date, description, lang = art
+    element, text, title, byline, date, description, lang, canonical, site_name, tags, image = art
     assert element is art.element
     assert text is art.text
-    assert (title, byline, date, description, lang) == (
+    assert (title, byline, date, description, lang, canonical, site_name, tags, image) == (
         art.title,
         art.byline,
         art.date,
         art.description,
         art.lang,
+        art.canonical,
+        art.site_name,
+        art.tags,
+        art.image,
     )
 
 


### PR DESCRIPTION
Anyone migrating from `trafilatura` or `metadata_parser` hit the same wall: `article()` harvested `title`, `byline`, `date`, `description`, and `lang`, but not the canonical URL, site name, tags, or lead image those libraries surface. 📰 Scrapers that key on the canonical URL or a social-card image had to reach back into the DOM by hand, which defeats the one-call promise.

This adds four fields to the `Article` record, each sourced from the tags the page already declares: `canonical` from `<link rel="canonical">` (falling back to `og:url`), `site_name` from `og:site_name` (then `<meta name="application-name">`), `tags` from every `<meta name="keywords">` (comma-split) and each `article:tag` in document order, and `image` from `og:image` (then `twitter:image`). ✨ The harvest stays a pure-C pass in `readability.c`; the Python facade only materializes the buffers into the record, with the single-valued fields typed `str | None` like their neighbours and `tags` a `tuple[str, ...]` that is empty when the page declares none.

The existing fields keep their positions and values, so unpacking or index access up to `lang` is unchanged and the four new fields append after it. The two migration guides drop the metadata gaps they listed against `article()`.

part of #459
