### PR TITLE
⚡ perf(build): profile-guided optimization for the release build

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -27,10 +27,15 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
-      # build the optimized extension and install the benchmark deps outside the runner, so
-      # only the pytest process below is measured under instrumentation, never the uv/meson build
-      - name: 🏗️ Build the extension and install benchmark deps
-        run: uvx --with tox-uv tox run -e codspeed --notest
+      # build the optimized extension and install the benchmark deps outside the runner, so only the pytest process
+      # below is measured under instrumentation, never the uv/meson build. --notest creates the environment and installs
+      # the benchmark deps but skips tox's commands; pgo_build then does the two-phase profile-guided build (instrument,
+      # train on the real corpora, rebuild against the profile) into that environment, so the gate measures the same
+      # optimization the release wheels ship rather than a plain -O3 build.
+      - name: 🏗️ Build the extension profile-guided and install benchmark deps
+        run: |
+          uvx --with tox-uv tox run -e codspeed --notest
+          .tox/codspeed/bin/python tools/pgo_build.py --python .tox/codspeed/bin/python --build-dir .tox/codspeed/cbuild
         env:
           UV_PYTHON_PREFERENCE: only-managed
       - name: 🚀 Run benchmarks

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          submodules: true # the Linux wheels train the profile-guided build on the vendored html5lib and War-and-Peace corpora
           persist-credentials: false
       - name: 🔄 Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/docs/changelog/481.packaging.rst
+++ b/docs/changelog/481.packaging.rst
@@ -1,0 +1,3 @@
+Build the manylinux and musllinux wheels with profile-guided optimization. gcc compiles the extension against a profile
+that training collects over the real corpora across the parser, selectors, serializer, and the other hot operations, so
+the published binary is laid out for the way turbohtml runs. part of #478

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -128,6 +128,12 @@ C tree and expose all of this to users.
 <https://mesonbuild.com/meson-python/>`_ is the build backend because `hatchling <https://hatch.pypa.io>`_ (used by our
 pure-Python projects) does not compile C; meson-python builds C extensions and supports coverage instrumentation.
 
+**Profile-guided optimization on the Linux wheels.** ``tools/pgo_build.py`` builds the manylinux and musllinux extension
+twice: instrumented, then against a profile that ``tools/pgo_train.py`` collects by driving the hot operations over the
+real corpora. It reaches the parser hot path no other build flag speeds up. The ``codspeed`` gate builds the same way,
+so it measures the win the wheels ship; the macOS and Windows wheels and the coverage, sanitizer, and dev builds stay
+un-profiled, so those gates are untouched.
+
 **No stable ABI (abi3).** The fast paths require buffer macros outside the :ref:`Limited API <python:stable>`:
 ``PyUnicode_KIND``, ``PyUnicode_DATA``, ``PyUnicode_READ``, ``PyUnicode_WRITE`` and ``PyUnicode_New`` (see the
 `PyUnicode C API <https://docs.python.org/3/c-api/unicode.html>`_ and :PEP:`393`). The `Limited API
@@ -215,4 +221,5 @@ Adding a C feature:
 
 The ``🚀 Release`` GitHub Actions workflow cuts a release: it builds the sdist and the full wheel matrix with
 `cibuildwheel <https://cibuildwheel.pypa.io>`_ and publishes to PyPI via `trusted publishing
-<https://docs.pypi.org/trusted-publishers/>`_, so it stores no API token.
+<https://docs.pypi.org/trusted-publishers/>`_, so it stores no API token. The Linux wheels build profile-guided (see the
+architecture decision above), so that job checks out the training submodules the ``before-build`` hook reads.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,8 +178,8 @@ test-command = "python -c \"import turbohtml; assert turbohtml.unescape(turbohtm
 # hot paths. Scoped to Linux on purpose: the measured win is gcc's, and clang/MSVC add a profile-merge step the
 # release does not need. See tools/pgo_build.py.
 linux.before-build = """\
-  pip install uv meson-python meson ninja && python {project}/tools/pgo_build.py --python python --project {project} \
-  --build-dir /tmp/turbohtml-pgo --phase profile\
+  rm -rf /tmp/turbohtml-pgo && pip install uv meson-python meson ninja && python {project}/tools/pgo_build.py --python \
+  python --system --project {project} --build-dir /tmp/turbohtml-pgo --phase profile\
   """
 linux.config-settings.build-dir = "/tmp/turbohtml-pgo"
 linux.config-settings.setup-args = [ "-Dbuildtype=release", "-Db_pgo=use" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,17 @@ release = [
 enable = [ "cpython-prerelease" ]
 build-frontend = "build[uv]"
 test-command = "python -c \"import turbohtml; assert turbohtml.unescape(turbohtml.escape('a & b')) == 'a & b'\""
+# Profile-guided optimization for the manylinux/musllinux wheels, where the gcc the spike measured runs. before-build
+# builds the extension instrumented and trains it on the real corpora, leaving the profile in the shared build
+# directory; the wheel build below reuses that directory with -Db_pgo=use so the shipped object is laid out for the
+# hot paths. Scoped to Linux on purpose: the measured win is gcc's, and clang/MSVC add a profile-merge step the
+# release does not need. See tools/pgo_build.py.
+linux.before-build = """\
+  pip install uv meson-python meson ninja && python {project}/tools/pgo_build.py --python python --project {project} \
+  --build-dir /tmp/turbohtml-pgo --phase profile\
+  """
+linux.config-settings.build-dir = "/tmp/turbohtml-pgo"
+linux.config-settings.setup-args = [ "-Dbuildtype=release", "-Db_pgo=use" ]
 macos.archs = [ "arm64" ]  # Apple silicon only; x86_64 macOS is end-of-life
 windows.archs = [ "AMD64" ]  # 64-bit only; skip the 32-bit x86 build
 # force the MSVC toolchain: meson otherwise picks up MinGW from the runner's PATH

--- a/tools/pgo_build.py
+++ b/tools/pgo_build.py
@@ -27,7 +27,7 @@ from typing import Final
 _ROOT: Final = Path(__file__).resolve().parent.parent
 
 
-def _install(python: str, build_dir: Path, root: Path, phase: str) -> None:
+def _install(python: str, build_dir: Path, root: Path, phase: str, *, system: bool) -> None:
     """Reinstall the extension editable into ``python``'s environment at PGO ``phase``, reusing ``build_dir``."""
     subprocess.run(
         [
@@ -36,6 +36,8 @@ def _install(python: str, build_dir: Path, root: Path, phase: str) -> None:
             "install",
             "--python",
             python,
+            # cibuildwheel's manylinux interpreter is a system install, not a venv; uv refuses to touch it otherwise
+            *(["--system"] if system else []),
             "--reinstall",
             "--no-deps",
             "--no-build-isolation",
@@ -71,14 +73,14 @@ def _merge_clang_profile(build_dir: Path) -> None:
     subprocess.run([tool, "merge", "-output", str(build_dir / "default.profdata"), *map(str, raw)], check=True)
 
 
-def build(python: str, build_dir: Path, root: Path, phase: str) -> None:
+def build(python: str, build_dir: Path, root: Path, phase: str, *, system: bool) -> None:
     """Run the instrument-train-merge sequence, then optionally the profiled ``use`` install when ``phase`` is full."""
     build_dir.mkdir(parents=True, exist_ok=True)
-    _install(python, build_dir, root, "generate")
+    _install(python, build_dir, root, "generate", system=system)
     _train(python, build_dir, root)
     _merge_clang_profile(build_dir)
     if phase == "full":
-        _install(python, build_dir, root, "use")
+        _install(python, build_dir, root, "use", system=system)
 
 
 def main() -> None:
@@ -93,8 +95,13 @@ def main() -> None:
         choices=("full", "profile"),
         help="full finishes with the profiled use install; profile stops after collecting it for a later use build",
     )
+    parser.add_argument(
+        "--system",
+        action="store_true",
+        help="install into a non-virtual (system) interpreter, as cibuildwheel's manylinux image provides",
+    )
     args = parser.parse_args()
-    build(args.python, args.build_dir.resolve(), args.project.resolve(), args.phase)
+    build(args.python, args.build_dir.resolve(), args.project.resolve(), args.phase, system=args.system)
 
 
 if __name__ == "__main__":

--- a/tools/pgo_build.py
+++ b/tools/pgo_build.py
@@ -1,0 +1,106 @@
+"""
+Two-phase profile-guided build of the turbohtml C extension.
+
+Profile-guided optimization compiles the extension twice: once instrumented to record which branches and calls the hot
+paths take, then again with that profile so the compiler lays out the code the way the real workload runs it.
+This driver runs both phases against one persistent meson build directory -- an instrumented ``-Db_pgo=generate`` build,
+the representative training workload from :mod:`pgo_train`, then a ``-Db_pgo=use`` rebuild that reads the collected
+counters. gcc writes ``.gcda`` files the second build reads directly; clang writes ``.profraw`` that must first be
+merged into ``default.profdata``, which this driver does when it finds them, so one command works under either compiler.
+
+The CodSpeed gate builds this way through the ``codspeed`` tox environment (``--phase full``, which finishes with the
+profiled editable install the benchmarks then import). The release wheels build this way through cibuildwheel, whose
+``before-build`` hook runs ``--phase profile`` to leave the profile in the shared build directory that the wheel build
+then reuses with ``-Db_pgo=use``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+_ROOT: Final = Path(__file__).resolve().parent.parent
+
+
+def _install(python: str, build_dir: Path, root: Path, phase: str) -> None:
+    """Reinstall the extension editable into ``python``'s environment at PGO ``phase``, reusing ``build_dir``."""
+    subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            python,
+            "--reinstall",
+            "--no-deps",
+            "--no-build-isolation",
+            "--editable",
+            str(root),
+            f"--config-settings=build-dir={build_dir}",
+            "--config-settings=setup-args=-Dbuildtype=release",
+            f"--config-settings=setup-args=-Db_pgo={phase}",
+        ],
+        check=True,
+    )
+
+
+def _train(python: str, build_dir: Path, root: Path) -> None:
+    """Drive the training workload against the instrumented build, pointing clang's counters into ``build_dir``."""
+    subprocess.run(
+        [python, str(root / "tools" / "pgo_train.py")],
+        check=True,
+        env={**os.environ, "LLVM_PROFILE_FILE": str(build_dir / "pgo-%p.profraw")},
+    )
+
+
+def _merge_clang_profile(build_dir: Path) -> None:
+    """Merge clang's ``.profraw`` counters into the ``default.profdata`` the ``use`` build reads; gcc needs no merge."""
+    if not (raw := sorted(build_dir.glob("*.profraw"))):
+        return  # gcc left .gcda beside the objects, which -fprofile-use reads directly
+    if (tool := shutil.which("llvm-profdata")) is None:
+        located = subprocess.run(["xcrun", "--find", "llvm-profdata"], capture_output=True, text=True, check=False)
+        if located.returncode != 0:
+            msg = "clang produced .profraw counters but llvm-profdata is not available to merge them"
+            raise RuntimeError(msg)
+        tool = located.stdout.strip()
+    subprocess.run([tool, "merge", "-output", str(build_dir / "default.profdata"), *map(str, raw)], check=True)
+
+
+def build(python: str, build_dir: Path, root: Path, phase: str) -> None:
+    """Run the instrument-train-merge sequence, then optionally the profiled ``use`` install when ``phase`` is full."""
+    build_dir.mkdir(parents=True, exist_ok=True)
+    _install(python, build_dir, root, "generate")
+    _train(python, build_dir, root)
+    _merge_clang_profile(build_dir)
+    if phase == "full":
+        _install(python, build_dir, root, "use")
+
+
+def main() -> None:
+    """Parse the target interpreter, build directory, and phase, then run the two-phase build."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--python", default=sys.executable, help="interpreter whose environment to install into")
+    parser.add_argument("--build-dir", required=True, type=Path, help="persistent meson build directory to reuse")
+    parser.add_argument("--project", default=_ROOT, type=Path, help="source tree to build (defaults to this repo)")
+    parser.add_argument(
+        "--phase",
+        default="full",
+        choices=("full", "profile"),
+        help="full finishes with the profiled use install; profile stops after collecting it for a later use build",
+    )
+    args = parser.parse_args()
+    build(args.python, args.build_dir.resolve(), args.project.resolve(), args.phase)
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "build",
+]

--- a/tools/pgo_train.py
+++ b/tools/pgo_train.py
@@ -1,0 +1,62 @@
+"""
+Representative training workload for the profile-guided build of the C extension.
+
+Drives every turbohtml operation the project tracks over its real corpus, so the profile the compiler collects reflects
+the whole hot surface -- parse, tokenize, select, serialize, minify and the rest -- rather than one document. The cases
+come from :func:`bench.ci.benchmarks`, the same registry the CodSpeed gate measures over the same vendored
+html5lib-python spec, War-and-Peace text, and pinned stylesheet and JS corpora, so the profile is collected against
+exactly the inputs whose regressions CI watches. A case whose corpus is not checked out (or cannot be fetched offline)
+is skipped, so a build without the optional submodules still trains on whatever is present.
+
+Run against an extension built with ``-Db_pgo=generate``; each measured call writes into the instrumented counters that
+the following ``-Db_pgo=use`` build reads back. See :mod:`pgo_build` for the two-phase driver.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bench.ci import benchmarks  # the bench package sits beside this script, added to the path above
+from bench.timing import Mutating
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_ITERATIONS: Final[int] = 8  # weight the hot paths without dragging the build; the spec parse dominates
+
+
+def train(iterations: int = _ITERATIONS) -> tuple[int, int]:
+    """Exercise every operation over its real corpus ``iterations`` times; return the trained and skipped counts."""
+    trained = skipped = 0
+    for _name, operation, load in benchmarks():
+        try:
+            case = load()
+        except OSError:  # corpus submodule absent, or a pinned upstream file could not be fetched offline
+            skipped += 1
+            continue
+        for _ in range(iterations):
+            if isinstance(operation, Mutating):
+                operation.run(operation.setup(case))
+            else:
+                cast("Callable[[object], object]", operation)(case)
+        trained += 1
+    return trained, skipped
+
+
+def main() -> None:
+    """Run the training workload and report the coverage so a bare-checkout build's thin profile is visible."""
+    trained, skipped = train()
+    print(f"pgo training: exercised {trained} operations, skipped {skipped} for a missing corpus")
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = [
+    "train",
+]

--- a/tox.toml
+++ b/tox.toml
@@ -213,10 +213,21 @@ commands = [ [ "python", "-m", "bench", { replace = "posargs", extend = true } ]
 [env.codspeed]
 description = "run the pytest-codspeed hot-path benchmarks (the CodSpeed CI regression gate)"
 base_python = [ "3.14" ]
-package = "editable"  # an optimized build, not the coverage-instrumented one env_run_base installs
+package = "skip"  # pgo_build below reinstalls a profile-guided editable build; a plain editable package would undo it
 deps = []  # drop the gcovr the coverage gate pulls in; the benchmarks never measure coverage
-dependency_groups = [ "test" ]  # carries pytest-codspeed and the benchmark fixture
-commands_pre = []  # no instrumented reinstall; the editable package above is the build we benchmark
+dependency_groups = [ "test" ]  # carries pytest-codspeed, the benchmark fixture, and the meson build backend
+commands_pre = [
+  # build the extension profile-guided (instrument, train on the real corpora, rebuild against the profile) so the
+  # gate measures the same optimization the release wheels ship; the training corpora ride in as submodules in CI
+  [
+    "python",
+    "{tox_root}{/}tools{/}pgo_build.py",
+    "--python",
+    "{env_python}",
+    "--build-dir",
+    "{env_dir}{/}cbuild"
+  ],
+]
 commands = [
   [ "pytest", "{tox_root}{/}tests{/}benchmarks", "--codspeed", { replace = "posargs", extend = true } ],
 ]


### PR DESCRIPTION
turbohtml's C core carries the parser hot path that no build flag other than profile-guided optimization speeds up. A deterministic cachegrind measurement posted to #478 put gcc PGO at parse `-15.7%`, select `-27.5%`, and serialize `-13.2%` instructions over the plain `-O3` release, several times the reach of LTO, and it shrank the shipped object. Landing it now also absorbs the `+3.5%` parse cost that enabling LTO later would show on the CodSpeed gate. part of #478.

`tools/pgo_build.py` runs the two phases against one build directory: an instrumented `-Db_pgo=generate` build, a training pass, then a `-Db_pgo=use` rebuild that reads the collected profile. The training workload in `tools/pgo_train.py` drives every operation the project tracks over its real corpus through the same `bench.ci` registry the CodSpeed gate measures, so the profile covers the whole hot surface (parse, tokenize, select, serialize, minify, and the rest) rather than one document. gcc writes `.gcda` the second build reads directly; clang writes `.profraw` that the driver merges into `default.profdata`, so one command works under either compiler.

The `codspeed` environment and its CI job build this way, so the regression gate measures the optimization the wheels ship rather than a plain `-O3` build. cibuildwheel builds the manylinux and musllinux wheels the same way, its `before-build` hook collecting the profile the wheel build reuses through a shared build directory, and the release job now checks out the training submodules for it. The optimization stays scoped to Linux, where the measured gain is gcc's, so the macOS and Windows wheels and the coverage, sanitizer, and dev builds stay un-profiled and their gates are untouched.
