### PR TITLE
♻️ refactor(c): house style, decompose run_drain

### DIFF
--- a/HOUSE_STYLE.md
+++ b/HOUSE_STYLE.md
@@ -1,0 +1,77 @@
+# House style
+
+turbohtml is a C extension (`src/turbohtml/_c`) behind a thin Python shim (`src/turbohtml/*.py`). All non-trivial logic
+lives in C; Python only validates config, unpacks arguments, calls into `_html`, and wraps the result. This document
+records the conventions the two trees already follow so new code matches without a review round-trip. It records what
+the code does. Where a rule and the tree disagree, the tree is the bug.
+
+## C tree
+
+### Comments
+
+Every `.c` and `.h` file opens with a block comment saying what the unit is and why it exists as a separate unit, not
+how it works. Example, from `serialize/escape.c`:
+
+```c
+/* HTML escaping. */
+```
+
+and, where the split needs justifying, from `core/common.h`:
+
+```c
+/* Internal header shared by the turbohtml._html translation units.
+
+   The module is split per feature for readability (escape.c, unescape.c) but
+   compiled into a single _html extension. ... */
+```
+
+No section-divider or grouping-header banners: no `/* ---- parsing ---- */` between top-level definitions, and none
+inside a function body. Function names and the file header carry the structure. A comment earns its place only by
+explaining a *why* that the code cannot: a spec citation, an issue number, a non-obvious invariant. It never restates
+the next line.
+
+No `TODO`, no commented-out code, no dead branches left "for later".
+
+### Naming
+
+Descriptive names everywhere, including loop counters: `index`, `pos`, `offset`, `inner_index`, never `i`, `j`, `c`,
+`n`. C has no comprehensions, so there is no single-letter exception.
+
+Two prefixes mark the boundary:
+
+- `th_` for internal C symbols shared across translation units (`th_tree`, `th_tok_next`, `th_url_resolve`).
+- `turbohtml_` for a Python entry point, matching a `METH_*` signature and wired into a method table
+  (`turbohtml_escape`, `turbohtml_detect_encoding`).
+
+A file-local static helper needs no prefix.
+
+### Iteration and errors
+
+One child-iteration idiom: walk `node->first_child` and follow `->next_sibling`. Do not index children or cache a count
+that a mutation can invalidate.
+
+Growable buffers go through `core/vec.h`; ASCII classification and compact-buffer reads go through `core/ascii.h`. Both
+are `static inline` in a header so every translation unit still inlines them. Do not re-open a capacity-doubling
+`realloc` loop or an `ch >= 'a' && ch <= 'z'` test inline.
+
+Allocation is the only failure a builder function guards. On `NULL` from the allocator it sets the owning tree's
+`failed` flag (or returns `NULL`/`-1` per the function's contract) and unwinds. No bare `if (!p)` that swallows the
+error, and no re-check of a state the types rule out.
+
+## Python shim
+
+Each module opens with a one-line docstring naming the module and its job:
+
+```python
+"""turbohtml.detect: standalone character-encoding detection over bytes."""
+```
+
+`__all__` lists every name other modules import, placed after the imports. Module-scope constants are `UPPER_CASE`,
+prefixed with `_` when no other module imports them, and typed `Final`:
+
+```python
+_EARLIEST: Final = date(1995, 1, 1)
+_MODIFIED_MARKERS: Final = ("updated", "modified", "lastmod", "revised")
+```
+
+The shim stays a shim: if deleting a line of Python would change a returned value, that logic belongs in C.

--- a/docs/changelog/478.misc.rst
+++ b/docs/changelog/478.misc.rst
@@ -1,0 +1,4 @@
+Split the ~1640-line ``run_drain`` tree-construction driver into one handler per insertion mode, reading top to bottom
+in call order, and settle the C house style: drop the section-divider banner comments the audit found in a minority of
+files, rename the single-letter locals ``markdown.c`` had drifted to, and record the conventions in a repository
+``HOUSE_STYLE.md``. Parser output is byte-identical; this is structure only. Part of #478.

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -2137,9 +2137,8 @@ PyObject *node_xpath_one(PyObject *self, PyObject *args, PyObject *kwds) {
     return first;
 }
 
-/* ---- XPath: the precompiled, reusable expression object (issue #267) ---- */
-
-/* XPath(expression, *, smart_strings=False, extensions=None): parse the expression
+/* XPath(expression, *, smart_strings=False, extensions=None), the precompiled
+   reusable expression object (issue #267): parse the expression
    once into an immutable program and bind the two evaluation options. The program
    is tree-independent and re-entrant, so the object is shareable across threads. */
 static PyObject *xpath_compiled_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
@@ -2685,8 +2684,6 @@ PyDoc_STRVAR(wrap_children_doc, "wrap_children(wrapper, /)\n--\n\n"
                                 ":returns: wrapper, now holding the moved children.\n"
                                 ":raises TypeError: if wrapper is not an element.");
 
-/* --- classList: the space-separated class token set ------------------------ */
-
 /* Whether the value run [start, end) equals the token. */
 static int class_token_equals(const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, const Py_UCS4 *token,
                               Py_ssize_t token_len) {
@@ -2892,8 +2889,6 @@ PyDoc_STRVAR(insert_adjacent_html_doc, "insert_adjacent_html(position, html, /)\
                                        ":raises TypeError: if position or html is not a str.\n"
                                        ":raises ValueError: if position is not one of the four keywords, or a\n"
                                        "    sibling-relative position is used on a node without an element parent.");
-
-/* ---- css_path() / xpath_path(): the unique locator for a node ---- */
 
 /* A growable code-point buffer for assembling a path string. failed records an
    allocation failure so the caller raises once, after the walk. */

--- a/src/turbohtml/_c/dom/foreign.h
+++ b/src/turbohtml/_c/dom/foreign.h
@@ -2,8 +2,6 @@
    integration-point and breakout checks, and the foreign insertion-mode step.
    #included into dom/tree.c so the static helpers inline against the tree. */
 
-/* ------------------------------------------------------- foreign content */
-
 /* SVG element names that take a specific mixed case (the spec's "SVG element
    name adjustments"); everything else stays lowercase. */
 static const struct {

--- a/src/turbohtml/_c/dom/nodes.h
+++ b/src/turbohtml/_c/dom/nodes.h
@@ -166,8 +166,6 @@ typedef struct {
     int smart_strings;
 } XPathObject;
 
-/* ---- hot inline helpers shared across the split units ---- */
-
 static inline module_state *state_of(PyObject *self) {
     return PyType_GetModuleState(Py_TYPE(self));
 }
@@ -475,8 +473,6 @@ static inline int append_wrapped(PyObject *out, module_state *state, PyObject *h
     Py_DECREF(wrapped);
     return 0;
 }
-
-/* ---- definitions living in one unit, referenced from others ---- */
 
 /* Free a handle's compiled-selector and compiled-XPath caches. Lives in element.c so the
    header-only css/selector.h stays confined to the single unit that uses it. */

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -18,8 +18,6 @@
 
 #include <string.h>
 
-/* --------------------------------------------------------- input reading */
-
 /* Copy a th_buf's code points into an arena UCS4 array. */
 static Py_UCS4 *buf_to_ucs4(th_tree *tree, const th_buf *buf, Py_ssize_t *out_len) {
     *out_len = buf->len;
@@ -58,8 +56,6 @@ static inline Py_UCS4 input_read(const th_tree *tree, Py_ssize_t index) {
     }
     return ((const uint32_t *)tree->data)[index];
 }
-
-/* ----------------------------------------------------------- tag interning */
 
 static uint16_t intern_atom(const th_buf *name, uint8_t *out_flags) {
     *out_flags = 0;
@@ -102,8 +98,6 @@ static uint16_t intern_atom(const th_buf *name, uint8_t *out_flags) {
 static uint16_t tok_atom(const th_token *tok) {
     return tok->atom;
 }
-
-/* ---------------------------------------------------- attribute interning */
 
 static uint32_t fnv1a(const char *bytes, Py_ssize_t len) {
     uint32_t hash = 2166136261u;
@@ -334,8 +328,6 @@ int th_tag_is_void(uint16_t atom) {
     return is_void_atom(atom);
 }
 
-/* --------------------------------------------------------------- nodes */
-
 /* node_pos, node_new and the node_append/node_remove/node_insert_before linkers
    live in dom/tree_internal.h, shared with the construction/mutation API (mutate.c). */
 
@@ -355,8 +347,6 @@ int th_node_source_position(th_tree *tree, th_node *node, Py_ssize_t *line, Py_s
 /* A shallow element clone (same atom/name/attrs, no children) for the adoption
    agency and active-formatting-element reconstruction. */
 static th_node *node_clone(th_tree *tree, const th_node *src);
-
-/* ---------------------------------------------------- stack of open elements */
 
 static th_node *current_node(th_tree *tree) {
     return tree->open_len > 0 ? tree->open[tree->open_len - 1] : tree->document;
@@ -519,8 +509,6 @@ static int has_in_table_scope(th_tree *tree, uint16_t atom) {
     } /* GCOVR_EXCL_BR_LINE: the stack always bottoms out at an html table-scope boundary */
     return 0; /* GCOVR_EXCL_LINE: same — has_in_table_scope always returns inside the loop */
 }
-
-/* ----------------------------------------------------------- insertion */
 
 /* The appropriate place for inserting a node: normally the current node, but
    when foster parenting is active and the current node is a table-context
@@ -891,8 +879,6 @@ static Py_UCS4 *token_text(th_tree *tree, const th_token *token, Py_ssize_t *out
     }
     return out;
 }
-
-/* ------------------------------------------- active formatting elements */
 
 static th_node *node_clone(th_tree *tree, const th_node *src) {
     th_node *node = node_new(tree, TH_NODE_ELEMENT);
@@ -1324,8 +1310,6 @@ static int adoption_agency(th_tree *tree, uint16_t atom) {
     return 1;
 }
 
-/* ----------------------------------------------------- in-body predicates */
-
 /* has_in_scope but with <button> also a scope boundary (the "button scope"). */
 static int has_in_button_scope(th_tree *tree, uint16_t atom) {
     for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) {
@@ -1475,8 +1459,6 @@ static void any_other_end_tag(th_tree *tree, uint16_t atom, const th_token *toke
 }
 
 #include "dom/foreign.h"
-
-/* --------------------------------------------------- insertion-mode engine */
 
 enum mode {
     M_INITIAL,
@@ -3352,8 +3334,6 @@ static void run_close(th_tree *tree) {
     }
 }
 
-/* --------------------------------------------------------------- public API */
-
 /* Feed the input to the tokenizer (borrowing when there is no CR to normalize)
    and point tree->data at the tokenizer's authoritative input base. */
 static void setup_input(th_tree *tree, th_tokenizer *sm, int kind, const void *data, Py_ssize_t length) {
@@ -3685,8 +3665,6 @@ void th_tree_free(th_tree *tree) {
     th_error_sink_free(&tree->errors);
     PyMem_Free(tree);
 }
-
-/* ----------------------------------------------------------- streaming parse */
 
 /* A push parser: a document tree under construction, the resumable tokenizer
    feeding it, and the insertion-mode state that lets a feed suspend mid-document

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -1675,22 +1675,1589 @@ static void run_state_init(th_run_state *run_state, enum mode start_mode) {
     run_state->foster_pending = 0;
 }
 
+/* What one insertion-mode handler reads and updates for the token it is handed:
+   the tokenizer (to switch its scanner state) plus the insertion-mode state. The
+   four mode fields mirror th_run_state; table_origin is per-token and never crosses
+   a feed. A handler returns TH_DRAIN_NEXT to advance to the next token, or
+   TH_DRAIN_REPROCESS to run the same token again under the mode it just set. */
+typedef struct {
+    th_tokenizer *sm;
+    enum mode mode;
+    enum mode original_mode;
+    enum mode foster_return;
+    enum mode table_origin;
+    int foster_pending;
+} th_insert;
+
+enum th_drain { TH_DRAIN_NEXT, TH_DRAIN_REPROCESS };
+
+static enum th_drain drain_initial(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        if (all_whitespace(text, len)) {
+            return TH_DRAIN_NEXT; /* ignore leading whitespace */
+        }
+        tree->quirks = 1; /* no doctype before content */
+        dc->mode = M_BEFORE_HTML;
+        return TH_DRAIN_REPROCESS;
+    }
+    if (tok->kind == TH_DOCTYPE) {
+        th_node *node = node_new(tree, TH_NODE_DOCTYPE);
+        if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            node->text = build_doctype_text(tree, tok, &node->text_len);
+            node->tag_flags = (uint8_t)((tok->has_public_id ? TH_DOCTYPE_HAS_PUBLIC : 0) |
+                                        (tok->has_system_id ? TH_DOCTYPE_HAS_SYSTEM : 0));
+            node_append(tree->document, node);
+        }
+        tree->quirks = doctype_is_quirky(tok);
+        dc->mode = M_BEFORE_HTML;
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, tree->document);
+        return TH_DRAIN_NEXT;
+    }
+    tree->quirks = 1; /* no doctype before content */
+    dc->mode = M_BEFORE_HTML;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_before_html(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, tree->document);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        if (all_whitespace(text, len)) {
+            return TH_DRAIN_NEXT;
+        }
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
+        th_node *html = insert_element(tree, tok);
+        if (html != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            stack_push(tree, html);
+        }
+        dc->mode = M_BEFORE_HEAD;
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_END_TAG) {
+        uint16_t end_atom = tok_atom(tok);
+        if (end_atom != TH_TAG_HEAD && end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML && end_atom != TH_TAG_BR) {
+            return TH_DRAIN_NEXT; /* any other end tag before html is a parse error and ignored */
+        }
+    }
+    {
+        th_node *html = insert_implicit(tree, "html", TH_TAG_HTML, TH_TAG_SPECIAL | TH_TAG_SCOPING);
+        if (html != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            stack_push(tree, html);
+        }
+    }
+    dc->mode = M_BEFORE_HEAD;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_before_head(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        Py_ssize_t ws = 0;
+        while (ws < len && (is_space(text[ws]))) {
+            ws++;
+        }
+        if (ws == len) {
+            return TH_DRAIN_NEXT; /* whitespace only: ignored before the head */
+        }
+        tree->text_offset += ws; /* the whitespace prefix is dropped, not moved */
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
+        /* a redundant html start tag is processed via the in-body rules
+           (merge attributes onto the open html), leaving the mode intact */
+        if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
+            stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+            merge_attrs(tree, tree->open[0], tok);
+        }
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HEAD) {
+        th_node *head = insert_element(tree, tok);
+        if (head != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            stack_push(tree, head);
+            tree->head = head;
+        }
+        dc->mode = M_IN_HEAD;
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_END_TAG) {
+        uint16_t end_atom = tok_atom(tok);
+        if (end_atom != TH_TAG_HEAD && end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML && end_atom != TH_TAG_BR) {
+            return TH_DRAIN_NEXT; /* any other end tag before head is a parse error and ignored */
+        }
+    }
+    tree->head = insert_implicit(tree, "head", TH_TAG_HEAD, TH_TAG_SPECIAL);
+    stack_push(tree, tree->head);
+    dc->mode = M_IN_HEAD;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_in_head(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        Py_ssize_t ws = 0;
+        while (ws < len && (is_space(text[ws]))) {
+            ws++;
+        }
+        if (ws > 0) {
+            insert_text(tree, text, ws); /* leading whitespace stays in the head */
+        }
+        if (ws == len) {
+            return TH_DRAIN_NEXT;
+        }
+        tree->text_offset += ws; /* reprocess only the remainder after the head */
+        stack_pop(tree);         /* pop head */
+        dc->mode = M_AFTER_HEAD;
+        return TH_DRAIN_REPROCESS;
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint8_t flags = tok->tag_flags;
+        uint16_t atom = tok->atom;
+        if (atom == TH_TAG_HTML) {
+            /* a redundant html start tag merges attributes via the in-body
+               rules; the head insertion mode is left untouched */
+            if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
+                stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+                merge_attrs(tree, tree->open[0], tok);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_HEAD) {
+            return TH_DRAIN_NEXT; /* a duplicate head start tag is a parse error, ignored */
+        }
+        /* only the head's own raw-text/RCDATA elements switch to text
+           mode here; textarea/xmp/iframe/etc belong in the body */
+        if (atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT || atom == TH_TAG_NOFRAMES) {
+            int model = content_model_for(atom, flags);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            th_tok_switch(dc->sm, (enum th_initial_state)model);
+            dc->original_mode = M_IN_HEAD;
+            dc->mode = M_TEXT;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BASE || atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK ||
+            atom == TH_TAG_META) {
+            insert_element(tree, tok); /* void metadata: inserted, not pushed */
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_NOSCRIPT) {
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            dc->mode = M_IN_HEAD_NOSCRIPT;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TEMPLATE) {
+            th_node *node = insert_template(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+                afe_push_marker(tree);
+            }
+            tmpl_push(tree, M_IN_TEMPLATE);
+            dc->mode = M_IN_TEMPLATE;
+            return TH_DRAIN_NEXT;
+        }
+        /* anything else belongs after the head */
+        stack_pop(tree);
+        dc->mode = M_AFTER_HEAD;
+        return TH_DRAIN_REPROCESS;
+    }
+    /* only an end tag reaches here: text/comment/start break above, a DOCTYPE is ignored before the switch */
+    if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
+        uint16_t end_atom = tok_atom(tok);
+        if (end_atom == TH_TAG_HEAD) {
+            stack_pop(tree);
+            dc->mode = M_AFTER_HEAD;
+            return TH_DRAIN_NEXT;
+        }
+        if (end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML && end_atom != TH_TAG_BR) {
+            return TH_DRAIN_NEXT; /* any other end tag in head is a parse error, ignored */
+        }
+    }
+    stack_pop(tree);
+    dc->mode = M_AFTER_HEAD;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_in_head_noscript(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_END_TAG) {
+        uint16_t end_atom = tok_atom(tok);
+        if (end_atom == TH_TAG_NOSCRIPT) {
+            stack_pop(tree); /* pop noscript */
+            dc->mode = M_IN_HEAD;
+            return TH_DRAIN_NEXT;
+        }
+        if (end_atom != TH_TAG_BR) {
+            return TH_DRAIN_NEXT; /* any other end tag is a parse error, ignored */
+        }
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
+        /* process via the in-body rules (merges attributes) */
+        /* open stack always holds html at index 0 */
+        if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
+            stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+            merge_attrs(tree, tree->open[0], tok);
+        }
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        if (all_whitespace(text, len)) {
+            insert_text(tree, text, len);
+            return TH_DRAIN_NEXT;
+        }
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK || atom == TH_TAG_META) {
+            insert_element(tree, tok); /* void metadata */
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_STYLE || atom == TH_TAG_NOFRAMES) {
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            th_tok_switch(dc->sm, TH_INIT_RAWTEXT);
+            dc->original_mode = M_IN_HEAD_NOSCRIPT;
+            dc->mode = M_TEXT;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_HEAD || atom == TH_TAG_NOSCRIPT) {
+            return TH_DRAIN_NEXT; /* ignore */
+        }
+    }
+    /* anything else: pop the noscript (parse error) and reprocess in head */
+    stack_pop(tree);
+    dc->mode = M_IN_HEAD;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_after_head(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        Py_ssize_t ws = 0;
+        while (ws < len && is_space(text[ws])) {
+            ws++;
+        }
+        if (ws > 0) {
+            insert_text(tree, text, ws); /* leading whitespace goes under html, between head and body */
+        }
+        if (ws == len) {
+            return TH_DRAIN_NEXT;
+        }
+        tree->text_offset += ws; /* the body is created below; reprocess only the remainder there */
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_BODY) {
+        th_node *body = insert_element(tree, tok);
+        if (body != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            stack_push(tree, body);
+        }
+        tree->frameset_ok = 0; /* an explicit body can't be replaced by a frameset */
+        dc->mode = M_IN_BODY;
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_FRAMESET) {
+        th_node *fs = insert_element(tree, tok);
+        if (fs != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            stack_push(tree, fs);
+        }
+        dc->mode = M_IN_FRAMESET;
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint8_t flags = tok->tag_flags;
+        uint16_t atom = tok->atom;
+        /* head-content tags re-enter the head element, are processed
+           there, and leave the head off the stack again */
+        if (atom == TH_TAG_BASE || atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK ||
+            atom == TH_TAG_META || atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT ||
+            atom == TH_TAG_NOFRAMES || atom == TH_TAG_TEMPLATE) {
+            /* after-head is entered only once a head element exists */
+            if (tree->head != NULL /* GCOVR_EXCL_BR_LINE */) {
+                stack_push(tree, tree->head); /* insert into the head element */
+                if (atom == TH_TAG_TEMPLATE) {
+                    th_node *node = insert_template(tree, tok);
+                    /* the head is removed from under the template on the
+                       stack; the template itself stays open */
+                    tree->open[tree->open_len - 1] = node;
+                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                        afe_push_marker(tree);
+                        tmpl_push(tree, M_IN_TEMPLATE);
+                        dc->mode = M_IN_TEMPLATE;
+                    } else {
+                        stack_pop(tree); /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
+                    }
+                    return TH_DRAIN_NEXT;
+                }
+                th_node *node = insert_element(tree, tok);
+                stack_pop(tree); /* remove head again */
+                if (atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT || atom == TH_TAG_NOFRAMES) {
+                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                        stack_push(tree, node);
+                    }
+                    th_tok_switch(dc->sm, (enum th_initial_state)content_model_for(atom, flags));
+                    dc->original_mode = M_AFTER_HEAD;
+                    dc->mode = M_TEXT;
+                }
+            }
+            return TH_DRAIN_NEXT;
+        }
+    }
+    if (tok->kind == TH_END_TAG) {
+        uint16_t end_atom = tok_atom(tok);
+        if (end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML && end_atom != TH_TAG_BR) {
+            return TH_DRAIN_NEXT; /* any other end tag after head is a parse error, ignored */
+        }
+    }
+    {
+        th_node *body = insert_implicit(tree, "body", TH_TAG_BODY, TH_TAG_SPECIAL);
+        if (body != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            stack_push(tree, body);
+        }
+    }
+    dc->mode = M_IN_BODY;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_in_template(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_END_TAG) {
+        return TH_DRAIN_NEXT; /* </template> is handled by the dispatcher above; other end tags are ignored */
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint8_t flags = tok->tag_flags;
+        uint16_t atom = tok->atom;
+        if (atom == TH_TAG_TEMPLATE) {
+            th_node *node = insert_template(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+                afe_push_marker(tree);
+            }
+            tmpl_push(tree, M_IN_TEMPLATE);
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BASE || atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK ||
+            atom == TH_TAG_META) {
+            insert_element(tree, tok); /* void head content */
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT || atom == TH_TAG_NOFRAMES) {
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            th_tok_switch(dc->sm, (enum th_initial_state)content_model_for(atom, flags));
+            dc->original_mode = M_IN_TEMPLATE;
+            dc->mode = M_TEXT;
+            return TH_DRAIN_NEXT;
+        }
+        /* table-section tags select the matching table sub-mode (updating
+           the template insertion stack so a later reset resumes here);
+           everything else is body content */
+        if (atom == TH_TAG_CAPTION || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY || atom == TH_TAG_TFOOT ||
+            atom == TH_TAG_THEAD) {
+            tmpl_set(tree, M_IN_TABLE);
+            dc->mode = M_IN_TABLE;
+            return TH_DRAIN_REPROCESS;
+        }
+        if (atom == TH_TAG_COL) {
+            tmpl_set(tree, M_IN_COLUMN_GROUP);
+            dc->mode = M_IN_COLUMN_GROUP;
+            return TH_DRAIN_REPROCESS;
+        }
+        if (atom == TH_TAG_TR) {
+            tmpl_set(tree, M_IN_TABLE_BODY);
+            dc->mode = M_IN_TABLE_BODY;
+            return TH_DRAIN_REPROCESS;
+        }
+        if (atom == TH_TAG_TD || atom == TH_TAG_TH) {
+            tmpl_set(tree, M_IN_ROW);
+            dc->mode = M_IN_ROW;
+            return TH_DRAIN_REPROCESS;
+        }
+        /* any other start tag switches the template to body content */
+        tmpl_set(tree, M_IN_BODY);
+        dc->mode = M_IN_BODY;
+        return TH_DRAIN_REPROCESS;
+    }
+    /* characters and comments run the in-body rules, then return here */
+    dc->foster_pending = 1;
+    dc->foster_return = M_IN_TEMPLATE;
+    dc->mode = M_IN_BODY;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_in_frameset(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        insert_whitespace_only(tree, text, len);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_FRAMESET) {
+            th_node *fs = insert_element(tree, tok);
+            if (fs != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, fs);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_FRAME) {
+            insert_element(tree, tok); /* void */
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_NOFRAMES) {
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            th_tok_switch(dc->sm, TH_INIT_RAWTEXT);
+            dc->original_mode = M_IN_FRAMESET;
+            dc->mode = M_TEXT;
+            return TH_DRAIN_NEXT;
+        }
+        return TH_DRAIN_NEXT;
+    }
+    /* a DOCTYPE is ignored before the switch, so the kind!=end-tag branch here is dead */
+    if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_FRAMESET) { /* GCOVR_EXCL_BR_LINE */
+        if (current_node(tree)->atom != TH_TAG_HTML) {
+            stack_pop(tree);
+        }
+        if (tree->fragment_root == NULL && current_node(tree)->atom != TH_TAG_FRAMESET) {
+            dc->mode = M_AFTER_FRAMESET;
+        }
+        return TH_DRAIN_NEXT;
+    }
+    return TH_DRAIN_NEXT;
+}
+
+static enum th_drain drain_after_frameset(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        insert_whitespace_only(tree, text, len);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_NOFRAMES) {
+        th_node *node = insert_element(tree, tok);
+        if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            stack_push(tree, node);
+        }
+        th_tok_switch(dc->sm, TH_INIT_RAWTEXT);
+        dc->original_mode = M_AFTER_FRAMESET;
+        dc->mode = M_TEXT;
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_HTML) {
+        dc->mode = M_AFTER_AFTER_FRAMESET; /* only comments and whitespace remain */
+    }
+    return TH_DRAIN_NEXT;
+}
+
+static enum th_drain drain_in_body(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        if (tok->is_slice && tree->can_span && !tree->has_nul) {
+            /* zero-copy: scan the input span directly for the frameset
+               and leading-newline rules, then store a span node */
+            Py_ssize_t off = tok->src_start + tree->text_offset;
+            Py_ssize_t len = tok->src_len - tree->text_offset;
+            /* a text token always has a positive length */
+            if (tree->drop_newline && len > 0 /* GCOVR_EXCL_BR_LINE */ && input_read(tree, off) == '\n') {
+                off++;
+                len--;
+            }
+            tree->drop_newline = 0;
+            reconstruct_afe(tree);
+            for (Py_ssize_t index = 0; index < len; index++) {
+                Py_UCS4 character = input_read(tree, off + index);
+                if (!is_space(character)) {
+                    tree->frameset_ok = 0;
+                    break;
+                }
+            }
+            insert_text_span(tree, off, len);
+            return TH_DRAIN_NEXT;
+        }
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        /* a text token always has a positive length */
+        if (tree->drop_newline && len > 0 /* GCOVR_EXCL_BR_LINE */ && text[0] == '\n') {
+            text++;
+            len--;
+        }
+        tree->drop_newline = 0;
+        reconstruct_afe(tree);
+        /* a U+0000 is dropped and, like whitespace, does not clear
+           frameset-ok; only a real visible character does */
+        for (Py_ssize_t index = 0; index < len; index++) {
+            Py_UCS4 character = text[index];
+            if (!is_space(character) && character != 0) {
+                tree->frameset_ok = 0;
+                break;
+            }
+        }
+        insert_text(tree, text, len);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint8_t flags = tok->tag_flags;
+        uint16_t atom = tok->atom;
+        if (atom_breaks_frameset(atom) || (atom == TH_TAG_INPUT && !input_is_hidden(tok))) {
+            tree->frameset_ok = 0;
+        }
+        if (atom == TH_TAG_HTML) {
+            /* open stack always holds html at index 0 */
+            if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
+                stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+                merge_attrs(tree, tree->open[0], tok);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BODY) {
+            if (tree->open_len > 1 && tree->open[1]->atom == TH_TAG_BODY &&
+                stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+                merge_attrs(tree, tree->open[1], tok);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_HEAD || atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
+            atom == TH_TAG_FRAME || atom == TH_TAG_TBODY || atom == TH_TAG_TD || atom == TH_TAG_TFOOT ||
+            atom == TH_TAG_TH || atom == TH_TAG_THEAD || atom == TH_TAG_TR) {
+            return TH_DRAIN_NEXT; /* stray table-structure tags are parse errors, ignored */
+        }
+        if (atom == TH_TAG_FRAMESET) {
+            /* replaces an empty body when no non-whitespace content yet */
+            if (tree->frameset_ok && tree->open_len > 1 && tree->open[1]->atom == TH_TAG_BODY) {
+                node_remove(tree->open[1]);
+                while (tree->open_len > 1) {
+                    stack_pop(tree);
+                }
+                th_node *fs = insert_element(tree, tok);
+                if (fs != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                    stack_push(tree, fs);
+                }
+                dc->mode = M_IN_FRAMESET;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        /* block and heading elements close an open p and are inserted
+           WITHOUT reconstructing the active formatting elements */
+        if (is_heading_atom(atom)) {
+            close_p_in_button_scope(tree);
+            if (is_heading_atom(current_node(tree)->atom)) {
+                stack_pop(tree); /* nested headings don't stack */
+            }
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (is_p_closing_block(atom) && atom != TH_TAG_PLAINTEXT && atom != TH_TAG_PRE &&
+            atom != TH_TAG_LISTING) { /* pre/listing also drop a leading newline below */
+            close_p_in_button_scope(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TABLE) {
+            if (!tree->quirks && has_in_button_scope(tree, TH_TAG_P)) {
+                generate_implied_end_tags(tree, TH_TAG_P);
+                pop_until_atom(tree, TH_TAG_P);
+            }
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            dc->mode = M_IN_TABLE;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_SELECT) {
+            /* select content is plain in-body content now; a nested
+               select start closes the open one instead of nesting */
+            if (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT) {
+                return TH_DRAIN_NEXT; /* fragment case: ignored */
+            }
+            if (has_in_scope(tree, TH_TAG_SELECT)) {
+                pop_until_atom(tree, TH_TAG_SELECT);
+                return TH_DRAIN_NEXT;
+            }
+            reconstruct_afe(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            tree->frameset_ok = 0;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_SVG || atom == TH_TAG_MATH) {
+            reconstruct_afe(tree);
+            th_node *node = insert_foreign(tree, tok, atom == TH_TAG_SVG ? TH_NS_SVG : TH_NS_MATHML);
+            if (node != NULL && !tok->self_closing) { /* GCOVR_EXCL_BR_LINE: insert_foreign returns NULL only on
+                                                         allocation failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_LI) {
+            /* html bounds the stack walk */
+            for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
+                uint16_t open_atom = tree->open[index]->atom;
+                if (open_atom == TH_TAG_LI) {
+                    generate_implied_end_tags(tree, TH_TAG_LI);
+                    pop_until_atom(tree, TH_TAG_LI);
+                    break;
+                }
+                if ((tree->open[index]->tag_flags & TH_TAG_SPECIAL) && open_atom != TH_TAG_ADDRESS &&
+                    open_atom != TH_TAG_DIV && open_atom != TH_TAG_P) {
+                    break;
+                }
+            }
+            close_p_in_button_scope(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_DD || atom == TH_TAG_DT) {
+            /* html bounds the stack walk */
+            for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
+                uint16_t open_atom = tree->open[index]->atom;
+                if (open_atom == TH_TAG_DD || open_atom == TH_TAG_DT) {
+                    generate_implied_end_tags(tree, open_atom);
+                    pop_until_atom(tree, open_atom);
+                    break;
+                }
+                if ((tree->open[index]->tag_flags & TH_TAG_SPECIAL) && open_atom != TH_TAG_ADDRESS &&
+                    open_atom != TH_TAG_DIV && open_atom != TH_TAG_P) {
+                    break;
+                }
+            }
+            close_p_in_button_scope(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_HR) {
+            close_p_in_button_scope(tree);
+            if (has_in_scope(tree, TH_TAG_SELECT) || (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT)) {
+                /* in a select (or a select-context fragment) close the open option/optgroup
+                   first, so the hr lands at select level rather than inside the option */
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+            }
+            insert_element(tree, tok); /* void */
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BUTTON) {
+            if (has_in_scope(tree, TH_TAG_BUTTON)) {
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                pop_until_atom(tree, TH_TAG_BUTTON);
+            }
+            reconstruct_afe(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_OPTION || atom == TH_TAG_OPTGROUP) {
+            if (has_in_scope(tree, TH_TAG_SELECT) || (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT)) {
+                /* inside a select (or a select-context fragment, where no select node
+                   is on the stack), implied end tags close open option and (for an
+                   optgroup start) optgroup elements */
+                generate_implied_end_tags(tree, atom == TH_TAG_OPTION ? TH_TAG_OPTGROUP : TH_TAG_UNKNOWN);
+            } else if (current_node(tree)->atom == TH_TAG_OPTION) {
+                stack_pop(tree);
+            }
+            reconstruct_afe(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_RB || atom == TH_TAG_RTC) {
+            if (has_in_scope(tree, TH_TAG_RUBY)) {
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+            }
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_RP || atom == TH_TAG_RT) {
+            if (has_in_scope(tree, TH_TAG_RUBY)) {
+                generate_implied_end_tags(tree, TH_TAG_RTC);
+            }
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BASE || atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK ||
+            atom == TH_TAG_META) {
+            insert_element(tree, tok); /* head metadata: in-head rules, no AFE reconstruction */
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_FORM) {
+            int in_template = stack_index_of_atom(tree, TH_TAG_TEMPLATE) >= 0;
+            if (tree->form != NULL && !in_template) {
+                return TH_DRAIN_NEXT; /* a nested form is ignored */
+            }
+            close_p_in_button_scope(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+                if (!in_template) {
+                    tree->form = node;
+                }
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_INPUT || atom == TH_TAG_KEYGEN) {
+            /* an input or keygen closes an open select entirely (and is
+               ignored outright in a select-context fragment) */
+            if (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT) {
+                return TH_DRAIN_NEXT;
+            }
+            if (has_in_scope(tree, TH_TAG_SELECT)) {
+                pop_until_atom(tree, TH_TAG_SELECT);
+            }
+            reconstruct_afe(tree);
+            insert_element(tree, tok); /* void */
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_IMAGE) {
+            /* the famous quirk: <image> becomes <img> */
+            reconstruct_afe(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                node->atom = TH_TAG_IMG;
+                static const char img[] = "img";
+                node->text = arena_alloc(tree, 3 * (Py_ssize_t)sizeof(Py_UCS4));
+                if (node->text != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                    for (int index = 0; index < 3; index++) {
+                        node->text[index] = (Py_UCS4)img[index];
+                    }
+                    node->text_len = 3;
+                }
+            }
+            return TH_DRAIN_NEXT; /* img is void */
+        }
+        if (atom == TH_TAG_PLAINTEXT) {
+            close_p_in_button_scope(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            th_tok_switch(dc->sm, TH_INIT_PLAINTEXT);
+            return TH_DRAIN_NEXT; /* PLAINTEXT runs to EOF; no end tag returns from it */
+        }
+        int model = content_model_for(atom, flags);
+        if (model >= 0) { /* rawtext / rcdata / script: no reconstruction */
+            if (atom == TH_TAG_XMP) {
+                close_p_in_button_scope(tree);
+                reconstruct_afe(tree);
+                tree->frameset_ok = 0;
+            }
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            if (atom == TH_TAG_TEXTAREA) {
+                tree->drop_newline = 1; /* a leading LF in a textarea is ignored */
+            }
+            th_tok_switch(dc->sm, (enum th_initial_state)model);
+            /* when fostered out of a table the in-body rules run but the real insertion
+               mode is still the table mode, so the text mode must return there, not to
+               in body, or the table's later rows would be dropped */
+            dc->original_mode = dc->foster_pending ? dc->foster_return : M_IN_BODY;
+            dc->mode = M_TEXT;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_PRE || atom == TH_TAG_LISTING) {
+            close_p_in_button_scope(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            tree->drop_newline = 1; /* a leading LF in pre/listing is ignored */
+            tree->frameset_ok = 0;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_A) {
+            th_node *existing = afe_find_atom(tree, TH_TAG_A);
+            if (existing != NULL) {
+                adoption_agency(tree, TH_TAG_A);
+                Py_ssize_t ai = afe_index_of(tree, existing);
+                if (ai >= 0) {
+                    afe_remove_at(tree, ai);
+                }
+                Py_ssize_t si = stack_index_of(tree, existing);
+                if (si >= 0) {
+                    stack_remove_at(tree, si);
+                }
+            }
+        }
+        if (atom == TH_TAG_NOBR) {
+            reconstruct_afe(tree);
+            if (has_in_scope(tree, TH_TAG_NOBR)) {
+                adoption_agency(tree, TH_TAG_NOBR);
+                reconstruct_afe(tree);
+            }
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+                afe_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (flags & TH_TAG_FORMATTING) {
+            reconstruct_afe(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+                afe_push(tree, node);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_APPLET || atom == TH_TAG_MARQUEE || atom == TH_TAG_OBJECT) {
+            reconstruct_afe(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            afe_push_marker(tree);
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TEMPLATE) {
+            th_node *node = insert_template(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+                afe_push_marker(tree);
+            }
+            tmpl_push(tree, M_IN_TEMPLATE);
+            dc->mode = M_IN_TEMPLATE;
+            return TH_DRAIN_NEXT;
+        }
+        reconstruct_afe(tree);
+        th_node *node = insert_element(tree, tok);
+        if (is_void_atom(atom)) {
+            return TH_DRAIN_NEXT; /* void: inserted, not pushed (a stray "/" on any
+                      other element is ignored in HTML content) */
+        }
+        if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            stack_push(tree, node);
+        }
+        return TH_DRAIN_NEXT;
+    }
+    /* only an end tag reaches here: text/comment/start break above, a DOCTYPE is ignored before the switch */
+    if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
+        uint8_t flags = tok->tag_flags;
+        uint16_t atom = tok->atom;
+        if (atom == TH_TAG_BODY || atom == TH_TAG_HTML) {
+            dc->mode = M_AFTER_BODY;
+            if (atom == TH_TAG_HTML) {
+                return TH_DRAIN_REPROCESS;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_P) {
+            if (!has_in_button_scope(tree, TH_TAG_P)) {
+                insert_implicit(tree, "p", TH_TAG_P, TH_TAG_SPECIAL); /* empty p, immediately closed */
+            } else {
+                generate_implied_end_tags(tree, TH_TAG_P);
+                pop_until_atom(tree, TH_TAG_P);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (is_heading_atom(atom)) {
+            int in_scope = 0;
+            /* html bounds the stack walk */
+            for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
+                if (is_heading_atom(tree->open[index]->atom)) {
+                    in_scope = 1;
+                    break;
+                }
+                if (tree->open[index]->tag_flags & TH_TAG_SCOPING) {
+                    break;
+                }
+            }
+            if (in_scope) {
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                while (tree->open_len > 0) { /* GCOVR_EXCL_BR_LINE: the heading is in scope when this runs, so
+                                                the stack never empties */
+                    th_node *node = current_node(tree);
+                    stack_pop(tree);
+                    if (is_heading_atom(node->atom)) {
+                        break;
+                    }
+                }
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_LI || atom == TH_TAG_DD || atom == TH_TAG_DT) {
+            if (atom == TH_TAG_LI ? has_in_list_item_scope(tree, atom) : has_in_scope(tree, atom)) {
+                generate_implied_end_tags(tree, atom);
+                pop_until_atom(tree, atom);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_FORM) {
+            if (stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+                th_node *node = tree->form;
+                tree->form = NULL;
+                int in_scope = 0;
+                /* the html element is a scope boundary, so the walk always breaks before the stack bottom */
+                for (Py_ssize_t index = tree->open_len - 1; node != NULL && index >= 0 /* GCOVR_EXCL_BR_LINE */;
+                     index--) {
+                    if (tree->open[index] == node) {
+                        in_scope = 1;
+                        break;
+                    }
+                    if (is_scope_boundary(tree->open[index])) {
+                        break;
+                    }
+                }
+                if (!in_scope) {
+                    return TH_DRAIN_NEXT; /* parse error, ignored */
+                }
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                /* the form is removed from wherever it sits on the stack */
+                /* the form element is on the stack when this runs, so it */
+                for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
+                    if (tree->open[index] == node) {
+                        stack_remove_at(tree, index);
+                        break;
+                    }
+                }
+                /* a template on the stack always has a form in scope when this end tag runs */
+            } else if (has_in_scope(tree, TH_TAG_FORM) /* GCOVR_EXCL_BR_LINE */) {
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                pop_until_atom(tree, TH_TAG_FORM);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (is_block_end_atom(atom)) {
+            if (has_in_scope(tree, atom)) {
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                pop_until_atom(tree, atom);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (flags & TH_TAG_FORMATTING) {
+            adoption_agency(tree, atom);
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_APPLET || atom == TH_TAG_MARQUEE || atom == TH_TAG_OBJECT) {
+            if (has_in_scope(tree, atom)) {
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                pop_until_atom(tree, atom);
+                afe_clear_to_marker(tree);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BR) {
+            /* </br> acts as a <br> start tag (attributes dropped) */
+            reconstruct_afe(tree);
+            insert_implicit(tree, "br", TH_TAG_BR, TH_TAG_SPECIAL);
+            tree->frameset_ok = 0;
+            return TH_DRAIN_NEXT;
+        }
+        any_other_end_tag(tree, atom, tok);
+        return TH_DRAIN_NEXT;
+    }
+    return TH_DRAIN_NEXT; /* GCOVR_EXCL_LINE: in body handles every text/comment/start/end token in a branch
+              that breaks, and a DOCTYPE is ignored before the switch, so nothing reaches here */
+}
+
+static enum th_drain drain_text(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        /* a nul anywhere in the input disables span sharing */
+        if (tok->is_slice && tree->can_span && !tree->has_nul /* GCOVR_EXCL_BR_LINE */) {
+            Py_ssize_t off = tok->src_start + tree->text_offset;
+            Py_ssize_t len = tok->src_len - tree->text_offset;
+            /* a text token always has a positive length */
+            if (tree->drop_newline && len > 0 /* GCOVR_EXCL_BR_LINE */ && input_read(tree, off) == '\n') {
+                off++;
+                len--;
+            }
+            tree->drop_newline = 0;
+            insert_text_span(tree, off, len);
+            return TH_DRAIN_NEXT;
+        }
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        /* a text token always has a positive length */
+        if (tree->drop_newline && len > 0 /* GCOVR_EXCL_BR_LINE */ && text[0] == '\n') {
+            text++;
+            len--;
+        }
+        tree->drop_newline = 0;
+        insert_text(tree, text, len);
+        return TH_DRAIN_NEXT;
+    }
+    /* end tag (or EOF) closes the raw-text/RCDATA element */
+    stack_pop(tree);
+    dc->mode = dc->original_mode;
+    return TH_DRAIN_NEXT;
+}
+
+static enum th_drain drain_in_table(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        if (all_whitespace_or_nul(text, len)) {
+            insert_text(tree, text, len);
+        } else {
+            /* non-space character: foster-parent it out of the table */
+            tree->foster = 1;
+            reconstruct_afe(tree);
+            insert_text(tree, text, len);
+            tree->foster = 0;
+        }
+        dc->mode = dc->table_origin;
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        dc->mode = dc->table_origin;
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint16_t atom = tok->atom;
+        if (atom == TH_TAG_CAPTION) {
+            clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
+            afe_push_marker(tree);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            dc->mode = M_IN_CAPTION;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_COLGROUP) {
+            clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            dc->mode = M_IN_COLUMN_GROUP;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_COL) {
+            clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
+            {
+                th_node *cg = insert_implicit(tree, "colgroup", TH_TAG_COLGROUP, TH_TAG_SPECIAL);
+                if (cg != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                    stack_push(tree, cg);
+                }
+            }
+            dc->mode = M_IN_COLUMN_GROUP;
+            return TH_DRAIN_REPROCESS;
+        }
+        if (atom == TH_TAG_TBODY || atom == TH_TAG_THEAD || atom == TH_TAG_TFOOT) {
+            clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            dc->mode = M_IN_TABLE_BODY;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TD || atom == TH_TAG_TH || atom == TH_TAG_TR) {
+            clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
+            {
+                th_node *tb = insert_implicit(tree, "tbody", TH_TAG_TBODY, TH_TAG_SPECIAL);
+                if (tb != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                    stack_push(tree, tb);
+                }
+            }
+            dc->mode = M_IN_TABLE_BODY;
+            return TH_DRAIN_REPROCESS;
+        }
+        if (atom == TH_TAG_TABLE) {
+            /* a nested table closes the current one, then reprocesses */
+            if (has_in_table_scope(tree, TH_TAG_TABLE)) {
+                pop_until_atom(tree, TH_TAG_TABLE);
+                dc->mode = reset_insertion_mode(tree);
+                return TH_DRAIN_REPROCESS;
+            }
+            dc->mode = dc->table_origin;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT) {
+            uint8_t f2 = tok->tag_flags;
+            uint16_t a2 = tok->atom;
+            int model = content_model_for(a2, f2);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            th_tok_switch(dc->sm, (enum th_initial_state)model);
+            dc->original_mode = dc->table_origin;
+            dc->mode = M_TEXT;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_INPUT && input_is_hidden(tok)) {
+            insert_element(tree, tok); /* a hidden input stays in the table, no fostering */
+            dc->mode = dc->table_origin;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_FORM) {
+            /* a form in a table is inserted in place and closed at once,
+               unless one is already open or a template is on the stack */
+            if (tree->form == NULL && stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+                tree->form = insert_element(tree, tok);
+            }
+            dc->mode = dc->table_origin;
+            return TH_DRAIN_NEXT;
+        }
+        /* anything else: foster-parent this one token under in-body rules */
+        tree->foster = 1;
+        dc->foster_pending = 1;
+        dc->foster_return = dc->table_origin;
+        dc->mode = M_IN_BODY;
+        return TH_DRAIN_REPROCESS;
+    }
+    /* only an end tag reaches here: text/comment/start break or foster above, a DOCTYPE is ignored before it */
+    if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_TABLE) {
+            if (has_in_table_scope(tree, TH_TAG_TABLE)) {
+                pop_until_atom(tree, TH_TAG_TABLE);
+                dc->mode = reset_insertion_mode(tree);
+            } else {
+                dc->mode = dc->table_origin;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BODY || atom == TH_TAG_HTML || atom == TH_TAG_TBODY || atom == TH_TAG_TFOOT ||
+            atom == TH_TAG_THEAD || atom == TH_TAG_TR || atom == TH_TAG_TD || atom == TH_TAG_TH ||
+            atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP) {
+            dc->mode = dc->table_origin;
+            return TH_DRAIN_NEXT; /* ignore stray table-related end tags */
+        }
+        tree->foster = 1;
+        dc->foster_pending = 1;
+        dc->foster_return = dc->table_origin;
+        dc->mode = M_IN_BODY;
+        return TH_DRAIN_REPROCESS;
+    }
+    return TH_DRAIN_NEXT; /* GCOVR_EXCL_LINE: in table handles every text/comment/start/end token in a branch
+              that breaks, and a DOCTYPE is ignored before the switch, so nothing reaches here */
+}
+
+static enum th_drain drain_in_caption(th_tree *tree, th_token *tok, th_insert *dc) {
+    uint16_t atom = tok_atom(tok);
+    if (tok->kind == TH_END_TAG && atom == TH_TAG_CAPTION) {
+        if (has_in_table_scope(tree, TH_TAG_CAPTION)) {
+            generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+            pop_until_atom(tree, TH_TAG_CAPTION);
+            afe_clear_to_marker(tree);
+            dc->mode = M_IN_TABLE;
+        }
+        return TH_DRAIN_NEXT;
+    }
+    if ((tok->kind == TH_START_TAG && (atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
+                                       atom == TH_TAG_TBODY || atom == TH_TAG_TD || atom == TH_TAG_TFOOT ||
+                                       atom == TH_TAG_TH || atom == TH_TAG_THEAD || atom == TH_TAG_TR)) ||
+        (tok->kind == TH_END_TAG && atom == TH_TAG_TABLE)) {
+        if (has_in_table_scope(tree, TH_TAG_CAPTION)) {
+            generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+            pop_until_atom(tree, TH_TAG_CAPTION);
+            afe_clear_to_marker(tree);
+            dc->mode = M_IN_TABLE;
+            return TH_DRAIN_REPROCESS;
+        }
+        return TH_DRAIN_NEXT;
+    }
+    dc->foster_pending = 1;
+    dc->foster_return = M_IN_CAPTION;
+    dc->mode = M_IN_BODY;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_in_column_group(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        Py_ssize_t ws = 0;
+        while (ws < len && (is_space(text[ws]))) {
+            ws++;
+        }
+        if (ws > 0) {
+            insert_text(tree, text, ws); /* the whitespace prefix stays in the colgroup */
+        }
+        if (ws == len) {
+            return TH_DRAIN_NEXT;
+        }
+        tree->text_offset += ws; /* reprocess only the remainder below */
+    }
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, NULL);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
+        /* a stray html start tag uses the in-body rules: merge attributes onto
+           the open html and leave the stack (so the colgroup stays open) */
+        if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
+            stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
+            merge_attrs(tree, tree->open[0], tok);
+        }
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_COL) {
+        insert_element(tree, tok); /* col is void */
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_COLGROUP) {
+        if (current_node(tree)->atom == TH_TAG_COLGROUP) {
+            stack_pop(tree);
+            dc->mode = M_IN_TABLE;
+        }
+        return TH_DRAIN_NEXT;
+    }
+    /* anything else: only a real colgroup can be popped to fall back to
+       in-table; otherwise (fragment/template root) the token is ignored */
+    if (current_node(tree)->atom != TH_TAG_COLGROUP) {
+        return TH_DRAIN_NEXT;
+    }
+    stack_pop(tree);
+    dc->mode = M_IN_TABLE;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_in_table_body(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_START_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_TR) {
+            clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            dc->mode = M_IN_ROW;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TD || atom == TH_TAG_TH) {
+            clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
+            {
+                th_node *row = insert_implicit(tree, "tr", TH_TAG_TR, TH_TAG_SPECIAL);
+                if (row != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                    stack_push(tree, row);
+                }
+            }
+            dc->mode = M_IN_ROW;
+            return TH_DRAIN_REPROCESS;
+        }
+        if (atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY ||
+            atom == TH_TAG_TFOOT || atom == TH_TAG_THEAD) {
+            if (has_in_table_scope(tree, TH_TAG_TBODY) || has_in_table_scope(tree, TH_TAG_THEAD) ||
+                has_in_table_scope(tree, TH_TAG_TFOOT)) {
+                clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
+                stack_pop(tree);
+                dc->mode = M_IN_TABLE;
+                return TH_DRAIN_REPROCESS;
+            }
+            return TH_DRAIN_NEXT;
+        }
+    }
+    if (tok->kind == TH_END_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_TBODY || atom == TH_TAG_THEAD || atom == TH_TAG_TFOOT) {
+            if (has_in_table_scope(tree, atom)) {
+                clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
+                stack_pop(tree);
+                dc->mode = M_IN_TABLE;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TABLE) {
+            if (has_in_table_scope(tree, TH_TAG_TBODY) || has_in_table_scope(tree, TH_TAG_THEAD) ||
+                has_in_table_scope(tree, TH_TAG_TFOOT)) {
+                clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
+                stack_pop(tree);
+                dc->mode = M_IN_TABLE;
+                return TH_DRAIN_REPROCESS;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BODY || atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
+            atom == TH_TAG_HTML || atom == TH_TAG_TD || atom == TH_TAG_TH || atom == TH_TAG_TR) {
+            return TH_DRAIN_NEXT; /* ignore */
+        }
+    }
+    dc->table_origin = dc->mode;
+    dc->mode = M_IN_TABLE;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_in_row(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_START_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_TD || atom == TH_TAG_TH) {
+            clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            afe_push_marker(tree);
+            dc->mode = M_IN_CELL;
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY ||
+            atom == TH_TAG_TFOOT || atom == TH_TAG_THEAD || atom == TH_TAG_TR) {
+            if (has_in_table_scope(tree, TH_TAG_TR)) {
+                clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
+                stack_pop(tree);
+                dc->mode = M_IN_TABLE_BODY;
+                return TH_DRAIN_REPROCESS;
+            }
+            return TH_DRAIN_NEXT;
+        }
+    }
+    if (tok->kind == TH_END_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_TR) {
+            if (has_in_table_scope(tree, TH_TAG_TR)) {
+                clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
+                stack_pop(tree);
+                dc->mode = M_IN_TABLE_BODY;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TABLE) {
+            if (has_in_table_scope(tree, TH_TAG_TR)) {
+                clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
+                stack_pop(tree);
+                dc->mode = M_IN_TABLE_BODY;
+                return TH_DRAIN_REPROCESS;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TBODY || atom == TH_TAG_THEAD || atom == TH_TAG_TFOOT) {
+            if (has_in_table_scope(tree, atom)) {
+                clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
+                stack_pop(tree);
+                dc->mode = M_IN_TABLE_BODY;
+                return TH_DRAIN_REPROCESS;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BODY || atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
+            atom == TH_TAG_HTML || atom == TH_TAG_TD || atom == TH_TAG_TH) {
+            return TH_DRAIN_NEXT; /* ignore */
+        }
+    }
+    dc->table_origin = dc->mode;
+    dc->mode = M_IN_TABLE;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_in_cell(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_END_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_TD || atom == TH_TAG_TH) {
+            if (has_in_table_scope(tree, atom)) {
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                pop_until_atom(tree, atom);
+                afe_clear_to_marker(tree);
+                dc->mode = M_IN_ROW;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_TABLE || atom == TH_TAG_TBODY || atom == TH_TAG_TFOOT || atom == TH_TAG_THEAD ||
+            atom == TH_TAG_TR) {
+            if (has_in_table_scope(tree, atom)) {
+                uint16_t close = has_in_table_scope(tree, TH_TAG_TD) ? TH_TAG_TD : TH_TAG_TH;
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                pop_until_atom(tree, close);
+                afe_clear_to_marker(tree);
+                dc->mode = M_IN_ROW;
+                return TH_DRAIN_REPROCESS;
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_BODY || atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
+            atom == TH_TAG_HTML) {
+            return TH_DRAIN_NEXT; /* ignore */
+        }
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY ||
+            atom == TH_TAG_TD || atom == TH_TAG_TFOOT || atom == TH_TAG_TH || atom == TH_TAG_THEAD ||
+            atom == TH_TAG_TR) {
+            uint16_t close = has_in_table_scope(tree, TH_TAG_TD) ? TH_TAG_TD : TH_TAG_TH;
+            if (has_in_table_scope(tree, close)) {
+                generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                pop_until_atom(tree, close);
+                afe_clear_to_marker(tree);
+                dc->mode = M_IN_ROW;
+                return TH_DRAIN_REPROCESS;
+            }
+            return TH_DRAIN_NEXT;
+        }
+    }
+    dc->foster_pending = 1;
+    dc->foster_return = M_IN_CELL;
+    dc->mode = M_IN_BODY;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_after_body(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_COMMENT) {
+        /* open[0] is always the html element in this mode, never the document */
+        th_node *root = tree->open_len > 0 ? tree->open[0] : tree->document; /* GCOVR_EXCL_BR_LINE */
+        insert_comment(tree, tok, root);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        if (all_whitespace(text, len)) {
+            /* whitespace runs the in-body rules without leaving after-body */
+            dc->foster_pending = 1;
+            dc->foster_return = M_AFTER_BODY;
+            dc->mode = M_IN_BODY;
+            return TH_DRAIN_REPROCESS;
+        }
+    }
+    if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_HTML) {
+        dc->mode = M_AFTER_AFTER_BODY;
+        return TH_DRAIN_NEXT;
+    }
+    dc->mode = M_IN_BODY;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_after_after_body(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_COMMENT) {
+        /* a fragment has no document node to attach to; use its root */
+        insert_comment(tree, tok, tree->fragment_root != NULL ? tree->fragment_root : tree->document);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        if (all_whitespace(text, len)) {
+            /* whitespace runs the in-body rules without leaving this mode */
+            dc->foster_pending = 1;
+            dc->foster_return = M_AFTER_AFTER_BODY;
+            dc->mode = M_IN_BODY;
+            return TH_DRAIN_REPROCESS;
+        }
+    }
+    dc->mode = M_IN_BODY;
+    return TH_DRAIN_REPROCESS;
+}
+
+static enum th_drain drain_after_after_frameset(th_tree *tree, th_token *tok, th_insert *dc) {
+    if (tok->kind == TH_COMMENT) {
+        insert_comment(tree, tok, tree->document);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_TEXT) {
+        Py_ssize_t len;
+        Py_UCS4 *text = token_text(tree, tok, &len);
+        insert_whitespace_only(tree, text, len);
+        return TH_DRAIN_NEXT;
+    }
+    if (tok->kind == TH_START_TAG) {
+        uint16_t atom = tok_atom(tok);
+        if (atom == TH_TAG_HTML) {
+            /* in-body rules: merge attributes into the existing html */
+            /* open stack always holds html at index 0 */
+            if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML) { /* GCOVR_EXCL_BR_LINE */
+                merge_attrs(tree, tree->open[0], tok);
+            }
+            return TH_DRAIN_NEXT;
+        }
+        if (atom == TH_TAG_NOFRAMES) {
+            th_node *node = insert_element(tree, tok);
+            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+                stack_push(tree, node);
+            }
+            th_tok_switch(dc->sm, TH_INIT_RAWTEXT);
+            dc->original_mode = M_AFTER_AFTER_FRAMESET;
+            dc->mode = M_TEXT;
+        }
+    }
+    return TH_DRAIN_NEXT; /* everything else is a parse error and ignored */
+}
+
 /* Drive tree construction over the tokens the tokenizer can produce now,
    returning when it stalls (TH_STEP_NEED_MORE), reaches EOF (TH_STEP_DONE), or
    fails. The insertion-mode state is restored from run_state on entry and saved
    back on exit so a later call resumes the WHATWG algorithm in place. */
 static void run_drain(th_tree *tree, th_tokenizer *sm, th_run_state *run_state) {
-    enum mode mode = run_state->mode;
-    enum mode original_mode = run_state->original_mode;
-    /* a table mode foster-parents a stray token by processing it once under
-       in-body rules and then returning to the table mode; foster_return holds
-       the mode to restore once that one token has been consumed */
-    enum mode foster_return = run_state->foster_return;
-    int foster_pending = run_state->foster_pending;
-    /* the row/section modes delegate unhandled tokens to the in-table rules;
-       per spec that delegation does not change the insertion mode, so the
-       delegating mode is remembered and restored after the token is consumed */
-    enum mode table_origin = M_IN_TABLE;
+    /* foster_return: a table mode foster-parents a stray token by processing it
+       once under in-body rules and then returning to the table mode. table_origin:
+       the row/section modes delegate unhandled tokens to the in-table rules without
+       changing the insertion mode, so the delegating mode is remembered here. */
+    th_insert local = {
+        .sm = sm,
+        .mode = run_state->mode,
+        .original_mode = run_state->original_mode,
+        .foster_return = run_state->foster_return,
+        .foster_pending = run_state->foster_pending,
+        .table_origin = M_IN_TABLE,
+    };
+    th_insert *dc = &local;
     th_token *tok;
 
     /* the <![CDATA[ decision depends on the adjusted current node, so the
@@ -1699,18 +3266,18 @@ static void run_drain(th_tree *tree, th_tokenizer *sm, th_run_state *run_state) 
     while (!tree->failed /* GCOVR_EXCL_BR_LINE */ &&
            (th_tok_set_cdata(sm, tree->open_len > 0 && current_node(tree)->ns != TH_NS_HTML),
             th_tok_next(sm, &tok) == TH_STEP_TOKEN)) {
-        if (foster_pending) {
+        if (dc->foster_pending) {
             /* The one fostered token was processed under in-body rules; restore
                the table/cell mode only if those rules did not themselves switch
                the insertion mode (a fostered <select>/<table> legitimately
                does, and that switch must survive). */
-            if (mode == M_IN_BODY) {
-                mode = foster_return;
+            if (dc->mode == M_IN_BODY) {
+                dc->mode = dc->foster_return;
             }
             tree->foster = 0;
-            foster_pending = 0;
+            dc->foster_pending = 0;
         }
-        table_origin = M_IN_TABLE;
+        dc->table_origin = M_IN_TABLE;
         tree->text_offset = 0; /* a fresh token: any consumed-prefix offset is stale */
         /* the pre/listing/textarea leading-LF skip applies only to the token
            immediately following the start tag: a text token consumes it in its
@@ -1736,19 +3303,19 @@ static void run_drain(th_tree *tree, th_tokenizer *sm, th_run_state *run_state) 
         /* template tags are handled uniformly across the table/select modes (the
            spec routes them through in-head); in-body/in-head/in-template keep
            their own handlers for the active-formatting interactions */
-        if (tok->kind == TH_END_TAG && mode >= M_IN_HEAD && tok_atom(tok) == TH_TAG_TEMPLATE) {
+        if (tok->kind == TH_END_TAG && dc->mode >= M_IN_HEAD && tok_atom(tok) == TH_TAG_TEMPLATE) {
             if (stack_index_of_atom(tree, TH_TAG_TEMPLATE) >= 0) {
                 generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
                 pop_until_atom(tree, TH_TAG_TEMPLATE);
                 afe_clear_to_marker(tree);
                 tmpl_pop(tree);
-                mode = reset_insertion_mode(tree);
+                dc->mode = reset_insertion_mode(tree);
             }
             continue;
         }
         if (tok->kind == TH_START_TAG &&
-            (mode == M_IN_TABLE || mode == M_IN_TABLE_BODY || mode == M_IN_ROW || mode == M_IN_CELL ||
-             mode == M_IN_COLUMN_GROUP || mode == M_IN_CAPTION) &&
+            (dc->mode == M_IN_TABLE || dc->mode == M_IN_TABLE_BODY || dc->mode == M_IN_ROW || dc->mode == M_IN_CELL ||
+             dc->mode == M_IN_COLUMN_GROUP || dc->mode == M_IN_CAPTION) &&
             tok_atom(tok) == TH_TAG_TEMPLATE) {
             th_node *node = insert_template(tree, tok);
             if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
@@ -1756,7 +3323,7 @@ static void run_drain(th_tree *tree, th_tokenizer *sm, th_run_state *run_state) 
                 afe_push_marker(tree);
             }
             tmpl_push(tree, M_IN_TEMPLATE);
-            mode = M_IN_TEMPLATE;
+            dc->mode = M_IN_TEMPLATE;
             continue;
         }
         /* "in select in table": a select opened in a table context does not get its own
@@ -1764,1566 +3331,95 @@ static void run_drain(th_tree *tree, th_tokenizer *sm, th_run_state *run_state) 
            Per the spec it pops the select, resets the insertion mode, and reprocesses, so
            the table element becomes a sibling of the closed select (#90). */
         if (tok->kind == TH_START_TAG && has_in_scope(tree, TH_TAG_SELECT) &&
-            (mode == M_IN_TABLE || mode == M_IN_TABLE_BODY || mode == M_IN_ROW || mode == M_IN_CELL ||
-             mode == M_IN_CAPTION)) {
+            (dc->mode == M_IN_TABLE || dc->mode == M_IN_TABLE_BODY || dc->mode == M_IN_ROW || dc->mode == M_IN_CELL ||
+             dc->mode == M_IN_CAPTION)) {
             uint16_t a = tok_atom(tok);
             if (a == TH_TAG_CAPTION || a == TH_TAG_TABLE || a == TH_TAG_TBODY || a == TH_TAG_TFOOT ||
                 a == TH_TAG_THEAD || a == TH_TAG_TR || a == TH_TAG_TD || a == TH_TAG_TH) {
                 pop_until_atom(tree, TH_TAG_SELECT);
-                mode = reset_insertion_mode(tree);
+                dc->mode = reset_insertion_mode(tree);
                 goto reprocess;
             }
         }
         /* a DOCTYPE in any insertion mode other than "initial" is a parse error that is
            ignored without changing the insertion mode (foreign content already handled
            its own DOCTYPE above); only the initial mode builds the doctype node */
-        if (tok->kind == TH_DOCTYPE && mode != M_INITIAL) {
+        if (tok->kind == TH_DOCTYPE && dc->mode != M_INITIAL) {
             th_error_sink_push(&tree->errors, "unexpected-doctype", tok->line, tok->col);
             continue;
         }
         /* every insertion mode has an explicit case, so the compiler default arm is unreachable */
-        switch (mode) /* GCOVR_EXCL_BR_LINE */ {
+        enum th_drain action = TH_DRAIN_NEXT;
+        switch (dc->mode) /* GCOVR_EXCL_BR_LINE */ {
         case M_INITIAL:
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                if (all_whitespace(text, len)) {
-                    break; /* ignore leading whitespace */
-                }
-                tree->quirks = 1; /* no doctype before content */
-                mode = M_BEFORE_HTML;
-                goto reprocess;
-            }
-            if (tok->kind == TH_DOCTYPE) {
-                th_node *node = node_new(tree, TH_NODE_DOCTYPE);
-                if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    node->text = build_doctype_text(tree, tok, &node->text_len);
-                    node->tag_flags = (uint8_t)((tok->has_public_id ? TH_DOCTYPE_HAS_PUBLIC : 0) |
-                                                (tok->has_system_id ? TH_DOCTYPE_HAS_SYSTEM : 0));
-                    node_append(tree->document, node);
-                }
-                tree->quirks = doctype_is_quirky(tok);
-                mode = M_BEFORE_HTML;
-                break;
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, tree->document);
-                break;
-            }
-            tree->quirks = 1; /* no doctype before content */
-            mode = M_BEFORE_HTML;
-            goto reprocess;
-
+            action = drain_initial(tree, tok, dc);
+            break;
         case M_BEFORE_HTML:
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, tree->document);
-                break;
-            }
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                if (all_whitespace(text, len)) {
-                    break;
-                }
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
-                th_node *html = insert_element(tree, tok);
-                if (html != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    stack_push(tree, html);
-                }
-                mode = M_BEFORE_HEAD;
-                break;
-            }
-            if (tok->kind == TH_END_TAG) {
-                uint16_t end_atom = tok_atom(tok);
-                if (end_atom != TH_TAG_HEAD && end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML &&
-                    end_atom != TH_TAG_BR) {
-                    break; /* any other end tag before html is a parse error and ignored */
-                }
-            }
-            {
-                th_node *html = insert_implicit(tree, "html", TH_TAG_HTML, TH_TAG_SPECIAL | TH_TAG_SCOPING);
-                if (html != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    stack_push(tree, html);
-                }
-            }
-            mode = M_BEFORE_HEAD;
-            goto reprocess;
-
+            action = drain_before_html(tree, tok, dc);
+            break;
         case M_BEFORE_HEAD:
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                break;
-            }
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                Py_ssize_t ws = 0;
-                while (ws < len && (is_space(text[ws]))) {
-                    ws++;
-                }
-                if (ws == len) {
-                    break; /* whitespace only: ignored before the head */
-                }
-                tree->text_offset += ws; /* the whitespace prefix is dropped, not moved */
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
-                /* a redundant html start tag is processed via the in-body rules
-                   (merge attributes onto the open html), leaving the mode intact */
-                if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
-                    stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
-                    merge_attrs(tree, tree->open[0], tok);
-                }
-                break;
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HEAD) {
-                th_node *head = insert_element(tree, tok);
-                if (head != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    stack_push(tree, head);
-                    tree->head = head;
-                }
-                mode = M_IN_HEAD;
-                break;
-            }
-            if (tok->kind == TH_END_TAG) {
-                uint16_t end_atom = tok_atom(tok);
-                if (end_atom != TH_TAG_HEAD && end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML &&
-                    end_atom != TH_TAG_BR) {
-                    break; /* any other end tag before head is a parse error and ignored */
-                }
-            }
-            tree->head = insert_implicit(tree, "head", TH_TAG_HEAD, TH_TAG_SPECIAL);
-            stack_push(tree, tree->head);
-            mode = M_IN_HEAD;
-            goto reprocess;
-
+            action = drain_before_head(tree, tok, dc);
+            break;
         case M_IN_HEAD:
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                Py_ssize_t ws = 0;
-                while (ws < len && (is_space(text[ws]))) {
-                    ws++;
-                }
-                if (ws > 0) {
-                    insert_text(tree, text, ws); /* leading whitespace stays in the head */
-                }
-                if (ws == len) {
-                    break;
-                }
-                tree->text_offset += ws; /* reprocess only the remainder after the head */
-                stack_pop(tree);         /* pop head */
-                mode = M_AFTER_HEAD;
-                goto reprocess;
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                break;
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint8_t flags = tok->tag_flags;
-                uint16_t atom = tok->atom;
-                if (atom == TH_TAG_HTML) {
-                    /* a redundant html start tag merges attributes via the in-body
-                       rules; the head insertion mode is left untouched */
-                    if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
-                        stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
-                        merge_attrs(tree, tree->open[0], tok);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_HEAD) {
-                    break; /* a duplicate head start tag is a parse error, ignored */
-                }
-                /* only the head's own raw-text/RCDATA elements switch to text
-                   mode here; textarea/xmp/iframe/etc belong in the body */
-                if (atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT || atom == TH_TAG_NOFRAMES) {
-                    int model = content_model_for(atom, flags);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    th_tok_switch(sm, (enum th_initial_state)model);
-                    original_mode = M_IN_HEAD;
-                    mode = M_TEXT;
-                    break;
-                }
-                if (atom == TH_TAG_BASE || atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK ||
-                    atom == TH_TAG_META) {
-                    insert_element(tree, tok); /* void metadata: inserted, not pushed */
-                    break;
-                }
-                if (atom == TH_TAG_NOSCRIPT) {
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    mode = M_IN_HEAD_NOSCRIPT;
-                    break;
-                }
-                if (atom == TH_TAG_TEMPLATE) {
-                    th_node *node = insert_template(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                        afe_push_marker(tree);
-                    }
-                    tmpl_push(tree, M_IN_TEMPLATE);
-                    mode = M_IN_TEMPLATE;
-                    break;
-                }
-                /* anything else belongs after the head */
-                stack_pop(tree);
-                mode = M_AFTER_HEAD;
-                goto reprocess;
-            }
-            /* only an end tag reaches here: text/comment/start break above, a DOCTYPE is ignored before the switch */
-            if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
-                uint16_t end_atom = tok_atom(tok);
-                if (end_atom == TH_TAG_HEAD) {
-                    stack_pop(tree);
-                    mode = M_AFTER_HEAD;
-                    break;
-                }
-                if (end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML && end_atom != TH_TAG_BR) {
-                    break; /* any other end tag in head is a parse error, ignored */
-                }
-            }
-            stack_pop(tree);
-            mode = M_AFTER_HEAD;
-            goto reprocess;
-
+            action = drain_in_head(tree, tok, dc);
+            break;
         case M_IN_HEAD_NOSCRIPT:
-            if (tok->kind == TH_END_TAG) {
-                uint16_t end_atom = tok_atom(tok);
-                if (end_atom == TH_TAG_NOSCRIPT) {
-                    stack_pop(tree); /* pop noscript */
-                    mode = M_IN_HEAD;
-                    break;
-                }
-                if (end_atom != TH_TAG_BR) {
-                    break; /* any other end tag is a parse error, ignored */
-                }
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
-                /* process via the in-body rules (merges attributes) */
-                /* open stack always holds html at index 0 */
-                if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
-                    stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
-                    merge_attrs(tree, tree->open[0], tok);
-                }
-                break;
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                break;
-            }
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                if (all_whitespace(text, len)) {
-                    insert_text(tree, text, len);
-                    break;
-                }
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK || atom == TH_TAG_META) {
-                    insert_element(tree, tok); /* void metadata */
-                    break;
-                }
-                if (atom == TH_TAG_STYLE || atom == TH_TAG_NOFRAMES) {
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    th_tok_switch(sm, TH_INIT_RAWTEXT);
-                    original_mode = M_IN_HEAD_NOSCRIPT;
-                    mode = M_TEXT;
-                    break;
-                }
-                if (atom == TH_TAG_HEAD || atom == TH_TAG_NOSCRIPT) {
-                    break; /* ignore */
-                }
-            }
-            /* anything else: pop the noscript (parse error) and reprocess in head */
-            stack_pop(tree);
-            mode = M_IN_HEAD;
-            goto reprocess;
-
+            action = drain_in_head_noscript(tree, tok, dc);
+            break;
         case M_AFTER_HEAD:
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                Py_ssize_t ws = 0;
-                while (ws < len && is_space(text[ws])) {
-                    ws++;
-                }
-                if (ws > 0) {
-                    insert_text(tree, text, ws); /* leading whitespace goes under html, between head and body */
-                }
-                if (ws == len) {
-                    break;
-                }
-                tree->text_offset += ws; /* the body is created below; reprocess only the remainder there */
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                break;
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_BODY) {
-                th_node *body = insert_element(tree, tok);
-                if (body != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    stack_push(tree, body);
-                }
-                tree->frameset_ok = 0; /* an explicit body can't be replaced by a frameset */
-                mode = M_IN_BODY;
-                break;
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_FRAMESET) {
-                th_node *fs = insert_element(tree, tok);
-                if (fs != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    stack_push(tree, fs);
-                }
-                mode = M_IN_FRAMESET;
-                break;
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint8_t flags = tok->tag_flags;
-                uint16_t atom = tok->atom;
-                /* head-content tags re-enter the head element, are processed
-                   there, and leave the head off the stack again */
-                if (atom == TH_TAG_BASE || atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK ||
-                    atom == TH_TAG_META || atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT ||
-                    atom == TH_TAG_NOFRAMES || atom == TH_TAG_TEMPLATE) {
-                    /* after-head is entered only once a head element exists */
-                    if (tree->head != NULL /* GCOVR_EXCL_BR_LINE */) {
-                        stack_push(tree, tree->head); /* insert into the head element */
-                        if (atom == TH_TAG_TEMPLATE) {
-                            th_node *node = insert_template(tree, tok);
-                            /* the head is removed from under the template on the
-                               stack; the template itself stays open */
-                            tree->open[tree->open_len - 1] = node;
-                            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                                afe_push_marker(tree);
-                                tmpl_push(tree, M_IN_TEMPLATE);
-                                mode = M_IN_TEMPLATE;
-                            } else {
-                                stack_pop(tree); /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
-                            }
-                            break;
-                        }
-                        th_node *node = insert_element(tree, tok);
-                        stack_pop(tree); /* remove head again */
-                        if (atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT ||
-                            atom == TH_TAG_NOFRAMES) {
-                            if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                                stack_push(tree, node);
-                            }
-                            th_tok_switch(sm, (enum th_initial_state)content_model_for(atom, flags));
-                            original_mode = M_AFTER_HEAD;
-                            mode = M_TEXT;
-                        }
-                    }
-                    break;
-                }
-            }
-            if (tok->kind == TH_END_TAG) {
-                uint16_t end_atom = tok_atom(tok);
-                if (end_atom != TH_TAG_BODY && end_atom != TH_TAG_HTML && end_atom != TH_TAG_BR) {
-                    break; /* any other end tag after head is a parse error, ignored */
-                }
-            }
-            {
-                th_node *body = insert_implicit(tree, "body", TH_TAG_BODY, TH_TAG_SPECIAL);
-                if (body != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    stack_push(tree, body);
-                }
-            }
-            mode = M_IN_BODY;
-            goto reprocess;
-
+            action = drain_after_head(tree, tok, dc);
+            break;
         case M_IN_TEMPLATE:
-            if (tok->kind == TH_END_TAG) {
-                break; /* </template> is handled by the dispatcher above; other end tags are ignored */
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint8_t flags = tok->tag_flags;
-                uint16_t atom = tok->atom;
-                if (atom == TH_TAG_TEMPLATE) {
-                    th_node *node = insert_template(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                        afe_push_marker(tree);
-                    }
-                    tmpl_push(tree, M_IN_TEMPLATE);
-                    break;
-                }
-                if (atom == TH_TAG_BASE || atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK ||
-                    atom == TH_TAG_META) {
-                    insert_element(tree, tok); /* void head content */
-                    break;
-                }
-                if (atom == TH_TAG_TITLE || atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT || atom == TH_TAG_NOFRAMES) {
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    th_tok_switch(sm, (enum th_initial_state)content_model_for(atom, flags));
-                    original_mode = M_IN_TEMPLATE;
-                    mode = M_TEXT;
-                    break;
-                }
-                /* table-section tags select the matching table sub-mode (updating
-                   the template insertion stack so a later reset resumes here);
-                   everything else is body content */
-                if (atom == TH_TAG_CAPTION || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY || atom == TH_TAG_TFOOT ||
-                    atom == TH_TAG_THEAD) {
-                    tmpl_set(tree, M_IN_TABLE);
-                    mode = M_IN_TABLE;
-                    goto reprocess;
-                }
-                if (atom == TH_TAG_COL) {
-                    tmpl_set(tree, M_IN_COLUMN_GROUP);
-                    mode = M_IN_COLUMN_GROUP;
-                    goto reprocess;
-                }
-                if (atom == TH_TAG_TR) {
-                    tmpl_set(tree, M_IN_TABLE_BODY);
-                    mode = M_IN_TABLE_BODY;
-                    goto reprocess;
-                }
-                if (atom == TH_TAG_TD || atom == TH_TAG_TH) {
-                    tmpl_set(tree, M_IN_ROW);
-                    mode = M_IN_ROW;
-                    goto reprocess;
-                }
-                /* any other start tag switches the template to body content */
-                tmpl_set(tree, M_IN_BODY);
-                mode = M_IN_BODY;
-                goto reprocess;
-            }
-            /* characters and comments run the in-body rules, then return here */
-            foster_pending = 1;
-            foster_return = M_IN_TEMPLATE;
-            mode = M_IN_BODY;
-            goto reprocess;
-
+            action = drain_in_template(tree, tok, dc);
+            break;
         case M_IN_FRAMESET:
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                insert_whitespace_only(tree, text, len);
-                break;
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                break;
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_FRAMESET) {
-                    th_node *fs = insert_element(tree, tok);
-                    if (fs != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, fs);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_FRAME) {
-                    insert_element(tree, tok); /* void */
-                    break;
-                }
-                if (atom == TH_TAG_NOFRAMES) {
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    th_tok_switch(sm, TH_INIT_RAWTEXT);
-                    original_mode = M_IN_FRAMESET;
-                    mode = M_TEXT;
-                    break;
-                }
-                break;
-            }
-            /* a DOCTYPE is ignored before the switch, so the kind!=end-tag branch here is dead */
-            if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_FRAMESET) { /* GCOVR_EXCL_BR_LINE */
-                if (current_node(tree)->atom != TH_TAG_HTML) {
-                    stack_pop(tree);
-                }
-                if (tree->fragment_root == NULL && current_node(tree)->atom != TH_TAG_FRAMESET) {
-                    mode = M_AFTER_FRAMESET;
-                }
-                break;
-            }
+            action = drain_in_frameset(tree, tok, dc);
             break;
-
         case M_AFTER_FRAMESET:
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                insert_whitespace_only(tree, text, len);
-                break;
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                break;
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_NOFRAMES) {
-                th_node *node = insert_element(tree, tok);
-                if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    stack_push(tree, node);
-                }
-                th_tok_switch(sm, TH_INIT_RAWTEXT);
-                original_mode = M_AFTER_FRAMESET;
-                mode = M_TEXT;
-                break;
-            }
-            if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_HTML) {
-                mode = M_AFTER_AFTER_FRAMESET; /* only comments and whitespace remain */
-            }
+            action = drain_after_frameset(tree, tok, dc);
             break;
-
         case M_IN_BODY:
-            if (tok->kind == TH_TEXT) {
-                if (tok->is_slice && tree->can_span && !tree->has_nul) {
-                    /* zero-copy: scan the input span directly for the frameset
-                       and leading-newline rules, then store a span node */
-                    Py_ssize_t off = tok->src_start + tree->text_offset;
-                    Py_ssize_t len = tok->src_len - tree->text_offset;
-                    /* a text token always has a positive length */
-                    if (tree->drop_newline && len > 0 /* GCOVR_EXCL_BR_LINE */ && input_read(tree, off) == '\n') {
-                        off++;
-                        len--;
-                    }
-                    tree->drop_newline = 0;
-                    reconstruct_afe(tree);
-                    for (Py_ssize_t index = 0; index < len; index++) {
-                        Py_UCS4 character = input_read(tree, off + index);
-                        if (!is_space(character)) {
-                            tree->frameset_ok = 0;
-                            break;
-                        }
-                    }
-                    insert_text_span(tree, off, len);
-                    break;
-                }
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                /* a text token always has a positive length */
-                if (tree->drop_newline && len > 0 /* GCOVR_EXCL_BR_LINE */ && text[0] == '\n') {
-                    text++;
-                    len--;
-                }
-                tree->drop_newline = 0;
-                reconstruct_afe(tree);
-                /* a U+0000 is dropped and, like whitespace, does not clear
-                   frameset-ok; only a real visible character does */
-                for (Py_ssize_t index = 0; index < len; index++) {
-                    Py_UCS4 character = text[index];
-                    if (!is_space(character) && character != 0) {
-                        tree->frameset_ok = 0;
-                        break;
-                    }
-                }
-                insert_text(tree, text, len);
-                break;
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                break;
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint8_t flags = tok->tag_flags;
-                uint16_t atom = tok->atom;
-                if (atom_breaks_frameset(atom) || (atom == TH_TAG_INPUT && !input_is_hidden(tok))) {
-                    tree->frameset_ok = 0;
-                }
-                if (atom == TH_TAG_HTML) {
-                    /* open stack always holds html at index 0 */
-                    if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
-                        stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
-                        merge_attrs(tree, tree->open[0], tok);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_BODY) {
-                    if (tree->open_len > 1 && tree->open[1]->atom == TH_TAG_BODY &&
-                        stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
-                        merge_attrs(tree, tree->open[1], tok);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_HEAD || atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
-                    atom == TH_TAG_FRAME || atom == TH_TAG_TBODY || atom == TH_TAG_TD || atom == TH_TAG_TFOOT ||
-                    atom == TH_TAG_TH || atom == TH_TAG_THEAD || atom == TH_TAG_TR) {
-                    break; /* stray table-structure tags are parse errors, ignored */
-                }
-                if (atom == TH_TAG_FRAMESET) {
-                    /* replaces an empty body when no non-whitespace content yet */
-                    if (tree->frameset_ok && tree->open_len > 1 && tree->open[1]->atom == TH_TAG_BODY) {
-                        node_remove(tree->open[1]);
-                        while (tree->open_len > 1) {
-                            stack_pop(tree);
-                        }
-                        th_node *fs = insert_element(tree, tok);
-                        if (fs != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                            stack_push(tree, fs);
-                        }
-                        mode = M_IN_FRAMESET;
-                    }
-                    break;
-                }
-                /* block and heading elements close an open p and are inserted
-                   WITHOUT reconstructing the active formatting elements */
-                if (is_heading_atom(atom)) {
-                    close_p_in_button_scope(tree);
-                    if (is_heading_atom(current_node(tree)->atom)) {
-                        stack_pop(tree); /* nested headings don't stack */
-                    }
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (is_p_closing_block(atom) && atom != TH_TAG_PLAINTEXT && atom != TH_TAG_PRE &&
-                    atom != TH_TAG_LISTING) { /* pre/listing also drop a leading newline below */
-                    close_p_in_button_scope(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_TABLE) {
-                    if (!tree->quirks && has_in_button_scope(tree, TH_TAG_P)) {
-                        generate_implied_end_tags(tree, TH_TAG_P);
-                        pop_until_atom(tree, TH_TAG_P);
-                    }
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    mode = M_IN_TABLE;
-                    break;
-                }
-                if (atom == TH_TAG_SELECT) {
-                    /* select content is plain in-body content now; a nested
-                       select start closes the open one instead of nesting */
-                    if (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT) {
-                        break; /* fragment case: ignored */
-                    }
-                    if (has_in_scope(tree, TH_TAG_SELECT)) {
-                        pop_until_atom(tree, TH_TAG_SELECT);
-                        break;
-                    }
-                    reconstruct_afe(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    tree->frameset_ok = 0;
-                    break;
-                }
-                if (atom == TH_TAG_SVG || atom == TH_TAG_MATH) {
-                    reconstruct_afe(tree);
-                    th_node *node = insert_foreign(tree, tok, atom == TH_TAG_SVG ? TH_NS_SVG : TH_NS_MATHML);
-                    if (node != NULL && !tok->self_closing) { /* GCOVR_EXCL_BR_LINE: insert_foreign returns NULL only on
-                                                                 allocation failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_LI) {
-                    /* html bounds the stack walk */
-                    for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
-                        uint16_t open_atom = tree->open[index]->atom;
-                        if (open_atom == TH_TAG_LI) {
-                            generate_implied_end_tags(tree, TH_TAG_LI);
-                            pop_until_atom(tree, TH_TAG_LI);
-                            break;
-                        }
-                        if ((tree->open[index]->tag_flags & TH_TAG_SPECIAL) && open_atom != TH_TAG_ADDRESS &&
-                            open_atom != TH_TAG_DIV && open_atom != TH_TAG_P) {
-                            break;
-                        }
-                    }
-                    close_p_in_button_scope(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_DD || atom == TH_TAG_DT) {
-                    /* html bounds the stack walk */
-                    for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
-                        uint16_t open_atom = tree->open[index]->atom;
-                        if (open_atom == TH_TAG_DD || open_atom == TH_TAG_DT) {
-                            generate_implied_end_tags(tree, open_atom);
-                            pop_until_atom(tree, open_atom);
-                            break;
-                        }
-                        if ((tree->open[index]->tag_flags & TH_TAG_SPECIAL) && open_atom != TH_TAG_ADDRESS &&
-                            open_atom != TH_TAG_DIV && open_atom != TH_TAG_P) {
-                            break;
-                        }
-                    }
-                    close_p_in_button_scope(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_HR) {
-                    close_p_in_button_scope(tree);
-                    if (has_in_scope(tree, TH_TAG_SELECT) ||
-                        (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT)) {
-                        /* in a select (or a select-context fragment) close the open option/optgroup
-                           first, so the hr lands at select level rather than inside the option */
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                    }
-                    insert_element(tree, tok); /* void */
-                    break;
-                }
-                if (atom == TH_TAG_BUTTON) {
-                    if (has_in_scope(tree, TH_TAG_BUTTON)) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        pop_until_atom(tree, TH_TAG_BUTTON);
-                    }
-                    reconstruct_afe(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_OPTION || atom == TH_TAG_OPTGROUP) {
-                    if (has_in_scope(tree, TH_TAG_SELECT) ||
-                        (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT)) {
-                        /* inside a select (or a select-context fragment, where no select node
-                           is on the stack), implied end tags close open option and (for an
-                           optgroup start) optgroup elements */
-                        generate_implied_end_tags(tree, atom == TH_TAG_OPTION ? TH_TAG_OPTGROUP : TH_TAG_UNKNOWN);
-                    } else if (current_node(tree)->atom == TH_TAG_OPTION) {
-                        stack_pop(tree);
-                    }
-                    reconstruct_afe(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_RB || atom == TH_TAG_RTC) {
-                    if (has_in_scope(tree, TH_TAG_RUBY)) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                    }
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_RP || atom == TH_TAG_RT) {
-                    if (has_in_scope(tree, TH_TAG_RUBY)) {
-                        generate_implied_end_tags(tree, TH_TAG_RTC);
-                    }
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_BASE || atom == TH_TAG_BASEFONT || atom == TH_TAG_BGSOUND || atom == TH_TAG_LINK ||
-                    atom == TH_TAG_META) {
-                    insert_element(tree, tok); /* head metadata: in-head rules, no AFE reconstruction */
-                    break;
-                }
-                if (atom == TH_TAG_FORM) {
-                    int in_template = stack_index_of_atom(tree, TH_TAG_TEMPLATE) >= 0;
-                    if (tree->form != NULL && !in_template) {
-                        break; /* a nested form is ignored */
-                    }
-                    close_p_in_button_scope(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                        if (!in_template) {
-                            tree->form = node;
-                        }
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_INPUT || atom == TH_TAG_KEYGEN) {
-                    /* an input or keygen closes an open select entirely (and is
-                       ignored outright in a select-context fragment) */
-                    if (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT) {
-                        break;
-                    }
-                    if (has_in_scope(tree, TH_TAG_SELECT)) {
-                        pop_until_atom(tree, TH_TAG_SELECT);
-                    }
-                    reconstruct_afe(tree);
-                    insert_element(tree, tok); /* void */
-                    break;
-                }
-                if (atom == TH_TAG_IMAGE) {
-                    /* the famous quirk: <image> becomes <img> */
-                    reconstruct_afe(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        node->atom = TH_TAG_IMG;
-                        static const char img[] = "img";
-                        node->text = arena_alloc(tree, 3 * (Py_ssize_t)sizeof(Py_UCS4));
-                        if (node->text != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                            for (int index = 0; index < 3; index++) {
-                                node->text[index] = (Py_UCS4)img[index];
-                            }
-                            node->text_len = 3;
-                        }
-                    }
-                    break; /* img is void */
-                }
-                if (atom == TH_TAG_PLAINTEXT) {
-                    close_p_in_button_scope(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    th_tok_switch(sm, TH_INIT_PLAINTEXT);
-                    break; /* PLAINTEXT runs to EOF; no end tag returns from it */
-                }
-                int model = content_model_for(atom, flags);
-                if (model >= 0) { /* rawtext / rcdata / script: no reconstruction */
-                    if (atom == TH_TAG_XMP) {
-                        close_p_in_button_scope(tree);
-                        reconstruct_afe(tree);
-                        tree->frameset_ok = 0;
-                    }
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    if (atom == TH_TAG_TEXTAREA) {
-                        tree->drop_newline = 1; /* a leading LF in a textarea is ignored */
-                    }
-                    th_tok_switch(sm, (enum th_initial_state)model);
-                    /* when fostered out of a table the in-body rules run but the real insertion
-                       mode is still the table mode, so the text mode must return there, not to
-                       in body, or the table's later rows would be dropped */
-                    original_mode = foster_pending ? foster_return : M_IN_BODY;
-                    mode = M_TEXT;
-                    break;
-                }
-                if (atom == TH_TAG_PRE || atom == TH_TAG_LISTING) {
-                    close_p_in_button_scope(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    tree->drop_newline = 1; /* a leading LF in pre/listing is ignored */
-                    tree->frameset_ok = 0;
-                    break;
-                }
-                if (atom == TH_TAG_A) {
-                    th_node *existing = afe_find_atom(tree, TH_TAG_A);
-                    if (existing != NULL) {
-                        adoption_agency(tree, TH_TAG_A);
-                        Py_ssize_t ai = afe_index_of(tree, existing);
-                        if (ai >= 0) {
-                            afe_remove_at(tree, ai);
-                        }
-                        Py_ssize_t si = stack_index_of(tree, existing);
-                        if (si >= 0) {
-                            stack_remove_at(tree, si);
-                        }
-                    }
-                }
-                if (atom == TH_TAG_NOBR) {
-                    reconstruct_afe(tree);
-                    if (has_in_scope(tree, TH_TAG_NOBR)) {
-                        adoption_agency(tree, TH_TAG_NOBR);
-                        reconstruct_afe(tree);
-                    }
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                        afe_push(tree, node);
-                    }
-                    break;
-                }
-                if (flags & TH_TAG_FORMATTING) {
-                    reconstruct_afe(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                        afe_push(tree, node);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_APPLET || atom == TH_TAG_MARQUEE || atom == TH_TAG_OBJECT) {
-                    reconstruct_afe(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    afe_push_marker(tree);
-                    break;
-                }
-                if (atom == TH_TAG_TEMPLATE) {
-                    th_node *node = insert_template(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                        afe_push_marker(tree);
-                    }
-                    tmpl_push(tree, M_IN_TEMPLATE);
-                    mode = M_IN_TEMPLATE;
-                    break;
-                }
-                reconstruct_afe(tree);
-                th_node *node = insert_element(tree, tok);
-                if (is_void_atom(atom)) {
-                    break; /* void: inserted, not pushed (a stray "/" on any
-                              other element is ignored in HTML content) */
-                }
-                if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                    stack_push(tree, node);
-                }
-                break;
-            }
-            /* only an end tag reaches here: text/comment/start break above, a DOCTYPE is ignored before the switch */
-            if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
-                uint8_t flags = tok->tag_flags;
-                uint16_t atom = tok->atom;
-                if (atom == TH_TAG_BODY || atom == TH_TAG_HTML) {
-                    mode = M_AFTER_BODY;
-                    if (atom == TH_TAG_HTML) {
-                        goto reprocess;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_P) {
-                    if (!has_in_button_scope(tree, TH_TAG_P)) {
-                        insert_implicit(tree, "p", TH_TAG_P, TH_TAG_SPECIAL); /* empty p, immediately closed */
-                    } else {
-                        generate_implied_end_tags(tree, TH_TAG_P);
-                        pop_until_atom(tree, TH_TAG_P);
-                    }
-                    break;
-                }
-                if (is_heading_atom(atom)) {
-                    int in_scope = 0;
-                    /* html bounds the stack walk */
-                    for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
-                        if (is_heading_atom(tree->open[index]->atom)) {
-                            in_scope = 1;
-                            break;
-                        }
-                        if (tree->open[index]->tag_flags & TH_TAG_SCOPING) {
-                            break;
-                        }
-                    }
-                    if (in_scope) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        while (tree->open_len > 0) { /* GCOVR_EXCL_BR_LINE: the heading is in scope when this runs, so
-                                                        the stack never empties */
-                            th_node *node = current_node(tree);
-                            stack_pop(tree);
-                            if (is_heading_atom(node->atom)) {
-                                break;
-                            }
-                        }
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_LI || atom == TH_TAG_DD || atom == TH_TAG_DT) {
-                    if (atom == TH_TAG_LI ? has_in_list_item_scope(tree, atom) : has_in_scope(tree, atom)) {
-                        generate_implied_end_tags(tree, atom);
-                        pop_until_atom(tree, atom);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_FORM) {
-                    if (stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
-                        th_node *node = tree->form;
-                        tree->form = NULL;
-                        int in_scope = 0;
-                        /* the html element is a scope boundary, so the walk always breaks before the stack bottom */
-                        for (Py_ssize_t index = tree->open_len - 1; node != NULL && index >= 0 /* GCOVR_EXCL_BR_LINE */;
-                             index--) {
-                            if (tree->open[index] == node) {
-                                in_scope = 1;
-                                break;
-                            }
-                            if (is_scope_boundary(tree->open[index])) {
-                                break;
-                            }
-                        }
-                        if (!in_scope) {
-                            break; /* parse error, ignored */
-                        }
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        /* the form is removed from wherever it sits on the stack */
-                        /* the form element is on the stack when this runs, so it */
-                        for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
-                            if (tree->open[index] == node) {
-                                stack_remove_at(tree, index);
-                                break;
-                            }
-                        }
-                        /* a template on the stack always has a form in scope when this end tag runs */
-                    } else if (has_in_scope(tree, TH_TAG_FORM) /* GCOVR_EXCL_BR_LINE */) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        pop_until_atom(tree, TH_TAG_FORM);
-                    }
-                    break;
-                }
-                if (is_block_end_atom(atom)) {
-                    if (has_in_scope(tree, atom)) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        pop_until_atom(tree, atom);
-                    }
-                    break;
-                }
-                if (flags & TH_TAG_FORMATTING) {
-                    adoption_agency(tree, atom);
-                    break;
-                }
-                if (atom == TH_TAG_APPLET || atom == TH_TAG_MARQUEE || atom == TH_TAG_OBJECT) {
-                    if (has_in_scope(tree, atom)) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        pop_until_atom(tree, atom);
-                        afe_clear_to_marker(tree);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_BR) {
-                    /* </br> acts as a <br> start tag (attributes dropped) */
-                    reconstruct_afe(tree);
-                    insert_implicit(tree, "br", TH_TAG_BR, TH_TAG_SPECIAL);
-                    tree->frameset_ok = 0;
-                    break;
-                }
-                any_other_end_tag(tree, atom, tok);
-                break;
-            }
-            break; /* GCOVR_EXCL_LINE: in body handles every text/comment/start/end token in a branch
-                      that breaks, and a DOCTYPE is ignored before the switch, so nothing reaches here */
-
-        case M_TEXT:
-            if (tok->kind == TH_TEXT) {
-                /* a nul anywhere in the input disables span sharing */
-                if (tok->is_slice && tree->can_span && !tree->has_nul /* GCOVR_EXCL_BR_LINE */) {
-                    Py_ssize_t off = tok->src_start + tree->text_offset;
-                    Py_ssize_t len = tok->src_len - tree->text_offset;
-                    /* a text token always has a positive length */
-                    if (tree->drop_newline && len > 0 /* GCOVR_EXCL_BR_LINE */ && input_read(tree, off) == '\n') {
-                        off++;
-                        len--;
-                    }
-                    tree->drop_newline = 0;
-                    insert_text_span(tree, off, len);
-                    break;
-                }
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                /* a text token always has a positive length */
-                if (tree->drop_newline && len > 0 /* GCOVR_EXCL_BR_LINE */ && text[0] == '\n') {
-                    text++;
-                    len--;
-                }
-                tree->drop_newline = 0;
-                insert_text(tree, text, len);
-                break;
-            }
-            /* end tag (or EOF) closes the raw-text/RCDATA element */
-            stack_pop(tree);
-            mode = original_mode;
+            action = drain_in_body(tree, tok, dc);
             break;
-
+        case M_TEXT:
+            action = drain_text(tree, tok, dc);
+            break;
         case M_IN_TABLE:
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                if (all_whitespace_or_nul(text, len)) {
-                    insert_text(tree, text, len);
-                } else {
-                    /* non-space character: foster-parent it out of the table */
-                    tree->foster = 1;
-                    reconstruct_afe(tree);
-                    insert_text(tree, text, len);
-                    tree->foster = 0;
-                }
-                mode = table_origin;
-                break;
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                mode = table_origin;
-                break;
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint16_t atom = tok->atom;
-                if (atom == TH_TAG_CAPTION) {
-                    clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
-                    afe_push_marker(tree);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    mode = M_IN_CAPTION;
-                    break;
-                }
-                if (atom == TH_TAG_COLGROUP) {
-                    clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    mode = M_IN_COLUMN_GROUP;
-                    break;
-                }
-                if (atom == TH_TAG_COL) {
-                    clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
-                    {
-                        th_node *cg = insert_implicit(tree, "colgroup", TH_TAG_COLGROUP, TH_TAG_SPECIAL);
-                        if (cg != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                            stack_push(tree, cg);
-                        }
-                    }
-                    mode = M_IN_COLUMN_GROUP;
-                    goto reprocess;
-                }
-                if (atom == TH_TAG_TBODY || atom == TH_TAG_THEAD || atom == TH_TAG_TFOOT) {
-                    clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    mode = M_IN_TABLE_BODY;
-                    break;
-                }
-                if (atom == TH_TAG_TD || atom == TH_TAG_TH || atom == TH_TAG_TR) {
-                    clear_to(tree, TH_TAG_TABLE, TH_TAG_TABLE, TH_TAG_TABLE);
-                    {
-                        th_node *tb = insert_implicit(tree, "tbody", TH_TAG_TBODY, TH_TAG_SPECIAL);
-                        if (tb != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                            stack_push(tree, tb);
-                        }
-                    }
-                    mode = M_IN_TABLE_BODY;
-                    goto reprocess;
-                }
-                if (atom == TH_TAG_TABLE) {
-                    /* a nested table closes the current one, then reprocesses */
-                    if (has_in_table_scope(tree, TH_TAG_TABLE)) {
-                        pop_until_atom(tree, TH_TAG_TABLE);
-                        mode = reset_insertion_mode(tree);
-                        goto reprocess;
-                    }
-                    mode = table_origin;
-                    break;
-                }
-                if (atom == TH_TAG_STYLE || atom == TH_TAG_SCRIPT) {
-                    uint8_t f2 = tok->tag_flags;
-                    uint16_t a2 = tok->atom;
-                    int model = content_model_for(a2, f2);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    th_tok_switch(sm, (enum th_initial_state)model);
-                    original_mode = table_origin;
-                    mode = M_TEXT;
-                    break;
-                }
-                if (atom == TH_TAG_INPUT && input_is_hidden(tok)) {
-                    insert_element(tree, tok); /* a hidden input stays in the table, no fostering */
-                    mode = table_origin;
-                    break;
-                }
-                if (atom == TH_TAG_FORM) {
-                    /* a form in a table is inserted in place and closed at once,
-                       unless one is already open or a template is on the stack */
-                    if (tree->form == NULL && stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
-                        tree->form = insert_element(tree, tok);
-                    }
-                    mode = table_origin;
-                    break;
-                }
-                /* anything else: foster-parent this one token under in-body rules */
-                tree->foster = 1;
-                foster_pending = 1;
-                foster_return = table_origin;
-                mode = M_IN_BODY;
-                goto reprocess;
-            }
-            /* only an end tag reaches here: text/comment/start break or foster above, a DOCTYPE is ignored before it */
-            if (tok->kind == TH_END_TAG) { /* GCOVR_EXCL_BR_LINE: the non-end-tag branch is unreachable */
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_TABLE) {
-                    if (has_in_table_scope(tree, TH_TAG_TABLE)) {
-                        pop_until_atom(tree, TH_TAG_TABLE);
-                        mode = reset_insertion_mode(tree);
-                    } else {
-                        mode = table_origin;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_BODY || atom == TH_TAG_HTML || atom == TH_TAG_TBODY || atom == TH_TAG_TFOOT ||
-                    atom == TH_TAG_THEAD || atom == TH_TAG_TR || atom == TH_TAG_TD || atom == TH_TAG_TH ||
-                    atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP) {
-                    mode = table_origin;
-                    break; /* ignore stray table-related end tags */
-                }
-                tree->foster = 1;
-                foster_pending = 1;
-                foster_return = table_origin;
-                mode = M_IN_BODY;
-                goto reprocess;
-            }
-            break; /* GCOVR_EXCL_LINE: in table handles every text/comment/start/end token in a branch
-                      that breaks, and a DOCTYPE is ignored before the switch, so nothing reaches here */
-
-        case M_IN_CAPTION: {
-            uint16_t atom = tok_atom(tok);
-            if (tok->kind == TH_END_TAG && atom == TH_TAG_CAPTION) {
-                if (has_in_table_scope(tree, TH_TAG_CAPTION)) {
-                    generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                    pop_until_atom(tree, TH_TAG_CAPTION);
-                    afe_clear_to_marker(tree);
-                    mode = M_IN_TABLE;
-                }
-                break;
-            }
-            if ((tok->kind == TH_START_TAG &&
-                 (atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY ||
-                  atom == TH_TAG_TD || atom == TH_TAG_TFOOT || atom == TH_TAG_TH || atom == TH_TAG_THEAD ||
-                  atom == TH_TAG_TR)) ||
-                (tok->kind == TH_END_TAG && atom == TH_TAG_TABLE)) {
-                if (has_in_table_scope(tree, TH_TAG_CAPTION)) {
-                    generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                    pop_until_atom(tree, TH_TAG_CAPTION);
-                    afe_clear_to_marker(tree);
-                    mode = M_IN_TABLE;
-                    goto reprocess;
-                }
-                break;
-            }
-            foster_pending = 1;
-            foster_return = M_IN_CAPTION;
-            mode = M_IN_BODY;
-            goto reprocess;
-        }
-
+            action = drain_in_table(tree, tok, dc);
+            break;
+        case M_IN_CAPTION:
+            action = drain_in_caption(tree, tok, dc);
+            break;
         case M_IN_COLUMN_GROUP:
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                Py_ssize_t ws = 0;
-                while (ws < len && (is_space(text[ws]))) {
-                    ws++;
-                }
-                if (ws > 0) {
-                    insert_text(tree, text, ws); /* the whitespace prefix stays in the colgroup */
-                }
-                if (ws == len) {
-                    break;
-                }
-                tree->text_offset += ws; /* reprocess only the remainder below */
-            }
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, NULL);
-                break;
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_HTML) {
-                /* a stray html start tag uses the in-body rules: merge attributes onto
-                   the open html and leave the stack (so the colgroup stays open) */
-                if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML && /* GCOVR_EXCL_BR_LINE */
-                    stack_index_of_atom(tree, TH_TAG_TEMPLATE) < 0) {
-                    merge_attrs(tree, tree->open[0], tok);
-                }
-                break;
-            }
-            if (tok->kind == TH_START_TAG && tok_atom(tok) == TH_TAG_COL) {
-                insert_element(tree, tok); /* col is void */
-                break;
-            }
-            if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_COLGROUP) {
-                if (current_node(tree)->atom == TH_TAG_COLGROUP) {
-                    stack_pop(tree);
-                    mode = M_IN_TABLE;
-                }
-                break;
-            }
-            /* anything else: only a real colgroup can be popped to fall back to
-               in-table; otherwise (fragment/template root) the token is ignored */
-            if (current_node(tree)->atom != TH_TAG_COLGROUP) {
-                break;
-            }
-            stack_pop(tree);
-            mode = M_IN_TABLE;
-            goto reprocess;
-
+            action = drain_in_column_group(tree, tok, dc);
+            break;
         case M_IN_TABLE_BODY:
-            if (tok->kind == TH_START_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_TR) {
-                    clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    mode = M_IN_ROW;
-                    break;
-                }
-                if (atom == TH_TAG_TD || atom == TH_TAG_TH) {
-                    clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
-                    {
-                        th_node *row = insert_implicit(tree, "tr", TH_TAG_TR, TH_TAG_SPECIAL);
-                        if (row != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                            stack_push(tree, row);
-                        }
-                    }
-                    mode = M_IN_ROW;
-                    goto reprocess;
-                }
-                if (atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY ||
-                    atom == TH_TAG_TFOOT || atom == TH_TAG_THEAD) {
-                    if (has_in_table_scope(tree, TH_TAG_TBODY) || has_in_table_scope(tree, TH_TAG_THEAD) ||
-                        has_in_table_scope(tree, TH_TAG_TFOOT)) {
-                        clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
-                        stack_pop(tree);
-                        mode = M_IN_TABLE;
-                        goto reprocess;
-                    }
-                    break;
-                }
-            }
-            if (tok->kind == TH_END_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_TBODY || atom == TH_TAG_THEAD || atom == TH_TAG_TFOOT) {
-                    if (has_in_table_scope(tree, atom)) {
-                        clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
-                        stack_pop(tree);
-                        mode = M_IN_TABLE;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_TABLE) {
-                    if (has_in_table_scope(tree, TH_TAG_TBODY) || has_in_table_scope(tree, TH_TAG_THEAD) ||
-                        has_in_table_scope(tree, TH_TAG_TFOOT)) {
-                        clear_to(tree, TH_TAG_TBODY, TH_TAG_TFOOT, TH_TAG_THEAD);
-                        stack_pop(tree);
-                        mode = M_IN_TABLE;
-                        goto reprocess;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_BODY || atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
-                    atom == TH_TAG_HTML || atom == TH_TAG_TD || atom == TH_TAG_TH || atom == TH_TAG_TR) {
-                    break; /* ignore */
-                }
-            }
-            table_origin = mode;
-            mode = M_IN_TABLE;
-            goto reprocess;
-
+            action = drain_in_table_body(tree, tok, dc);
+            break;
         case M_IN_ROW:
-            if (tok->kind == TH_START_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_TD || atom == TH_TAG_TH) {
-                    clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    afe_push_marker(tree);
-                    mode = M_IN_CELL;
-                    break;
-                }
-                if (atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY ||
-                    atom == TH_TAG_TFOOT || atom == TH_TAG_THEAD || atom == TH_TAG_TR) {
-                    if (has_in_table_scope(tree, TH_TAG_TR)) {
-                        clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
-                        stack_pop(tree);
-                        mode = M_IN_TABLE_BODY;
-                        goto reprocess;
-                    }
-                    break;
-                }
-            }
-            if (tok->kind == TH_END_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_TR) {
-                    if (has_in_table_scope(tree, TH_TAG_TR)) {
-                        clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
-                        stack_pop(tree);
-                        mode = M_IN_TABLE_BODY;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_TABLE) {
-                    if (has_in_table_scope(tree, TH_TAG_TR)) {
-                        clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
-                        stack_pop(tree);
-                        mode = M_IN_TABLE_BODY;
-                        goto reprocess;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_TBODY || atom == TH_TAG_THEAD || atom == TH_TAG_TFOOT) {
-                    if (has_in_table_scope(tree, atom)) {
-                        clear_to(tree, TH_TAG_TR, TH_TAG_TR, TH_TAG_TR);
-                        stack_pop(tree);
-                        mode = M_IN_TABLE_BODY;
-                        goto reprocess;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_BODY || atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
-                    atom == TH_TAG_HTML || atom == TH_TAG_TD || atom == TH_TAG_TH) {
-                    break; /* ignore */
-                }
-            }
-            table_origin = mode;
-            mode = M_IN_TABLE;
-            goto reprocess;
-
+            action = drain_in_row(tree, tok, dc);
+            break;
         case M_IN_CELL:
-            if (tok->kind == TH_END_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_TD || atom == TH_TAG_TH) {
-                    if (has_in_table_scope(tree, atom)) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        pop_until_atom(tree, atom);
-                        afe_clear_to_marker(tree);
-                        mode = M_IN_ROW;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_TABLE || atom == TH_TAG_TBODY || atom == TH_TAG_TFOOT || atom == TH_TAG_THEAD ||
-                    atom == TH_TAG_TR) {
-                    if (has_in_table_scope(tree, atom)) {
-                        uint16_t close = has_in_table_scope(tree, TH_TAG_TD) ? TH_TAG_TD : TH_TAG_TH;
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        pop_until_atom(tree, close);
-                        afe_clear_to_marker(tree);
-                        mode = M_IN_ROW;
-                        goto reprocess;
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_BODY || atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP ||
-                    atom == TH_TAG_HTML) {
-                    break; /* ignore */
-                }
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_CAPTION || atom == TH_TAG_COL || atom == TH_TAG_COLGROUP || atom == TH_TAG_TBODY ||
-                    atom == TH_TAG_TD || atom == TH_TAG_TFOOT || atom == TH_TAG_TH || atom == TH_TAG_THEAD ||
-                    atom == TH_TAG_TR) {
-                    uint16_t close = has_in_table_scope(tree, TH_TAG_TD) ? TH_TAG_TD : TH_TAG_TH;
-                    if (has_in_table_scope(tree, close)) {
-                        generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
-                        pop_until_atom(tree, close);
-                        afe_clear_to_marker(tree);
-                        mode = M_IN_ROW;
-                        goto reprocess;
-                    }
-                    break;
-                }
-            }
-            foster_pending = 1;
-            foster_return = M_IN_CELL;
-            mode = M_IN_BODY;
-            goto reprocess;
-
+            action = drain_in_cell(tree, tok, dc);
+            break;
         case M_AFTER_BODY:
-            if (tok->kind == TH_COMMENT) {
-                /* open[0] is always the html element in this mode, never the document */
-                th_node *root = tree->open_len > 0 ? tree->open[0] : tree->document; /* GCOVR_EXCL_BR_LINE */
-                insert_comment(tree, tok, root);
-                break;
-            }
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                if (all_whitespace(text, len)) {
-                    /* whitespace runs the in-body rules without leaving after-body */
-                    foster_pending = 1;
-                    foster_return = M_AFTER_BODY;
-                    mode = M_IN_BODY;
-                    goto reprocess;
-                }
-            }
-            if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_HTML) {
-                mode = M_AFTER_AFTER_BODY;
-                break;
-            }
-            mode = M_IN_BODY;
-            goto reprocess;
-
+            action = drain_after_body(tree, tok, dc);
+            break;
         case M_AFTER_AFTER_BODY:
-            if (tok->kind == TH_COMMENT) {
-                /* a fragment has no document node to attach to; use its root */
-                insert_comment(tree, tok, tree->fragment_root != NULL ? tree->fragment_root : tree->document);
-                break;
-            }
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                if (all_whitespace(text, len)) {
-                    /* whitespace runs the in-body rules without leaving this mode */
-                    foster_pending = 1;
-                    foster_return = M_AFTER_AFTER_BODY;
-                    mode = M_IN_BODY;
-                    goto reprocess;
-                }
-            }
-            mode = M_IN_BODY;
-            goto reprocess;
-
+            action = drain_after_after_body(tree, tok, dc);
+            break;
         case M_AFTER_AFTER_FRAMESET:
-            if (tok->kind == TH_COMMENT) {
-                insert_comment(tree, tok, tree->document);
-                break;
-            }
-            if (tok->kind == TH_TEXT) {
-                Py_ssize_t len;
-                Py_UCS4 *text = token_text(tree, tok, &len);
-                insert_whitespace_only(tree, text, len);
-                break;
-            }
-            if (tok->kind == TH_START_TAG) {
-                uint16_t atom = tok_atom(tok);
-                if (atom == TH_TAG_HTML) {
-                    /* in-body rules: merge attributes into the existing html */
-                    /* open stack always holds html at index 0 */
-                    if (tree->open_len > 0 && tree->open[0]->atom == TH_TAG_HTML) { /* GCOVR_EXCL_BR_LINE */
-                        merge_attrs(tree, tree->open[0], tok);
-                    }
-                    break;
-                }
-                if (atom == TH_TAG_NOFRAMES) {
-                    th_node *node = insert_element(tree, tok);
-                    if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                        stack_push(tree, node);
-                    }
-                    th_tok_switch(sm, TH_INIT_RAWTEXT);
-                    original_mode = M_AFTER_AFTER_FRAMESET;
-                    mode = M_TEXT;
-                }
-            }
-            break; /* everything else is a parse error and ignored */
+            action = drain_after_after_frameset(tree, tok, dc);
+            break;
+        }
+        if (action == TH_DRAIN_REPROCESS) {
+            goto reprocess;
         }
     }
-    run_state->mode = mode;
-    run_state->original_mode = original_mode;
-    run_state->foster_return = foster_return;
-    run_state->foster_pending = foster_pending;
+    run_state->mode = dc->mode;
+    run_state->original_mode = dc->original_mode;
+    run_state->foster_return = dc->foster_return;
+    run_state->foster_pending = dc->foster_pending;
 }
 
 /* Stop parsing at EOF: pop the remaining open elements, which runs the

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -196,8 +196,6 @@ int th_tree_fragment_context_known(const char *context, Py_ssize_t context_len);
 
 void th_tree_free(th_tree *tree);
 
-/* --- streaming (push) parse --- */
-
 /* A push parser driving the tokenizer and tree builder incrementally, so a
    document can be fed in chunks without ever holding the whole source: the
    tokenizer reclaims its consumed input on each feed and the insertion-mode
@@ -228,8 +226,6 @@ void th_stream_free(th_stream *stream);
    *out_len receives the length. Returns NULL on allocation failure. Used by the
    conformance harness to diff against the .dat expectations. */
 Py_UCS4 *th_tree_serialize(th_tree *tree, Py_ssize_t *out_len);
-
-/* --- navigable-tree accessors for the public Python Node API --- */
 
 /* The document (root) node; its children are the doctype/comments and <html>.
    For a fragment the children of the context root are exposed instead. */

--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -11,8 +11,6 @@
 
 #include <string.h>
 
-/* --------------------------------------------------------------- arena */
-
 #define ARENA_BLOCK ((Py_ssize_t)64 * 1024)
 
 typedef struct arena_block {
@@ -157,8 +155,6 @@ static inline int is_void_atom(uint16_t atom) {
         return 0;
     }
 }
-
-/* ----------------------------------------------------------------- nodes */
 
 /* When the tree tracks positions, an element node carries its source line
    (1-based) and column (0-based) in two uint32 slots appended right after the

--- a/src/turbohtml/_c/encoding/detect.h
+++ b/src/turbohtml/_c/encoding/detect.h
@@ -568,7 +568,7 @@ static const struct {
 #define TH_SB_LOGICAL_SLOT 8 /* the windows-1255 row above, for the Hebrew tiebreak */
 #define TH_DETECT_ISO_8859_8_INDEX 13
 
-/* ---- CJK multi-byte candidates (issue #182, phase 3) -----------------------
+/* CJK multi-byte candidates (issue #182, phase 3).
 
    chardetng scores the CJK candidates by feeding each byte to an encoding_rs
    decoder and classifying every scalar it emits. turbohtml has no encoding_rs, so

--- a/src/turbohtml/_c/features/links.c
+++ b/src/turbohtml/_c/features/links.c
@@ -221,8 +221,6 @@ static int scan_meta_refresh(const Py_UCS4 *value, Py_ssize_t len, link_emit emi
     return 0;
 }
 
-/* ----------------------------------------------------------------- the walk */
-
 typedef struct {
     Py_ssize_t start;
     Py_ssize_t end;

--- a/src/turbohtml/_c/query/css/selector.h
+++ b/src/turbohtml/_c/query/css/selector.h
@@ -106,8 +106,6 @@ typedef struct {
     int quirks;
 } sel_ctx;
 
-/* ---------------------------------------------------------------- parsing */
-
 typedef struct {
     Py_UCS4 *src; /* the owned source copy; sel_ident decodes escapes into it in place */
     Py_ssize_t pos;
@@ -1145,8 +1143,6 @@ static sel_compiled *selector_compile(PyObject *selector_error, th_tree *tree, P
     return compiled;
 }
 
-/* --------------------------------------------------------------- matching */
-
 /* The functional pseudo-classes recurse into the matcher: :is()/:where() test the
    element against a nested list, and :has() searches for a relative match, so the
    matching primitives they call are forward-declared here. */
@@ -1316,7 +1312,7 @@ static int sel_is_empty(const th_node *node, th_tree *tree) {
     return 1;
 }
 
-/* ---- the §12 input pseudo-classes, determinable from the static tree ---- */
+/* The §12 input pseudo-classes, determinable from the static tree. */
 
 static int sel_has_attr(th_node *node, uint32_t atom) {
     return sel_find_attr(node, atom) != NULL;

--- a/src/turbohtml/_c/query/css/to_xpath.h
+++ b/src/turbohtml/_c/query/css/to_xpath.h
@@ -17,8 +17,6 @@
 
 #include "query/css/selector.h"
 
-/* ------------------------------------------------------------ output buffer */
-
 typedef struct {
     Py_UCS4 *data;
     Py_ssize_t len;
@@ -85,8 +83,6 @@ static void xt_int(xt_buf *buf, long value) {
     xt_text(buf, digits);
 }
 
-/* ------------------------------------------------------------ name helpers */
-
 /* Whether a name can appear verbatim as an XPath name test / @-reference; the same
    conservative pattern cssselect uses. The letter and digit tests use the unsigned-wrap
    range form (one comparison each) so every gcov branch here is reachable. */
@@ -113,8 +109,6 @@ static int xt_has_space(const Py_UCS4 *text, Py_ssize_t length) {
     }
     return 0;
 }
-
-/* ------------------------------------------------------------ literals */
 
 /* Emit an XPath 1.0 string literal. XPath has no quote escapes, so a value holding
    both quote kinds becomes a concat() of single-quoted runs and double-quoted
@@ -179,8 +173,6 @@ static void xt_value_literal(xt_ctx *ctx, const Py_UCS4 *value, Py_ssize_t lengt
     PyMem_Free(temp);
 }
 
-/* ------------------------------------------------------------ attribute references */
-
 /* Emit the node-set reference for an attribute: @name for a safe name, otherwise the
    attribute::*[name() = '...'] form XPath needs for names its grammar rejects. */
 static void xt_attr_ref(xt_ctx *ctx, const sel_simple *simple) {
@@ -214,8 +206,6 @@ static void xt_folded_attr(xt_ctx *ctx, const char *name) {
     xt_text(&ctx->out, ", 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')");
 }
 
-/* ------------------------------------------------------------ forward declarations */
-
 static int xt_compound_conds(xt_ctx *ctx, const sel_compound *compound, const sel_simple *skip);
 static void xt_condition_alts(xt_ctx *ctx, const sel_complex *alts, int count);
 static void xt_has_path(xt_ctx *ctx, const sel_complex *rel);
@@ -240,8 +230,6 @@ static void xt_emit_nodetest(xt_ctx *ctx, const sel_simple *test) {
         xt_char(&ctx->out, '*');
     }
 }
-
-/* ------------------------------------------------------------ nth-* algebra */
 
 /* Emit the An+B condition over a sibling count expression (the axis text), following
    the same derivation cssselect documents: with EXPR = count(axis) = position-1, an
@@ -384,8 +372,6 @@ static void xt_nth_pseudo(xt_ctx *ctx, const sel_simple *simple, const sel_compo
     PyMem_Free(axis);
 }
 
-/* ------------------------------------------------------------ input pseudo-classes */
-
 /* The elements HTML can disable, as a self-test union. */
 static void xt_disableable(xt_ctx *ctx) {
     xt_text(&ctx->out, "(self::button or self::input or self::select or self::textarea"
@@ -478,8 +464,6 @@ static void xt_lang_cond(xt_ctx *ctx, const sel_simple *simple) {
     }
     xt_char(&ctx->out, ']');
 }
-
-/* ------------------------------------------------------------ pseudo-class dispatch */
 
 /* Emit the condition for one pseudo-class simple; the compound provides the type
    selector the of-type family counts by. Returns 0 for a pseudo-class that holds on
@@ -623,8 +607,6 @@ static int xt_pseudo_cond(xt_ctx *ctx, const sel_simple *simple, const sel_compo
     }
 }
 
-/* ------------------------------------------------------------ simple selectors */
-
 /* Emit the condition for one simple selector. Returns 0 when the simple holds on
    every element (the universal selector and the type already used as the node test). */
 static int xt_simple_cond(xt_ctx *ctx, const sel_simple *simple, const sel_compound *compound, const sel_simple *skip) {
@@ -744,8 +726,6 @@ static int xt_compound_conds(xt_ctx *ctx, const sel_compound *compound, const se
     }
     return wrote;
 }
-
-/* ------------------------------------------------------------ complex selectors */
 
 /* Emit the existence condition for the chain to the left of compounds[index]: the
    reverse axis named by the combinator, its target's node test, and (bracketed) the
@@ -891,8 +871,6 @@ static void xt_path_complex(xt_ctx *ctx, const sel_complex *complex) {
         xt_step(ctx, compound);
     }
 }
-
-/* ------------------------------------------------------------ binding */
 
 /* _css_to_xpath(selector, prefix, /): translate a CSS selector list to XPath 1.0.
    Raises SelectorSyntaxError on a selector the CSS grammar rejects and NotImplementedError

--- a/src/turbohtml/_c/query/xpath/ast.c
+++ b/src/turbohtml/_c/query/xpath/ast.c
@@ -27,8 +27,6 @@ int32_t xn_new(xp_program *prog, enum xn_kind kind) {
     return idx;
 }
 
-/* ------------------------------------------------------------- AST dump */
-
 typedef struct {
     Py_UCS4 *buf;
     Py_ssize_t len;

--- a/src/turbohtml/_c/query/xpath/eval.c
+++ b/src/turbohtml/_c/query/xpath/eval.c
@@ -9,8 +9,6 @@
 #include <math.h>
 #include <string.h>
 
-/* ---------------------------------------------------------- evaluation */
-
 int ns_push(xp_nodeset *ns, struct th_node *node, Py_ssize_t attr) {
     if (ns->len == ns->cap) {
         Py_ssize_t cap = ns->cap ? ns->cap * 2 : 8;
@@ -363,8 +361,6 @@ static void sort_unique(xp_nodeset *ns) {
     ns->len = write_pos;
 }
 
-/* --------------------------------------------------------- value model */
-
 void xp_result_free(xp_result *result) {
     if (result->kind == XP_STRING) {
         PyMem_Free(result->string);
@@ -626,8 +622,6 @@ double to_number(struct th_tree *tree, const xp_result *value) {
     PyMem_Free(text);
     return number;
 }
-
-/* ---------------------------------------------------------- evaluation */
 
 /* Apply each predicate in the XN_PRED chain to set, in place, in proximity order. */
 static int apply_predicates(const xp_program *prog, int32_t pred_head, xp_ctx *ctx, xp_nodeset *set) {

--- a/src/turbohtml/_c/query/xpath/functions.c
+++ b/src/turbohtml/_c/query/xpath/functions.c
@@ -9,8 +9,6 @@
 #include <math.h>
 #include <string.h>
 
-/* -------------------------------------------------------- function library */
-
 /* XPath 1.0 round(): the integer closest to the argument, ties resolved toward
    positive infinity (§4.4, so round(-2.5) is -2, not the -3 that C round() gives
    by rounding half away from zero). NaN and the infinities pass through floor. */
@@ -352,7 +350,7 @@ static int eval_id(xp_ctx *ctx, xp_result *arg, xp_result *out) {
     return rc;
 }
 
-/* --- EXSLT regular-expression functions (re:test / re:replace) ------------ */
+/* The EXSLT regular-expression functions (re:test / re:replace). */
 /* parsel and scrapy lean on these, so the engine borrows Python's re module.
    Evaluation runs inside the tree's critical section, but re touches no turbohtml
    handle, so the call cannot deadlock against it. */
@@ -494,7 +492,7 @@ static int exslt_re_replace(struct th_tree *tree, xp_result *args, xp_result *ou
     return 0;
 }
 
-/* --- EXSLT set functions (set:) ------------------------------------------- */
+/* The EXSLT set functions (set:). */
 /* The node-set arguments arrive in document order and duplicate-free (every
    node-set the engine builds is sorted_unique), so the results below preserve that
    order by copying in place and never need a re-sort. */
@@ -636,7 +634,7 @@ static int set_split(const xp_result *args, int want_before, xp_result *out) {
     return rc;
 }
 
-/* --- EXSLT string functions (str:) ---------------------------------------- */
+/* The EXSLT string functions (str:). */
 
 /* str:concat(node-set): the string-values of every member joined in document order. */
 static int str_concat(struct th_tree *tree, const xp_result *arg, xp_result *out) {
@@ -812,7 +810,7 @@ static int str_align(struct th_tree *tree, const xp_result *args, int argc, xp_r
     return 0;
 }
 
-/* --- EXSLT math functions (math:) ----------------------------------------- */
+/* The EXSLT math functions (math:). */
 
 /* math:min / math:max over a node-set's numeric string-values. An empty node-set or
    any non-numeric member yields NaN, matching EXSLT. */
@@ -892,7 +890,7 @@ static int math_select(struct th_tree *tree, const xp_result *arg, int want_max,
     return rc;
 }
 
-/* --- EXSLT date functions (date:) ----------------------------------------- */
+/* The EXSLT date functions (date:). */
 
 /* Parse `count` ASCII digits into *value; 0 on a non-digit. */
 static int ucs4_digits(const Py_UCS4 *text, Py_ssize_t count, int *value) {
@@ -1324,8 +1322,6 @@ int eval_function(const xp_program *prog, int32_t idx, xp_ctx *ctx, xp_result *o
     PyMem_Free(args);
     return rc;
 }
-
-/* --------------------------------------------------- Python test hook */
 
 PyObject *turbohtml_xpath_parse(PyObject *Py_UNUSED(module), PyObject *arg) {
     if (!PyUnicode_Check(arg)) {

--- a/src/turbohtml/_c/query/xpath/internal.h
+++ b/src/turbohtml/_c/query/xpath/internal.h
@@ -12,8 +12,6 @@
 
 #include "query/xpath/xpath.h"
 
-/* ----------------------------------------------------------------- AST */
-
 enum xn_kind {
     XN_OR,
     XN_AND,
@@ -89,8 +87,6 @@ struct xp_program {
 /* Append a blank node, returning its index or -1 on OOM. */
 int32_t xn_new(xp_program *prog, enum xn_kind kind);
 
-/* ----------------------------------------------------------------- lexer */
-
 typedef enum {
     TK_EOF,
     TK_SLASH,
@@ -147,8 +143,6 @@ void lex_next(lexer *lx);
 
 /* Whether the lexer's current NAME/LITERAL text equals the ASCII keyword kw. */
 int xp_name_eq(const lexer *lx, const char *kw);
-
-/* --------------------------------------------------------- value model */
 
 /* The implicit xml namespace, the only namespace node an HTML tree exposes. */
 #define XP_XML_NS_URI "http://www.w3.org/XML/1998/namespace"

--- a/src/turbohtml/_c/query/xpath/parser.c
+++ b/src/turbohtml/_c/query/xpath/parser.c
@@ -595,8 +595,6 @@ static int32_t parse_expr(parser *ps) {
     return left;
 }
 
-/* ---------------------------------------------------------- public API */
-
 static int func_name_is(const xn *node, const char *name) {
     Py_ssize_t length = (Py_ssize_t)strlen(name);
     if (node->str_len != length) {

--- a/src/turbohtml/_c/serialize/document.c
+++ b/src/turbohtml/_c/serialize/document.c
@@ -9,8 +9,6 @@
 
 #include <string.h>
 
-/* ---------------------------------------- html5lib "#document" dump */
-
 /* Write an attribute's displayed name (the form the #document line uses) into buf:
    namespaced foreign attributes show "prefix localname", everything else is the
    stored name (foreign attribute case adjustments are applied at construction). */
@@ -190,8 +188,6 @@ Py_UCS4 *th_tree_serialize(th_tree *tree, Py_ssize_t *out_len) {
     return out.data;
 }
 
-/* ------------------------------------------------- navigable HTML output */
-
 /* Emit one node under the compact (WHATWG fragment) layout and return the next node
    the walk rooted at root visits, or NULL once the subtree is fully written. Split
    out of serialize_compact so serialize_iter can resume the walk one node at a time
@@ -276,8 +272,6 @@ static void serialize_compact(sbuf *out, th_tree *tree, th_node *root, const th_
         node = serialize_compact_step(out, tree, node, root, opts);
     }
 }
-
-/* --------------------------------------------- indented "pretty" output */
 
 /* Indentation context for the pretty form: the output options plus the per-level
    unit the layout's Indent supplies. */
@@ -412,8 +406,6 @@ static void serialize_pretty(sbuf *out, th_tree *tree, th_node *root, const ser_
         node = serialize_pretty_step(out, tree, node, root, opts, &depth);
     }
 }
-
-/* ----------------------------------------------------- node accessors */
 
 th_node *th_tree_document(th_tree *tree) {
     return tree->fragment_root != NULL ? tree->fragment_root : tree->document;

--- a/src/turbohtml/_c/serialize/internal.h
+++ b/src/turbohtml/_c/serialize/internal.h
@@ -16,8 +16,6 @@
 
 #include <string.h>
 
-/* ---------------------------------------------------------- code-point buffer */
-
 typedef struct {
     Py_UCS4 *data;
     Py_ssize_t len;
@@ -122,8 +120,6 @@ static inline void sbuf_put_utf8(sbuf *out, const char *bytes, Py_ssize_t len) {
    attributes are ordered, each rendered name capped at this many bytes. */
 #define MAX_SORTED_ATTRS 64
 #define MAX_ATTR_NAME 128
-
-/* --------------------------------------------- navigable-tree HTML output */
 
 /* The escape policy serialize()/encode() expose through the Formatter enum. */
 enum th_formatter {
@@ -520,8 +516,6 @@ static inline int foreign_attr_namespaced(const char *lower, Py_ssize_t len) {
     }
     return 0;
 }
-
-/* ----------------------------------------- markdown / text shared predicates */
 
 /* A block-level element opens its own line(s); everything else is inline and
    flows into the surrounding line. Shared by the markdown and text renderers. */

--- a/src/turbohtml/_c/serialize/js/ast.c
+++ b/src/turbohtml/_c/serialize/js/ast.c
@@ -7,8 +7,6 @@
 
 #include <string.h>
 
-/* ----------------------------------------------------------- growable tables */
-
 static int jm_grow_nodes(jm_program *prog) {
     if (prog->node_count < prog->node_cap) {
         return 0;
@@ -122,8 +120,6 @@ const Py_UCS4 *jm_program_own(jm_program *prog, const Py_UCS4 *buf, Py_ssize_t l
     prog->owned[prog->owned_count++] = copy;
     return copy;
 }
-
-/* ----------------------------------------------------------- string/identifier values */
 
 /* The value of one hex digit. The lexer only forms a \x / \u escape over hex digits in valid input,
    so a non-hex code point here is malformed input outside the minifier's valid-JS contract; it
@@ -343,8 +339,6 @@ void jm_program_free(jm_program *prog) {
     jm_free(prog);
 }
 
-/* ----------------------------------------------------------- dump buffer */
-
 typedef struct {
     Py_UCS4 *data;
     Py_ssize_t len;
@@ -388,8 +382,6 @@ static void sb_run(jm_sb *out, const Py_UCS4 *text, Py_ssize_t add) {
     memcpy(out->data + out->len, text, (size_t)add * sizeof(Py_UCS4));
     out->len += add;
 }
-
-/* ----------------------------------------------------------- S-expression dump */
 
 static const char *jm_kind_name(uint8_t kind);
 static void dump_node(jm_sb *out, const jm_program *prog, int32_t index);

--- a/src/turbohtml/_c/serialize/js/fold.c
+++ b/src/turbohtml/_c/serialize/js/fold.c
@@ -61,8 +61,6 @@ static void replace_with(F *folder, int32_t dst, int32_t src) {
     folder->changed = 1;
 }
 
-/* ----------------------------------------------------------- constant truthiness */
-
 /* Whether a number lexeme is the value zero: 1 zero, 0 non-zero, -1 unknown (an
    exponent or BigInt suffix is left to the engine rather than guessed). */
 static int number_is_zero(const jm_node *node) {
@@ -212,8 +210,6 @@ static int is_nullish(F *folder, int32_t idx) {
     return 0;
 }
 
-/* ----------------------------------------------------------- hoisting check */
-
 static int chain_hoists(F *folder, int32_t first);
 
 /* Whether the statement subtree at idx declares a `var` or a function that hoists out
@@ -268,8 +264,6 @@ static int chain_hoists(F *folder, int32_t first) {
     return 0;
 }
 
-/* ----------------------------------------------------------- literal folds */
-
 static void fold_boolean(F *folder, int32_t idx, int truth) {
     static const Py_UCS4 zero = '0';
     static const Py_UCS4 one = '1';
@@ -305,8 +299,6 @@ static void fold_void(F *folder, int32_t idx) {
     node->a = num;
     folder->changed = 1;
 }
-
-/* ----------------------------------------------------------- declaration scan (for undefined) */
 
 static int pattern_binds(F *folder, int32_t idx, const char *name) {
     if (idx < 0) {
@@ -389,8 +381,6 @@ static int declares(F *folder, int32_t idx, const char *name) {
     }
     return 0;
 }
-
-/* ----------------------------------------------------------- walk + transforms */
 
 static void walk(F *folder, int32_t idx);
 

--- a/src/turbohtml/_c/serialize/js/internal.h
+++ b/src/turbohtml/_c/serialize/js/internal.h
@@ -13,8 +13,6 @@
 
 #include "serialize/js/jstypes.h"
 
-/* ----------------------------------------------------------------- tokens */
-
 /* ECMAScript token kinds. The lexer never decides whether a `/` is division or a
    regular-expression literal (that needs grammar position): it always reports
    JT_DIV / JT_DIV_ASSIGN, and the parser calls jm_lex_rescan_regex when a value is
@@ -95,8 +93,6 @@ typedef enum {
     JT_NULLISH_ASSIGN, /* ??= */
 } jm_tok;
 
-/* ----------------------------------------------------------------- comments */
-
 /* A license/banner comment kept through minification: a bang block comment (its body opens with `!`, the
    marker the CSS minifier also keeps) or one whose body carries an @license or @preserve annotation. text
    borrows the source span including the surrounding block-comment delimiters, so the printer re-emits it
@@ -107,8 +103,6 @@ typedef struct {
 } jm_comment;
 
 struct jm_program; /* the lexer accrues kept comments into the program's list (defined below) */
-
-/* ----------------------------------------------------------------- lexer */
 
 typedef struct {
     const Py_UCS4 *src;
@@ -151,8 +145,6 @@ int jm_text_eq(const jm_lexer *lx, const char *keyword);
 
 /* A short, stable name for a token kind, used by the parser-test dump hook. */
 const char *jm_tok_name(jm_tok kind);
-
-/* ----------------------------------------------------------------- AST */
 
 /* The node kinds of the arena AST. One flat array of jm_node holds the whole tree
    (statements and expressions share the array); children are int32 indices into it,
@@ -245,8 +237,6 @@ typedef struct {
     Py_ssize_t str_len;
 } jm_node;
 
-/* ----------------------------------------------------------------- scope/symbols */
-
 /* A lexical binding. name borrows the source; resolved follows references to their
    declaration after the whole program is parsed (a reference's symbol points at the
    nearest enclosing declaration once scopes close). uses counts references so the
@@ -289,8 +279,6 @@ typedef struct {
     int32_t first_stmt;   /* a function scope's first body statement: nothing executes before it,
                              so a var literal declared there dominates every read (-1 elsewhere) */
 } jm_scope;
-
-/* ----------------------------------------------------------------- program */
 
 /* A parsed program: the node arena, the symbol and scope tables, the root node, and
    the borrowed source. Owned by one minify call and freed with jm_program_free. */

--- a/src/turbohtml/_c/serialize/js/lexer.c
+++ b/src/turbohtml/_c/serialize/js/lexer.c
@@ -15,8 +15,6 @@
 
 #include <string.h>
 
-/* ----------------------------------------------------------- character classes */
-
 /* The hot scanners classify every code point of the source, so the ASCII range (where
    nearly all of a script's bytes live) is resolved with a single table load and mask
    instead of a chain of range compares; code points >= 0x80 fall back to the Unicode
@@ -75,8 +73,6 @@ static int jm_is_hex(Py_UCS4 ch) {
     return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
 }
 
-/* ----------------------------------------------------------- lifecycle */
-
 void jm_lex_init(jm_lexer *lx, const Py_UCS4 *src, Py_ssize_t len) {
     lx->src = src;
     lx->len = len;
@@ -100,8 +96,6 @@ int jm_text_eq(const jm_lexer *lx, const char *keyword) {
     }
     return index == lx->text_len;
 }
-
-/* ----------------------------------------------------------- kept comments */
 
 /* Whether body[0..body_len) contains needle (an ASCII literal) as a substring. */
 static int jm_body_has(const Py_UCS4 *body, Py_ssize_t body_len, const char *needle) {
@@ -154,8 +148,6 @@ static void jm_capture_comment(jm_lexer *lx, const Py_UCS4 *text, Py_ssize_t len
     lx->comment_count++;
 }
 
-/* ----------------------------------------------------------- skipping */
-
 /* Consume white space and comments, recording in lx->newline_before whether any
    line terminator was crossed (a block comment counts when it spans one): the
    parser turns that flag into automatic-semicolon-insertion decisions. */
@@ -199,8 +191,6 @@ static void jm_skip_trivia(jm_lexer *lx) {
         }
     }
 }
-
-/* ----------------------------------------------------------- scanners */
 
 /* Finish a value-bearing token: record its lexeme span and kind. */
 static void jm_emit(jm_lexer *lx, jm_tok kind) {
@@ -363,8 +353,6 @@ static void jm_scan_template_body(jm_lexer *lx, int is_head) {
     }
     jm_fail(lx);
 }
-
-/* ----------------------------------------------------------- punctuators */
 
 /* Read a one-, two- or three-byte operator starting at lx->pos. Each arm peeks the
    following code points only as far as the longest operator that begins with the
@@ -641,8 +629,6 @@ static void jm_scan_punct(jm_lexer *lx) {
         return; /* report the stray byte as the error lexeme */
     }
 }
-
-/* ----------------------------------------------------------- entry points */
 
 void jm_lex_next(jm_lexer *lx) {
     jm_skip_trivia(lx);

--- a/src/turbohtml/_c/serialize/js/mangle.c
+++ b/src/turbohtml/_c/serialize/js/mangle.c
@@ -44,7 +44,7 @@ static int name_eq(const Py_UCS4 *left, Py_ssize_t left_len, const Py_UCS4 *righ
     return memcmp(left, right, (size_t)left_len * sizeof(Py_UCS4)) == 0;
 }
 
-/* ----------------------------------------------------------- name hash table
+/* Name hash table.
 
    An open-addressing (linear-probe) map from an identifier name to an int32 value.
    Used three ways: the visible-binding map (value = symbol index, or -1 when the
@@ -128,8 +128,6 @@ static hslot *htab_slot(htab *table, const Py_UCS4 *name, Py_ssize_t len, int cr
     }
 }
 
-/* ----------------------------------------------------------- reserved words */
-
 static int is_reserved(const Py_UCS4 *name, Py_ssize_t len) {
     static const char *const words[] = {
         "break",   "case",   "catch",  "class",      "const",   "continue",   "debugger", "default",   "delete",
@@ -157,8 +155,6 @@ static int is_reserved(const Py_UCS4 *name, Py_ssize_t len) {
     return 0;
 }
 
-/* ----------------------------------------------------------- base54 names */
-
 /* The i-th shortest identifier name: a bijective base-54-then-64 numeral. The first
    character comes from 54 options (no digit, identifiers cannot start with one); the
    rest from 64. PyMem-owned. */
@@ -184,7 +180,7 @@ static Py_UCS4 *base54(Py_ssize_t index, Py_ssize_t *out_len) {
     return name;
 }
 
-/* ----------------------------------------------------------- analysis state
+/* Analysis state.
 
    Resolution uses one visible-binding table (name -> innermost visible symbol) rather
    than a per-reference walk up the scope chain. Entering a scope pushes its bindings,
@@ -275,8 +271,6 @@ static void declare(M *mangler, int32_t scope, const Py_UCS4 *name, Py_ssize_t l
     }
     push(mangler, &mangler->visible, name, len, sym);
 }
-
-/* ----------------------------------------------------------- declaration walk */
 
 static void declare_pattern(M *mangler, int32_t idx, int32_t scope, uint8_t decl);
 static void hoist_vars(M *mangler, int32_t idx, int32_t fn_scope);
@@ -369,8 +363,6 @@ static void hoist_block(M *mangler, int32_t first, int32_t scope) {
         }
     }
 }
-
-/* ----------------------------------------------------------- resolve walk */
 
 static void walk(M *mangler, int32_t idx, int32_t scope, int bind);
 
@@ -726,8 +718,6 @@ static void walk(M *mangler, int32_t idx, int32_t scope, int bind) {
     walk(mangler, node->d, scope, bind);
 }
 
-/* ----------------------------------------------------------- rename */
-
 /* Whether name is a reserved word or a name that must not be reused: a free/global
    name, or a kept function/class declaration name (reserved globally so a mangled
    binding never shadows one). The free table holds both, so this is O(1). */
@@ -905,8 +895,6 @@ static Py_ssize_t literal_print_len(jm_program *prog, int32_t idx) {
     }
     return node->str_len;
 }
-
-/* ----------------------------------------------------------- forward collapse */
 
 static void collapse_walk(jm_program *prog, int32_t idx, int *changed);
 static int is_droppable_init(jm_program *prog, int32_t init);

--- a/src/turbohtml/_c/serialize/js/parser.c
+++ b/src/turbohtml/_c/serialize/js/parser.c
@@ -31,8 +31,6 @@ typedef struct {
    (hundreds of operands). The point is to fail cleanly on a pathological input rather than fault. */
 enum { JM_MAX_DEPTH = 1000 };
 
-/* ----------------------------------------------------------- token helpers */
-
 /* Report the first error: the construct that failed, the byte offset, and the offending token slice
    (or end-of-input), so a diagnostic names what and where rather than an offset alone (#434). */
 static void fail(P *parser, const char *message) {
@@ -122,8 +120,6 @@ static void reset(P *parser, jm_mark saved) {
     parser->err = saved.err;
 }
 
-/* ----------------------------------------------------------- forward decls */
-
 static int32_t parse_stmt(P *parser);
 static int32_t parse_stmt_body(P *parser);
 static int32_t parse_block(P *parser);
@@ -209,8 +205,6 @@ static int32_t leaf(P *parser, jm_kind kind) {
     advance(parser);
     return index;
 }
-
-/* ----------------------------------------------------------- statements */
 
 /* Consume a statement terminator: an explicit `;`, or an ASI boundary (a `}`, EOF,
    or a preceding line break). The parser is lenient - it never rejects a missing
@@ -600,8 +594,6 @@ static int32_t parse_stmt_body(P *parser) {
     semicolon(parser);
     return parser->err ? -1 : node;
 }
-
-/* ----------------------------------------------------------- expressions */
 
 /* Binding power of a binary/logical operator in operator position, or 0 if the
    current token is not one. *logical reports whether it is &&/||/??. no_in masks the
@@ -1109,8 +1101,6 @@ chain:
     return expr;
 }
 
-/* ----------------------------------------------------------- primary */
-
 static int32_t parse_template(P *parser) {
     int32_t node = jm_node_new(parser->prog, JN_TEMPLATE);
     int32_t head = jm_node_new(parser->prog, JN_QUASI);
@@ -1343,8 +1333,6 @@ static int32_t parse_primary(P *parser) {
     }
 }
 
-/* ----------------------------------------------------------- functions/classes */
-
 static void parse_params(P *parser, int32_t fn) {
     expect(parser, JT_LPAREN, "expected (");
     int32_t tail = -1;
@@ -1506,8 +1494,6 @@ static int32_t parse_class(P *parser, int is_expr) {
     expect(parser, JT_RBRACE, "expected }");
     return parser->err ? -1 : node;
 }
-
-/* ----------------------------------------------------------- entry */
 
 jm_program *jm_parse(const Py_UCS4 *src, Py_ssize_t len, char *errbuf, size_t errlen) {
     jm_program *prog = jm_calloc(1, sizeof(jm_program));

--- a/src/turbohtml/_c/serialize/js/printer.c
+++ b/src/turbohtml/_c/serialize/js/printer.c
@@ -33,8 +33,6 @@ typedef struct {
     int failed;
 } St;
 
-/* ----------------------------------------------------------- output */
-
 static int is_id_char(Py_UCS4 ch) {
     return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '$' ||
            ch >= 0x80;
@@ -180,8 +178,6 @@ static void put_char(St *st, Py_UCS4 ch) {
     sync_tail(st);
 }
 
-/* ----------------------------------------------------------- precedence */
-
 static int op_prec(uint16_t op) {
     switch (op) { /* GCOVR_EXCL_BR_LINE: exhaustive switch; default unreachable */
     case JT_NULLISH:
@@ -271,8 +267,6 @@ static int new_callee_needs_parens(const jm_program *prog, int32_t index) {
     }
 }
 
-/* ----------------------------------------------------------- forward decls */
-
 static void print_expr(St *st, int32_t index);
 static int print_stmt(St *st, int32_t index);
 static void print_block(St *st, int32_t index);
@@ -308,8 +302,6 @@ static void print_mix_operand(St *st, uint16_t parent_op, int32_t child, int min
     }
     print_sub(st, child, min_prec);
 }
-
-/* ----------------------------------------------------------- operators */
 
 static const char *binary_op_str(uint16_t op) {
     switch (op) { /* GCOVR_EXCL_BR_LINE: exhaustive switch; default unreachable */
@@ -402,8 +394,6 @@ static const char *assign_op_str(uint16_t op) {
         return "=";    /* GCOVR_EXCL_LINE */
     }
 }
-
-/* ----------------------------------------------------------- expressions */
 
 static void print_text(St *st, const jm_node *node) {
     /* a renamed binding or reference emits its mangled name; everything else (literals,
@@ -925,8 +915,6 @@ static void print_expr(St *st, int32_t index) {
     }
 }
 
-/* ----------------------------------------------------------- functions/classes */
-
 static void print_function(St *st, int32_t index, int as_method) {
     const jm_node *node = &st->prog->nodes[index];
     if (!as_method) {
@@ -991,8 +979,6 @@ static void print_class(St *st, int32_t index) {
     }
     put_char(st, '}');
 }
-
-/* ----------------------------------------------------------- statements */
 
 static void print_var(St *st, int32_t index) {
     const jm_node *node = &st->prog->nodes[index];

--- a/src/turbohtml/_c/serialize/markdown.c
+++ b/src/turbohtml/_c/serialize/markdown.c
@@ -25,8 +25,6 @@
 
 #include <string.h>
 
-/* ----------------------------------------------------------- block classes */
-
 /* Whether an element's own Markdown markup is dropped under the strip/convert
    filter, leaving its children to render transparently in the surrounding flow.
    A strip set names the tags to drop; a convert set names the only tags to keep,
@@ -38,8 +36,6 @@ static int md_tag_filtered(const md_opts *opt, uint16_t atom) {
     int present = (opt->filter_tags[atom >> 6] >> (atom & 63)) & 1;
     return opt->tag_filter == TH_MD_FILTER_STRIP ? present : !present;
 }
-
-/* ----------------------------------------------------------------- options */
 
 md_opts th_markdown_default_opts(void) {
     md_opts opt = {0};
@@ -82,8 +78,6 @@ md_opts th_markdown_default_opts(void) {
     opt.wrap_node_ctx = NULL;
     return opt;
 }
-
-/* -------------------------------------------------------------- the cursor */
 
 /* A reference-style link or image collected during the walk, flushed as a
    numbered "[n]: url" definition at the end. */
@@ -132,15 +126,15 @@ typedef struct {
 
 /* Emit a configured option string, which may hold non-ASCII (a typographic
    quote, a unicode bullet), decoding its UTF-8 to code points. */
-static void md_puts8(sbuf *out, const char *s) {
-    sbuf_put_utf8(out, s, (Py_ssize_t)strlen(s));
+static void md_puts8(sbuf *out, const char *text) {
+    sbuf_put_utf8(out, text, (Py_ssize_t)strlen(text));
 }
 
 /* Append n spaces to the continuation prefix and return the start offset, so the
    caller can pop them back off after the nested block. */
-static Py_ssize_t md_push_spaces(md_ctx *ctx, Py_ssize_t n) {
+static Py_ssize_t md_push_spaces(md_ctx *ctx, Py_ssize_t count) {
     Py_ssize_t base = ctx->prefix.len;
-    for (Py_ssize_t i = 0; i < n; i++) {
+    for (Py_ssize_t index = 0; index < count; index++) {
         sbuf_putc(&ctx->prefix, ' ');
     }
     return base;
@@ -252,13 +246,11 @@ static void md_before_visible(md_ctx *ctx) {
     md_emit_pending(ctx, ctx->pending);
 }
 
-/* ----------------------------------------------------------- inline output */
-
 /* Characters that begin a markdown construct and so are backslash-escaped in
    running text. Leading line markers (#, >, -, +) are handled separately, only
    at the very start of a line. */
-static int md_needs_escape(const md_opts *opt, Py_UCS4 c) {
-    switch (c) {
+static int md_needs_escape(const md_opts *opt, Py_UCS4 ch) {
+    switch (ch) {
     case '\\':
     case '`':
     case '[':
@@ -272,8 +264,8 @@ static int md_needs_escape(const md_opts *opt, Py_UCS4 c) {
         break;
     }
     /* the "all" mode escapes every other character a markdown reader could act on */
-    return opt->escape_mode == TH_MD_ESCAPE_ALL && (c == '<' || c == '>' || c == '#' || c == '+' || c == '-' ||
-                                                    c == '=' || c == '~' || c == '|' || c == '!' || c == '&');
+    return opt->escape_mode == TH_MD_ESCAPE_ALL && (ch == '<' || ch == '>' || ch == '#' || ch == '+' || ch == '-' ||
+                                                    ch == '=' || ch == '~' || ch == '|' || ch == '!' || ch == '&');
 }
 
 /* The transliterate map: common non-ASCII typography folded to an ASCII spelling.
@@ -302,21 +294,21 @@ static const md_translit_entry MD_TRANSLIT[] = {
 
 /* The ASCII spelling for a code point, or NULL to emit it unchanged. ASCII never
    maps, so the common path costs one comparison. */
-static const char *md_translit(Py_UCS4 c) {
-    if (c < 0x80) {
+static const char *md_translit(Py_UCS4 ch) {
+    if (ch < 0x80) {
         return NULL;
     }
     for (size_t index = 0; index < sizeof(MD_TRANSLIT) / sizeof(MD_TRANSLIT[0]); index++) {
-        if (MD_TRANSLIT[index].cp == c) {
+        if (MD_TRANSLIT[index].cp == ch) {
             return MD_TRANSLIT[index].ascii;
         }
     }
     return NULL;
 }
 
-static void md_put_char(md_ctx *ctx, Py_UCS4 c) {
+static void md_put_char(md_ctx *ctx, Py_UCS4 ch) {
     if (ctx->opt->transliterate) {
-        const char *ascii = md_translit(c);
+        const char *ascii = md_translit(ch);
         if (ascii != NULL) {
             for (const char *cursor = ascii; *cursor != '\0'; cursor++) {
                 md_put_char(ctx, (Py_UCS4)(unsigned char)*cursor);
@@ -324,31 +316,31 @@ static void md_put_char(md_ctx *ctx, Py_UCS4 c) {
             return;
         }
     }
-    int line_start_marker = !ctx->line_has_content && (c == '#' || c == '>' || c == '-' || c == '+');
-    if (md_needs_escape(ctx->opt, c) || line_start_marker) {
+    int line_start_marker = !ctx->line_has_content && (ch == '#' || ch == '>' || ch == '-' || ch == '+');
+    if (md_needs_escape(ctx->opt, ch) || line_start_marker) {
         sbuf_putc(&ctx->out, '\\');
     }
-    sbuf_putc(&ctx->out, c);
+    sbuf_putc(&ctx->out, ch);
     ctx->line_has_content = 1;
 }
 
 /* At a line start, "12. " or "3) " would be read as an ordered-list item, so a
    leading run of digits before a dot or paren is escaped. Returns how many code
    points were consumed (0 when the run is not list-like). */
-static Py_ssize_t md_escape_line_number(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t i, Py_ssize_t len) {
+static Py_ssize_t md_escape_line_number(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t index, Py_ssize_t len) {
     /* the caller only enters here on a digit, so the run is at least one long */
-    Py_ssize_t j = i;
-    while (j < len && text[j] >= '0' && text[j] <= '9') {
-        j++;
+    Py_ssize_t scan = index;
+    while (scan < len && text[scan] >= '0' && text[scan] <= '9') {
+        scan++;
     }
-    if (j >= len || (text[j] != '.' && text[j] != ')')) {
+    if (scan >= len || (text[scan] != '.' && text[scan] != ')')) {
         return 0;
     }
-    sbuf_put_run(&ctx->out, &text[i], j - i);
+    sbuf_put_run(&ctx->out, &text[index], scan - index);
     sbuf_putc(&ctx->out, '\\');
-    sbuf_putc(&ctx->out, text[j]);
+    sbuf_putc(&ctx->out, text[scan]);
     ctx->line_has_content = 1;
-    return j + 1 - i;
+    return scan + 1 - index;
 }
 
 /* Emit inline text with normal-flow whitespace collapsing and markdown escaping.
@@ -357,37 +349,38 @@ static Py_ssize_t md_escape_line_number(md_ctx *ctx, const Py_UCS4 *text, Py_ssi
    no whitespace, nothing to escape — is bulk-copied in one memcpy. */
 static void md_emit_text(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
     int translit = ctx->opt->transliterate;
-    Py_ssize_t i = 0;
-    while (i < len) {
-        Py_UCS4 c = text[i];
-        if (md_is_ws(c)) {
+    Py_ssize_t index = 0;
+    while (index < len) {
+        Py_UCS4 ch = text[index];
+        if (md_is_ws(ch)) {
             ctx->space_pending = 1;
-            i++;
+            index++;
             continue;
         }
         /* the upcoming word's code-point count tells md_flush_space whether the
            owed space should become a wrap break before the word is laid down */
-        Py_ssize_t word_end = i;
+        Py_ssize_t word_end = index;
         while (word_end < len && !md_is_ws(text[word_end])) {
             word_end++;
         }
-        ctx->pending_word = (int)(word_end - i);
+        ctx->pending_word = (int)(word_end - index);
         md_before_visible(ctx);
-        if (!ctx->line_has_content && c >= '0' && c <= '9') {
-            Py_ssize_t consumed = md_escape_line_number(ctx, text, i, len);
+        if (!ctx->line_has_content && ch >= '0' && ch <= '9') {
+            Py_ssize_t consumed = md_escape_line_number(ctx, text, index, len);
             if (consumed > 0) {
-                i += consumed;
+                index += consumed;
                 continue;
             }
         }
-        md_put_char(ctx, c);
-        i++;
-        Py_ssize_t start = i;
-        while (i < len && !md_is_ws(text[i]) && !md_needs_escape(ctx->opt, text[i]) && !(translit && text[i] >= 0x80)) {
-            i++;
+        md_put_char(ctx, ch);
+        index++;
+        Py_ssize_t start = index;
+        while (index < len && !md_is_ws(text[index]) && !md_needs_escape(ctx->opt, text[index]) &&
+               !(translit && text[index] >= 0x80)) {
+            index++;
         }
-        if (i > start) {
-            sbuf_put_run(&ctx->out, &text[start], i - start);
+        if (index > start) {
+            sbuf_put_run(&ctx->out, &text[start], index - start);
         }
     }
 }
@@ -520,11 +513,11 @@ static void md_wrap(md_ctx *ctx, th_node *node, const char *marker) {
 
 /* The longest run of backticks anywhere in s, so an inline code span can fence
    with one more backtick than that and never be split by its own content. */
-static Py_ssize_t md_max_backtick_run(const Py_UCS4 *s, Py_ssize_t len) {
+static Py_ssize_t md_max_backtick_run(const Py_UCS4 *text, Py_ssize_t len) {
     Py_ssize_t best = 0;
     Py_ssize_t run = 0;
-    for (Py_ssize_t i = 0; i < len; i++) {
-        if (s[i] == '`') {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        if (text[index] == '`') {
             run++;
             if (run > best) {
                 best = run;
@@ -565,7 +558,7 @@ static void md_emit_code_span(md_ctx *ctx, th_node *node) {
     Py_ssize_t len = content.len;
     Py_ssize_t fence = md_max_backtick_run(content.data, len) + 1;
     int pad = len > 0 && (content.data[0] == '`' || content.data[len - 1] == '`');
-    for (Py_ssize_t i = 0; i < fence; i++) {
+    for (Py_ssize_t index = 0; index < fence; index++) {
         sbuf_putc(&ctx->out, '`');
     }
     if (pad) {
@@ -575,7 +568,7 @@ static void md_emit_code_span(md_ctx *ctx, th_node *node) {
     if (pad) {
         sbuf_putc(&ctx->out, ' ');
     }
-    for (Py_ssize_t i = 0; i < fence; i++) {
+    for (Py_ssize_t index = 0; index < fence; index++) {
         sbuf_putc(&ctx->out, '`');
     }
     ctx->line_has_content = 1;
@@ -586,8 +579,8 @@ static void md_emit_code_span(md_ctx *ctx, th_node *node) {
    wrapped in angle brackets so the destination stays a single token. */
 static void md_emit_url(md_ctx *ctx, const Py_UCS4 *url, Py_ssize_t len) {
     int has_space = 0;
-    for (Py_ssize_t i = 0; i < len; i++) {
-        if (url[i] == ' ') {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        if (url[index] == ' ') {
             has_space = 1;
         }
     }
@@ -603,11 +596,11 @@ static void md_emit_url(md_ctx *ctx, const Py_UCS4 *url, Py_ssize_t len) {
 /* Write a link/image title inside its `"..."` delimiters: a `"` would close the
    title early and a `\` would escape the next character, so both are backslashed. */
 static void md_emit_title(sbuf *out, const Py_UCS4 *title, Py_ssize_t len) {
-    for (Py_ssize_t i = 0; i < len; i++) {
-        if (title[i] == '"' || title[i] == '\\') {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        if (title[index] == '"' || title[index] == '\\') {
             sbuf_putc(out, '\\');
         }
-        sbuf_putc(out, title[i]);
+        sbuf_putc(out, title[index]);
     }
 }
 
@@ -620,11 +613,11 @@ static int md_href_internal(const Py_UCS4 *href) {
 /* An href that already carries a scheme ("https://", "mailto:") is absolute and
    takes no base-url prefix; the autolink shortcut also needs an absolute target. */
 static int md_href_absolute(const Py_UCS4 *href, Py_ssize_t len) {
-    for (Py_ssize_t i = 0; i < len; i++) {
-        if (href[i] == ':') {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        if (href[index] == ':') {
             return 1;
         }
-        if (href[i] == '/' || href[i] == '#' || href[i] == '?') {
+        if (href[index] == '/' || href[index] == '#' || href[index] == '?') {
             return 0;
         }
     }
@@ -741,11 +734,11 @@ static void md_emit_raw_html(md_ctx *ctx, th_node *node) {
 static void md_emit_alt(md_ctx *ctx, const Py_UCS4 *alt, Py_ssize_t alt_len, int escape) {
     if (alt != NULL) {
         if (escape) {
-            for (Py_ssize_t i = 0; i < alt_len; i++) {
-                if (alt[i] == '[' || alt[i] == ']' || alt[i] == '\\') {
+            for (Py_ssize_t index = 0; index < alt_len; index++) {
+                if (alt[index] == '[' || alt[index] == ']' || alt[index] == '\\') {
                     sbuf_putc(&ctx->out, '\\');
                 }
-                sbuf_putc(&ctx->out, alt[i]);
+                sbuf_putc(&ctx->out, alt[index]);
             }
         } else {
             sbuf_put_run(&ctx->out, alt, alt_len);
@@ -964,8 +957,6 @@ static void md_render_inline(md_ctx *ctx, th_node *node) {
     md_render_inline_tag(ctx, node);
 }
 
-/* ------------------------------------------------------------ block output */
-
 /* A block that lays out as a plain paragraph run, as opposed to a list, blockquote,
    table, heading, rule or pre that frames its own lines. Its first paragraph rides
    the list marker, and a second such block makes the item loose. <p> is the explicit
@@ -982,8 +973,8 @@ static int md_leads_with_inline(md_ctx *ctx, th_node *node) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
         if (child->type == TH_NODE_TEXT) {
             const Py_UCS4 *text = need_text(ctx->tree, child);
-            for (Py_ssize_t i = 0; i < child->text_len; i++) {
-                if (!md_is_ws(text[i])) {
+            for (Py_ssize_t index = 0; index < child->text_len; index++) {
+                if (!md_is_ws(text[index])) {
                     return 1; /* leading visible text rides on the bullet line */
                 }
             }
@@ -1012,8 +1003,8 @@ static int md_item_is_loose(md_ctx *ctx, th_node *node) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
         if (child->type == TH_NODE_TEXT) {
             const Py_UCS4 *text = need_text(ctx->tree, child);
-            for (Py_ssize_t i = 0; i < child->text_len; i++) {
-                if (!md_is_ws(text[i])) {
+            for (Py_ssize_t index = 0; index < child->text_len; index++) {
+                if (!md_is_ws(text[index])) {
                     if (!in_run) {
                         units++;
                         in_run = 1;
@@ -1074,8 +1065,8 @@ static void md_block_children(md_ctx *ctx, th_node *node) {
             int only_ws = child->type == TH_NODE_TEXT;
             if (only_ws) {
                 const Py_UCS4 *text = need_text(ctx->tree, child);
-                for (Py_ssize_t i = 0; i < child->text_len; i++) {
-                    if (!md_is_ws(text[i])) {
+                for (Py_ssize_t index = 0; index < child->text_len; index++) {
+                    if (!md_is_ws(text[index])) {
                         only_ws = 0;
                         break;
                     }
@@ -1255,9 +1246,9 @@ static void md_render_list(md_ctx *ctx, th_node *node, int ordered) {
         if (start != NULL) {
             Py_ssize_t value = 0;
             int seen = 0;
-            for (Py_ssize_t i = 0; i < start_len; i++) {
-                if (start[i] >= '0' && start[i] <= '9') {
-                    value = value * 10 + (start[i] - '0');
+            for (Py_ssize_t index = 0; index < start_len; index++) {
+                if (start[index] >= '0' && start[index] <= '9') {
+                    value = value * 10 + (start[index] - '0');
                     seen = 1;
                 } else {
                     break;
@@ -1373,9 +1364,9 @@ static void md_cell_text(md_ctx *ctx, th_node *node, sbuf *dst) {
     ctx->space_pending = saved_space;
     ctx->drop_space = saved_drop;
     int space_run = 0;
-    for (Py_ssize_t i = 0; i < rendered.len; i++) {
-        Py_UCS4 c = rendered.data[i];
-        if (c == '\n' || c == ' ') {
+    for (Py_ssize_t index = 0; index < rendered.len; index++) {
+        Py_UCS4 ch = rendered.data[index];
+        if (ch == '\n' || ch == ' ') {
             space_run = 1;
             continue;
         }
@@ -1383,10 +1374,10 @@ static void md_cell_text(md_ctx *ctx, th_node *node, sbuf *dst) {
             sbuf_putc(dst, ' ');
             space_run = 0;
         }
-        if (c == '|') {
+        if (ch == '|') {
             sbuf_puts(dst, "\\|");
         } else {
-            sbuf_putc(dst, c);
+            sbuf_putc(dst, ch);
         }
     }
     PyMem_Free(rendered.data);
@@ -1458,14 +1449,14 @@ static Py_ssize_t md_collect_rows(th_node *node, th_node **rows, Py_ssize_t *cou
    width, wrapped in pipes. A NULL grid emits an all-spaces (empty header) row. */
 static void md_emit_padded_row(md_ctx *ctx, sbuf *grid, Py_ssize_t row, Py_ssize_t columns, const Py_ssize_t *widths) {
     sbuf_puts(&ctx->out, "| ");
-    for (Py_ssize_t c = 0; c < columns; c++) {
+    for (Py_ssize_t column = 0; column < columns; column++) {
         Py_ssize_t len = 0;
         if (grid != NULL) {
-            sbuf *cell = &grid[row * columns + c];
+            sbuf *cell = &grid[row * columns + column];
             sbuf_put_run(&ctx->out, cell->data, cell->len);
             len = cell->len;
         }
-        for (Py_ssize_t pad = len; pad < widths[c]; pad++) {
+        for (Py_ssize_t pad = len; pad < widths[column]; pad++) {
             sbuf_putc(&ctx->out, ' ');
         }
         sbuf_puts(&ctx->out, " | ");
@@ -1484,42 +1475,42 @@ static void md_render_table_padded(md_ctx *ctx, th_node **rows, Py_ssize_t count
         ctx->out.failed = 1;              /* GCOVR_EXCL_LINE: allocation-failure path */
         return;                           /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    for (Py_ssize_t r = 0; r < count; r++) {
+    for (Py_ssize_t row = 0; row < count; row++) {
         Py_ssize_t col = 0;
-        for (th_node *cell = rows[r]->first_child; cell != NULL; cell = cell->next_sibling) {
+        for (th_node *cell = rows[row]->first_child; cell != NULL; cell = cell->next_sibling) {
             if (cell->type != TH_NODE_ELEMENT || (cell->atom != TH_TAG_TD && cell->atom != TH_TAG_TH)) {
                 continue;
             }
             /* columns is the widest row's cell count, so col never reaches it */
-            md_cell_text(ctx, cell, &grid[r * columns + col]);
-            if (grid[r * columns + col].len > widths[col]) {
-                widths[col] = grid[r * columns + col].len;
+            md_cell_text(ctx, cell, &grid[row * columns + col]);
+            if (grid[row * columns + col].len > widths[col]) {
+                widths[col] = grid[row * columns + col].len;
             }
             col++;
         }
     }
-    for (Py_ssize_t c = 0; c < columns; c++) {
-        if (widths[c] < 3) {
-            widths[c] = 3; /* the "---" separator needs at least three dashes */
+    for (Py_ssize_t column = 0; column < columns; column++) {
+        if (widths[column] < 3) {
+            widths[column] = 3; /* the "---" separator needs at least three dashes */
         }
     }
     Py_ssize_t body_start = has_header ? 1 : 0;
     md_emit_padded_row(ctx, has_header ? grid : NULL, 0, columns, widths);
     md_newline(ctx);
     sbuf_puts(&ctx->out, "| ");
-    for (Py_ssize_t c = 0; c < columns; c++) {
-        for (Py_ssize_t d = 0; d < widths[c]; d++) {
+    for (Py_ssize_t column = 0; column < columns; column++) {
+        for (Py_ssize_t pad = 0; pad < widths[column]; pad++) {
             sbuf_putc(&ctx->out, '-');
         }
         sbuf_puts(&ctx->out, " | ");
     }
     ctx->line_has_content = 1;
-    for (Py_ssize_t r = body_start; r < count; r++) {
+    for (Py_ssize_t row = body_start; row < count; row++) {
         md_newline(ctx);
-        md_emit_padded_row(ctx, grid, r, columns, widths);
+        md_emit_padded_row(ctx, grid, row, columns, widths);
     }
-    for (Py_ssize_t i = 0; i < count * columns; i++) {
-        PyMem_Free(grid[i].data);
+    for (Py_ssize_t index = 0; index < count * columns; index++) {
+        PyMem_Free(grid[index].data);
     }
     PyMem_Free(grid);
     PyMem_Free(widths);
@@ -1553,10 +1544,10 @@ static void md_render_table(md_ctx *ctx, th_node *node) {
     }
     if (opt->table_mode == TH_MD_TABLE_STRIP) {
         /* drop the grid, keep each cell's text as a space-joined block per row */
-        for (Py_ssize_t r = 0; r < count; r++) {
+        for (Py_ssize_t row = 0; row < count; row++) {
             md_block_line(ctx, 1);
             int first = 1;
-            for (th_node *cell = rows[r]->first_child; cell != NULL; cell = cell->next_sibling) {
+            for (th_node *cell = rows[row]->first_child; cell != NULL; cell = cell->next_sibling) {
                 if (cell->type != TH_NODE_ELEMENT || (cell->atom != TH_TAG_TD && cell->atom != TH_TAG_TH)) {
                     continue;
                 }
@@ -1583,20 +1574,20 @@ static void md_render_table(md_ctx *ctx, th_node *node) {
             md_emit_row(ctx, rows[0], columns);
         } else {
             sbuf_puts(&ctx->out, "| ");
-            for (Py_ssize_t c = 0; c < columns; c++) {
+            for (Py_ssize_t column = 0; column < columns; column++) {
                 sbuf_puts(&ctx->out, " | ");
             }
             ctx->line_has_content = 1;
         }
         md_newline(ctx);
         sbuf_puts(&ctx->out, "| ");
-        for (Py_ssize_t c = 0; c < columns; c++) {
+        for (Py_ssize_t column = 0; column < columns; column++) {
             sbuf_puts(&ctx->out, "--- | ");
         }
         ctx->line_has_content = 1;
-        for (Py_ssize_t r = body_start; r < count; r++) {
+        for (Py_ssize_t row = body_start; row < count; row++) {
             md_newline(ctx);
-            md_emit_row(ctx, rows[r], columns);
+            md_emit_row(ctx, rows[row], columns);
         }
     }
     PyMem_Free(rows);
@@ -1605,11 +1596,11 @@ static void md_render_table(md_ctx *ctx, th_node *node) {
 /* Emit preformatted text verbatim, restarting the line prefix at each newline so
    a fence indent or blockquote marker carries down every line. */
 static void md_emit_pre_text(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t end) {
-    for (Py_ssize_t i = 0; i < end; i++) {
-        if (text[i] == '\n') {
+    for (Py_ssize_t index = 0; index < end; index++) {
+        if (text[index] == '\n') {
             md_newline(ctx);
         } else {
-            sbuf_putc(&ctx->out, text[i]);
+            sbuf_putc(&ctx->out, text[index]);
             ctx->line_has_content = 1;
         }
     }
@@ -1630,8 +1621,8 @@ static void md_render_pre(md_ctx *ctx, th_node *node) {
             Py_ssize_t want_len = 9;
             if (cls_len > want_len) {
                 int match = 1;
-                for (Py_ssize_t i = 0; i < want_len; i++) {
-                    if (cls[i] != (Py_UCS4)(unsigned char)want[i]) {
+                for (Py_ssize_t index = 0; index < want_len; index++) {
+                    if (cls[index] != (Py_UCS4)(unsigned char)want[index]) {
                         match = 0;
                         break;
                     }
@@ -1639,9 +1630,9 @@ static void md_render_pre(md_ctx *ctx, th_node *node) {
                 if (match) {
                     lang = cls + want_len;
                     lang_len = cls_len - want_len;
-                    for (Py_ssize_t i = 0; i < lang_len; i++) {
-                        if (md_is_ws(lang[i])) {
-                            lang_len = i;
+                    for (Py_ssize_t index = 0; index < lang_len; index++) {
+                        if (md_is_ws(lang[index])) {
+                            lang_len = index;
                             break;
                         }
                     }
@@ -1682,7 +1673,7 @@ static void md_render_pre(md_ctx *ctx, th_node *node) {
     } else {
         Py_ssize_t fence = md_max_backtick_run(text, text_len);
         fence = fence + 1 > 3 ? fence + 1 : 3;
-        for (Py_ssize_t i = 0; i < fence; i++) {
+        for (Py_ssize_t index = 0; index < fence; index++) {
             sbuf_putc(&ctx->out, '`');
         }
         if (lang != NULL) {
@@ -1694,7 +1685,7 @@ static void md_render_pre(md_ctx *ctx, th_node *node) {
         md_newline(ctx);
         md_emit_pre_text(ctx, text, end);
         md_newline(ctx);
-        for (Py_ssize_t i = 0; i < fence; i++) {
+        for (Py_ssize_t index = 0; index < fence; index++) {
             sbuf_putc(&ctx->out, '`');
         }
         ctx->line_has_content = 1;
@@ -1733,13 +1724,13 @@ static void md_render_block(md_ctx *ctx, th_node *node) {
             Py_ssize_t width = ctx->out.len - mark;
             md_newline(ctx);
             Py_UCS4 rule = level == 1 ? '=' : '-';
-            for (Py_ssize_t i = 0; i < width; i++) {
+            for (Py_ssize_t index = 0; index < width; index++) {
                 sbuf_putc(&ctx->out, rule);
             }
             ctx->line_has_content = 1;
             return;
         }
-        for (int i = 0; i < level; i++) {
+        for (int index = 0; index < level; index++) {
             sbuf_putc(&ctx->out, '#');
         }
         sbuf_putc(&ctx->out, ' ');
@@ -1748,7 +1739,7 @@ static void md_render_block(md_ctx *ctx, th_node *node) {
         md_inline_children(ctx, node);
         if (ctx->opt->heading_style == TH_MD_HEADING_ATX_CLOSED) {
             sbuf_putc(&ctx->out, ' ');
-            for (int i = 0; i < level; i++) {
+            for (int index = 0; index < level; index++) {
                 sbuf_putc(&ctx->out, '#');
             }
         }
@@ -1817,17 +1808,17 @@ static void md_flush_references(md_ctx *ctx) {
         return;
     }
     sbuf_puts(&ctx->out, "\n\n");
-    for (Py_ssize_t i = 0; i < ctx->ref_count; i++) {
-        if (i > 0) {
+    for (Py_ssize_t index = 0; index < ctx->ref_count; index++) {
+        if (index > 0) {
             sbuf_putc(&ctx->out, '\n');
         }
         sbuf_putc(&ctx->out, '[');
-        md_put_decimal(&ctx->out, i + 1);
+        md_put_decimal(&ctx->out, index + 1);
         sbuf_puts(&ctx->out, "]: ");
-        sbuf_put_run(&ctx->out, ctx->refs[i].url, ctx->refs[i].url_len);
-        if (ctx->refs[i].title != NULL) {
+        sbuf_put_run(&ctx->out, ctx->refs[index].url, ctx->refs[index].url_len);
+        if (ctx->refs[index].title != NULL) {
             sbuf_puts(&ctx->out, " \"");
-            md_emit_title(&ctx->out, ctx->refs[i].title, ctx->refs[i].title_len);
+            md_emit_title(&ctx->out, ctx->refs[index].title, ctx->refs[index].title_len);
             sbuf_putc(&ctx->out, '"');
         }
     }

--- a/src/turbohtml/_c/serialize/readability.c
+++ b/src/turbohtml/_c/serialize/readability.c
@@ -395,8 +395,6 @@ th_node *th_node_main_content(th_tree *tree, th_node *root) {
     return best;
 }
 
-/* ----------------------------------------------------- article metadata */
-
 static int read_is_ws(Py_UCS4 character) {
     /* the tokenizer normalizes CR to LF in the input stream, so tree text and
        attribute values never hold a carriage return (as md_is_ws also assumes) */

--- a/src/turbohtml/_c/serialize/text.c
+++ b/src/turbohtml/_c/serialize/text.c
@@ -14,8 +14,6 @@
 
 #include <string.h>
 
-/* ----------------------------------------------------------------- options */
-
 text_opts th_text_default_opts(void) {
     text_opts opt = {0};
     opt.width = 0;
@@ -27,8 +25,6 @@ text_opts th_text_default_opts(void) {
     opt.bullet = "* ";
     return opt;
 }
-
-/* -------------------------------------------------------------- the cursor */
 
 typedef struct {
     const Py_UCS4 *url;
@@ -384,8 +380,6 @@ static void text_emit_text2(text_ctx *ctx, const char *s) {
         }
     }
 }
-
-/* ------------------------------------------------------------ block output */
 
 /* A run of n spaces appended to the continuation prefix; returns the prior len. */
 static Py_ssize_t text_push_indent(text_ctx *ctx, Py_ssize_t n) {

--- a/src/turbohtml/_c/tokenizer/statemachine.c
+++ b/src/turbohtml/_c/tokenizer/statemachine.c
@@ -37,8 +37,6 @@
 
 #define REPLACEMENT 0xFFFD
 
-/* ------------------------------------------------------------------ buffers */
-
 static void buf_init(th_buf *buf) {
     buf->data = NULL;
     buf->len = 0;
@@ -113,8 +111,6 @@ static int buf_push(th_buf *buf, Py_UCS4 ch) {
     return 0;
 }
 
-/* ------------------------------------------------------------------- states */
-
 enum state {
     ST_DATA,
     ST_RCDATA,
@@ -188,8 +184,6 @@ enum state {
     ST_CDATA_BRACKET,
     ST_CDATA_END,
 };
-
-/* --------------------------------------------------------------- tokenizer */
 
 struct th_tokenizer {
     enum state state;
@@ -536,8 +530,6 @@ void th_tok_close(th_tokenizer *self) {
     self->eof = 1;
 }
 
-/* --------------------------------------------------------------- emitting */
-
 static void enqueue(th_tokenizer *self, th_token *tok) {
     self->queue[(self->queue_head + self->queue_len) % 2] = tok;
     self->queue_len++;
@@ -758,10 +750,6 @@ static void text_begin_mark(th_tokenizer *self) {
         self->text_col = self->mark_col;
     }
 }
-
-/* -------------------------------------------------------- character refs */
-
-/* ----------------------------------------------------------------- run */
 
 /* Append input[pos..stop) to the text buffer in one step, advancing the
    line/column counters by the run's newline structure. The plain-text states

--- a/src/turbohtml/_c/tokenizer/tokenizer.c
+++ b/src/turbohtml/_c/tokenizer/tokenizer.c
@@ -29,8 +29,6 @@ static module_state *state_of(PyObject *self) {
     return PyType_GetModuleState(Py_TYPE(self));
 }
 
-/* ----------------------------------------------------------- content model */
-
 static int name_eq(const th_buf *name, const char *literal, size_t len) {
     if ((size_t)name->len != len || name->kind != PyUnicode_1BYTE_KIND) {
         return 0;
@@ -58,8 +56,6 @@ static int content_model_for(const th_buf *name) {
     }
     return -1;
 }
-
-/* --------------------------------------------------------------- iterator */
 
 static PyObject *iter_new(module_state *state, PyObject *owner) {
     IterObject *self = PyObject_GC_New(IterObject, (PyTypeObject *)state->iter_type);
@@ -144,8 +140,6 @@ static PyType_Spec iter_spec = {
     .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_DISALLOW_INSTANTIATION,
     .slots = iter_slots,
 };
-
-/* -------------------------------------------------------------- tokenizer */
 
 static PyObject *tokenizer_new(PyTypeObject *type, PyObject *args, PyObject *kwds) {
     static char *keywords[] = {"resolve_references", "capture_source", NULL};
@@ -306,8 +300,6 @@ static PyType_Spec tokenizer_spec = {
     .slots = tokenizer_slots,
 };
 
-/* --------------------------------------------------------------- tokenize */
-
 // NOLINTNEXTLINE(misc-use-internal-linkage): declared in core/common.h and called from core/module.c
 PyObject *turbohtml_tokenize(PyObject *module, PyObject *args, PyObject *kwargs) {
     static char *keywords[] = {"", "resolve_references", "capture_source", NULL};
@@ -343,8 +335,6 @@ PyObject *turbohtml_tokenize(PyObject *module, PyObject *args, PyObject *kwargs)
     Py_DECREF(tokenizer);
     return iterator;
 }
-
-/* --------------------------------------------------- conformance hook */
 
 /* Format one record the way the html5lib tokenizer tests express tokens, so the
    test harness can compare directly. Used only by _tokenize_states. */


### PR DESCRIPTION
This is the consistency-and-house-style workstream of the pre-1.0 review (#478). The C tree had grown a well-built but unevenly-styled surface: file-section banner comments in a minority of files and none in the rest, `markdown.c` locals that had drifted to single letters against the strict `dom/` convention, and a `run_drain` tree-construction driver that had swollen to roughly 1640 lines of one giant switch. None of this changes what the parser does; all of it makes the code harder to read and to keep consistent as 1.0 approaches.

The headline is `run_drain`. Its body was a single switch over the twenty WHATWG insertion modes, so following any one mode meant scrolling past the other nineteen. 🧵 Each case now lifts into a `drain_<mode>` handler that takes the tree, the current token, and a `th_insert` context carrying the tokenizer handle and the insertion-mode state the algorithm threads across tokens. A handler returns `TH_DRAIN_NEXT` to advance or `TH_DRAIN_REPROCESS` to run the same token again under the mode it just set; `run_drain` keeps the token pump, the shared foreign/template/select pre-dispatch, and the reprocess loop, and now reads top to bottom in call order. The handlers are single-call-site statics the compiler still inlines, so the hot path is unchanged.

Alongside that, a new repository `HOUSE_STYLE.md` records the conventions the audit found in the good majority, for both the C tree and the Python shim. The banner sweep applies the majority convention uniformly by dropping the section dividers, folding the few that carried a spec or issue reference (the EXSLT families, issue #182/#267, the CSS Level 4 input pseudo-classes) into a plain comment on the declaration. The `markdown.c` rename restores descriptive local names.

Every change is behavior-preserving: parser output is byte-identical. The shared `core/vec.h` and `core/ascii.h` deduplication the workstream also scopes is deferred to a focused follow-up, since it is an all-or-nothing consistency change across heterogeneous allocators and cap types that a partial pass would leave less consistent, not more. Part of #478.
