### PR TITLE
⚡ perf(core): find() atom index for tag+attr, presize streaming chunks

### DIFF
--- a/docs/changelog/487.misc.rst
+++ b/docs/changelog/487.misc.rst
@@ -1,0 +1,7 @@
+Speed up two read-path operations without changing their output. The streaming serializer
+(:meth:`~turbohtml.Node.serialize_iter`) now sizes each chunk buffer to a whole chunk up front instead of growing it
+from 256 code points on every chunk, cutting streaming serialization of the read-path corpus by about 9%. A
+:meth:`~turbohtml.Node.find`/:meth:`~turbohtml.Node.find_all` query that pins a known tag alongside class or attribute
+filters now runs the matcher over that tag's atom-index bucket rather than every descendant, so ``find_all("a",
+attrs={"href": True})`` on the WHATWG spec drops from 33.5 to 4.4 microseconds and a rare tag such as ``meta`` falls to
+a sliver of its former cost. Part of #478.

--- a/src/turbohtml/_c/query/find/find.c
+++ b/src/turbohtml/_c/query/find/find.c
@@ -536,12 +536,20 @@ static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_
     return 0;
 }
 
+/* Whether the query pins a known subject tag on the descendant axis: the shape
+   whose candidates are exactly the tag's atom-index bucket. A query with no other
+   constraint reads the bucket straight through (query_is_simple_tag); one that adds
+   class or attribute filters runs the general matcher over the bucket instead of
+   over every descendant, so it tests only the elements of that tag. */
+static int query_is_indexed_tag(const query_t *query) {
+    return query->tag_plain && query->tag_atom != TH_TAG_UNKNOWN && query->axis == TH_AXIS_DESCENDANTS;
+}
+
 /* Whether the query is a plain known tag with no other constraint on the
    descendant axis: the shape the tag-only fast path handles with a pre-order
    walk and an integer atom compare, skipping the general matcher. */
 static int query_is_simple_tag(const query_t *query) {
-    return query->tag_plain && query->tag_atom != TH_TAG_UNKNOWN && query->nattr == 0 && query->class_ucs4 == NULL &&
-           query->class_filter == NULL && query->axis == TH_AXIS_DESCENDANTS;
+    return query_is_indexed_tag(query) && query->nattr == 0 && query->class_ucs4 == NULL && query->class_filter == NULL;
 }
 
 /* The cheap, pure-C structural prefilter for the text-search path: whether node
@@ -832,9 +840,25 @@ PyObject *node_find(PyObject *self, PyObject *args, PyObject *kwargs) {
        the child/sibling pointers mid-read (a no-op on the GIL build) */
     Py_BEGIN_CRITICAL_SECTION(handle);
     HandleObject *handle_obj = (HandleObject *)handle;
-    if (handle_use_index(handle_obj, origin, query_is_simple_tag(&query))) {
-        if (handle_obj->index_offsets[query.tag_atom + 1] > handle_obj->index_offsets[query.tag_atom]) {
-            found = handle_obj->index_nodes[handle_obj->index_offsets[query.tag_atom]];
+    if (handle_use_index(handle_obj, origin, query_is_indexed_tag(&query))) {
+        Py_ssize_t pos = handle_obj->index_offsets[query.tag_atom];
+        Py_ssize_t end = handle_obj->index_offsets[query.tag_atom + 1];
+        if (query_is_simple_tag(&query)) {
+            if (end > pos) {
+                found = handle_obj->index_nodes[pos];
+            }
+        } else {
+            for (; pos < end; pos++) {
+                int matched = node_matches(state, handle_obj->index_nodes[pos], &query);
+                if (matched < 0) {
+                    error = 1;
+                    break;
+                }
+                if (matched) {
+                    found = handle_obj->index_nodes[pos];
+                    break;
+                }
+            }
         }
     } else if (query_is_simple_tag(&query)) {
         /* the first element whose atom matches, found with an integer compare */
@@ -891,15 +915,27 @@ PyObject *node_find_all(PyObject *self, PyObject *args, PyObject *kwargs) {
        the child/sibling pointers mid-read (a no-op on the GIL build) */
     Py_BEGIN_CRITICAL_SECTION(handle);
     HandleObject *handle_obj = (HandleObject *)handle;
-    if (handle_use_index(handle_obj, origin, query_is_simple_tag(&query))) {
+    if (handle_use_index(handle_obj, origin, query_is_indexed_tag(&query))) {
+        int simple = query_is_simple_tag(&query);
         Py_ssize_t end = handle_obj->index_offsets[query.tag_atom + 1];
         for (Py_ssize_t pos = handle_obj->index_offsets[query.tag_atom]; pos < end; pos++) {
             if (query.limit >= 0 && PyList_GET_SIZE(out) >= query.limit) {
                 break;
             }
-            if (append_wrapped(out, state, handle, handle_obj->index_nodes[pos]) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
-                break;     /* GCOVR_EXCL_LINE: allocation-failure path */
+            th_node *node = handle_obj->index_nodes[pos];
+            if (!simple) {
+                int matched = node_matches(state, node, &query);
+                if (matched < 0) {
+                    error = 1;
+                    break;
+                }
+                if (matched == 0) {
+                    continue;
+                }
+            }
+            if (append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                error = 1;                                      /* GCOVR_EXCL_LINE: allocation-failure path */
+                break;                                          /* GCOVR_EXCL_LINE: allocation-failure path */
             }
         }
     } else if (query_is_simple_tag(&query)) {

--- a/src/turbohtml/_c/serialize/document.c
+++ b/src/turbohtml/_c/serialize/document.c
@@ -533,6 +533,10 @@ Py_UCS4 *th_node_serialize(th_tree *tree, th_node *node, const th_serialize_opts
 Py_UCS4 *th_node_serialize_chunk(th_tree *tree, th_node *root, const th_serialize_opts *opts, const Py_UCS4 *indent,
                                  Py_ssize_t indent_len, th_ser_cursor *cursor, Py_ssize_t *out_len) {
     sbuf out = {NULL, 0, 0, 0};
+    /* one chunk grows to about TH_SERIALIZE_CHUNK before it is handed off, so size the
+       buffer to that up front rather than let the doubling reserve walk 256 -> 8192 on
+       every chunk (a node straddling the limit still forces at most one more grow) */
+    sbuf_reserve(&out, TH_SERIALIZE_CHUNK);
     if (indent == NULL) {
         while (cursor->node != NULL && out.len < TH_SERIALIZE_CHUNK) {
             cursor->node = serialize_compact_step(&out, tree, cursor->node, root, opts);

--- a/tests/query/find/test_tree_find.py
+++ b/tests/query/find/test_tree_find.py
@@ -300,6 +300,14 @@ def test_callable_error_propagates(id_filter: Filter) -> None:
         parse("<p>").find(id=id_filter)
 
 
+# a known-tag + attribute query rooted at the document reaches the matcher through the
+# atom-index bucket, so its error path is distinct from the general descendant walk's
+@pytest.mark.parametrize("query", [lambda doc: doc.find("p", id=_raise), lambda doc: doc.find_all("p", id=_raise)])
+def test_indexed_tag_filter_error_propagates(query: Callable[[Document], object]) -> None:
+    with pytest.raises(ZeroDivisionError):
+        query(parse("<p>x</p>"))
+
+
 # --- argument errors ---
 
 


### PR DESCRIPTION
Two read-path operations did avoidable work on every call, and both show up on large pages. This is the performance shortlist from the 1.0 rearchitecture (#478). I kept each change only after measuring it against the read-path corpus on a release build and confirming it holds every other operation while improving its own.

The streaming serializer began each chunk from an empty buffer, so its doubling reserve walked from 256 code points up to the 8 KiB chunk size before it handed the chunk off. ⚡ Reserving one chunk's worth up front removes those repeated grows; a text node straddling the limit still forces at most one more. `''.join(node.serialize_iter())` over the corpus drops about 9% across sizes (whatwg spec 311 to 282 microseconds), and the output stays byte-identical to `serialize()`.

`find()` and `find_all()` already read the per-tag atom-index bucket for a bare known tag, but a tag paired with class or attribute filters fell back to the general matcher over every descendant. Restricting that matcher to the tag's bucket tests only the elements of that tag. The bucket carries elements in pre-order and the remaining filters run through the same `node_matches` the walk used, so document order and results hold. `find_all("a", attrs={"href": True})` on the WHATWG spec falls from 33.5 to 4.4 microseconds. A rare tag gains most, since its bucket is a sliver of the tree, so `find_all("meta", attrs={"name": "viewport"})` over that document goes from 29.2 to 0.17 microseconds. The tag-only and subtree-rooted paths keep their old behavior.

The other four shortlisted items did not land. Fusing the `structured_data()` document walks moves the operation a few percent at most, because parsing and property extraction dominate it, not the outer walks. Dropping the redundant UCS4 copy of interned tag names would rewrite the hottest parse path, end-tag matching and the adoption agency, for a memory-only win, which carries more regression risk than this batch should. The document-order ordinal cache for XPath axis steps and the bottom-up `:has()` rewrite both want per-node scratch that the full 80-byte node struct has no room for; a side table for either grows past a shortlist commit. `:has()` runs quadratic on trees nested many levels deep and stands as the strongest follow-up.
