### PR TITLE
🔧 build(ci): measure a deterministic LTO-only build on CodSpeed

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -27,15 +27,20 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
-      # build the optimized extension and install the benchmark deps outside the runner, so only the pytest process
-      # below is measured under instrumentation, never the uv/meson build. --notest creates the environment and installs
-      # the benchmark deps but skips tox's commands; pgo_build then does the two-phase profile-guided build (instrument,
-      # train on the real corpora, rebuild against the profile) into that environment, so the gate measures the same
-      # optimization the release wheels ship rather than a plain -O3 build.
-      - name: 🏗️ Build the extension profile-guided and install benchmark deps
+      # build the extension and install the benchmark deps outside the runner, so only the pytest process below is
+      # measured under instrumentation, never the uv/meson build. --notest creates the environment and installs the
+      # benchmark deps but skips tox's commands; the uv install then builds a deterministic LTO-only editable extension
+      # into that environment. The gate measures LTO, not PGO, on purpose: PGO regenerates a fresh profile every build,
+      # which is not byte-reproducible, so a re-profiled binary flips marginal ops a few percent across CodSpeed's
+      # heterogeneous CPU runners and reports false regressions that mask real ones (spike #478). LTO is deterministic.
+      # The shipped wheels keep PGO+LTO for max perf (see tools/pgo_build.py and pyproject's cibuildwheel config).
+      - name: 🏗️ Build the deterministic LTO extension and install benchmark deps
         run: |
           uvx --with tox-uv tox run -e codspeed --notest
-          .tox/codspeed/bin/python tools/pgo_build.py --python .tox/codspeed/bin/python --build-dir .tox/codspeed/cbuild
+          uv pip install --python .tox/codspeed/bin/python --reinstall --no-deps --no-build-isolation --editable . \
+            --config-settings=build-dir=.tox/codspeed/cbuild \
+            --config-settings=setup-args=-Dbuildtype=release \
+            --config-settings=setup-args=-Db_lto=true
         env:
           UV_PYTHON_PREFERENCE: only-managed
       - name: 🚀 Run benchmarks

--- a/docs/changelog/491.misc.rst
+++ b/docs/changelog/491.misc.rst
@@ -1,0 +1,7 @@
+Measure a deterministic link-time-optimized build on CodSpeed rather than a profile-guided one. Profile-guided
+optimization recollects a fresh profile on every build, and that profile is not byte-reproducible: across CodSpeed's mix
+of CPU runners a re-profiled binary lays its hot paths out slightly differently each run, and the gate reported marginal
+operations swinging a few percent build-to-build, which buried real regressions in the noise. Link-time optimization
+alone is deterministic and still re-inlines the selector and tokenizer bodies the 1.0 header split moved out of their
+original units, so the gate now measures a stable binary and every pull request compares against a fixed baseline. The
+published wheels keep profile-guided optimization for maximum speed. part of #478

--- a/tox.toml
+++ b/tox.toml
@@ -213,19 +213,28 @@ commands = [ [ "python", "-m", "bench", { replace = "posargs", extend = true } ]
 [env.codspeed]
 description = "run the pytest-codspeed hot-path benchmarks (the CodSpeed CI regression gate)"
 base_python = [ "3.14" ]
-package = "skip"  # pgo_build below reinstalls a profile-guided editable build; a plain editable package would undo it
+package = "skip"  # commands_pre reinstalls a deterministic LTO editable build; a plain editable package would undo it
 deps = []  # drop the gcovr the coverage gate pulls in; the benchmarks never measure coverage
 dependency_groups = [ "test" ]  # carries pytest-codspeed, the benchmark fixture, and the meson build backend
 commands_pre = [
-  # build the extension profile-guided (instrument, train on the real corpora, rebuild against the profile) so the
-  # gate measures the same optimization the release wheels ship; the training corpora ride in as submodules in CI
+  # Build a deterministic LTO-only editable extension, not a profile-guided one. PGO regenerates a fresh profile every
+  # build, and that profile is not byte-reproducible: across CodSpeed's heterogeneous CPU runners a re-profiled binary
+  # flips marginal ops a few percent build-to-build, so the perf gate reports false regressions that mask real ones
+  # (spike #478). LTO alone is deterministic and still re-inlines the selector/tokenizer bodies the 1.0 header split
+  # moved out of their monolith units, so the gate measures a stable binary. buildtype matches the release wheel; only
+  # PGO is dropped. The shipped wheels keep PGO+LTO for max perf -- see tools/pgo_build.py and pyproject's cibuildwheel.
   [
-    "python",
-    "{tox_root}{/}tools{/}pgo_build.py",
-    "--python",
-    "{env_python}",
-    "--build-dir",
-    "{env_dir}{/}cbuild"
+    "uv",
+    "pip",
+    "install",
+    "--reinstall",
+    "--no-deps",
+    "--no-build-isolation",
+    "--editable",
+    "{tox_root}",
+    "--config-settings=build-dir={env_dir}{/}cbuild",
+    "--config-settings=setup-args=-Dbuildtype=release",
+    "--config-settings=setup-args=-Db_lto=true",
   ],
 ]
 commands = [


### PR DESCRIPTION
PR #481 wired a two-phase profile-guided build into the `codspeed` tox environment the CodSpeed performance gate measures. Profile-guided optimization recollects a fresh profile on every CI run, and that profile is not byte-reproducible. Across CodSpeed's heterogeneous CPU runners a re-profiled binary gives its hot paths a different layout each build. Marginal operations then swing a few percent between runs (text-content this build, find-text the next, whack-a-mole), and CodSpeed reports "Different runtime environments detected". 🔴 The required Performance Analysis check stayed red on false positives that masked the real regressions the gate exists to catch.

This decouples the two builds. The CodSpeed gate now builds a deterministic link-time-optimized extension with `-Dbuildtype=release -Db_lto=true`, the release buildtype minus PGO. Link-time optimization alone is reproducible and still re-inlines the selector and tokenizer bodies the 1.0 header split moved out of their original translation units, so the measured binary is stable run-to-run. The shipped wheels are untouched: `tools/pgo_build.py`, `release.yaml`, and the cibuildwheel config in `pyproject.toml` keep full PGO+LTO for maximum performance. Only the measurement build changed.

This PR carries a one-time baseline shift. ⚠️ Main's CodSpeed baseline was PGO-built and this head is LTO-only, so its CodSpeed run shows a large apparent regression (around 10 to 12 percent) across many operations. That is the gate re-baselining from PGO to LTO-only, not a real slowdown, and it happens once. After merge every pull request measures against the stable deterministic LTO-only baseline. Performance Analysis is not a branch-protection-required check, so the shift does not block the merge.

part of #478
