### PR TITLE
🔒 fix(url): guard registrable-domain against non-ASCII host OOB read

### DIFF
--- a/docs/changelog/478.bugfix.rst
+++ b/docs/changelog/478.bugfix.rst
@@ -1,0 +1,5 @@
+Bounds-check the first code point in the ``_registrable_domain`` suffix lookups. The IANA-TLD and Public-Suffix-List
+tables index the host by its first code point but hold only ASCII entries, so a host whose first code point is non-ASCII
+-- reachable when Python calls the entrypoint without the punycode step the ``external_only`` site check applies -- ran
+off the table end and could segfault. A non-ASCII first code point now short-circuits to no known suffix, so the host
+stays its own registrable domain. Part of #478 - by :user:`gaborbernat`.

--- a/src/turbohtml/_c/url/registrable.c
+++ b/src/turbohtml/_c/url/registrable.c
@@ -21,6 +21,10 @@ enum { PSL_NORMAL = 0, PSL_WILDCARD = 1, PSL_EXCEPTION = 2 };
    case-insensitively; a digit-led label (an IPv4 octet) buckets into an empty range and falls through to 0. */
 static int is_iana_tld(const Py_UCS4 *cand, Py_ssize_t len) {
     Py_UCS4 first = cand[0];
+    /* a non-ASCII first code point starts no IANA TLD (all ASCII / punycode) and would index past th_tld_first[257] */
+    if (first > 255) {
+        return 0;
+    }
     for (int index = th_tld_first[first]; index < th_tld_first[first + 1]; index++) {
         if (th_tld_table[index].name_len != len) {
             continue;
@@ -43,6 +47,10 @@ static int is_iana_tld(const Py_UCS4 *cand, Py_ssize_t len) {
    wildcard rule is stored with its "*." prefix, so a candidate carrying that prefix is how a wildcard is looked up. */
 static int psl_kind(const Py_UCS4 *cand, Py_ssize_t len) {
     Py_UCS4 first = cand[0];
+    /* a non-ASCII first code point matches no PSL rule (all ASCII / punycode) and would index past th_psl_first[257] */
+    if (first > 255) {
+        return -1;
+    }
     for (int index = th_psl_first[first]; index < th_psl_first[first + 1]; index++) {
         if (th_psl_table[index].name_len != len) {
             continue;

--- a/tests/features/test_extract_urls_links.py
+++ b/tests/features/test_extract_urls_links.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from turbohtml._html import _registrable_domain
 from turbohtml.extract import UrlCleaning, extract_links
 
 _BASE = "https://test.com/dir/"
@@ -100,6 +101,20 @@ def test_external_only_keeps_other_sites() -> None:
 def test_external_boundary_is_the_registrable_domain(base: str, href: str, *, external: bool) -> None:
     links = extract_links(f'<a href="{href}">x</a>', base, external_only=True)
     assert links == ({href} if external else set())
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        pytest.param("россия.рф", "россия.рф", id="cyrillic-unknown-suffix"),
+        pytest.param("例え.jp", "例え.jp", id="cjk-label-ascii-suffix"),
+        pytest.param("рф", "рф", id="bare-cyrillic-label"),
+    ],
+)
+def test_registrable_domain_handles_a_raw_non_ascii_host(host: str, expected: str) -> None:
+    # the internal entrypoint is reachable from Python without _ascii_host punycoding, so a non-ASCII first code
+    # point must not index past the ASCII-sized suffix tables; it has no known suffix and stays its own domain
+    assert _registrable_domain(host) == expected
 
 
 def test_external_boundary_punycodes_a_unicode_base_host() -> None:


### PR DESCRIPTION
`_registrable_domain` is exposed to Python, so it accepts whatever host a caller hands it. Inside, `is_iana_tld` and `psl_kind` index the suffix tables `th_tld_first[257]` and `th_psl_first[257]` by the host's first code point. Those tables cover ASCII plus one sentinel, so a host whose first code point is `>= 256` indexes past the end of the array, reads garbage, and can segfault. A raw Unicode host such as `россия.рф` starts at U+0440 and hits exactly that path. 🔒 For a library that parses untrusted input that is a denial-of-service vector.

The bug stayed latent because the production path never reaches it: `_site_of` punycodes every host through `_ascii_host` first, so the tables only ever saw ASCII, and the function's contract already documents an ASCII host. The direct Python entrypoint is the one door that skips the punycode step, which is why the crash is reachable at all.

The guard bounds-checks the first code point before either lookup. A non-ASCII first code point can begin no IANA TLD and match no Public Suffix List rule, since every entry in both tables is ASCII or a punycode `xn--` label, so it short-circuits to no match. The host then has no known public suffix and stays its own registrable domain, the same result an ASCII host with an unknown suffix already gets. No ASCII host changes behavior.

Part of #478
