### PR TITLE
📝 docs: add a how-this-was-built transparency note

### DIFF
--- a/docs/changelog/497.doc.rst
+++ b/docs/changelog/497.doc.rst
@@ -1,2 +1,3 @@
 A new "How turbohtml was built" page states how the library was built and thanks the libraries and specifications it
-stands on - part of #478.
+stands on, the development guide opens with the same note, and it now carries an AI-assisted contributions policy - part
+of #478.

--- a/docs/changelog/497.doc.rst
+++ b/docs/changelog/497.doc.rst
@@ -1,0 +1,2 @@
+A new "How turbohtml was built" page states how the library was built and thanks the libraries and specifications it
+stands on - part of #478.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -2,6 +2,10 @@
  Development
 #############
 
+turbohtml 1.0 was not written by hand. It was built over about a month of continuous background co-work with Anthropic's
+Claude Opus 4.8, with some help from Fable, across close to 300 pull requests and commits and many rounds of iteration.
+See :doc:`/how-this-was-built` for the full acknowledgment and the libraries and specifications turbohtml stands on.
+
 This page covers how we build, test, and maintain turbohtml; the :doc:`performance` page collects the benchmark tables
 the rest of the docs link into.
 
@@ -9,6 +13,14 @@ the rest of the docs link into.
     :hidden:
 
     performance
+
+***************************
+ AI-assisted contributions
+***************************
+
+AI-assisted contributions are welcome. Much of turbohtml itself was written with AI tools, and you are free to use them.
+You are responsible for every line you submit: review it, understand it, and make sure it meets the project's standards
+and passes the tests before opening a pull request. The same bar applies whether a human or a model wrote the code.
 
 ****************
  Getting set up

--- a/docs/how-this-was-built.rst
+++ b/docs/how-this-was-built.rst
@@ -1,0 +1,14 @@
+#########################
+ How turbohtml was built
+#########################
+
+turbohtml was not written by hand. It was built over about a month of continuous background co-work with Anthropic's
+Claude Opus 4.8, with some help from Fable, across close to 300 pull requests and commits and many rounds of iteration.
+
+I reviewed most of the code myself, and I put real work into the guardrails around it. turbohtml is differentially
+tested against a wide range of existing libraries across the Python, Rust, C, C++, and Go ecosystems, exercised through
+their own test suites. The aim was correctness as much as speed, checked against the tools that came before.
+
+None of this would exist without that prior work. turbohtml stands on the shoulders of the competing libraries across
+those ecosystems and on the specifications for HTML, CSS, and JavaScript and the people who wrote them. The saying about
+standing on the shoulders of giants applies here in full. My thanks to all of them.

--- a/docs/how-this-was-built.rst
+++ b/docs/how-this-was-built.rst
@@ -2,7 +2,7 @@
  How turbohtml was built
 #########################
 
-turbohtml was not written by hand. It was built over about a month of continuous background co-work with Anthropic's
+turbohtml 1.0 was not written by hand. It was built over about a month of continuous background co-work with Anthropic's
 Claude Opus 4.8, with some help from Fable, across close to 300 pull requests and commits and many rounds of iteration.
 
 I reviewed most of the code myself, and I put real work into the guardrails around it. turbohtml is differentially

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,5 +74,6 @@ The documentation follows the `Diátaxis <https://diataxis.fr>`_ framework.
     reference
     explanation/index
     development/index
+    how-this-was-built
     changelog
     license


### PR DESCRIPTION
turbohtml was built with heavy AI assistance, and the docs should say so plainly. This adds a first-person transparency note from the maintainer, reachable as a top-level page so anyone can find it rather than having it buried.

📝 The page states how the library came together: about a month of background co-work with Claude Opus 4.8, with some help from Fable, across close to 300 PRs and commits. It also records the guardrails behind that work, differential testing against existing libraries across the Python, Rust, C, C++, and Go ecosystems through their own suites, and it thanks the competing libraries and the HTML, CSS, and JavaScript specifications the project stands on.

The note lives at `docs/how-this-was-built.rst` and is wired into the root `toctree` in `docs/index.rst` next to the changelog and license meta pages. It stays a short, sincere statement with no extra sections. Part of #478.
