### PR TITLE
🔧 build(bench): add --pgo flag to build the release-representative baseline

### DIFF
--- a/docs/changelog/498.misc.rst
+++ b/docs/changelog/498.misc.rst
@@ -1,0 +1,3 @@
+Add a ``--pgo`` flag to the local bench harness (``python -m bench --pgo <command>``) that builds the turbohtml ``core``
+baseline with the profile-guided, link-time-optimized recipe the release wheels ship rather than a plain wheel, so the
+reports measure a release-representative binary. The default stays the plain build for fast iteration. part of #478

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -21,7 +21,10 @@ benchmarks each competitor in its own isolated ``uv`` venv -- turbohtml in a ven
 so one library's dependency pins never perturb another's. Every table below is one harness operation, so each is
 reproducible with ``tox -e bench <command>``, where the command is ``core`` (turbohtml's own baseline for every
 operation), an operation name (the cross-competitor table), a package name (that competitor's own report), or ``all``.
-Most operations are a single call; a few aggregate workloads (``build``, ``build-e``) sweep a size, and the
+By default the turbohtml baseline is a plain wheel, which builds quickly for iterating; pass ``--pgo`` before the
+command (``tox -e bench -- --pgo core``) to build it instead with the shipped profile-guided, link-time-optimized
+release recipe, so the baseline reads as what a release ships rather than a plain build, at the cost of a much slower
+build. Most operations are a single call; a few aggregate workloads (``build``, ``build-e``) sweep a size, and the
 ``construct`` and ``emit`` breakdowns decompose that write path into the constructor and the serializer in isolation.
 Numbers vary with input and hardware.
 

--- a/tools/bench/__main__.py
+++ b/tools/bench/__main__.py
@@ -1,9 +1,12 @@
 """
-CLI entry point: ``python -m bench <command>``.
+CLI entry point: ``python -m bench [--pgo] <command>``.
 
 Commands: ``core`` (turbohtml baseline for every operation), ``all`` (every operation table), an operation name
 (cross-package table), or a package name (that package's own report). Anything after the command is forwarded verbatim
-to pyperf in every worker (e.g. ``--rigorous``, ``--affinity=2``). The orchestrator provisions one isolated venv per
+to pyperf in every worker (e.g. ``--rigorous``, ``--affinity=2``). ``--pgo``, before the command so pyperf never sees
+it, builds the turbohtml ``core`` baseline with the shipped release recipe -- the two-phase profile-guided,
+link-time-optimized build of :mod:`pgo_build` -- so the baseline measures release-representative numbers; omit it (the
+default) for a plain wheel that builds far faster while iterating. The orchestrator provisions one isolated venv per
 target, so this entry point itself needs only uv on PATH -- no turbohtml, no competitor.
 """
 
@@ -23,10 +26,13 @@ def main() -> None:
         position = arguments.index("--table-json")
         report.TABLE_JSON_DIR = Path(arguments[position + 1])
         del arguments[position : position + 2]
+    pgo = "--pgo" in arguments  # kept out of the pyperf passthrough: it selects how the core wheel is built
+    if pgo:
+        arguments.remove("--pgo")
     if not arguments:
-        msg = "usage: python -m bench [--table-json DIR] <core|all|operation|package> [pyperf options...]"
+        msg = "usage: python -m bench [--table-json DIR] [--pgo] <core|all|operation|package> [pyperf options...]"
         raise SystemExit(msg)
-    orchestrator.run(arguments[0], tuple(arguments[1:]))
+    orchestrator.run(arguments[0], tuple(arguments[1:]), pgo=pgo)
 
 
 if __name__ == "__main__":

--- a/tools/bench/orchestrator.py
+++ b/tools/bench/orchestrator.py
@@ -17,6 +17,9 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pgo_build
+import tomllib
+
 from bench import operations, report
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -77,6 +80,24 @@ def _venv_python(workdir: Path, name: str, reqs: tuple[str, ...]) -> Path:
     return python
 
 
+def _core_python(workdir: Path, *, pgo: bool) -> Path:
+    """
+    Provision the turbohtml baseline venv, plain by default or with the shipped PGO+LTO release recipe when ``pgo``.
+
+    The plain path installs the wheel :func:`_build_wheel` builds -- fast, good for iterating. The ``pgo`` path instead
+    reproduces what ships: the venv gets the build backend, then :func:`pgo_build.build` drives the two-phase
+    profile-guided, link-time-optimized editable install (``--no-build-isolation``, so the backend has to live in the
+    venv), leaving the baseline measured against a release-representative binary.
+    """
+    if not pgo:
+        return _venv_python(workdir, "core", (str(_build_wheel(workdir)),))
+    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    build_backend = tuple(pyproject["build-system"]["requires"])
+    python = _venv_python(workdir, "core", build_backend)
+    pgo_build.build(str(python), workdir / "core-pgo-build", _REPO_ROOT, "full", system=False)
+    return python
+
+
 def _run_worker(
     python: Path, target: str, operation: str, workdir: Path, pyperf_args: tuple[str, ...]
 ) -> dict[str, dict[str, float]]:
@@ -112,23 +133,22 @@ def _try_competitor(
     return _run_worker(python, competitor, operation, workdir, pyperf_args)
 
 
-def report_operation(operation: str, pyperf_args: tuple[str, ...]) -> None:
+def report_operation(operation: str, pyperf_args: tuple[str, ...], *, pgo: bool) -> None:
     """Render one operation: the turbohtml baseline against every competitor that implements it, each isolated."""
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)
-        wheel = _build_wheel(workdir)
-        stats = _run_worker(_venv_python(workdir, "core", (str(wheel),)), "core", operation, workdir, pyperf_args)
+        stats = _run_worker(_core_python(workdir, pgo=pgo), "core", operation, workdir, pyperf_args)
         for competitor in _packages_for(operation):
             stats.update(_try_competitor(workdir, competitor, operation, pyperf_args))
         report.render(operation, stats)
 
 
-def report_package(competitor: str, pyperf_args: tuple[str, ...]) -> None:
+def report_package(competitor: str, pyperf_args: tuple[str, ...], *, pgo: bool) -> None:
     """Render one competitor's report: it against the turbohtml baseline across every operation it implements."""
     reqs, operation_names = COMPETITORS[competitor]
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)
-        core_python = _venv_python(workdir, "core", (str(_build_wheel(workdir)),))
+        core_python = _core_python(workdir, pgo=pgo)
         competitor_python = _venv_python(workdir, competitor, reqs)
         for operation in operation_names:
             stats = _run_worker(core_python, "core", operation, workdir, pyperf_args)
@@ -136,16 +156,16 @@ def report_package(competitor: str, pyperf_args: tuple[str, ...]) -> None:
             report.render(operation, stats)
 
 
-def report_core(pyperf_args: tuple[str, ...]) -> None:
+def report_core(pyperf_args: tuple[str, ...], *, pgo: bool) -> None:
     """Render turbohtml's own baseline for every operation in a turbohtml-only venv."""
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)
-        python = _venv_python(workdir, "core", (str(_build_wheel(workdir)),))
+        python = _core_python(workdir, pgo=pgo)
         for operation in operations.OPERATIONS:
             report.render(operation, _run_worker(python, "core", operation, workdir, pyperf_args))
 
 
-def run(command: str, pyperf_args: tuple[str, ...] = ()) -> None:
+def run(command: str, pyperf_args: tuple[str, ...] = (), *, pgo: bool = False) -> None:
     """Dispatch a CLI command to the matching report, forwarding any extra pyperf options to every worker."""
     print(
         "tip: for low-noise results run `pyperf system tune` first (and `sudo pyperf system reset` after); pass "
@@ -153,14 +173,14 @@ def run(command: str, pyperf_args: tuple[str, ...] = ()) -> None:
         file=sys.stderr,
     )
     if command == "core":
-        report_core(pyperf_args)
+        report_core(pyperf_args, pgo=pgo)
     elif command == "all":
         for operation in operations.OPERATIONS:
-            report_operation(operation, pyperf_args)
+            report_operation(operation, pyperf_args, pgo=pgo)
     elif command in COMPETITORS:
-        report_package(command, pyperf_args)
+        report_package(command, pyperf_args, pgo=pgo)
     elif command in operations.OPERATIONS:
-        report_operation(command, pyperf_args)
+        report_operation(command, pyperf_args, pgo=pgo)
     else:
         choices = ", ".join(["core", "all", *operations.OPERATIONS, *COMPETITORS])
         msg = f"unknown command {command!r}; choose one of: {choices}"


### PR DESCRIPTION
The local bench harness builds the turbohtml `core` baseline as a plain `meson-python` wheel. Release wheels ship a profile-guided, link-time-optimized binary built by `tools/pgo_build.py`, so every `core`, `all`, operation, and package report measured the baseline below what a release runs, and a competitor's numbers read closer to turbohtml's than they are against the shipped build.

`python -m bench --pgo <command>` now builds the `core` baseline venv through `pgo_build.build` instead: the two-phase instrument-train-use build carrying `-Db_pgo` and `-Db_lto` over the training corpus, the same recipe cibuildwheel uses for the release wheels. The flag is parsed before the command, alongside `--table-json`, so pyperf never receives it. Only the `core` baseline venv changes; each competitor still installs its own package in its own isolated venv. The default stays the plain wheel, which builds far faster and keeps day-to-day iteration quick.

part of #478
