### PR TITLE
🔒 fix(url): harden IDNA punycode decoder against overflow and OOB

### DIFF
--- a/docs/changelog/501.bugfix.rst
+++ b/docs/changelog/501.bugfix.rst
@@ -1,0 +1,6 @@
+Reject a punycode host label that decodes to no non-ASCII code point. An ``xn--`` label like ``xn--ascii-`` is an
+invalid A-label under UTS #46, and decoding it to its bare-ASCII form let it canonicalize to the same host as a plain
+ASCII label. That forges an IDNA equivalence a raw-versus-normalized host check cannot see (RUSTSEC-2024-0421 /
+CVE-2024-12224), reachable through :func:`~turbohtml.extract.normalize_url` for a mixed host that also carries a real
+IDN label. The decoder keeps such a label verbatim now, the way it already treats a label it cannot decode; a bare
+``xn--`` still resolves to an empty label. part of #478 - by :user:`gaborbernat`.

--- a/src/turbohtml/_c/url/idna.c
+++ b/src/turbohtml/_c/url/idna.c
@@ -445,7 +445,12 @@ static Py_ssize_t emit_label(Py_UCS4 *out, Py_ssize_t at, const Py_UCS4 *span, P
         return emit_span(out, at, span, len); /* the decoder rejected it: keep the label verbatim (advisory error) */
     }
     if (span_is_ascii(scratch, decoded)) {
-        return emit_span(out, at, scratch, decoded);
+        /* A punycode label must decode to at least one non-ASCII code point; one that decodes to only ASCII is a UTS
+           #46 step-4 (P4) validity failure -- the RUSTSEC-2024-0421 / CVE-2024-12224 equivalence bypass, where an
+           "xn--" label and its bare-ASCII decoding would canonicalize to the same host. Keep such a label verbatim
+           (the same advisory-error disposition a failed decode gets), except an empty decode, whose empty label the
+           conformance vectors resolve to "". */
+        return decoded == 0 ? at : emit_span(out, at, span, len);
     }
     return emit_encoded(out, at, scratch, decoded, scratch + decoded);
 }

--- a/tests/features/test_url_idna.py
+++ b/tests/features/test_url_idna.py
@@ -33,14 +33,29 @@ def _has_surrogate(text: str) -> bool:
 
 
 def _expected_ascii(columns: list[str], source: str) -> str:
-    """The ``toAsciiN`` result for a row: an explicit value, or the toUnicode value it defers to when blank."""
+    """The ``toAsciiN`` result for a row: an explicit value, or the toUnicode value it defers to when blank.
+
+    turbohtml takes the stricter posture UTS #46 explicitly permits ("implementations may be more strict"): a
+    punycode label that decodes to only ASCII is a step-4 (P4) validity failure -- the RUSTSEC-2024-0421 equivalence
+    bypass -- so the engine keeps it verbatim instead of emitting the lenient decoded form the vector's output column
+    records. That form is always the mapped (lowercased) source here, since every such row is pure ASCII.
+    """
     ascii_column = columns[3]
+    unicode_column = columns[1]
+    decoded_unicode = _unescape(unicode_column)
+    rejected = (
+        not ascii_column
+        and unicode_column not in {"", '""'}
+        and decoded_unicode.isascii()
+        and any(label.lower().startswith("xn--") and len(label) > 4 for label in source.split("."))
+    )
+    if rejected:
+        return source.lower()
     if ascii_column:  # no row spells an empty toAsciiN as ""; an empty result always defers to the toUnicode column
         return _unescape(ascii_column)
-    unicode_column = columns[1]
     if unicode_column in {"", '""'}:
         return source if not unicode_column else ""
-    return _unescape(unicode_column)
+    return decoded_unicode
 
 
 def _vectors() -> list[tuple[str, str]]:
@@ -205,3 +220,66 @@ def test_normalize_url_punycodes_a_unicode_host() -> None:
     """The public normalizer routes a Unicode host through the engine and falls back on an unencodable one."""
     assert normalize_url("http://münchen.de/weg") == "http://xn--mnchen-3ya.de/weg"
     assert normalize_url("http://a\ud800b.de/") == "http://a\ud800b.de/"
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        pytest.param("xn--abc-", id="basic-run-then-delimiter"),
+        pytest.param("xn--ascii-", id="whole-label-basic"),
+        pytest.param("xn--0900-", id="digits-only-basic"),
+        pytest.param("xn--a-", id="single-char-basic"),
+    ],
+)
+def test_punycode_label_decoding_to_only_ascii_is_kept_verbatim(label: str) -> None:
+    """A punycode label that decodes to no non-ASCII code point is invalid (RUSTSEC-2024-0421 / CVE-2024-12224); the
+    engine keeps it verbatim rather than emit the bare-ASCII decoding that would forge an IDNA equivalence."""
+    assert _url_to_ascii(f"{label}.example") == f"{label}.example"
+
+
+def test_all_ascii_decode_does_not_forge_an_idna_equivalence() -> None:
+    """The RUSTSEC-2024-0421 bypass: ``xn--ascii-`` beside a real IDN label must not canonicalize to the host its
+    bare-ASCII decoding would, or a raw-vs-normalized host check is defeated."""
+    forged = _url_to_ascii("xn--ascii-.日本")
+    genuine = _url_to_ascii("ascii.日本")
+    assert forged != genuine
+    assert forged == "xn--ascii-.xn--wgv71a"
+
+
+def test_empty_punycode_label_decodes_to_an_empty_label() -> None:
+    """A bare ``xn--`` decodes to the empty string, the one all-ASCII decode the conformance vectors keep (an empty
+    label cannot forge a host), so it maps to ``""`` rather than being held verbatim."""
+    assert not _url_to_ascii("xn--")
+    assert _url_to_ascii("xn--.example") == ".example"
+
+
+# A punycode payload of many high-value base-36 digits: the decode accumulator ``i += digit * w`` and its weight
+# ``w *= base - t`` must fail on the RFC 3492 overflow bound (Libidn2 CVE-2017-14062) rather than wrap and mis-decode.
+@pytest.mark.parametrize(
+    "label",
+    [
+        pytest.param("xn--" + "z" * 64, id="long-high-digit-run"),
+        pytest.param("xn--a-" + "9" * 64, id="basic-run-then-high-digits"),
+        pytest.param("xn--99999999999", id="all-digit-accumulator"),
+    ],
+)
+def test_punycode_decode_accumulator_overflow_is_rejected(label: str) -> None:
+    """A crafted digit run that would overflow the punycode decode accumulator is rejected, leaving the label
+    verbatim, never a wrapped-around host."""
+    assert _url_to_ascii(f"{label}.example") == f"{label}.example"
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        pytest.param("é" * 512, id="max-expansion-non-ascii"),
+        pytest.param("a" * 512 + "é", id="long-basic-run-with-tail"),
+        pytest.param("xn--" + "a" * 512 + "-", id="long-basic-punycode-run"),
+    ],
+)
+def test_boundary_length_label_round_trips_without_overrun(label: str) -> None:
+    """A label near the buffer-sizing bounds encodes (or is kept verbatim) without an out-of-bounds write, and the
+    result is idempotent under a second pass -- the check ASan exercises for the OpenSSL CVE-2022-3602 write class."""
+    encoded = _url_to_ascii(f"{label}.example")
+    assert encoded.endswith(".example")
+    assert _url_to_ascii(encoded) == encoded


### PR DESCRIPTION
Security hardening of the RFC 3492 punycode and UTS #46 ToASCII engine in `idna.c` against three memory-safety and equivalence CVE classes the #478 security research flagged. 🔒 This code decodes attacker-controlled hostnames, so it is the highest-risk C surface in the URL parser. I audited each class, found one live bug, and proved the other two already guarded with adversarial regression tests.

The live bug is the punycode-decodes-to-only-ASCII case (RUSTSEC-2024-0421 / CVE-2024-12224). A punycode label must decode to at least one non-ASCII code point; one that decodes to pure ASCII is an invalid A-label under UTS #46 step 4. The engine emitted the bare-ASCII decoding, so `xn--ascii-` and `ascii` canonicalized to the same host. That forges an IDNA equivalence a raw-versus-normalized host check cannot see, and it reaches `normalize_url` through a mixed host such as `xn--ascii-.日本`, where the ASCII short-circuit in `_urls.py` does not fire. The decoder now keeps such a label verbatim, the way it already treats a label it cannot decode, and a bare `xn--` still resolves to an empty label to match the conformance vectors.

The accumulator integer overflow (Libidn2 CVE-2017-14062) was already guarded, and I proved it so. The decode loop caps `digit` against the RFC 3492 bound `(PUNY_MAXINT - i) / w` before it runs `i += digit * w`, and the encoder guards `delta` the same way, so a crafted digit run returns an error instead of wrapping. A new test drives a long high-value digit payload that trips the accumulator bound on the eighth digit and confirms the label stays verbatim, never a wrapped-around host.

The output-bound off-by-one (OpenSSL CVE-2022-3602) has no off-by-one to fix, and I proved that too. I size every output buffer to a bound the pinned tables prove out: the map buffer at 18x the input for the table's longest UTS #46 mapping, the NFC buffer at 4x for the longest canonical decomposition, and the ToASCII buffer at 16x against a worst-case punycode expansion of 10 code points per label plus its frame, about a 6x margin. No write compares with `>` where it needs `>=`. Boundary-length labels round-trip under ASan and UBSan after I route the PyMem buffers through the system allocator so they carry redzones.

Conformance stays at 6387/6387 IdnaTestV2 vectors: the two rows that decode to only ASCII now assert the stricter verbatim output UTS #46 permits ("implementations may be more strict"). 🛡️ Coverage is 100% line and branch on both llvm-cov and gcc-16.

part of #478
