### PR TITLE
📝 docs(security): document single-pass sanitization

### DIFF
--- a/docs/changelog/506.bugfix.rst
+++ b/docs/changelog/506.bugfix.rst
@@ -1,0 +1,3 @@
+:attr:`~turbohtml.Doctype.system_id` and :attr:`~turbohtml.Doctype.public_id` now keep a quote embedded in a
+differently-quoted identifier, so ``<!DOCTYPE html SYSTEM 'taco"quote'>`` reads back as ``taco"quote`` instead of
+truncating at the inner quote. part of #478

--- a/docs/changelog/506.doc.rst
+++ b/docs/changelog/506.doc.rst
@@ -1,0 +1,3 @@
+Document that :func:`~turbohtml.clean.sanitize` runs a single parse pass like DOMPurify. Its output is inert, but
+reparsing it can yield a different, still-inert tree, so consumers must trust the first pass rather than reparse the
+sanitized string. part of #478

--- a/docs/how-to/sanitizing.rst
+++ b/docs/how-to/sanitizing.rst
@@ -22,3 +22,16 @@ non-overridable baseline drops scripting and ``javascript:`` URLs no matter what
 .. testoutput::
 
     <p>Hi <a>link</a></p>&lt;script&gt;evil()&lt;/script&gt;
+
+**************************************
+ Trust the first pass, do not reparse
+**************************************
+
+Sanitizing is a single parse pass, like DOMPurify. Its output is safe to insert into a DOM as it stands. Do not parse it
+again with a different engine or in a different context and then trust that second tree.
+
+HTML parsing is not a fixpoint: serialize a tree and reparse it, and you can get a different tree. In foreign content a
+``</p>`` or ``</br>`` end tag builds an HTML element *inside* the SVG/MathML root, while the matching start tag on a
+later parse breaks *out* of it; a raw carriage return in text also becomes a newline on reparse. ``sanitize`` resolves
+all of that in its one pass, so the string it returns is inert. Reparsing and reserializing that string can yield a
+different string that is still inert. The guarantee is inertness, not byte-stable output across a round trip.

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -1238,8 +1238,9 @@ static PyObject *reconstruct_doctype(module_state *state, PyObject *data) {
     if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    ((NodeObject *)node)->node->tag_flags =
-        (uint8_t)((has_public ? TH_DOCTYPE_HAS_PUBLIC : 0) | (has_system ? TH_DOCTYPE_HAS_SYSTEM : 0));
+    th_node *raw = ((NodeObject *)node)->node;
+    raw->attr_count = has_public ? PyUnicode_GET_LENGTH(public_id) : 0; /* public-id split point */
+    raw->tag_flags = (uint8_t)((has_public ? TH_DOCTYPE_HAS_PUBLIC : 0) | (has_system ? TH_DOCTYPE_HAS_SYSTEM : 0));
     return node;
 }
 

--- a/src/turbohtml/_c/dom/mutate.c
+++ b/src/turbohtml/_c/dom/mutate.c
@@ -380,8 +380,8 @@ static th_node *copy_node_at(th_tree *dest, th_tree *src, th_node *src_node, int
         node->text = owned;
         node->text_len = src_node->text_len;
     }
-    if (src_node->type == TH_NODE_PI) {
-        node->attr_count = src_node->attr_count; /* the packed target/data split point */
+    if (src_node->type == TH_NODE_PI || src_node->type == TH_NODE_DOCTYPE) {
+        node->attr_count = src_node->attr_count; /* PI target/data or doctype public-id split point */
     }
     if (src_node->type == TH_NODE_ELEMENT && src_node->attr_count > 0) {
         node->attrs = arena_alloc(dest, src_node->attr_count * (Py_ssize_t)sizeof(th_node_attr));

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -1716,6 +1716,7 @@ static enum th_drain drain_initial(th_tree *tree, th_token *tok, th_insert *dc) 
         th_node *node = node_new(tree, TH_NODE_DOCTYPE);
         if (node != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
             node->text = build_doctype_text(tree, tok, &node->text_len);
+            node->attr_count = tok->has_public_id ? tok->public_id.len : 0; /* public-id split point */
             node->tag_flags = (uint8_t)((tok->has_public_id ? TH_DOCTYPE_HAS_PUBLIC : 0) |
                                         (tok->has_system_id ? TH_DOCTYPE_HAS_SYSTEM : 0));
             node_append(tree->document, node);

--- a/src/turbohtml/_c/serialize/document.c
+++ b/src/turbohtml/_c/serialize/document.c
@@ -424,31 +424,29 @@ Py_UCS4 *th_node_data(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
     return out;
 }
 
-/* The doctype's public and system identifiers, parsed out of the stored
-   "name \"public\" \"system\"" text into slices of the node's own text. Returns 1
-   and sets all four out params when the doctype carries identifiers, 0 when it is
-   just a name. Either identifier may be present but empty (a SYSTEM doctype has no
-   public id, a PUBLIC doctype may omit the system id), and build_doctype_text
-   always writes both quoted strings together, so the closing quotes are
-   guaranteed and no bounds check is needed. */
+/* The doctype's public and system identifiers, sliced out of the stored
+   "name \"public\" \"system\"" text. Returns 1 and sets all four out params when
+   the doctype carries identifiers, 0 when it is just a name. Either identifier may
+   be present but empty (a SYSTEM doctype has no public id, a PUBLIC doctype may
+   omit the system id), and build_doctype_text always writes both quoted strings
+   together, so the closing quotes are guaranteed and no bounds check is needed.
+   node->attr_count records the public id's length so the split holds even when an
+   identifier embeds a quote. */
 int th_node_doctype_ids(th_node *node, const Py_UCS4 **public_id, Py_ssize_t *public_len, const Py_UCS4 **system_id,
                         Py_ssize_t *system_len) {
     Py_ssize_t name_len = doctype_name_len(node);
     if (name_len >= node->text_len) {
         return 0;
     }
+    /* attr_count holds the public id's length, so the two identifiers split
+       unambiguously even when either one embeds a quote (a scan for the closing
+       `"` would stop early on `SYSTEM 'taco"quote'`). */
     Py_ssize_t pos = name_len + 2; /* skip the space and the opening quote */
     *public_id = &node->text[pos];
-    while (node->text[pos] != '"') {
-        pos++;
-    }
-    *public_len = &node->text[pos] - *public_id;
-    pos += 3; /* skip the closing quote, the separating space, and the next opening quote */
+    *public_len = node->attr_count;
+    pos += node->attr_count + 3; /* skip the closing quote, the separating space, and the next opening quote */
     *system_id = &node->text[pos];
-    while (node->text[pos] != '"') {
-        pos++;
-    }
-    *system_len = &node->text[pos] - *system_id;
+    *system_len = node->text_len - pos - 1; /* drop the trailing closing quote */
     return 1;
 }
 

--- a/tests/dom/test_tree_copy.py
+++ b/tests/dom/test_tree_copy.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import Element, Text, parse
+from turbohtml import Doctype, Element, Text, parse
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,3 +39,15 @@ def test_copy_of_a_constructed_node() -> None:
     element = Element("p", {"class": ["a", "b"]})
     element.append(Text("hi"))
     assert copy.copy(element).html == '<p class="a b">hi</p>'
+
+
+@pytest.mark.parametrize(
+    "duplicate",
+    [pytest.param(copy.copy, id="shallow"), pytest.param(copy.deepcopy, id="deep")],
+)
+def test_copy_preserves_doctype_identifiers(duplicate: Callable[[Doctype], Doctype]) -> None:
+    # the clone must carry the public-id split point so an embedded quote survives (part of #478)
+    doctype = parse("<!DOCTYPE html PUBLIC 'pub\"lic' 'sys\"tem'>").children[0]
+    assert isinstance(doctype, Doctype)
+    clone = duplicate(doctype)
+    assert (clone.public_id, clone.system_id) == ('pub"lic', 'sys"tem')

--- a/tests/dom/test_tree_node_types.py
+++ b/tests/dom/test_tree_node_types.py
@@ -41,6 +41,18 @@ def _doctype(markup: str) -> Doctype:
             "",  # a system identifier given as "" is present but empty, distinct from missing
             id="public-and-empty-system",
         ),
+        pytest.param(
+            "<!DOCTYPE html SYSTEM 'taco\"quote'>",
+            None,
+            'taco"quote',  # a quote embedded in the single-quoted identifier survives (part of #478)
+            id="system-embedded-quote",
+        ),
+        pytest.param(
+            "<!DOCTYPE html PUBLIC 'pub\"lic' 'sys\"tem'>",
+            'pub"lic',
+            'sys"tem',  # both identifiers keep their embedded quotes
+            id="public-and-system-embedded-quotes",
+        ),
     ],
 )
 def test_doctype_identifiers(markup: str, public_id: str | None, system_id: str | None) -> None:

--- a/tests/dom/test_tree_pickle.py
+++ b/tests/dom/test_tree_pickle.py
@@ -91,6 +91,8 @@ def test_document_round_trips() -> None:
         pytest.param('<!DOCTYPE html PUBLIC "p">', "p", None, id="public-only-missing-system"),
         pytest.param('<!DOCTYPE html SYSTEM "s">', None, "s", id="system-only-missing-public"),
         pytest.param('<!DOCTYPE html PUBLIC "p" "">', "p", "", id="public-and-empty-system"),
+        # an embedded quote in a single-quoted identifier must survive the round-trip (part of #478)
+        pytest.param("<!DOCTYPE html PUBLIC 'pub\"lic' 'sys\"tem'>", 'pub"lic', 'sys"tem', id="embedded-quotes"),
     ],
 )
 def test_doctype_round_trips(markup: str, public_id: str | None, system_id: str | None) -> None:

--- a/tests/dom/test_treebuilder_differential.py
+++ b/tests/dom/test_treebuilder_differential.py
@@ -21,10 +21,10 @@ Two divergence classes are documented rather than silently skipped:
   lexbor and html5lib's own library); the pinned data does not. For these the public tree is
   asserted against turbohtml's spec-validated parse, which the conformance suite pins to the
   corrected tree. See issues #32, #63, #93.
-- One benign public-API bug: ``Doctype.system_id`` drops an embedded quote (``taco"`` -> ``taco``).
-  Doctypes are stripped by the sanitizer's C-enforced baseline and never enter a keep/drop or URL
-  decision, so this is a correctness nit with no security impact; it is asserted explicitly so a
-  fix flips the test.
+- A ``.dat`` text-format limit: the html5lib ``#document`` dump wraps doctype identifiers in unescaped
+  quotes, so it cannot represent a quote embedded in one (``taco"`` reads back as ``taco``). turbohtml
+  keeps the quote, matching html5lib-python and the WHATWG tokenizer, so the public tree is asserted
+  against turbohtml's conformance-validated parse. See issue #478.
 """
 
 from __future__ import annotations
@@ -149,20 +149,20 @@ _SPEC_LAG: frozenset[tuple[str, str, str | None]] = frozenset({
     ("tests_innerHTML_1.dat", "<keygen><option>", "select"),
 })
 
-# Benign, non-security: Doctype.system_id drops the embedded quote of `taco"`. Doctypes are stripped
-# by the sanitizer baseline, so this never affects a keep/drop or URL decision. Asserted so a fix flips.
-_KNOWN_PUBLIC_DIVERGENCE: dict[tuple[str, str, str | None], str] = {
-    ("doctype01.dat", "<!DOCTYPE potato SYSTEM 'taco\"'>Hello", None): (
-        '| <!DOCTYPE potato "" "taco">\n| <html>\n|   <head>\n|   <body>\n|     "Hello"'
-    ),
-}
+# The html5lib `#document` text format wraps each doctype identifier in unescaped quotes, so it cannot
+# represent a quote embedded in one: `taco"` serializes to a .dat that reads back as `taco`. turbohtml
+# keeps the embedded quote (matching html5lib-python and the WHATWG tokenizer), so the public tree is
+# checked against turbohtml's conformance-validated parse, not the lossy .dat text. See issue #478.
+_DAT_UNREPRESENTABLE: frozenset[tuple[str, str, str | None]] = frozenset({
+    ("doctype01.dat", "<!DOCTYPE potato SYSTEM 'taco\"'>Hello", None),
+})
 
 
 def _expected(filename: str, data: str, document: str, context: str | None) -> str:
     key = (filename, data, context)
-    if key in _SPEC_LAG:
+    if key in _SPEC_LAG or key in _DAT_UNREPRESENTABLE:
         return _internal_dump(data, context)
-    return _KNOWN_PUBLIC_DIVERGENCE.get(key, document)
+    return document
 
 
 @pytest.mark.parametrize("filename", sorted({name for name, _, _, _ in _CASES}))

--- a/tests/features/test_sanitizer_security.py
+++ b/tests/features/test_sanitizer_security.py
@@ -177,6 +177,28 @@ def test_scheme_allowlist_parity(url: str, kept: bool) -> None:  # noqa: FBT001
 @pytest.mark.parametrize(
     "payload",
     [
+        # foreign-content start/end asymmetry: </li> synthesizes a sibling on the second parse.
+        pytest.param("<li><math><mtext><li>", id="li-math-mtext-nesting"),
+        # a raw carriage return normalizes to a newline when the sanitized text is reparsed.
+        pytest.param("a&#xd;b", id="cr-normalization"),
+        pytest.param("<div>&#xd;</div>", id="cr-in-element"),
+    ],
+)
+def test_inert_even_when_not_string_idempotent(payload: str) -> None:
+    # These are benign inputs whose sanitized form is *not* byte-identical on a second pass
+    # (foreign-content nesting shifts, CR->LF normalization). Sanitization is single-pass, so the
+    # guarantee is inertness, not string idempotence: no executable construct survives either pass,
+    # even though sanitize(sanitize(x)) != sanitize(x). Consumers must trust the first pass, not reparse.
+    once = sanitize(payload)
+    twice = sanitize(once)
+    assert once != twice, "expected a non-idempotent case; move it to the round-trip corpus if it stabilizes"
+    assert _live_danger(once) == []
+    assert _live_danger(twice) == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
         pytest.param("<select><plaintext></select><img src=x onerror=alert(1)>", id="plaintext-in-select"),
         pytest.param("<plaintext><img src=x onerror=alert(1)>", id="bare-plaintext"),
     ],


### PR DESCRIPTION
A fuzzer flagged `parse("<svg></p>")`. Its serialized form `<svg><p></p></svg>` reparses to `<svg></svg><p></p>`, so it is not a serialize/reparse fixpoint, and the report raised it as possible namespace-confusion mXSS. 🔍 Checked against html5lib-python (the WHATWG reference implementation), lexbor, and the parsing algorithm, turbohtml already builds the browser-correct tree: the `<p>` sits inside the SVG root but in the HTML namespace, so no element is mis-namespaced. `<svg></br>`, `<math></p>`, and `<li><math><mtext><li>` match the reference the same way, and `tests/dom/test_foreign_end_tag_breakout.py` already pins that decision. The non-idempotence is inherent to HTML parsing: a `</p>` or `</br>` end tag in foreign content builds an HTML element inside the root, while the matching start tag on a later parse breaks out of it. That asymmetry is why sanitizers, turbohtml among them, run a single parse pass.

The parser stays as it is. The sanitizer how-to now states that `sanitize` runs a single pass like DOMPurify: its output is inert, but reparsing it can yield a different, still-inert tree, so consumers must trust the first pass. A companion check confirms that the benign non-idempotent inputs, `<li><math><mtext><li>` and an embedded carriage return, stay inert on both passes.

The investigation surfaced one real, non-security bug. 🐛 `Doctype.system_id` and `Doctype.public_id` dropped everything past a quote embedded in a differently-quoted identifier, so `<!DOCTYPE html SYSTEM 'taco"quote'>` read back as `taco`. A doctype packs its name and both identifiers into one string, and the accessors split them by scanning for the next quote, which stops early when an identifier contains one. Recording the public id's length on the node, reusing the doctype's spare `attr_count` field the way processing-instruction nodes carry their target/data split, makes the split exact across the parse, pickle, and deep-copy paths.

part of #478
