### PR TITLE
🔒 fix(clean): per-node namespace-reachability check (mXSS defense-in-depth)

### DIFF
--- a/docs/changelog/507.feature.rst
+++ b/docs/changelog/507.feature.rst
@@ -1,0 +1,5 @@
+The sanitizer now checks each kept element's namespace against its parent's and drops any node whose namespace the HTML
+parser could not have produced there. The check adds defense in depth against mutation-XSS namespace confusion, such as
+an HTML element reparented under SVG or MathML, or a foreign element that escapes into HTML content where its children
+reparse as HTML. Valid parsed markup passes through unchanged, because turbohtml's parser already gives every node the
+right namespace; the check guards a tree a later mutation could leave confused. Part of #478.

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -1061,6 +1061,68 @@ static int escape_element(sanitizer *s, th_node *element) {
     return 0;
 }
 
+/* A MathML text integration point (mi/mo/mn/ms/mtext), where the parser resumes HTML parsing so an HTML child there is
+   no confusion. The caller has already established the node is in the MathML namespace. */
+static int is_mathml_text_point(const th_node *node) {
+    static const uint16_t atoms[] = {TH_TAG_MI, TH_TAG_MO, TH_TAG_MN, TH_TAG_MS, TH_TAG_MTEXT};
+    for (size_t index = 0; index < sizeof(atoms) / sizeof(atoms[0]); index++) {
+        if (node->atom == atoms[index]) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* An HTML integration point: an SVG foreignObject/desc/title, or a MathML annotation-xml. annotation-xml counts by
+   name, the way DOMPurify does, not by its encoding attribute: sanitize_attributes runs on a parent before its
+   children are walked, so an encoding-based test would drop a legitimately parsed HTML child the moment a policy
+   strips the parent's encoding. The caller has already established the node is foreign, so a non-SVG parent is MathML.
+ */
+static int is_html_integration_point(const th_node *node) {
+    static const uint16_t svg_atoms[] = {TH_TAG_FOREIGNOBJECT, TH_TAG_DESC, TH_TAG_TITLE};
+    if (node->ns == TH_NS_SVG) {
+        for (size_t index = 0; index < sizeof(svg_atoms) / sizeof(svg_atoms[0]); index++) {
+            if (node->atom == svg_atoms[index]) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    return node->atom == TH_TAG_ANNOTATION_XML;
+}
+
+/* Is the element's namespace reachable from its parent's? The (element, namespace, parent) triples the HTML parser can
+   legitimately produce, per the WHATWG foreign-content and integration-point rules (DOMPurify's _checkValidNamespace
+   equivalent): enter SVG only through <svg>, MathML only through <math>, and return to HTML only through an integration
+   point. A tree the parser built always passes; only a namespace-confused node a later mutation could splice in -- an
+   HTML element reparented under SVG/MathML, or a foreign element escaped into HTML content where its children would
+   reparse as HTML -- fails, and is then dropped like any disallowed node (mXSS defense-in-depth). Returns 1 reachable,
+   0 confused. */
+static int namespace_reachable(const th_node *element) {
+    /* the walk only reaches an element through its parent, so element->parent is never NULL here; a fragment or
+       document root carries the HTML namespace, so reading parent->ns needs no element-type guard */
+    const th_node *parent = element->parent;
+    uint8_t parent_ns = parent->ns;
+    uint8_t ns = element->ns;
+    if (ns == parent_ns) {
+        return 1; /* within one namespace every element stays reachable (HTML<-HTML, SVG<-SVG, MathML<-MathML) */
+    }
+    if (ns == TH_NS_SVG) {
+        /* from HTML only <svg> enters SVG; from MathML only an <svg> under annotation-xml or a text point */
+        return element->atom == TH_TAG_SVG &&
+               (parent_ns == TH_NS_HTML || parent->atom == TH_TAG_ANNOTATION_XML || is_mathml_text_point(parent));
+    }
+    if (ns == TH_NS_MATHML) {
+        /* from HTML only <math> enters MathML; from SVG only a <math> under an HTML integration point */
+        return element->atom == TH_TAG_MATH && (parent_ns == TH_NS_HTML || is_html_integration_point(parent));
+    }
+    /* an HTML element under a foreign parent is reachable only at an integration point */
+    if (parent_ns == TH_NS_SVG) {
+        return is_html_integration_point(parent);
+    }
+    return is_mathml_text_point(parent) || is_html_integration_point(parent);
+}
+
 /* Keep, escape, strip, or remove one element according to the policy. parent_kept is
    1 when the element's parent is itself being kept; an allowlisted foreign (SVG/MathML)
    element is kept only then, so it never outlives its namespace context (e.g. an svg
@@ -1080,6 +1142,11 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
     int style_element = element->atom == TH_TAG_STYLE && is_html;
     int allowed = (is_unsafe_tag(element->atom) && !style_element) ? 0 : PySet_Contains(s->tags, tag);
     if (allowed > 0 && !is_html && !parent_kept) {
+        allowed = 0;
+    }
+    /* defense in depth: a node whose namespace is unreachable from its parent's is a namespace-confusion mutation, not
+       anything the parser produced, so drop it like any disallowed node even when the allowlist would admit its name */
+    if (allowed > 0 && !namespace_reachable(element)) {
         allowed = 0;
     }
     /* only disallowed elements consult remove_with_content, so a kept element never pays the set lookup */

--- a/tests/features/test_sanitizer_namespace.py
+++ b/tests/features/test_sanitizer_namespace.py
@@ -1,0 +1,127 @@
+"""The per-node namespace-reachability check: a namespace-confused node is dropped, valid foreign content is untouched.
+
+turbohtml parses once and its tree builder produces spec-correct namespacing, so no string a caller can pass carries a
+namespace-confused node. The check is defense in depth against a *mutated* tree: an element whose namespace is
+unreachable from its parent's -- an HTML element reparented under SVG/MathML, or a foreign element spliced into HTML
+content where its children would reparse as HTML -- is the mutation-XSS class DOMPurify's ``_checkValidNamespace``
+guards. These tests build such a node with the public mutation API (moving a real foreign node under a parent the
+parser would never give it) and drive the C sanitizer over it, then confirm the same element correctly nested survives,
+so the move -- not the policy -- is what triggers the drop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Element, parse_fragment
+from turbohtml._html import _sanitize
+from turbohtml.clean import OnDisallowed, Policy, sanitize
+
+# The set of tags the reachability check reasons over, allowed together so only the namespace relationship can drop one.
+_FOREIGN_TAGS = frozenset({"svg", "math", "foreignObject", "annotation-xml", "mtext", "circle", "p", "b", "i"})
+_FOREIGN_POLICY = Policy(tags=_FOREIGN_TAGS, attributes={"annotation-xml": frozenset({"encoding"})})
+
+
+def _find(root: Element, tag: str, namespace: str | None = None) -> Element:
+    """Return the first element named ``tag`` (optionally in ``namespace``) in document order."""
+    queue: list[Element] = list(getattr(root, "children", ()))
+    while queue:
+        node = queue.pop(0)
+        if isinstance(node, Element) and node.tag == tag and (namespace is None or node.namespace.value == namespace):
+            return node
+        queue[0:0] = list(getattr(node, "children", ()))
+    msg = f"no {tag!r} element found"
+    raise AssertionError(msg)
+
+
+def _sanitize_tree(root: Element, tags: frozenset[str]) -> str:
+    """Run the C sanitizer in place over a pre-built tree, removing every disallowed node's subtree."""
+    # named to keep the boolean positional arguments off the FBT003 lint, not to document them
+    allow_relative = strip_comments = True
+    empty: frozenset[str] = frozenset()
+    schemes = frozenset({"http", "https", "mailto"})
+    _sanitize(
+        root, tags, {}, schemes, allow_relative, OnDisallowed.REMOVE.value, strip_comments, None, None, {}, empty,
+        empty, empty, {}, empty,
+    )  # fmt: skip
+    return root.inner_html
+
+
+def test_find_helper_reports_a_missing_element() -> None:
+    """The navigation helper fails loudly rather than returning None when a case names a tag that is not present."""
+    with pytest.raises(AssertionError, match="no 'span' element"):
+        _find(parse_fragment("<div></div>"), "span")
+
+
+@pytest.mark.parametrize(
+    ("html", "policy"),
+    [
+        pytest.param("<svg>x</svg>", _FOREIGN_POLICY, id="svg-enters-from-html"),
+        pytest.param("<math>x</math>", _FOREIGN_POLICY, id="math-enters-from-html"),
+        pytest.param("<svg><circle></circle></svg>", _FOREIGN_POLICY, id="svg-child-of-svg"),
+        pytest.param("<svg><foreignObject><p>hi</p></foreignObject></svg>", _FOREIGN_POLICY, id="html-under-svg-point"),
+        pytest.param("<math><mtext><b>hi</b></mtext></math>", _FOREIGN_POLICY, id="html-under-mathml-text-point"),
+        pytest.param(
+            '<math><annotation-xml encoding="text/html"><b>hi</b></annotation-xml></math>',
+            _FOREIGN_POLICY,
+            id="html-under-annotation-xml",
+        ),
+        pytest.param(
+            '<math><annotation-xml encoding="application/xhtml+xml"><i>hi</i></annotation-xml></math>',
+            _FOREIGN_POLICY,
+            id="html-under-annotation-xml-xhtml",
+        ),
+        pytest.param("<svg><foreignObject><math>y</math></foreignObject></svg>", _FOREIGN_POLICY, id="math-under-svg"),
+        pytest.param("<math><mtext><svg>z</svg></mtext></math>", _FOREIGN_POLICY, id="svg-under-mathml-text-point"),
+        pytest.param(
+            "<math><annotation-xml><svg>z</svg></annotation-xml></math>", _FOREIGN_POLICY, id="svg-under-annotation-xml"
+        ),
+    ],
+)
+def test_namespace_reachable_foreign_content_untouched(html: str, policy: Policy) -> None:
+    """Every namespace transition the parser produces is reachable, so the check leaves valid foreign content as-is."""
+    assert sanitize(html, policy) == parse_fragment(html).inner_html
+
+
+# Each case parses valid markup, then moves a real foreign/HTML node under a parent the parser would never give it,
+# producing a namespace-confused node the reachability check must drop. move is (source, source-namespace, target):
+# source-namespace disambiguates a name that exists in more than one namespace. marker is the node's start tag, absent
+# once it is dropped and present while correctly nested.
+_CONFUSION_CASES = [
+    pytest.param(
+        "<div></div><svg><circle></circle></svg>", ("circle", "svg", "div"), {"div", "svg", "circle"}, "<circle",
+        id="svg-element-reparented-under-html",
+    ),
+    pytest.param(
+        "<math><mrow></mrow></math><svg></svg>", ("svg", "svg", "mrow"), {"math", "mrow", "svg"}, "<svg",
+        id="svg-under-non-integration-mathml",
+    ),
+    pytest.param(
+        "<div></div><math><mrow></mrow></math>", ("mrow", "math", "div"), {"div", "math", "mrow"}, "<mrow",
+        id="mathml-element-reparented-under-html",
+    ),
+    pytest.param(
+        "<math></math><svg><g></g></svg>", ("math", "math", "g"), {"math", "svg", "g"}, "<math",
+        id="math-under-non-integration-svg",
+    ),
+    pytest.param(
+        "<svg><g></g></svg><p></p>", ("p", "html", "g"), {"svg", "g", "p"}, "<p",
+        id="html-under-non-integration-svg",
+    ),
+    pytest.param(
+        "<math><mrow></mrow></math><p></p>", ("p", "html", "mrow"), {"math", "mrow", "p"}, "<p",
+        id="html-under-non-integration-mathml",
+    ),
+]  # fmt: skip
+
+
+@pytest.mark.parametrize(("html", "move", "tags", "marker"), _CONFUSION_CASES)
+def test_namespace_confusion_is_dropped(
+    html: str, move: tuple[str, str, str], tags: frozenset[str], marker: str
+) -> None:
+    """A node reparented into an unreachable namespace is dropped, while the same node correctly nested is kept."""
+    assert marker in _sanitize_tree(parse_fragment(html), tags)  # correctly nested: the policy keeps it
+    source, source_ns, target = move
+    root = parse_fragment(html)
+    _find(root, target).append(_find(root, source, source_ns))
+    assert marker not in _sanitize_tree(root, tags)  # confused by the move: the reachability check drops it


### PR DESCRIPTION
Mutation XSS turns an element that is inert in one namespace into an executable one once a browser reparses it in another, the class Cure53 formalized and the payloads that bypassed DOMPurify version after version. 🔒 turbohtml already closes this by parsing once and never reinserting, and the DOMPurify oracle in #502 found zero bypasses, so this adds the one explicit guard DOMPurify still ships on top of that architecture: a per-node namespace-reachability check.

For each element the sanitizer keeps, the check verifies its namespace against its parent's using the triples the HTML parser can produce, following the WHATWG foreign-content and integration-point rules (DOMPurify's `_checkValidNamespace` equivalent). A tree reaches SVG only through `<svg>`, MathML only through `<math>`, and HTML again only at an integration point (a MathML text point `mi`/`mo`/`mn`/`ms`/`mtext`, `annotation-xml`, or SVG `foreignObject`/`desc`/`title`). When a node's namespace is unreachable from its parent's, a mutation spliced it in, so the sanitizer drops it like any other disallowed node. `annotation-xml` counts as an integration point by name, the way DOMPurify does rather than by its `encoding` attribute, because the sanitizer scrubs a parent's attributes before it walks the children, so an encoding-based test would drop a valid parsed HTML child whenever a policy strips the parent's `encoding`.

turbohtml parses once and its tree builder gives every node the right namespace, confirmed by the #502 oracle and the #504 differential, so on parsed input the check rejects nothing: it guards a tree a later mutation or builder path could leave confused. The existing sanitizer suites and the DOMPurify oracle pass unchanged, the proof that valid input still sanitizes the same. No parser-producible namespace confusion turned up, so this is pure defense in depth.

part of #478
