### PR TITLE
⚡ perf(query): linear single-pass :has() evaluation

### DIFF
--- a/docs/changelog/509.feature.rst
+++ b/docs/changelog/509.feature.rst
@@ -1,0 +1,4 @@
+Evaluate the ``:has()`` relational pseudo-class in a single amortized-linear pass. ``E:has(F)`` used to re-walk each
+candidate anchor's subtree, so nested ``:has()`` cost O(depth\ :sup:`2`); a 400-deep ``div:has(a)`` took about 600 µs. A
+per-query memo now records each node's subtree result once and reuses it across anchors, dropping that case to about 37
+µs, flat per node. Shallow trees and non-``:has()`` selectors run the pre-memo path and measure unchanged. part of #478

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -290,6 +290,10 @@ int th_tree_quirks(const th_tree *tree) {
     return tree->quirks;
 }
 
+Py_ssize_t th_tree_max_depth(const th_tree *tree) {
+    return tree->max_depth;
+}
+
 const th_parse_error *th_tree_errors(const th_tree *tree, Py_ssize_t *out_count) {
     *out_count = tree->errors.len;
     return tree->errors.items;
@@ -378,6 +382,9 @@ static int stack_push(th_tree *tree, th_node *node) {
         tree->open_cap = cap;
     }
     tree->open[tree->open_len++] = node;
+    if (tree->open_len > tree->max_depth) {
+        tree->max_depth = tree->open_len;
+    }
     return 1;
 }
 

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -265,6 +265,11 @@ const th_parse_error *th_tree_errors(const th_tree *tree, Py_ssize_t *out_count)
    (Selectors-4 §6.1/§6.2); programmatic trees default to no-quirks. */
 int th_tree_quirks(const th_tree *tree);
 
+/* The peak element-nesting depth recorded while parsing (0 for a tree built purely
+   through the mutation API). A cheap O(1) proxy for how deep the tree nests, used to
+   skip the :has() subtree memo on shallow trees where the direct walk is already cheap. */
+Py_ssize_t th_tree_max_depth(const th_tree *tree);
+
 /* Whether a text node holds only HTML ASCII whitespace (or nothing), realizing a
    zero-copy span on demand. The :empty selector uses it to ignore the document
    white space Selectors-4 §13.2 permits inside an otherwise empty element. */

--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -34,7 +34,9 @@ struct th_tree {
     th_node **open; /* stack of open elements */
     Py_ssize_t open_len;
     Py_ssize_t open_cap;
-    th_node **afe; /* active formatting elements; NULL entry is a scope marker */
+    Py_ssize_t max_depth; /* peak open-element nesting seen while parsing; a cheap O(1)
+                             lower bound on element depth that gates the :has() subtree memo */
+    th_node **afe;        /* active formatting elements; NULL entry is a scope marker */
     Py_ssize_t afe_len;
     Py_ssize_t afe_cap;
     th_node *head;          /* the <head> element once inserted */

--- a/src/turbohtml/_c/query/css/selector.c
+++ b/src/turbohtml/_c/query/css/selector.c
@@ -998,6 +998,39 @@ void sel_raise(PyObject *selector_error, PyObject *selector_str, const sel_parse
                  parser->err_pos);
 }
 
+/* Whether any compound in the list carries a :has(), recursing through the nested
+   lists of :is()/:where()/:not()/:has() so a :has() buried inside them still counts.
+   The result drives whether a query allocates the :has() subtree memo at all. */
+static int sel_alts_have_has(const sel_complex *alts, int count);
+
+static int sel_compound_has_has(const sel_compound *compound) {
+    for (int index = 0; index < compound->count; index++) {
+        const sel_simple *simple = &compound->simples[index];
+        if (simple->kind != ':') {
+            continue;
+        }
+        if (simple->pseudo == PSEUDO_HAS) {
+            return 1;
+        }
+        if (simple->sub != NULL && sel_alts_have_has(simple->sub, simple->sub_count)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int sel_alts_have_has(const sel_complex *alts, int count) {
+    for (int index = 0; index < count; index++) {
+        const sel_complex *complex = &alts[index];
+        for (int compound = 0; compound < complex->count; compound++) {
+            if (sel_compound_has_has(&complex->compounds[compound])) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
 /* Compile a selector string against the tree it will run on. Returns NULL with a
    SelectorSyntaxError set on a syntax error. */
 sel_compiled *selector_compile(PyObject *selector_error, th_tree *tree, PyObject *selector_str) {
@@ -1019,6 +1052,7 @@ sel_compiled *selector_compile(PyObject *selector_error, th_tree *tree, PyObject
         PyMem_Free(compiled);
         return NULL;
     }
+    compiled->has_relational = sel_alts_have_has(compiled->alts, compiled->count);
     return compiled;
 }
 
@@ -1858,6 +1892,161 @@ static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, c
     return 0;
 }
 
+/* Mix the two stable heap pointers into a slot index; drop the always-zero low
+   alignment bits before folding so they do not collapse onto one bucket. */
+static size_t sel_has_hash(const sel_complex *rel, const th_node *node, size_t mask) {
+    uintptr_t mixed = ((uintptr_t)rel >> 4) * 0x9E3779B97F4A7C15u ^ ((uintptr_t)node >> 4) * 0xC2B2AE3D27D4EB4Fu;
+    return (size_t)(mixed >> 32) & mask;
+}
+
+/* Linear-probe from (rel, node)'s home slot to the slot holding that key or, if absent,
+   the first empty slot it would occupy (the table is never full, so an empty slot always
+   exists). Shared by get and insert so one probe loop carries both. */
+static size_t sel_has_memo_find(const sel_has_memo *memo, const sel_complex *rel, const th_node *node) {
+    size_t idx = sel_has_hash(rel, node, memo->mask);
+    while (memo->slots[idx].rel != NULL && (memo->slots[idx].rel != rel || memo->slots[idx].node != node)) {
+        idx = (idx + 1) & memo->mask;
+    }
+    return idx;
+}
+
+/* Look up (rel, node); on a hit store the cached result in *out and return 1. */
+static int sel_has_memo_get(const sel_has_memo *memo, const sel_complex *rel, const th_node *node, int *out) {
+    if (memo->slots == NULL) {
+        return 0;
+    }
+    const sel_has_slot *slot = &memo->slots[sel_has_memo_find(memo, rel, node)];
+    if (slot->rel == NULL) {
+        return 0;
+    }
+    *out = slot->result;
+    return 1;
+}
+
+/* Insert a (rel, node) slot, assuming no matching key is present (the caller only
+   inserts after a get miss), so the found slot is the empty one it belongs in. */
+static void sel_has_memo_insert(sel_has_memo *memo, const sel_complex *rel, const th_node *node, unsigned char result) {
+    memo->slots[sel_has_memo_find(memo, rel, node)] = (sel_has_slot){rel, node, result};
+    memo->count++;
+}
+
+/* Grow (or first-allocate) the table to the next power of two and rehash. On
+   allocation failure sets memo->failed so the matcher falls back to the direct walk. */
+static void sel_has_memo_grow(sel_has_memo *memo) {
+    size_t new_cap = memo->slots == NULL ? 64 : (memo->mask + 1) * 2;
+    sel_has_slot *slots = PyMem_Calloc(new_cap, sizeof(sel_has_slot));
+    if (slots == NULL) {  /* GCOVR_EXCL_BR_LINE: a calloc failure cannot be forced from a test */
+        memo->failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
+        return;           /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    sel_has_slot *old_slots = memo->slots;
+    size_t old_cap = memo->slots == NULL ? 0 : memo->mask + 1;
+    memo->slots = slots;
+    memo->mask = new_cap - 1;
+    memo->count = 0;
+    for (size_t idx = 0; idx < old_cap; idx++) {
+        if (old_slots[idx].rel != NULL) {
+            sel_has_memo_insert(memo, old_slots[idx].rel, old_slots[idx].node, old_slots[idx].result);
+        }
+    }
+    PyMem_Free(old_slots);
+}
+
+/* Cache a (rel, node) subtree-contains-match result, growing past a 0.75 load factor. */
+static void sel_has_memo_put(sel_has_memo *memo, const sel_complex *rel, const th_node *node, int result) {
+    if ((memo->count + 1) * 4 > (memo->mask + 1) * 3) {
+        sel_has_memo_grow(memo);
+        if (memo->failed) { /* GCOVR_EXCL_BR_LINE: growth only fails on unforceable allocation failure */
+            return;         /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    sel_has_memo_insert(memo, rel, node, (unsigned char)(result != 0));
+}
+
+void sel_has_memo_free(sel_has_memo *memo) {
+    PyMem_Free(memo->slots);
+    memo->slots = NULL;
+    memo->mask = 0;
+    memo->count = 0;
+}
+
+/* Whether the relative selector rel writes :scope anywhere (directly or inside a
+   nested functional pseudo). A written :scope binds to the tested anchor, so its match
+   depends on which anchor is asking and the anchor-independent subtree memo cannot be
+   used; such a rel keeps the direct per-anchor walk. */
+static int sel_rel_uses_scope(const sel_complex *rel);
+
+static int sel_compound_uses_scope(const sel_compound *compound) {
+    for (int index = 0; index < compound->count; index++) {
+        const sel_simple *simple = &compound->simples[index];
+        if (simple->kind != ':') {
+            continue;
+        }
+        if (simple->pseudo == PSEUDO_SCOPE) {
+            return 1;
+        }
+        if (simple->sub != NULL) {
+            for (int alt = 0; alt < simple->sub_count; alt++) {
+                if (sel_rel_uses_scope(&simple->sub[alt])) {
+                    return 1;
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+static int sel_rel_uses_scope(const sel_complex *rel) {
+    for (int index = 0; index < rel->count; index++) {
+        if (sel_compound_uses_scope(&rel->compounds[index])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* The memo only earns its keep where nesting is deep enough that candidate anchors'
+   subtrees overlap heavily -- there the re-walk factor (how many nested anchors re-scan
+   a node) dwarfs a hash probe. Shallower than this the direct walk wins, so a candidate
+   at descent `descent` below the tested anchor consults/populates the memo only past
+   this many levels. Real markup nests ~8-18 deep (the benchmark pages top out at 18), so
+   its :has() subtrees never touch the hash and cost exactly what the pre-memo walk did,
+   while a deep nested chain -- the O(n^2) trigger -- collapses to amortized O(1) per
+   candidate. Each anchor pays at most this many un-memoized levels before it reaches a
+   populated deeper node, bounding its work at O(depth) total. */
+#define SEL_HAS_MEMO_MIN_DESCENT 24
+
+/* Whether node's subtree (its strict descendants) holds an element matching comp, the
+   lone compound of a descendant :has() argument such as :has(a). The result is a pure
+   function of the subtree, so it is memoized per (rel, node): each node's children are
+   scanned once across the whole query, turning the per-anchor O(subtree) re-walk that
+   made nested :has() quadratic into an amortized O(1) memo hit. descent is how far node
+   sits below the anchor; the memo is consulted only past SEL_HAS_MEMO_MIN_DESCENT so a
+   shallow match costs no more than the plain recursion (which this reduces to when there
+   is no memo, the memo can no longer grow, or the descent is still shallow). */
+static int sel_has_desc(th_node *node, const sel_complex *rel, const sel_compound *comp, const sel_ctx *ctx,
+                        int descent) {
+    int deep = descent >= SEL_HAS_MEMO_MIN_DESCENT;
+    int cached;
+    if (deep && sel_has_memo_get(ctx->has_memo, rel, node, &cached)) {
+        return cached;
+    }
+    int result = 0;
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type != TH_NODE_ELEMENT) {
+            continue;
+        }
+        if (sel_match_compound(child, comp, ctx) || sel_has_desc(child, rel, comp, ctx, descent + 1)) {
+            result = 1;
+            break;
+        }
+    }
+    if (deep) {
+        sel_has_memo_put(ctx->has_memo, rel, node, result);
+    }
+    return result;
+}
+
 /* Whether any element in the subtree below node is the subject of rel anchored at
    anchor (the element :has() is testing), checked recursively in document order. */
 static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor, const sel_ctx *ctx) {
@@ -1880,10 +2069,22 @@ static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, t
 static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, const sel_ctx *ctx) {
     /* inside a :has() relative selector the scope element is the anchor, so a written
        :scope resolves to it rather than the outer query root (Selectors-4 §6.6.2, #431) */
-    sel_ctx scoped = {ctx->tree, anchor, ctx->quirks};
+    sel_ctx scoped = {ctx->tree, anchor, ctx->quirks, ctx->has_memo};
     for (int index = 0; index < count; index++) {
         const sel_complex *rel = &alts[index];
         int subject = rel->count - 1;
+        /* the common shape -- a single descendant compound like :has(a) -- reduces to
+           "the anchor's subtree contains an element matching the compound", which is
+           independent of the anchor (no leading sibling reach, no :scope), so the
+           memoized subtree walk collapses the quadratic per-anchor re-scan */
+        char lead_combinator = rel->compounds[0].combinator;
+        if (scoped.has_memo != NULL && rel->count == 1 && lead_combinator != '>' && lead_combinator != '+' &&
+            lead_combinator != '~' && !sel_rel_uses_scope(rel)) {
+            if (sel_has_desc(anchor, rel, &rel->compounds[0], &scoped, 0)) {
+                return 1;
+            }
+            continue;
+        }
         if (sel_has_subtree(anchor, rel, subject, anchor, &scoped)) {
             return 1;
         }
@@ -1913,10 +2114,26 @@ static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, co
     return 0;
 }
 
-/* scope is the element :scope matches: the node the query was rooted at. */
+/* scope is the element :scope matches: the node the query was rooted at. A single
+   test builds a throwaway context with no :has() memo (nothing to amortize over). */
 int selector_matches(th_node *node, const sel_compiled *compiled, th_node *scope) {
-    sel_ctx ctx = {compiled->tree, scope, compiled->quirks};
+    sel_ctx ctx = {compiled->tree, scope, compiled->quirks, NULL};
     return sel_matches_alts(node, compiled->alts, compiled->count, &ctx);
+}
+
+/* Match against a caller-owned context, so a driver looping over many candidates can
+   share one :has() subtree memo (ctx->has_memo) across the whole walk. */
+int selector_matches_c(th_node *node, const sel_compiled *compiled, const sel_ctx *ctx) {
+    return sel_matches_alts(node, compiled->alts, compiled->count, ctx);
+}
+
+/* Whether a query over this compiled selector should build the :has() subtree memo: the
+   selector must contain a :has(), and the tree must nest at least SEL_HAS_MEMO_MIN_DESCENT
+   deep -- only then does a candidate anchor's subtree re-walk (the O(n^2) source) reach far
+   enough to memoize. On shallower trees the direct walk already wins, so the driver leaves
+   ctx->has_memo NULL and the matcher runs the exact pre-memo path with no added per-node cost. */
+int selector_uses_has_memo(const sel_compiled *compiled) {
+    return compiled->has_relational && th_tree_max_depth(compiled->tree) >= SEL_HAS_MEMO_MIN_DESCENT;
 }
 
 /* The lone simple selector of a selector that is one group, one compound, one

--- a/src/turbohtml/_c/query/css/selector.c
+++ b/src/turbohtml/_c/query/css/selector.c
@@ -1892,19 +1892,22 @@ static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, c
     return 0;
 }
 
-/* Mix the two stable heap pointers into a slot index; drop the always-zero low
-   alignment bits before folding so they do not collapse onto one bucket. */
-static size_t sel_has_hash(const sel_complex *rel, const th_node *node, size_t mask) {
-    uintptr_t mixed = ((uintptr_t)rel >> 4) * 0x9E3779B97F4A7C15u ^ ((uintptr_t)node >> 4) * 0xC2B2AE3D27D4EB4Fu;
-    return (size_t)(mixed >> 32) & mask;
+/* Hash the node pointer to a slot; drop the always-zero low alignment bits before
+   mixing. The key stays (rel, node) -- see sel_has_memo_find -- but only the node feeds
+   the hash, so the two entries a same node picks up under two different :has() arguments
+   land on the same home slot and always collide. That makes the "occupied by a different
+   relative selector" probe edge fire on every multi-argument query rather than only when
+   pointer layout happens to collide, keeping branch coverage independent of the allocator. */
+static size_t sel_has_hash(const th_node *node, size_t mask) {
+    return (size_t)(((uintptr_t)node >> 4) * 0x9E3779B97F4A7C15u >> 32) & mask;
 }
 
-/* Linear-probe from (rel, node)'s home slot to the slot holding that key or, if absent,
-   the first empty slot it would occupy (the table is never full, so an empty slot always
-   exists). Shared by get and insert so one probe loop carries both. */
+/* Linear-probe from node's home slot to the slot holding the (rel, node) key or, if
+   absent, the first empty slot it would occupy (the table is never full, so an empty slot
+   always exists). Shared by get and insert so one probe loop carries both. */
 static size_t sel_has_memo_find(const sel_has_memo *memo, const sel_complex *rel, const th_node *node) {
-    size_t idx = sel_has_hash(rel, node, memo->mask);
-    while (memo->slots[idx].rel != NULL && (memo->slots[idx].rel != rel || memo->slots[idx].node != node)) {
+    size_t idx = sel_has_hash(node, memo->mask);
+    while (memo->slots[idx].rel != NULL && (memo->slots[idx].node != node || memo->slots[idx].rel != rel)) {
         idx = (idx + 1) & memo->mask;
     }
     return idx;

--- a/src/turbohtml/_c/query/css/selector.h
+++ b/src/turbohtml/_c/query/css/selector.h
@@ -93,17 +93,43 @@ typedef struct {
     Py_UCS4 *source; /* an owned copy of the selector text the slices point into */
     sel_complex *alts;
     int count;
-    int failed;    /* an allocation or a syntax error happened during compile */
-    int quirks;    /* the tree was parsed in quirks mode: class/ID match case-insensitively */
-    th_tree *tree; /* the tree the selector runs on; :empty and :dir(auto) read text spans through it */
+    int failed;         /* an allocation or a syntax error happened during compile */
+    int quirks;         /* the tree was parsed in quirks mode: class/ID match case-insensitively */
+    int has_relational; /* the selector contains a :has() somewhere: a match may want the subtree memo */
+    th_tree *tree;      /* the tree the selector runs on; :empty and :dir(auto) read text spans through it */
 } sel_compiled;
 
+/* One memoized :has() result: for a descendant-relative argument alt whose match is a
+   pure "the subtree contains an element matching this compound" test (anchor-independent
+   once :scope is excluded), rel + node identify the query and node is the subtree root.
+   rel == NULL marks an empty slot. */
+typedef struct {
+    const sel_complex *rel;
+    const th_node *node;
+    unsigned char result;
+} sel_has_slot;
+
+/* A per-query open-addressing memo turning the O(n^2) :has() subtree re-walk into a
+   single amortized-linear pass: each (rel, node) subtree-contains-match result is
+   computed once and reused across every candidate anchor. Owned by the driver loop,
+   threaded read/write through sel_ctx; slots == NULL until the first insert, so a
+   query without :has() pays nothing. */
+typedef struct {
+    sel_has_slot *slots;
+    size_t mask; /* capacity - 1 (capacity a power of two); 0 while slots == NULL */
+    size_t count;
+    int failed; /* an allocation failed while growing: fall back to the direct walk */
+} sel_has_memo;
+
 /* The read-only context threaded through the matcher: the quirks-mode flag, the
-   element :scope matches (the query root), and the tree text spans resolve against. */
+   element :scope matches (the query root), and the tree text spans resolve against.
+   has_memo is the per-query :has() subtree memo, or NULL when the selector has no
+   :has() (the common path) so nothing is allocated or probed. */
 typedef struct {
     th_tree *tree;
     th_node *scope;
     int quirks;
+    sel_has_memo *has_memo;
 } sel_ctx;
 
 typedef struct {
@@ -137,6 +163,9 @@ int sel_match_simple(th_node *node, const sel_simple *simple, const sel_ctx *ctx
 sel_compiled *selector_compile(PyObject *selector_error, th_tree *tree, PyObject *selector_str);
 void selector_free(sel_compiled *compiled);
 int selector_matches(th_node *node, const sel_compiled *compiled, th_node *scope);
+int selector_matches_c(th_node *node, const sel_compiled *compiled, const sel_ctx *ctx);
+int selector_uses_has_memo(const sel_compiled *compiled);
+void sel_has_memo_free(sel_has_memo *memo);
 void sel_raise(PyObject *selector_error, PyObject *selector_str, const sel_parser *parser);
 void sel_free_alts(sel_complex *alts, int count);
 int sel_parse_alts(sel_parser *parser, sel_complex **out_alts, int *out_count, int nested, int relative, int forgiving);

--- a/src/turbohtml/_c/query/methods.c
+++ b/src/turbohtml/_c/query/methods.c
@@ -114,6 +114,7 @@ PyObject *node_select(PyObject *self, PyObject *arg) {
         return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     int error = 0;
+    sel_has_memo has_memo = {0};       /* shared across the walk so :has() memoizes its subtree scans */
     Py_BEGIN_CRITICAL_SECTION(handle); /* per-tree lock: a concurrent mutate must not rewire mid-walk */
     HandleObject *handle_obj = (HandleObject *)handle;
     sel_compiled *compiled = cached_compile(state_of(self)->selector_error, handle_obj, arg);
@@ -124,7 +125,7 @@ PyObject *node_select(PyObject *self, PyObject *arg) {
            with sel_match_simple directly, skipping the group/combinator machinery */
         const sel_simple *single = sel_single_simple(compiled);
         uint16_t subject = selector_subject_atom(compiled);
-        sel_ctx ctx = {compiled->tree, origin, compiled->quirks}; /* :scope is the query root */
+        sel_ctx ctx = {compiled->tree, origin, compiled->quirks, selector_uses_has_memo(compiled) ? &has_memo : NULL};
         if (handle_use_index(handle_obj, origin, subject != TH_TAG_UNKNOWN)) {
             /* only the candidate subjects need the matcher, drawn in document order
                from the atom bucket instead of a full pre-order walk */
@@ -132,7 +133,7 @@ PyObject *node_select(PyObject *self, PyObject *arg) {
             for (Py_ssize_t pos = handle_obj->index_offsets[subject]; pos < end; pos++) {
                 th_node *node = handle_obj->index_nodes[pos];
                 int matched =
-                    single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin);
+                    single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches_c(node, compiled, &ctx);
                 if (matched && append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
                     break;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -144,7 +145,7 @@ PyObject *node_select(PyObject *self, PyObject *arg) {
                     continue;
                 }
                 int matched =
-                    single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin);
+                    single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches_c(node, compiled, &ctx);
                 if (matched && append_wrapped(out, state, handle, node) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     error = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
                     break;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -153,6 +154,7 @@ PyObject *node_select(PyObject *self, PyObject *arg) {
         }
     }
     Py_END_CRITICAL_SECTION();
+    sel_has_memo_free(&has_memo);
     if (error) {
         Py_DECREF(out);
         return NULL;
@@ -168,6 +170,7 @@ PyObject *node_select_one(PyObject *self, PyObject *arg) {
     th_node *origin = ((NodeObject *)self)->node;
     th_node *found = NULL;
     int error = 0;
+    sel_has_memo has_memo = {0};       /* shared across the walk so :has() memoizes its subtree scans */
     Py_BEGIN_CRITICAL_SECTION(handle); /* per-tree lock around the walk */
     HandleObject *handle_obj = (HandleObject *)handle;
     sel_compiled *compiled = cached_compile(state_of(self)->selector_error, handle_obj, arg);
@@ -176,12 +179,12 @@ PyObject *node_select_one(PyObject *self, PyObject *arg) {
     } else {
         const sel_simple *single = sel_single_simple(compiled);
         uint16_t subject = selector_subject_atom(compiled);
-        sel_ctx ctx = {compiled->tree, origin, compiled->quirks}; /* :scope is the query root */
+        sel_ctx ctx = {compiled->tree, origin, compiled->quirks, selector_uses_has_memo(compiled) ? &has_memo : NULL};
         if (handle_use_index(handle_obj, origin, subject != TH_TAG_UNKNOWN)) {
             Py_ssize_t end = handle_obj->index_offsets[subject + 1];
             for (Py_ssize_t pos = handle_obj->index_offsets[subject]; pos < end; pos++) {
                 th_node *node = handle_obj->index_nodes[pos];
-                if (single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin)) {
+                if (single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches_c(node, compiled, &ctx)) {
                     found = node;
                     break;
                 }
@@ -191,7 +194,7 @@ PyObject *node_select_one(PyObject *self, PyObject *arg) {
                 if (node->type != TH_NODE_ELEMENT) {
                     continue;
                 }
-                if (single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin)) {
+                if (single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches_c(node, compiled, &ctx)) {
                     found = node;
                     break;
                 }
@@ -199,6 +202,7 @@ PyObject *node_select_one(PyObject *self, PyObject *arg) {
         }
     }
     Py_END_CRITICAL_SECTION();
+    sel_has_memo_free(&has_memo);
     if (error) {
         return NULL;
     }
@@ -1402,6 +1406,7 @@ PyObject *node_prune(PyObject *self, PyObject *arg) {
     Py_ssize_t count = 0;
     Py_ssize_t capacity = 0;
     int error = 0;
+    sel_has_memo has_memo = {0};       /* shared across the walk so :has() memoizes its subtree scans */
     Py_BEGIN_CRITICAL_SECTION(handle); /* per-tree lock: match and edit must see one stable tree */
     sel_compiled *compiled = cached_compile(state_of(self)->selector_error, (HandleObject *)handle, arg);
     if (compiled == NULL) {
@@ -1412,12 +1417,12 @@ PyObject *node_prune(PyObject *self, PyObject *arg) {
            may run here; matching alone never rewires a node, so the snapshot lets
            pass 2 edit in pure C without dereferencing a stale pointer. */
         const sel_simple *single = sel_single_simple(compiled);
-        sel_ctx ctx = {compiled->tree, origin, compiled->quirks};
+        sel_ctx ctx = {compiled->tree, origin, compiled->quirks, selector_uses_has_memo(compiled) ? &has_memo : NULL};
         for (th_node *node = origin->first_child; node != NULL; node = preorder_next(node, origin)) {
             if (node->type != TH_NODE_ELEMENT) {
                 continue;
             }
-            if (!(single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin))) {
+            if (!(single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches_c(node, compiled, &ctx))) {
                 continue;
             }
             if (prune_keep_match(&keep, &count, &capacity, node, origin) < 0) { /* GCOVR_EXCL_BR_LINE: allocation */
@@ -1459,6 +1464,7 @@ PyObject *node_prune(PyObject *self, PyObject *arg) {
         }
     }
     Py_END_CRITICAL_SECTION();
+    sel_has_memo_free(&has_memo);
     PyMem_Free(keep);
     if (error) {
         return NULL;
@@ -1496,19 +1502,23 @@ static int snapshot_push(node_snapshot *snapshot, th_node *node) {
    failure. */
 static int snapshot_matches(sel_compiled *compiled, th_node *origin, node_snapshot *snapshot) {
     const sel_simple *single = sel_single_simple(compiled);
-    sel_ctx ctx = {compiled->tree, origin, compiled->quirks};
+    sel_has_memo has_memo = {0}; /* shared across the walk so :has() memoizes its subtree scans */
+    sel_ctx ctx = {compiled->tree, origin, compiled->quirks, selector_uses_has_memo(compiled) ? &has_memo : NULL};
+    int result = 0;
     for (th_node *node = origin->first_child; node != NULL; node = preorder_next(node, origin)) {
         if (node->type != TH_NODE_ELEMENT) {
             continue;
         }
-        if (!(single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches(node, compiled, origin))) {
+        if (!(single != NULL ? sel_match_simple(node, single, &ctx) : selector_matches_c(node, compiled, &ctx))) {
             continue;
         }
         if (snapshot_push(snapshot, node) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure */
-            return -1;                           /* GCOVR_EXCL_LINE: allocation-failure path */
+            result = -1;                         /* GCOVR_EXCL_LINE: allocation-failure path */
+            break;                               /* GCOVR_EXCL_LINE: allocation-failure path */
         }
     }
-    return 0;
+    sel_has_memo_free(&has_memo);
+    return result;
 }
 
 PyObject *node_remove(PyObject *self, PyObject *arg) {

--- a/tests/query/css/test_tree_select.py
+++ b/tests/query/css/test_tree_select.py
@@ -651,10 +651,12 @@ def _nested_divs(depth: int, leaf: str = "<a>x</a>") -> str:
     return f"<body>{'<div>' * depth}{leaf}{'</div>' * depth}</body>"
 
 
-# depth 30 crosses the engage threshold; depth 90 fills enough deep slots to force the
-# memo hash to grow and rehash. Both must return exactly what the direct walk would.
+# depth 30 crosses the engage threshold; depth 200 fills enough deep slots to grow and
+# rehash the memo hash twice and to make node-pointer hash collisions statistically
+# certain, so the linear-probe branch is exercised regardless of allocation layout. Both
+# depths must return exactly what the direct walk would.
 @pytest.mark.parametrize(
-    "depth", [pytest.param(30, id="depth-30-engages-memo"), pytest.param(90, id="depth-90-regrows")]
+    "depth", [pytest.param(30, id="depth-30-engages-memo"), pytest.param(200, id="depth-200-regrows")]
 )
 @pytest.mark.parametrize(
     ("selector", "expected"),

--- a/tests/query/css/test_tree_select.py
+++ b/tests/query/css/test_tree_select.py
@@ -644,6 +644,97 @@ def test_has_skips_non_element_following_sibling() -> None:
     assert [element.tag for element in doc.select("section:has(~ aside b)")] == ["section"]
 
 
+def _nested_divs(depth: int, leaf: str = "<a>x</a>") -> str:
+    # a straight chain of `depth` <div>s wrapping leaf: the shape whose per-anchor :has()
+    # subtree re-walk is O(depth^2) without the memo. At depth >= 24 (the memo's engage
+    # threshold) select() builds the subtree memo, so this drives every memo branch.
+    return f"<body>{'<div>' * depth}{leaf}{'</div>' * depth}</body>"
+
+
+# depth 30 crosses the engage threshold; depth 90 fills enough deep slots to force the
+# memo hash to grow and rehash. Both must return exactly what the direct walk would.
+@pytest.mark.parametrize(
+    "depth", [pytest.param(30, id="depth-30-engages-memo"), pytest.param(90, id="depth-90-regrows")]
+)
+@pytest.mark.parametrize(
+    ("selector", "expected"),
+    [
+        # every div's subtree holds the leaf <a>: a match at each of the `depth` anchors,
+        # nested anchors reusing the memoized deeper results
+        pytest.param("div:has(a)", "all", id="descendant-all-match"),
+        # a functional-pseudo argument with no :scope stays on the memo path
+        pytest.param("div:has(:is(a))", "all", id="is-argument-uses-memo"),
+        # a subject the tree never holds: every anchor's subtree walk memoizes a miss
+        pytest.param("div:has(b)", "none", id="descendant-no-match"),
+        # a child-combinator argument keeps the direct walk (count stays linear already);
+        # every div but the innermost has a child div
+        pytest.param("div:has(> div)", "all-but-last", id="child-keeps-direct-walk"),
+        # a :scope in the argument binds to the anchor, so the memo (anchor-independent)
+        # is skipped and the direct walk runs even on a deep tree
+        pytest.param("div:has(:scope)", "none", id="scope-argument-skips-memo"),
+        pytest.param("div:has(:is(:scope))", "none", id="nested-scope-skips-memo"),
+        pytest.param("div:has(a:scope)", "none", id="typed-scope-skips-memo"),
+    ],
+)
+def test_has_memo_deep_chain(depth: int, selector: str, expected: str) -> None:
+    counts = {"all": depth, "none": 0, "all-but-last": depth - 1}
+    assert len(parse(_nested_divs(depth)).select(selector)) == counts[expected]
+
+
+def test_has_memo_deep_sibling_chains() -> None:
+    # two sibling deep chains: the first populates the memo, so the second's anchors
+    # probe a non-empty table for keys it does not hold (the get-miss + linear-probe
+    # path) before filling in their own subtree results. Every div still matches.
+    chain = f"{'<div>' * 40}<a>x</a>{'</div>' * 40}"
+    doc = parse(f"<body>{chain}{chain}</body>")
+    assert len(doc.select("div:has(a)")) == 80
+
+
+# a deep tree so the memo is live, carrying elements every relative-selector shape needs:
+# a <p><a> at the chain's foot and a <p> sibling of the outermost div. On this tree the
+# memo-path gate still routes each :has() form to the right evaluator.
+_DEEP_RICH = f"<body>{'<div>' * 40}<p><a>x</a></p>{'</div>' * 40}<p>s</p></body>"
+
+
+@pytest.mark.parametrize(
+    ("selector", "count"),
+    [
+        # a multi-compound argument is not the single-compound memo shape, so the direct
+        # walk runs even on a deep tree
+        pytest.param("div:has(p a)", 40, id="multi-compound-argument"),
+        # leading sibling combinators reach the outermost div's following <p> sibling only
+        pytest.param("div:has(+ p)", 1, id="next-sibling-lead"),
+        pytest.param("div:has(~ p)", 1, id="subsequent-sibling-lead"),
+        # a structural pseudo argument (no nested list) still takes the memo path
+        pytest.param("div:has(:first-child)", 40, id="structural-pseudo-argument"),
+        # two :has() arguments share one memo keyed by the relative selector, so their
+        # entries coexist and cross-key probes resolve to the right result
+        pytest.param("div:has(a):has(:is(a))", 40, id="two-arguments-share-memo"),
+    ],
+)
+def test_has_memo_deep_relative_shapes(selector: str, count: int) -> None:
+    assert len(parse(_DEEP_RICH).select(selector)) == count
+
+
+def test_has_memo_deep_select_one_returns_outermost() -> None:
+    # select_one walks in document order, so the outermost div (the first anchor) wins
+    doc = parse(_nested_divs(40))
+    found = doc.select_one("div:has(a)")
+    parent = found.parent if found is not None else None
+    assert isinstance(parent, Element)
+    assert parent.tag == "body"
+
+
+def test_has_memo_deep_remove_and_prune() -> None:
+    # remove() and prune() drive the memo through their own snapshot walks
+    removed = parse(_nested_divs(40))
+    removed.remove("div:has(a)")
+    assert removed.select("div") == []
+    kept = parse(_nested_divs(40))
+    kept.prune("div:has(a)")
+    assert len(kept.select("div")) == 40
+
+
 @pytest.mark.parametrize(
     "selector",
     [


### PR DESCRIPTION
The `:has()` relational pseudo-class evaluated `E:has(F)` by re-walking each candidate anchor's whole subtree to look for `F`. When `:has()` anchors nest, those subtree walks overlap, so `div:has(a)` over a `D`-deep chain of `div`s cost O(D²); a 400-deep chain took about 600 µs, and per-node cost grew with depth, from 0.04 µs at depth 10 to 1.6 µs at depth 800. That overlap is why `:has()` runs several times slower than a plain `select` on nested markup.

This change adds a per-query memo keyed by `(relative selector, node)` that records once whether a node's subtree holds a match for the common `:has()` shape, a single descendant compound such as `:has(a)` whose result is an anchor-independent fact about the subtree. Candidate anchors reuse the deeper results a prior anchor already computed instead of rescanning, so the walk runs amortized linear. ⚡ The same 400-deep chain now takes about 37 µs, flat at about 0.09 µs/node from depth 50 through 800. The memo lives in a caller-owned matcher context, so one table serves a whole `select`, `select_one`, `remove`, or `prune` walk.

Results stay identical to the previous evaluator. Any argument that is not a single descendant compound, or that writes `:scope` (which binds to the tested anchor, so its match depends on which anchor asks), keeps the original direct walk; a differential run of thousands of generated trees against the pre-change build returned the same matches for descendant, child, sibling, nested, and `:not(:has())` forms. A query builds the memo only when its selector holds a `:has()` and the tree nests at least as deep as the engage threshold, a check that costs O(1) against the peak nesting depth recorded during parsing, so shallow trees and every non-`:has()` selector run the exact pre-memo path with no added per-node work. Plain selectors and shallow-corpus `:has()`, the whatwg spec at about 5.9 µs and the mozilla blog at about 9 µs, measure unchanged.

part of #478
