### PR TITLE
🔒 build(data): SHA-256 provenance for the IDNA table generator

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -82,13 +82,16 @@ and give us reasonable time to remediate before you disclose publicly.
 ## Supply-chain provenance of generated tables
 
 Some `_c/data/` tables are generated from a pinned upstream source rather than written by hand. `tools/generate_tlds.py`
-fetches the IANA top-level-domain list from `data.iana.org`, and `tools/generate_psl.py` fetches the Public Suffix List
-from GitHub. A poisoned or silently changed upstream table is a vulnerability that no review of the `.c` sources would
-catch, the class the xz-utils backdoor (CVE-2024-3094) exploited by hiding in a generated build artifact.
+fetches the IANA top-level-domain list from `data.iana.org`, `tools/generate_psl.py` fetches the Public Suffix List from
+GitHub, and `tools/generate_idna.py` fetches the UTS #46 mapping table and the Unicode Character Database files its NFC
+step needs from `unicode.org`. A poisoned or silently changed upstream table is a vulnerability that no review of the
+`.c` sources would catch, the class the xz-utils backdoor (CVE-2024-3094) exploited by hiding in a generated build
+artifact.
 
 To make a regeneration verifiable, each generator pins the SHA-256 of the exact upstream bytes the committed table was
 built from, on top of the version or commit it already names: `generate_tlds.py` pins `IANA_VERSION` and `IANA_SHA256`,
-`generate_psl.py` pins `PSL_COMMIT` and `PSL_SHA256`. A rebuild recomputes the digest of the download and aborts when it
-does not match the pin, so a changed or poisoned source cannot land silently. A real upstream bump is deliberate: a
+`generate_psl.py` pins `PSL_COMMIT` and `PSL_SHA256`, and `generate_idna.py` pins `UNICODE_VERSION` and a SHA-256 for
+each of the three files it downloads. A rebuild recomputes the digest of the download and aborts when it does not match
+the pin, so a changed or poisoned source cannot land silently. A real upstream bump is deliberate: a
 maintainer reviews the new source, updates the version-or-commit pin and its checksum together, and regenerates, so both
 the changed pin and the table diff show up in code review.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -92,6 +92,6 @@ To make a regeneration verifiable, each generator pins the SHA-256 of the exact 
 built from, on top of the version or commit it already names: `generate_tlds.py` pins `IANA_VERSION` and `IANA_SHA256`,
 `generate_psl.py` pins `PSL_COMMIT` and `PSL_SHA256`, and `generate_idna.py` pins `UNICODE_VERSION` and a SHA-256 for
 each of the three files it downloads. A rebuild recomputes the digest of the download and aborts when it does not match
-the pin, so a changed or poisoned source cannot land silently. A real upstream bump is deliberate: a
-maintainer reviews the new source, updates the version-or-commit pin and its checksum together, and regenerates, so both
-the changed pin and the table diff show up in code review.
+the pin, so a changed or poisoned source cannot land silently. A real upstream bump is deliberate: a maintainer reviews
+the new source, updates the version-or-commit pin and its checksum together, and regenerates, so both the changed pin
+and the table diff show up in code review.

--- a/docs/changelog/510.doc.rst
+++ b/docs/changelog/510.doc.rst
@@ -1,0 +1,3 @@
+``tools/generate_idna.py`` pins the SHA-256 of each Unicode source file it downloads, so regenerating the IDNA/NFC table
+aborts on a poisoned or silently changed upstream, the same provenance guard the TLD and Public Suffix List generators
+carry - part of #478.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -219,13 +219,14 @@ shared header, so each unit inlines its own copy; the serialize and tree-builder
 the same way.
 
 **Generated tables have one owner.** The ``data/`` headers come from ``tools/generate_*.py``; edit the generator, not
-the output, and they stay out of formatting and clang-tidy. The two network-sourced tables carry a pin so a rebuild
-stays deterministic and auditable, and each pin has a SHA-256 companion so a poisoned or silently rewritten source
-cannot slip a bad table past a ``.c`` review, the class the xz-utils backdoor used. ``generate_psl.py`` fetches the
-Public Suffix List at the ``PSL_COMMIT`` it names rather than off ``main`` and checks the file against ``PSL_SHA256``;
+the output, and they stay out of formatting and clang-tidy. The network-sourced tables carry a pin so a rebuild stays
+deterministic and auditable, and each pin has a SHA-256 companion so a poisoned or silently rewritten source cannot slip
+a bad table past a ``.c`` review, the class the xz-utils backdoor used. ``generate_psl.py`` fetches the Public Suffix
+List at the ``PSL_COMMIT`` it names rather than off ``main`` and checks the file against ``PSL_SHA256``;
 ``generate_tlds.py`` refuses to regenerate unless IANA still serves the ``IANA_VERSION`` it expects and the download
-matches ``IANA_SHA256``. Bump the version or commit and its checksum together, review the table diff, and let the header
-banner record the exact commit or version. The `security policy
+matches ``IANA_SHA256``; ``generate_idna.py`` pins ``UNICODE_VERSION`` and a SHA-256 for each UTS #46 and Unicode
+Character Database file it downloads. Bump the version or commit and its checksum together, review the table diff, and
+let the header banner record the exact commit or version. The `security policy
 <https://github.com/tox-dev/turbohtml/blob/main/.github/SECURITY.md>`_ places this in the wider threat model.
 
 **Coverage gates on two toolchains.** Both the gcc (Linux) and llvm-cov (macOS, Windows) gates require full line and

--- a/tools/generate_idna.py
+++ b/tools/generate_idna.py
@@ -11,7 +11,9 @@ downloads them at the pinned version and writes one generated header the ``idna.
 The mapping status is collapsed to the three outcomes the mechanical ToASCII output depends on -- keep, map, ignore --
 because ``valid``, ``deviation`` (non-transitional keeps the code point), and ``disallowed`` all leave the code point in
 place: the validity of a disallowed code point is an advisory error the best-effort host cleaner records by producing
-the punycode of the label anyway, exactly as the UTS #46 test vectors' toASCII column does. The pinned mapping file is
+the punycode of the label anyway, exactly as the UTS #46 test vectors' toASCII column does. Each fetched file is also
+pinned to the SHA-256 of its exact bytes, so a rebuild refuses a silently rewritten or poisoned mirror the version
+pin alone would not catch. The pinned mapping file is
 the "Compatible Preprocessing" variant, whose ``valid`` rows already fold in ``UseSTD3ASCIIRules=false`` (ASCII symbols
 such as ``_`` are ``valid`` rather than ``disallowed_STD3_valid``), so no STD3 toggle is needed at run time.
 
@@ -25,6 +27,7 @@ Usage:  python tools/generate_idna.py src/turbohtml/_c/data/idna_table.h
 
 from __future__ import annotations
 
+import hashlib
 import sys
 import unicodedata
 import urllib.request
@@ -41,6 +44,15 @@ UNICODE_VERSION = "16.0.0"
 _IDNA_BASE = f"https://www.unicode.org/Public/idna/{UNICODE_VERSION}"
 _UCD_BASE = f"https://www.unicode.org/Public/{UNICODE_VERSION}/ucd"
 
+# Pin the SHA-256 of the exact bytes of each fetched file, not just the version: a version pin fixes which release the
+# rebuild targets, but a poisoned or silently rewritten mirror could still serve altered content under that version's
+# stable URL, and no review of idna.c would catch a bad table. A rebuild recomputes each digest and aborts on a
+# mismatch. Bump a digest deliberately alongside UNICODE_VERSION and review the idna_table.h diff. All match the
+# committed table at Unicode 16.0.0.
+_IDNA_MAPPING_SHA256 = "6db2ef4ed35f3b3de74ebc2e00404a9607f76d499f576b8d4043cf14f1ed175c"
+_UNICODE_DATA_SHA256 = "ff58e5823bd095166564a006e47d111130813dcf8bf234ef79fa51a870edb48f"
+_DERIVED_NORM_SHA256 = "4d4c03892dea9146d674b686e495df2d55a28d071ac474041d73518f887abddc"
+
 _KEEP = 0
 _MAPPED = 1
 _IGNORED = 2
@@ -52,10 +64,14 @@ _HANGUL_TCOUNT = 28
 _HANGUL_SCOUNT = _HANGUL_LCOUNT * _HANGUL_VCOUNT * _HANGUL_TCOUNT
 
 
-def _fetch(url: str) -> str:
-    """Return the decoded body of a pinned Unicode data file."""
+def _fetch(url: str, expected_sha256: str) -> str:
+    """Return the decoded body of a pinned Unicode data file, aborting if its SHA-256 is not *expected_sha256*."""
     with urllib.request.urlopen(url) as response:  # noqa: S310 -- url is always a pinned https unicode.org constant
-        return response.read().decode("utf-8")
+        raw = response.read()
+    if (digest := hashlib.sha256(raw).hexdigest()) != expected_sha256:
+        msg = f"Unicode source {url} has sha256 {digest}, not the pinned {expected_sha256}; review, then bump the pin"
+        raise SystemExit(msg)
+    return raw.decode("utf-8")
 
 
 def _mapping_ranges(text: str) -> tuple[list[tuple[int, int, int, int, int]], list[int]]:
@@ -314,10 +330,12 @@ def _wrap(items: Iterable[str]) -> str:
 
 def generate(out_path: Path) -> None:
     """Write the generated IDNA/NFC C header to *out_path*."""
-    ranges, pool = _mapping_ranges(_fetch(f"{_IDNA_BASE}/IdnaMappingTable.txt"))
-    combining, raw_decomposition = _combining_and_decomposition(_fetch(f"{_UCD_BASE}/UnicodeData.txt"))
+    ranges, pool = _mapping_ranges(_fetch(f"{_IDNA_BASE}/IdnaMappingTable.txt", _IDNA_MAPPING_SHA256))
+    combining, raw_decomposition = _combining_and_decomposition(
+        _fetch(f"{_UCD_BASE}/UnicodeData.txt", _UNICODE_DATA_SHA256)
+    )
     full = _full_decomposition(raw_decomposition)
-    excluded = _composition_exclusions(_fetch(f"{_UCD_BASE}/DerivedNormalizationProps.txt"))
+    excluded = _composition_exclusions(_fetch(f"{_UCD_BASE}/DerivedNormalizationProps.txt", _DERIVED_NORM_SHA256))
     pairs = _composition_pairs(raw_decomposition, excluded)
     _self_check(combining, full, pairs)
     out_path.write_text(_emit(ranges, pool, combining, full, pairs), encoding="utf-8")


### PR DESCRIPTION
The IDNA/Unicode table generator downloads three files from `unicode.org` (the UTS #46 `IdnaMappingTable.txt` plus `UnicodeData.txt` and `DerivedNormalizationProps.txt` for its NFC step) but verified only the pinned `UNICODE_VERSION`, not the bytes served under it. 🔒 A mirror that swapped content under that stable version URL would land a bad table that no `idna.c` review would catch, the supply-chain gap PR #500 closed for the IANA and Public Suffix List tables.

This records a SHA-256 for each of the three downloads next to the version pin; `_fetch` recomputes the digest and aborts with a review-and-bump message on any mismatch, the same fail-loud guard as `IANA_SHA256` and `PSL_SHA256`. Regenerating with the pins in place produces a byte-identical `idna_table.h`, so only the provenance check is new. The security policy and the development docs' generated-tables note now list all three generators as carrying a checksum companion.

Part of #478.
