### PR TITLE
♻️ refactor(c): shared ascii.h and reconcile whitespace/case drift

### DIFF
--- a/docs/changelog/512.bugfix.rst
+++ b/docs/changelog/512.bugfix.rst
@@ -1,0 +1,6 @@
+:meth:`~turbohtml.Node.links`, :meth:`~turbohtml.Node.to_text`, :meth:`~turbohtml.Node.to_markdown`, and
+:meth:`~turbohtml.Node.main_text` now treat a carriage return as HTML whitespace. Four internal whitespace scanners had
+dropped U+000D on the assumption that input preprocessing folds every CR to LF, but a ``&#13;`` character reference
+decodes to a real carriage return after that step, so ``links()`` kept a stray CR on a trimmed URL and the text and
+markdown exporters left one uncollapsed. All four now share the full HTML ASCII-whitespace set, carriage return
+included. Part of #478.

--- a/src/turbohtml/_c/core/ascii.h
+++ b/src/turbohtml/_c/core/ascii.h
@@ -1,42 +1,50 @@
-/* Shared ASCII and compact-unicode-buffer primitives.
+/* ASCII code-point classification shared by every stage of the C core.
 
-   The tokenizer and the tree builder both classify ASCII bytes and read the
-   width-tagged th_buf storage; keeping these as static inline helpers in one
-   header means each translation unit still inlines them (no call, no linkage)
-   while there is a single definition to maintain. */
+   The tokenizer, tree builder, selector and XPath parsers, encoding sniffer,
+   link/date/sanitize scanners, and both standalone minifier engines each need to
+   ask the same handful of questions about a code point: is it an ASCII letter, a
+   digit, a hex digit, HTML whitespace; what is its ASCII-lowercase form. Kept as a
+   Python-free header (like core/vec.h) so a translation unit inlines each helper as
+   the comparison it replaces while there is one definition to audit, and so the
+   css/js engines compile it in their JM_STANDALONE builds with no CPython runtime.
 
-#ifndef TURBOHTML_ASCII_H
-#define TURBOHTML_ASCII_H
+   Every helper takes a uint32_t: a Py_UCS4, a byte, or a css_char widens to it, and
+   a signed char that carried a high bit widens to a large value that no ASCII range
+   accepts, so the classification stays correct without the caller masking first. */
 
-#include "tokenizer/statemachine.h" /* th_buf */
+#ifndef TURBOHTML_CORE_ASCII_H
+#define TURBOHTML_CORE_ASCII_H
 
-/* The storage width a code point needs; matches the PyUnicode kind values. */
-static inline int ucs_width(Py_UCS4 ch) {
-    return ch < 0x100 ? PyUnicode_1BYTE_KIND : ch < 0x10000 ? PyUnicode_2BYTE_KIND : PyUnicode_4BYTE_KIND;
-}
+#include <stdint.h>
 
-static inline Py_UCS4 buf_read(const th_buf *buf, Py_ssize_t index) {
-    return PyUnicode_READ(buf->kind, buf->data, index);
-}
-
-static inline void buf_write(th_buf *buf, Py_ssize_t index, Py_UCS4 ch) {
-    PyUnicode_WRITE(buf->kind, buf->data, index, ch);
-}
-
-static inline Py_UCS4 lower_ascii(Py_UCS4 ch) {
+/* ASCII-lowercase: fold A-Z, leave every other code point (including the Latin-1
+   and non-ASCII letters) untouched. This is the case fold the HTML, CSS, and URL
+   specs mean by "ASCII lowercase"; a caller that needs Latin-1 or Unicode folding
+   spells that out itself. */
+static inline uint32_t lower_ascii(uint32_t ch) {
     return (ch >= 'A' && ch <= 'Z') ? ch + 0x20 : ch;
 }
 
-static inline int is_ascii_alpha(Py_UCS4 ch) {
+static inline int is_ascii_alpha(uint32_t ch) {
     return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
 }
 
-/* The HTML "ASCII whitespace" set. Input preprocessing folds a literal CR to LF,
-   so the tokenizer's raw scan never sees U+000D; a CR decoded from a character
-   reference (&#13;) bypasses preprocessing and reaches tree construction, where
-   U+000D is whitespace in every insertion mode. */
-static inline int is_space(Py_UCS4 ch) {
+static inline int is_ascii_digit(uint32_t ch) {
+    return ch >= '0' && ch <= '9';
+}
+
+static inline int is_ascii_hexdigit(uint32_t ch) {
+    return is_ascii_digit(ch) || ((ch | 0x20) >= 'a' && (ch | 0x20) <= 'f');
+}
+
+/* The WHATWG HTML "ASCII whitespace" set: TAB, LF, FF, CR, SPACE. Tree
+   construction and the serializers classify against the full set. Input
+   preprocessing folds a literal CR in the byte stream to LF, so the tokenizer's
+   raw scan never sees U+000D, but a CR decoded from a character reference (&#13;)
+   bypasses preprocessing and reaches tree construction and the tree-walking
+   consumers, where U+000D is whitespace like any other. */
+static inline int is_space(uint32_t ch) {
     return ch == '\t' || ch == '\n' || ch == '\x0c' || ch == '\r' || ch == ' ';
 }
 
-#endif /* TURBOHTML_ASCII_H */
+#endif /* TURBOHTML_CORE_ASCII_H */

--- a/src/turbohtml/_c/encoding/encoding.h
+++ b/src/turbohtml/_c/encoding/encoding.h
@@ -282,7 +282,7 @@ static const th_encoding_entry *th_encoding_lookup(const char *label, Py_ssize_t
     }
     for (Py_ssize_t index = 0; index < len; index++) {
         unsigned char ch = (unsigned char)label[index];
-        lowered[index] = (ch >= 'A' && ch <= 'Z') ? (char)(ch + 32) : (char)ch;
+        lowered[index] = (char)lower_ascii(ch);
     }
     lowered[len] = '\0';
     for (size_t index = 0; index < sizeof(th_encoding_table) / sizeof(th_encoding_table[0]); index++) {
@@ -386,7 +386,7 @@ static int prescan_attribute(const unsigned char *buf, Py_ssize_t *pos, Py_ssize
             break;
         }
         if (name_len < name_cap - 1) {
-            name[name_len++] = (ch >= 'A' && ch <= 'Z') ? (char)(ch + 32) : (char)ch;
+            name[name_len++] = (char)lower_ascii(ch);
         }
         at++;
     }
@@ -405,7 +405,7 @@ static int prescan_attribute(const unsigned char *buf, Py_ssize_t *pos, Py_ssize
         while (at < end && buf[at] != quote) {
             unsigned char ch = buf[at++];
             if (value_len < value_cap - 1) {
-                value[value_len++] = (ch >= 'A' && ch <= 'Z') ? (char)(ch + 32) : (char)ch;
+                value[value_len++] = (char)lower_ascii(ch);
             }
         }
         if (at >= end) { /* unterminated quoted value */
@@ -420,7 +420,7 @@ static int prescan_attribute(const unsigned char *buf, Py_ssize_t *pos, Py_ssize
         while (at < end && !is_attr_space(buf[at]) && buf[at] != '>') {
             unsigned char ch = buf[at++];
             if (value_len < value_cap - 1) {
-                value[value_len++] = (ch >= 'A' && ch <= 'Z') ? (char)(ch + 32) : (char)ch;
+                value[value_len++] = (char)lower_ascii(ch);
             }
         }
         if (at >= end) { /* unquoted value ran to the end of input */

--- a/src/turbohtml/_c/features/dates.c
+++ b/src/turbohtml/_c/features/dates.c
@@ -25,20 +25,19 @@
    read ASCII [0-9] rather than Unicode \d, and the whitespace between written-out
    date tokens is ASCII [ \t\n\r\f\v] rather than Unicode \s. */
 
+#include "core/ascii.h"
 #include "core/common.h"
 
 #include <stdint.h>
 
 #define CP(index) PyUnicode_READ(kind, data, (index))
 
-static inline int is_digit(Py_UCS4 codepoint) {
-    return codepoint >= '0' && codepoint <= '9';
-}
-
-/* Lowercase for the case-insensitive month vocabulary: ASCII plus the Latin-1
-   uppercase block (0xC0-0xDE minus the 0xD7 multiplication sign), which covers
-   every accent the month names carry (É, Ä, Û). Nothing else needs folding. */
-static inline Py_UCS4 lower_cp(Py_UCS4 codepoint) {
+/* Lowercase for the case-insensitive month vocabulary: the ASCII fold plus the
+   Latin-1 uppercase block (0xC0-0xDE minus the 0xD7 multiplication sign), which
+   covers every accent the month names carry (É, Ä, Û). This is wider than the
+   shared ASCII lower_ascii on purpose; nothing else in the date grammar needs
+   folding. */
+static inline Py_UCS4 lower_month_cp(Py_UCS4 codepoint) {
     if (codepoint >= 'A' && codepoint <= 'Z') {
         return codepoint + ('a' - 'A');
     }
@@ -48,8 +47,12 @@ static inline Py_UCS4 lower_cp(Py_UCS4 codepoint) {
     return codepoint;
 }
 
-/* ASCII whitespace, the \s+ between written-out date tokens. */
-static inline int is_space(Py_UCS4 codepoint) {
+/* The Perl \s class -- SPACE, TAB, LF, VT, FF, CR -- the \s+ between written-out
+   date tokens. This is the whitespace the ported _dates.py regex matched, so it
+   keeps the vertical tab (0x0B) that HTML "ASCII whitespace" (the shared is_space)
+   omits; a date string is arbitrary extracted text, not a tokenizer stream, and a
+   stray VT between tokens still separates them. */
+static inline int is_perl_space(Py_UCS4 codepoint) {
     return codepoint == ' ' || (codepoint >= 0x09 && codepoint <= 0x0D);
 }
 
@@ -59,7 +62,7 @@ static int year_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, i
         return 0;
     }
     Py_UCS4 a = CP(pos), b = CP(pos + 1), c = CP(pos + 2), d = CP(pos + 3);
-    if (!(is_digit(a) && is_digit(b) && is_digit(c) && is_digit(d))) {
+    if (!(is_ascii_digit(a) && is_ascii_digit(b) && is_ascii_digit(c) && is_ascii_digit(d))) {
         return 0;
     }
     if (!((a == '1' && b == '9' && c == '9') || (a == '2' && b == '0'))) {
@@ -177,7 +180,7 @@ static int iso_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
    (?<!\d) boundary. */
 static int compact_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, int *year, int *month, int *day) {
     Py_ssize_t run = pos;
-    while (run < len && is_digit(CP(run))) {
+    while (run < len && is_ascii_digit(CP(run))) {
         run++;
     }
     Py_ssize_t width = run - pos;
@@ -207,22 +210,22 @@ static int compact_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos
 static int dmy_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, int *raw_day, int *raw_month,
                   int *raw_year, Py_ssize_t *out_end) {
     Py_ssize_t p = pos;
-    if (p + 2 < len && CP(p) >= '0' && CP(p) <= '3' && is_digit(CP(p + 1)) &&
+    if (p + 2 < len && CP(p) >= '0' && CP(p) <= '3' && is_ascii_digit(CP(p + 1)) &&
         (CP(p + 2) == '-' || CP(p + 2) == '/' || CP(p + 2) == '.')) {
         *raw_day = (int)(CP(p) - '0') * 10 + (int)(CP(p + 1) - '0');
         p += 2;
-    } else if (p + 1 < len && is_digit(CP(p)) && (CP(p + 1) == '-' || CP(p + 1) == '/' || CP(p + 1) == '.')) {
+    } else if (p + 1 < len && is_ascii_digit(CP(p)) && (CP(p + 1) == '-' || CP(p + 1) == '/' || CP(p + 1) == '.')) {
         *raw_day = (int)(CP(p) - '0');
         p += 1;
     } else {
         return 0;
     }
     p++;
-    if (p + 2 < len && CP(p) >= '0' && CP(p) <= '1' && is_digit(CP(p + 1)) &&
+    if (p + 2 < len && CP(p) >= '0' && CP(p) <= '1' && is_ascii_digit(CP(p + 1)) &&
         (CP(p + 2) == '-' || CP(p + 2) == '/' || CP(p + 2) == '.')) {
         *raw_month = (int)(CP(p) - '0') * 10 + (int)(CP(p + 1) - '0');
         p += 2;
-    } else if (p + 1 < len && is_digit(CP(p)) && (CP(p + 1) == '-' || CP(p + 1) == '/' || CP(p + 1) == '.')) {
+    } else if (p + 1 < len && is_ascii_digit(CP(p)) && (CP(p + 1) == '-' || CP(p + 1) == '/' || CP(p + 1) == '.')) {
         *raw_month = (int)(CP(p) - '0');
         p += 1;
     } else {
@@ -230,7 +233,7 @@ static int dmy_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
     }
     p++;
     Py_ssize_t start = p;
-    while (p < len && is_digit(CP(p))) {
+    while (p < len && is_ascii_digit(CP(p))) {
         p++;
     }
     Py_ssize_t run = p - start;
@@ -323,7 +326,7 @@ static int match_month_name(const void *data, int kind, Py_ssize_t len, Py_ssize
         const char *cursor = entry->name;
         int matched = 1;
         for (uint8_t offset = 0; offset < entry->length; offset++) {
-            if (lower_cp(CP(pos + offset)) != name_cp(&cursor)) {
+            if (lower_month_cp(CP(pos + offset)) != name_cp(&cursor)) {
                 matched = 0;
                 break;
             }
@@ -342,7 +345,7 @@ static int match_ordinal(const void *data, int kind, Py_ssize_t len, Py_ssize_t 
     if (pos + 2 > len) {
         return 0;
     }
-    Py_UCS4 a = lower_cp(CP(pos)), b = lower_cp(CP(pos + 1));
+    Py_UCS4 a = lower_month_cp(CP(pos)), b = lower_month_cp(CP(pos + 1));
     if ((a == 's' && b == 't') || (a == 'n' && b == 'd') || (a == 'r' && b == 'd') || (a == 't' && b == 'h')) {
         return 2;
     }
@@ -352,10 +355,10 @@ static int match_ordinal(const void *data, int kind, Py_ssize_t len, Py_ssize_t 
 /* Skip a run of ASCII whitespace, requiring at least one (\s+). Returns the
    position after it, or -1 when none is present. */
 static Py_ssize_t skip_spaces(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos) {
-    if (pos >= len || !is_space(CP(pos))) {
+    if (pos >= len || !is_perl_space(CP(pos))) {
         return -1;
     }
-    while (pos < len && is_space(CP(pos))) {
+    while (pos < len && is_perl_space(CP(pos))) {
         pos++;
     }
     return pos;
@@ -406,12 +409,12 @@ static int text_a(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
     if (p < 0) {
         return 0;
     }
-    if (p + 1 < len && CP(p) >= '0' && CP(p) <= '3' && is_digit(CP(p + 1)) &&
+    if (p + 1 < len && CP(p) >= '0' && CP(p) <= '3' && is_ascii_digit(CP(p + 1)) &&
         text_a_tail(data, kind, len, p + 2, year, out_end)) {
         *day = (int)(CP(p) - '0') * 10 + (int)(CP(p + 1) - '0');
         return 1;
     }
-    if (p < len && is_digit(CP(p)) && text_a_tail(data, kind, len, p + 1, year, out_end)) {
+    if (p < len && is_ascii_digit(CP(p)) && text_a_tail(data, kind, len, p + 1, year, out_end)) {
         *day = (int)(CP(p) - '0');
         return 1;
     }
@@ -439,7 +442,8 @@ static int text_b_tail(const void *data, int kind, Py_ssize_t len, Py_ssize_t st
         if (p < 0) {
             continue;
         }
-        if (p + 2 < len && lower_cp(CP(p)) == 'o' && lower_cp(CP(p + 1)) == 'f' && is_space(CP(p + 2))) {
+        if (p + 2 < len && lower_month_cp(CP(p)) == 'o' && lower_month_cp(CP(p + 1)) == 'f' &&
+            is_perl_space(CP(p + 2))) {
             p = skip_spaces(data, kind, len, p + 2);
         }
         int name_length = match_month_name(data, kind, len, p, month);
@@ -472,7 +476,7 @@ static int text_b_tail(const void *data, int kind, Py_ssize_t len, Py_ssize_t st
    Returns 1 with day/month/year and the end position. */
 static int text_b(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, int *day, int *month, int *year,
                   Py_ssize_t *out_end) {
-    if (pos + 1 < len && CP(pos) <= '3' && is_digit(CP(pos + 1)) &&
+    if (pos + 1 < len && CP(pos) <= '3' && is_ascii_digit(CP(pos + 1)) &&
         text_b_tail(data, kind, len, pos + 2, month, year, out_end)) {
         *day = (int)(CP(pos) - '0') * 10 + (int)(CP(pos + 1) - '0');
         return 1;
@@ -518,7 +522,7 @@ PyObject *turbohtml_date_scan(PyObject *Py_UNUSED(module), PyObject *args) {
         }
     }
     for (Py_ssize_t pos = 0; pos < len; pos++) {
-        if ((pos == 0 || !is_digit(CP(pos - 1))) && compact_at(data, kind, len, pos, &year, &month, &day)) {
+        if ((pos == 0 || !is_ascii_digit(CP(pos - 1))) && compact_at(data, kind, len, pos, &year, &month, &day)) {
             if (ymd_valid(year, month, day)) {
                 return Py_BuildValue("(iii)", year, month, day);
             }
@@ -527,7 +531,7 @@ PyObject *turbohtml_date_scan(PyObject *Py_UNUSED(module), PyObject *args) {
     }
     for (Py_ssize_t pos = 0; pos < len; pos++) {
         int raw_day, raw_month, raw_year;
-        if ((pos == 0 || !is_digit(CP(pos - 1))) &&
+        if ((pos == 0 || !is_ascii_digit(CP(pos - 1))) &&
             dmy_at(data, kind, len, pos, &raw_day, &raw_month, &raw_year, &end)) {
             int resolved_year = correct_year(raw_year, current_year);
             if (dmy_resolve(raw_day, raw_month, resolved_year, &month, &day)) {
@@ -572,7 +576,7 @@ PyObject *turbohtml_date_scan_all(PyObject *Py_UNUSED(module), PyObject *args) {
     pos = 0;
     while (pos < len) {
         int raw_day, raw_month, raw_year;
-        if ((pos == 0 || !is_digit(CP(pos - 1))) &&
+        if ((pos == 0 || !is_ascii_digit(CP(pos - 1))) &&
             dmy_at(data, kind, len, pos, &raw_day, &raw_month, &raw_year, &end)) {
             int resolved_year = correct_year(raw_year, current_year);
             if (dmy_resolve(raw_day, raw_month, resolved_year, &month, &day)) {
@@ -590,7 +594,7 @@ PyObject *turbohtml_date_scan_all(PyObject *Py_UNUSED(module), PyObject *args) {
         int matched = 0;
         if (CP(pos) >= 'A') { /* a written-out date opens with a month name (letter) */
             matched = text_a(data, kind, len, pos, &month, &day, &year, &end);
-        } else if (is_digit(CP(pos))) { /* or a leading day (digit) */
+        } else if (is_ascii_digit(CP(pos))) { /* or a leading day (digit) */
             matched = text_b(data, kind, len, pos, &day, &month, &year, &end);
         }
         if (!matched) {
@@ -628,10 +632,10 @@ static int url_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
         return 0;
     }
     p++;
-    if (p + 1 < len && day2(CP(p), CP(p + 1), day) && (p + 2 >= len || !is_digit(CP(p + 2)))) {
+    if (p + 1 < len && day2(CP(p), CP(p + 1), day) && (p + 2 >= len || !is_ascii_digit(CP(p + 2)))) {
         return 1;
     }
-    if (p < len && day1(CP(p), day) && (p + 1 >= len || !is_digit(CP(p + 1)))) {
+    if (p < len && day1(CP(p), day) && (p + 1 >= len || !is_ascii_digit(CP(p + 1)))) {
         return 1;
     }
     return 0;
@@ -648,7 +652,7 @@ PyObject *turbohtml_date_url(PyObject *Py_UNUSED(module), PyObject *url) {
     Py_ssize_t len = PyUnicode_GET_LENGTH(url);
     int year, month, day;
     for (Py_ssize_t pos = 0; pos < len; pos++) {
-        if ((pos == 0 || !is_digit(CP(pos - 1))) && url_at(data, kind, len, pos, &year, &month, &day)) {
+        if ((pos == 0 || !is_ascii_digit(CP(pos - 1))) && url_at(data, kind, len, pos, &year, &month, &day)) {
             if (ymd_valid(year, month, day)) {
                 return Py_BuildValue("(iii)", year, month, day);
             }

--- a/src/turbohtml/_c/features/linkify.c
+++ b/src/turbohtml/_c/features/linkify.c
@@ -10,6 +10,7 @@
    same rule bleach used. Matches are returned as (start, end, kind) spans into
    the input; the scan never allocates per match. */
 
+#include "core/ascii.h"
 #include "core/common.h"
 #include "url/url.h"
 
@@ -22,19 +23,6 @@ enum th_link_kind {
     TH_LINK_EMAIL = 1,
     TH_LINK_SCHEME = 2,
 };
-
-static inline Py_UCS4 ascii_lower(Py_UCS4 c) {
-    return (c >= 'A' && c <= 'Z') ? c + ('a' - 'A') : c;
-}
-
-static inline int is_ascii_alpha(Py_UCS4 c) {
-    Py_UCS4 lower = c | 0x20;
-    return lower >= 'a' && lower <= 'z';
-}
-
-static inline int is_ascii_digit(Py_UCS4 c) {
-    return c >= '0' && c <= '9';
-}
 
 /* A non-ASCII Unicode White_Space code point (the ASCII ones are c <= 0x20). UTS46
    domain-to-ASCII forbids these in host labels, and they end a URL in running text,
@@ -124,7 +112,7 @@ static int tuple_has_label(PyObject *names, int kind, const void *data, Py_ssize
         const void *candidate_data = PyUnicode_DATA(candidate);
         int matched = 1;
         for (Py_ssize_t offset = 0; offset < length; offset++) {
-            if (PyUnicode_READ(candidate_kind, candidate_data, offset) != ascii_lower(READ(start + offset))) {
+            if (PyUnicode_READ(candidate_kind, candidate_data, offset) != lower_ascii(READ(start + offset))) {
                 matched = 0;
                 break;
             }
@@ -146,7 +134,7 @@ static int is_known_tld(int kind, const void *data, Py_ssize_t start, Py_ssize_t
     if (length < 2) {
         return 0;
     }
-    Py_UCS4 first = ascii_lower(READ(start));
+    Py_UCS4 first = lower_ascii(READ(start));
     if (first < 'a' || first > 'z') {
         return tuple_has_label(extra_tlds, kind, data, start, end);
     }
@@ -156,7 +144,7 @@ static int is_known_tld(int kind, const void *data, Py_ssize_t start, Py_ssize_t
         }
         int matched = 1;
         for (Py_ssize_t offset = 0; offset < length; offset++) {
-            if ((Py_UCS4)(unsigned char)th_tld_table[index].name[offset] != ascii_lower(READ(start + offset))) {
+            if ((Py_UCS4)(unsigned char)th_tld_table[index].name[offset] != lower_ascii(READ(start + offset))) {
                 matched = 0;
                 break;
             }

--- a/src/turbohtml/_c/features/links.c
+++ b/src/turbohtml/_c/features/links.c
@@ -7,6 +7,7 @@
    list attributes. URL resolution itself (resolve_links) is stdlib urllib.parse.urljoin, bound through
    functools.partial here, so RFC 3986 is not reinvented. */
 
+#include "core/ascii.h"
 #include "core/common.h"
 
 #include "core/vec.h"
@@ -20,24 +21,10 @@
 typedef int (*link_emit)(void *ctx, Py_ssize_t start, Py_ssize_t end);
 typedef int (*scanner_fn)(const Py_UCS4 *value, Py_ssize_t len, link_emit emit, void *ctx);
 
-/* The ASCII whitespace that separates URL-list tokens, minus CR: the WHATWG input preprocessor converts CR to LF, so a
-   parsed value never carries a 0x0D. An array+loop (matching sanitize.c) keeps the branch count stable instead of the
-   chained-|| a compiler can leave with unreachable arms. */
-static int is_ws(Py_UCS4 c) {
-    static const Py_UCS4 whitespace[] = {0x09, 0x0A, 0x0C, 0x20};
-    for (size_t index = 0; index < sizeof(whitespace) / sizeof(whitespace[0]); index++) {
-        if (c == whitespace[index]) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
 /* A CSS/identifier byte, used to reject url(/import/url= matches that are only the tail of a longer identifier (e.g.
    "blur(" must not match "url(", "curl" must not match the refresh keyword). */
 static int is_ident(Py_UCS4 c) {
-    Py_UCS4 lower = c | 0x20;
-    return (lower >= 'a' && lower <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-';
+    return is_ascii_alpha(c) || is_ascii_digit(c) || c == '_' || c == '-';
 }
 
 /* Case-insensitive (ASCII) match of the literal `lit` at offset `pos`; letters compare case-folded, every other byte
@@ -48,7 +35,7 @@ static int imatch(const Py_UCS4 *value, Py_ssize_t len, Py_ssize_t pos, const ch
     }
     for (Py_ssize_t index = 0; index < lit_len; index++) {
         Py_UCS4 c = value[pos + index];
-        Py_UCS4 folded = (c >= 'A' && c <= 'Z') ? (c | 0x20) : c;
+        Py_UCS4 folded = lower_ascii(c);
         if (folded != (Py_UCS4)(unsigned char)lit[index]) {
             return 0;
         }
@@ -60,10 +47,10 @@ static int imatch(const Py_UCS4 *value, Py_ssize_t len, Py_ssize_t pos, const ch
 static int scan_single(const Py_UCS4 *value, Py_ssize_t len, link_emit emit, void *ctx) {
     Py_ssize_t start = 0;
     Py_ssize_t end = len;
-    while (start < end && is_ws(value[start])) {
+    while (start < end && is_space(value[start])) {
         start++;
     }
-    while (end > start && is_ws(value[end - 1])) {
+    while (end > start && is_space(value[end - 1])) {
         end--;
     }
     if (end > start) {
@@ -76,11 +63,11 @@ static int scan_single(const Py_UCS4 *value, Py_ssize_t len, link_emit emit, voi
 static int scan_space_list(const Py_UCS4 *value, Py_ssize_t len, link_emit emit, void *ctx) {
     Py_ssize_t pos = 0;
     while (pos < len) {
-        while (pos < len && is_ws(value[pos])) {
+        while (pos < len && is_space(value[pos])) {
             pos++;
         }
         Py_ssize_t start = pos;
-        while (pos < len && !is_ws(value[pos])) {
+        while (pos < len && !is_space(value[pos])) {
             pos++;
         }
         if (pos > start) {
@@ -97,11 +84,11 @@ static int scan_space_list(const Py_UCS4 *value, Py_ssize_t len, link_emit emit,
 static int scan_srcset(const Py_UCS4 *value, Py_ssize_t len, link_emit emit, void *ctx) {
     Py_ssize_t pos = 0;
     while (pos < len) {
-        while (pos < len && (value[pos] == ',' || is_ws(value[pos]))) {
+        while (pos < len && (value[pos] == ',' || is_space(value[pos]))) {
             pos++;
         }
         Py_ssize_t start = pos;
-        while (pos < len && value[pos] != ',' && !is_ws(value[pos])) {
+        while (pos < len && value[pos] != ',' && !is_space(value[pos])) {
             pos++;
         }
         if (pos > start) {
@@ -121,7 +108,7 @@ static int scan_srcset(const Py_UCS4 *value, Py_ssize_t len, link_emit emit, voi
 static int css_url_span(const Py_UCS4 *value, Py_ssize_t len, Py_ssize_t open, link_emit emit, void *ctx,
                         Py_ssize_t *resume) {
     Py_ssize_t pos = open;
-    while (pos < len && is_ws(value[pos])) {
+    while (pos < len && is_space(value[pos])) {
         pos++;
     }
     Py_UCS4 quote = 0;
@@ -129,7 +116,7 @@ static int css_url_span(const Py_UCS4 *value, Py_ssize_t len, Py_ssize_t open, l
         quote = value[pos++];
     }
     Py_ssize_t start = pos;
-    while (pos < len && value[pos] != ')' && (quote ? value[pos] != quote : !is_ws(value[pos]))) {
+    while (pos < len && value[pos] != ')' && (quote ? value[pos] != quote : !is_space(value[pos]))) {
         pos++;
     }
     *resume = pos;
@@ -144,7 +131,7 @@ static int css_url_span(const Py_UCS4 *value, Py_ssize_t len, Py_ssize_t open, l
 static int css_import_span(const Py_UCS4 *value, Py_ssize_t len, Py_ssize_t after, link_emit emit, void *ctx,
                            Py_ssize_t *resume) {
     Py_ssize_t pos = after;
-    while (pos < len && is_ws(value[pos])) {
+    while (pos < len && is_space(value[pos])) {
         pos++;
     }
     if (pos < len && (value[pos] == '"' || value[pos] == '\'')) {
@@ -194,14 +181,14 @@ static int scan_meta_refresh(const Py_UCS4 *value, Py_ssize_t len, link_emit emi
             continue;
         }
         Py_ssize_t after = pos + 3;
-        while (after < len && is_ws(value[after])) {
+        while (after < len && is_space(value[after])) {
             after++;
         }
         if (after >= len || value[after] != '=') {
             continue;
         }
         after++;
-        while (after < len && is_ws(value[after])) {
+        while (after < len && is_space(value[after])) {
             after++;
         }
         Py_UCS4 quote = 0;
@@ -210,7 +197,7 @@ static int scan_meta_refresh(const Py_UCS4 *value, Py_ssize_t len, link_emit emi
         }
         Py_ssize_t start = after;
         Py_ssize_t end = len;
-        while (after < len && (quote ? value[after] != quote : !is_ws(value[after]))) {
+        while (after < len && (quote ? value[after] != quote : !is_space(value[after]))) {
             after++;
         }
         end = after;

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -7,6 +7,7 @@
    safety baseline (scripting/framing elements, on* handlers, non-allowlisted URL schemes) is enforced here, not in
    Python, so a policy cannot route around it. */
 
+#include "core/ascii.h"
 #include "core/common.h"
 #include "url/url.h"
 
@@ -133,19 +134,6 @@ static int scheme_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t len) {
     return s->allow_relative; /* no colon: a relative URL */
 }
 
-/* The ASCII whitespace that separates srcset candidates, minus CR: the WHATWG input preprocessor converts CR to LF, so
-   a parsed attribute value never carries a 0x0D. An array+loop keeps the branch count stable when clang inlines this
-   into srcset_allowed's two call sites. */
-static int is_ascii_ws(Py_UCS4 c) {
-    static const Py_UCS4 whitespace[] = {0x09, 0x0A, 0x0C, 0x20};
-    for (size_t index = 0; index < sizeof(whitespace) / sizeof(whitespace[0]); index++) {
-        if (c == whitespace[index]) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
 /* srcset and imagesrcset hold a comma-separated list of "URL descriptor" candidates. Each candidate's leading URL is
    scheme-checked; the whole attribute is rejected if any candidate carries a disallowed scheme. Splitting on commas
    can over-segment a URL that contains one, but that only adds scheme checks of schemeless tails (read as relative),
@@ -153,11 +141,11 @@ static int is_ascii_ws(Py_UCS4 c) {
 static int srcset_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t len) {
     Py_ssize_t pos = 0;
     while (pos < len) {
-        while (pos < len && (value[pos] == ',' || is_ascii_ws(value[pos]))) {
+        while (pos < len && (value[pos] == ',' || is_space(value[pos]))) {
             pos++; /* skip separators before the candidate URL */
         }
         Py_ssize_t start = pos;
-        while (pos < len && value[pos] != ',' && !is_ascii_ws(value[pos])) {
+        while (pos < len && value[pos] != ',' && !is_space(value[pos])) {
             pos++; /* the URL runs up to a descriptor (whitespace) or the next candidate (comma) */
         }
         if (pos > start) {
@@ -347,7 +335,7 @@ static int host_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t len) {
     }
     for (Py_ssize_t index = 0; index < host_len; index++) {
         Py_UCS4 c = value[host_start + index];
-        host[index] = (c >= 'A' && c <= 'Z') ? (c | 0x20) : c;
+        host[index] = lower_ascii(c);
     }
     PyObject *key = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, host, host_len);
     if (key == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -447,7 +435,7 @@ static int css_property_allowed(sanitizer *s, const Py_UCS4 *name, Py_ssize_t le
     }
     for (Py_ssize_t index = 0; index < len; index++) {
         Py_UCS4 c = name[index];
-        lowered[index] = (char)((c >= 'A' && c <= 'Z') ? (c | 0x20) : c);
+        lowered[index] = (char)(lower_ascii(c));
     }
     PyObject *key = PyUnicode_FromStringAndSize(lowered, len);
     if (key == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -481,7 +469,7 @@ static Py_ssize_t css_match_keyword(const Py_UCS4 *value, Py_ssize_t pos, Py_ssi
    spliced in as `url` then comment then `(...)` is not read as a bare identifier. */
 static Py_ssize_t css_skip_ws_comments(const Py_UCS4 *value, Py_ssize_t pos, Py_ssize_t end) {
     while (pos < end) {
-        if (is_ascii_ws(value[pos])) {
+        if (is_space(value[pos])) {
             pos++;
         } else if (value[pos] == '/' && pos + 1 < end && value[pos + 1] == '*') {
             pos += 2;
@@ -506,7 +494,7 @@ static int css_url_scheme_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t
         quote = value[pos++];
     }
     Py_ssize_t url_start = pos;
-    while (pos < end && value[pos] != ')' && (quote ? value[pos] != quote : !is_ascii_ws(value[pos]))) {
+    while (pos < end && value[pos] != ')' && (quote ? value[pos] != quote : !is_space(value[pos]))) {
         pos++;
     }
     return scheme_allowed(s, value + url_start, pos - url_start);
@@ -553,10 +541,10 @@ static int css_declaration_kept(sanitizer *s, const Py_UCS4 *value, Py_ssize_t s
     }
     Py_ssize_t name_start = start;
     Py_ssize_t name_end = colon;
-    while (name_start < name_end && is_ascii_ws(value[name_start])) {
+    while (name_start < name_end && is_space(value[name_start])) {
         name_start++;
     }
-    while (name_end > name_start && is_ascii_ws(value[name_end - 1])) {
+    while (name_end > name_start && is_space(value[name_end - 1])) {
         name_end--;
     }
     int allowed = css_property_allowed(s, value + name_start, name_end - name_start);
@@ -574,7 +562,7 @@ static int css_declaration_kept(sanitizer *s, const Py_UCS4 *value, Py_ssize_t s
         return 0; /* an allowlisted property carrying expression()/url(disallowed-scheme) is still dropped */
     }
     Py_ssize_t decl_end = end;
-    while (decl_end > colon + 1 && is_ascii_ws(value[decl_end - 1])) {
+    while (decl_end > colon + 1 && is_space(value[decl_end - 1])) {
         decl_end--;
     }
     *name_start_out = name_start;
@@ -690,10 +678,10 @@ static int sanitize_style(sanitizer *s, th_node *element, th_node_attr *attr) {
    dangers (expression(), url(disallowed-scheme)) live in declaration values, which css_declaration_kept still vets. */
 static void css_emit_prelude(const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_UCS4 *out,
                              Py_ssize_t *out_len) {
-    while (start < end && is_ascii_ws(value[start])) {
+    while (start < end && is_space(value[start])) {
         start++;
     }
-    while (end > start && is_ascii_ws(value[end - 1])) {
+    while (end > start && is_space(value[end - 1])) {
         end--;
     }
     for (Py_ssize_t index = start; index < end; index++) {

--- a/src/turbohtml/_c/features/structured_data.c
+++ b/src/turbohtml/_c/features/structured_data.c
@@ -13,6 +13,7 @@
    (<meta name="dc.*">) join Microdata and OpenGraph in the same walk; microformats2 remains a documented later phase.
  */
 
+#include "core/ascii.h"
 #include "core/common.h"
 
 #include "core/vec.h"
@@ -40,7 +41,7 @@ static int ucs4_ieq_trimmed(const Py_UCS4 *value, Py_ssize_t len, const char *li
     }
     for (Py_ssize_t index = 0; index < lit_len; index++) {
         Py_UCS4 c = value[start + index];
-        Py_UCS4 folded = (c >= 'A' && c <= 'Z') ? (c | 0x20) : c;
+        Py_UCS4 folded = lower_ascii(c);
         if (folded != (Py_UCS4)(unsigned char)lit[index]) {
             return 0;
         }
@@ -1217,7 +1218,7 @@ static int ucs4_has_prefix_ci(const Py_UCS4 *value, Py_ssize_t len, const char *
     }
     for (Py_ssize_t index = 0; index < prefix_len; index++) {
         Py_UCS4 c = value[index];
-        Py_UCS4 folded = (c >= 'A' && c <= 'Z') ? (c | 0x20) : c;
+        Py_UCS4 folded = lower_ascii(c);
         if (folded != (Py_UCS4)(unsigned char)prefix[index]) {
             return 0;
         }
@@ -1245,7 +1246,7 @@ static PyObject *ucs4_lower_str(const Py_UCS4 *data, Py_ssize_t len) {
     }
     for (Py_ssize_t index = 0; index < len; index++) {
         Py_UCS4 c = data[index];
-        buffer[index] = (c >= 'A' && c <= 'Z') ? (c | 0x20) : c;
+        buffer[index] = lower_ascii(c);
     }
     PyObject *result = ucs4_to_str(buffer, len);
     PyMem_Free(buffer);

--- a/src/turbohtml/_c/query/css/selector.c
+++ b/src/turbohtml/_c/query/css/selector.c
@@ -15,11 +15,7 @@ static void sel_fail(sel_parser *parser, const char *reason) {
 }
 
 int sel_is_ident(Py_UCS4 ch) {
-    return is_ascii_alpha(ch) || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_' || ch >= 0x80;
-}
-
-static int sel_is_hex(Py_UCS4 ch) {
-    return (ch >= '0' && ch <= '9') || ((ch | 32) >= 'a' && (ch | 32) <= 'f');
+    return is_ascii_alpha(ch) || is_ascii_digit(ch) || ch == '-' || ch == '_' || ch >= 0x80;
 }
 
 /* Skip whitespace and CSS comments (CSS Syntax §4.3.2: a comment is valid anywhere
@@ -61,11 +57,12 @@ static Py_UCS4 sel_consume_escape(sel_parser *parser) {
     if (parser->pos >= parser->len) {
         return 0xFFFD; /* a trailing backslash escapes the replacement character */
     }
-    if (!sel_is_hex(parser->src[parser->pos])) {
+    if (!is_ascii_hexdigit(parser->src[parser->pos])) {
         return parser->src[parser->pos++]; /* the literal escaped character */
     }
     uint32_t value = 0;
-    for (int digit = 0; digit < 6 && parser->pos < parser->len && sel_is_hex(parser->src[parser->pos]); digit++) {
+    for (int digit = 0; digit < 6 && parser->pos < parser->len && is_ascii_hexdigit(parser->src[parser->pos]);
+         digit++) {
         Py_UCS4 hex = parser->src[parser->pos++];
         value = value * 16 + (hex <= '9' ? (uint32_t)(hex - '0') : (uint32_t)((hex | 32) - 'a' + 10));
     }
@@ -1070,7 +1067,7 @@ static int sel_matches_alts(th_node *node, const sel_complex *alts, int count, c
 static int sel_has_match(th_node *anchor, const sel_complex *alts, int count, const sel_ctx *ctx);
 
 Py_UCS4 sel_fold(Py_UCS4 ch, int ci) {
-    return (ci && ch >= 'A' && ch <= 'Z') ? ch + 32 : ch;
+    return ci ? lower_ascii(ch) : ch;
 }
 
 int sel_eq(const Py_UCS4 *left, Py_ssize_t alen, const Py_UCS4 *right, Py_ssize_t blen, int ci) {

--- a/src/turbohtml/_c/serialize/internal.h
+++ b/src/turbohtml/_c/serialize/internal.h
@@ -1,7 +1,7 @@
 /* Serialization primitives shared by every output mode (#document, HTML,
    minify, markdown, text, readability). The growable code-point buffer, the
    escape formatters, the start/close-tag writers, the attribute ordering and
-   the markdown block/whitespace predicates live here as `static inline` so each
+   the markdown block predicates live here as `static inline` so each
    serialize translation unit keeps its own inlined copy of the hot append and
    escape loops with no cross-TU call. */
 
@@ -11,6 +11,7 @@
 #include "dom/tree.h"
 #include "dom/tree_internal.h" /* struct th_tree, need_text, is_void_atom */
 
+#include "core/ascii.h"  /* is_space, the shared HTML ASCII-whitespace predicate */
 #include "core/common.h" /* SWAR lane probes for the serializer's clean-run scan */
 #include "core/vec.h"    /* th_grow_cap overflow-safe buffer growth */
 #include "data/entity_names.h"
@@ -575,12 +576,6 @@ static inline int is_md_skipped(const th_node *node) {
     return node->ns == TH_NS_HTML && node->atom == TH_TAG_HEAD;
 }
 
-static inline int md_is_ws(Py_UCS4 c) {
-    /* the tokenizer has already normalized CR to LF, so a tree text node never
-       holds a carriage return; classifying it here would be a dead branch */
-    return c == ' ' || c == '\t' || c == '\n' || c == '\f';
-}
-
 static inline Py_ssize_t md_put_decimal(sbuf *out, Py_ssize_t n) {
     Py_UCS4 digits[20];
     Py_ssize_t count = 0;
@@ -629,7 +624,7 @@ static inline Py_ssize_t md_trim(sbuf *out, int mode) {
     }
     Py_ssize_t end = out->len;
     if (mode == TH_MD_DOC_STRIP || mode == TH_MD_DOC_RSTRIP) {
-        while (end > start && md_is_ws(out->data[end - 1])) {
+        while (end > start && is_space(out->data[end - 1])) {
             end--;
         }
     }

--- a/src/turbohtml/_c/serialize/js/lexer.c
+++ b/src/turbohtml/_c/serialize/js/lexer.c
@@ -11,6 +11,7 @@
    is a safe over-approximation for the valid scripts a minifier is handed (all JS
    operators and punctuation are ASCII). */
 
+#include "core/ascii.h"
 #include "serialize/js/internal.h"
 
 #include <string.h>
@@ -63,14 +64,6 @@ static int jm_is_id_part(Py_UCS4 ch) {
         return jm_cc[ch] & (CC_ID | CC_DIGIT);
     }
     return jm_is_id_start(ch); /* for a code point >= 0x80, identifier-part == identifier-start */
-}
-
-static int jm_is_dec(Py_UCS4 ch) {
-    return ch >= '0' && ch <= '9';
-}
-
-static int jm_is_hex(Py_UCS4 ch) {
-    return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
 }
 
 void jm_lex_init(jm_lexer *lx, const Py_UCS4 *src, Py_ssize_t len) {
@@ -242,7 +235,7 @@ static Py_ssize_t jm_scan_digits(jm_lexer *lx, int hex) {
     Py_ssize_t digits = 0;
     while (lx->pos < lx->len) {
         Py_UCS4 ch = lx->src[lx->pos];
-        if (hex ? jm_is_hex(ch) : jm_is_dec(ch)) {
+        if (hex ? is_ascii_hexdigit(ch) : is_ascii_digit(ch)) {
             digits++;
             lx->pos++;
         } else if (ch == '_') {
@@ -273,7 +266,7 @@ static void jm_scan_number(jm_lexer *lx) {
     /* a legacy octal (010) or non-octal decimal (08) integer: a leading 0 then a
        decimal digit. These take no fraction or exponent, so a following `.` is a
        member access, not a decimal point. */
-    if (ch == '0' && lx->pos + 1 < lx->len && jm_is_dec(lx->src[lx->start + 1])) {
+    if (ch == '0' && lx->pos + 1 < lx->len && is_ascii_digit(lx->src[lx->start + 1])) {
         jm_scan_digits(lx, 0);
         jm_emit(lx, JT_NUM);
         return;
@@ -429,7 +422,7 @@ static void jm_scan_punct(jm_lexer *lx) {
             lx->kind = JT_NULLISH;
             return;
         }
-        if (next_ch == '.' && !jm_is_dec(next2_ch)) {
+        if (next_ch == '.' && !is_ascii_digit(next2_ch)) {
             lx->pos += 2;
             lx->kind = JT_OPT_CHAIN;
             return;
@@ -653,7 +646,7 @@ void jm_lex_next(jm_lexer *lx) {
     Py_UCS4 ch = lx->src[lx->pos];
     if (jm_is_id_start(ch) || (ch == '\\' && lx->pos + 1 < lx->len && lx->src[lx->pos + 1] == 'u')) {
         jm_scan_ident(lx);
-    } else if (jm_is_dec(ch) || (ch == '.' && lx->pos + 1 < lx->len && jm_is_dec(lx->src[lx->pos + 1]))) {
+    } else if (is_ascii_digit(ch) || (ch == '.' && lx->pos + 1 < lx->len && is_ascii_digit(lx->src[lx->pos + 1]))) {
         jm_scan_number(lx);
     } else if (ch == '"' || ch == '\'') {
         jm_scan_string(lx, ch);

--- a/src/turbohtml/_c/serialize/markdown.c
+++ b/src/turbohtml/_c/serialize/markdown.c
@@ -362,7 +362,7 @@ static void md_emit_text(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
     Py_ssize_t index = 0;
     while (index < len) {
         Py_UCS4 ch = text[index];
-        if (md_is_ws(ch)) {
+        if (is_space(ch)) {
             ctx->space_pending = 1;
             index++;
             continue;
@@ -370,7 +370,7 @@ static void md_emit_text(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
         /* the upcoming word's code-point count tells md_flush_space whether the
            owed space should become a wrap break before the word is laid down */
         Py_ssize_t word_end = index;
-        while (word_end < len && !md_is_ws(text[word_end])) {
+        while (word_end < len && !is_space(text[word_end])) {
             word_end++;
         }
         ctx->pending_word = (int)(word_end - index);
@@ -385,7 +385,7 @@ static void md_emit_text(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
         md_put_char(ctx, ch);
         index++;
         Py_ssize_t start = index;
-        while (index < len && !md_is_ws(text[index]) && !md_needs_escape(ctx->opt, text[index]) &&
+        while (index < len && !is_space(text[index]) && !md_needs_escape(ctx->opt, text[index]) &&
                !(translit && text[index] >= 0x80)) {
             index++;
         }
@@ -433,16 +433,16 @@ static int md_css_prop(const Py_UCS4 *style, Py_ssize_t style_len, const char *p
         }
         Py_ssize_t value_end = cursor;
         cursor++; /* past ';' */
-        while (name_start < name_end && md_is_ws(style[name_start])) {
+        while (name_start < name_end && is_space(style[name_start])) {
             name_start++;
         }
-        while (name_end > name_start && md_is_ws(style[name_end - 1])) {
+        while (name_end > name_start && is_space(style[name_end - 1])) {
             name_end--;
         }
-        while (value_start < value_end && md_is_ws(style[value_start])) {
+        while (value_start < value_end && is_space(style[value_start])) {
             value_start++;
         }
-        while (value_end > value_start && md_is_ws(style[value_end - 1])) {
+        while (value_end > value_start && is_space(style[value_end - 1])) {
             value_end--;
         }
         if (name_end - name_start == prop_len && md_ucs4_ieq(&style[name_start], prop_len, prop)) {
@@ -1001,7 +1001,7 @@ static int md_leads_with_inline(md_ctx *ctx, th_node *node) {
         if (child->type == TH_NODE_TEXT) {
             const Py_UCS4 *text = need_text(ctx->tree, child);
             for (Py_ssize_t index = 0; index < child->text_len; index++) {
-                if (!md_is_ws(text[index])) {
+                if (!is_space(text[index])) {
                     return 1; /* leading visible text rides on the bullet line */
                 }
             }
@@ -1031,7 +1031,7 @@ static int md_item_is_loose(md_ctx *ctx, th_node *node) {
         if (child->type == TH_NODE_TEXT) {
             const Py_UCS4 *text = need_text(ctx->tree, child);
             for (Py_ssize_t index = 0; index < child->text_len; index++) {
-                if (!md_is_ws(text[index])) {
+                if (!is_space(text[index])) {
                     if (!in_run) {
                         units++;
                         in_run = 1;
@@ -1093,7 +1093,7 @@ static void md_block_children(md_ctx *ctx, th_node *node) {
             if (only_ws) {
                 const Py_UCS4 *text = need_text(ctx->tree, child);
                 for (Py_ssize_t index = 0; index < child->text_len; index++) {
-                    if (!md_is_ws(text[index])) {
+                    if (!is_space(text[index])) {
                         only_ws = 0;
                         break;
                     }
@@ -1141,7 +1141,7 @@ static PyObject *md_children_markdown(md_ctx *ctx, th_node *node) {
     md_block_children(ctx, node);
     Py_UCS4 *data = ctx->out.data;
     Py_ssize_t end = ctx->out.len;
-    while (end > 0 && md_is_ws(data[end - 1])) {
+    while (end > 0 && is_space(data[end - 1])) {
         end--;
     }
     PyObject *content = NULL;
@@ -1658,7 +1658,7 @@ static void md_render_pre(md_ctx *ctx, th_node *node) {
                     lang = cls + want_len;
                     lang_len = cls_len - want_len;
                     for (Py_ssize_t index = 0; index < lang_len; index++) {
-                        if (md_is_ws(lang[index])) {
+                        if (is_space(lang[index])) {
                             lang_len = index;
                             break;
                         }

--- a/src/turbohtml/_c/serialize/minify.c
+++ b/src/turbohtml/_c/serialize/minify.c
@@ -10,6 +10,7 @@
    buffer, the escape helpers, ser_close_tag, is_rawtext_element,
    ser_needs_leading_newline and doctype_name_len from serialize/internal.h. */
 
+#include "core/ascii.h"
 #include "serialize/internal.h"
 
 #include "dom/tree.h"
@@ -18,11 +19,6 @@
 #include "serialize/js/minify.h"
 
 #include <string.h>
-
-/* HTML ASCII whitespace, the set the tree-construction whitespace rules use. */
-static inline int mini_is_ascii_ws(Py_UCS4 character) {
-    return character == ' ' || character == '\t' || character == '\n' || character == '\f' || character == '\r';
-}
 
 /* pre/textarea/listing keep their text verbatim: a collapse inside them would
    change rendered content. Raw-text elements (script/style/...) are emitted as
@@ -62,7 +58,7 @@ static void mini_put_collapsed_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t l
     int escape_nbsp = formatter == TH_FMT_WHATWG;
     Py_ssize_t index = 0;
     while (index < len) {
-        if (mini_is_ascii_ws(text[index])) {
+        if (is_space(text[index])) {
             if (!*last_was_space) {
                 /* a stripped comment can leave two whitespace text nodes adjacent; suppressing
                    the second's leading space keeps the fold idempotent, since the reparse merges
@@ -72,7 +68,7 @@ static void mini_put_collapsed_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t l
             }
             do {
                 index++;
-            } while (index < len && mini_is_ascii_ws(text[index]));
+            } while (index < len && is_space(text[index]));
             continue;
         }
         Py_ssize_t start = index;
@@ -86,14 +82,13 @@ static void mini_put_collapsed_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t l
                 index += UCS4_LANES;
             }
         }
-        while (index < len && !mini_is_ascii_ws(text[index]) &&
-               !mini_text_special(text[index], formatter, escape_nbsp)) {
+        while (index < len && !is_space(text[index]) && !mini_text_special(text[index], formatter, escape_nbsp)) {
             index++;
         }
         if (index > start) {
             sbuf_put_run(out, &text[start], index - start);
         }
-        if (index < len && !mini_is_ascii_ws(text[index])) {
+        if (index < len && !is_space(text[index])) {
             sbuf_put_special(out, text[index], formatter);
             index++;
         }
@@ -110,8 +105,8 @@ static void mini_put_collapsed_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t l
 static int mini_attr_unquotable(const Py_UCS4 *value, Py_ssize_t len) {
     for (Py_ssize_t index = 0; index < len; index++) {
         Py_UCS4 character = value[index];
-        if (mini_is_ascii_ws(character) || character == '"' || character == '\'' || character == '`' ||
-            character == '=' || character == '<' || character == '>' || character == '&') {
+        if (is_space(character) || character == '"' || character == '\'' || character == '`' || character == '=' ||
+            character == '<' || character == '>' || character == '&') {
             return 0;
         }
     }
@@ -329,7 +324,7 @@ static int mini_p_parent_excluded(uint16_t atom) {
 /* Whether a following sibling begins with ASCII whitespace (used by the head/
    body/caption "not followed by whitespace" omission tests). */
 static int mini_starts_with_ws(th_tree *tree, th_node *node) {
-    return node->type == TH_NODE_TEXT && node->text_len > 0 && mini_is_ascii_ws(need_text(tree, node)[0]);
+    return node->type == TH_NODE_TEXT && node->text_len > 0 && is_space(need_text(tree, node)[0]);
 }
 
 /* Whether node lies within an html <atom> ancestor the parser would have "in scope",

--- a/src/turbohtml/_c/serialize/readability.c
+++ b/src/turbohtml/_c/serialize/readability.c
@@ -117,7 +117,7 @@ static int read_ci_contains(const Py_UCS4 *hay, Py_ssize_t hay_len, const char *
         Py_ssize_t index = 0;
         while (index < needle_len) {
             Py_UCS4 current = hay[start + index];
-            Py_UCS4 folded = (current >= 'A' && current <= 'Z') ? (current | 0x20) : current;
+            Py_UCS4 folded = lower_ascii(current);
             if (folded != (Py_UCS4)(unsigned char)needle[index]) {
                 break;
             }
@@ -401,12 +401,6 @@ th_node *th_node_main_content(th_tree *tree, th_node *root) {
     return best;
 }
 
-static int read_is_ws(Py_UCS4 character) {
-    /* the tokenizer normalizes CR to LF in the input stream, so tree text and
-       attribute values never hold a carriage return (as md_is_ws also assumes) */
-    return character == ' ' || character == '\t' || character == '\n' || character == '\f';
-}
-
 /* Copy [text, text+len) into a fresh PyMem buffer with each run of HTML whitespace
    folded to a single space and the ends trimmed; *out_len receives the length.
    Returns NULL (with *out_len 0) when the trimmed value is empty, so a present but
@@ -421,7 +415,7 @@ static Py_UCS4 *read_normalize(const Py_UCS4 *text, Py_ssize_t len, Py_ssize_t *
     int seen = 0;
     int pending_space = 0;
     for (Py_ssize_t index = 0; index < len; index++) {
-        if (read_is_ws(text[index])) {
+        if (is_space(text[index])) {
             pending_space = seen;
             continue;
         }
@@ -501,11 +495,11 @@ static int read_is_meta(th_tree *tree, th_node *node, const void *ctx) {
 static int read_rel_has_token(const Py_UCS4 *value, Py_ssize_t value_len, const char *token) {
     Py_ssize_t index = 0;
     while (index < value_len) {
-        while (index < value_len && read_is_ws(value[index])) {
+        while (index < value_len && is_space(value[index])) {
             index++;
         }
         Py_ssize_t start = index;
-        while (index < value_len && !read_is_ws(value[index])) {
+        while (index < value_len && !is_space(value[index])) {
             index++;
         }
         if (index > start && ser_value_iequals(value + start, index - start, token)) {

--- a/src/turbohtml/_c/serialize/text.c
+++ b/src/turbohtml/_c/serialize/text.c
@@ -3,7 +3,7 @@
    as a column-aligned grid — for search indexing, diffing, or a terminal view.
 
    It shares sbuf, need_text(), the tag atoms, the attribute lookup, and the
-   md_is_ws()/is_md_block()/is_md_skipped() predicates from serialize/internal.h.
+   is_space()/is_md_block()/is_md_skipped() predicates from serialize/internal.h.
    Unlike to_markdown it emits no markup: it keeps the visual structure of the
    page as plain text. */
 
@@ -120,13 +120,13 @@ static void text_emit_word(text_ctx *ctx, const Py_UCS4 *word, Py_ssize_t len) {
 static void text_emit_text(text_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
     Py_ssize_t i = 0;
     while (i < len) {
-        if (md_is_ws(text[i])) {
+        if (is_space(text[i])) {
             ctx->space_pending = 1;
             i++;
             continue;
         }
         Py_ssize_t start = i;
-        while (i < len && !md_is_ws(text[i])) {
+        while (i < len && !is_space(text[i])) {
             i++;
         }
         text_emit_word(ctx, &text[start], i - start);
@@ -199,11 +199,11 @@ static int text_rule_matches(text_ctx *ctx, th_node *node, const text_rule *rule
     Py_ssize_t avlen = node->attrs[idx].value_len;
     Py_ssize_t i = 0;
     while (i < avlen) {
-        while (i < avlen && md_is_ws(av[i])) {
+        while (i < avlen && is_space(av[i])) {
             i++;
         }
         Py_ssize_t start = i;
-        while (i < avlen && !md_is_ws(av[i])) {
+        while (i < avlen && !is_space(av[i])) {
             i++;
         }
         if (i - start == rule->value_len &&
@@ -217,10 +217,10 @@ static int text_rule_matches(text_ctx *ctx, th_node *node, const text_rule *rule
 /* Record a labeled span over [start, end), trimming surrounding whitespace, one
    entry per label the rule carries. */
 static void text_record_span(text_ctx *ctx, Py_ssize_t start, Py_ssize_t end, PyObject *labels) {
-    while (start < end && md_is_ws(ctx->out.data[start])) {
+    while (start < end && is_space(ctx->out.data[start])) {
         start++;
     }
-    while (end > start && md_is_ws(ctx->out.data[end - 1])) {
+    while (end > start && is_space(ctx->out.data[end - 1])) {
         end--;
     }
     if (start >= end) {
@@ -394,7 +394,7 @@ static void text_render_inline(text_ctx *ctx, th_node *node) {
 static void text_emit_text2(text_ctx *ctx, const char *s) {
     for (const char *c = s; *c != '\0'; c++) {
         Py_UCS4 ch = (Py_UCS4)(unsigned char)*c;
-        if (md_is_ws(ch)) {
+        if (is_space(ch)) {
             ctx->space_pending = 1;
         } else {
             text_emit_word(ctx, &ch, 1);
@@ -416,7 +416,7 @@ static int text_leads_with_inline(text_ctx *ctx, th_node *node) {
         if (child->type == TH_NODE_TEXT) {
             const Py_UCS4 *text = need_text(ctx->tree, child);
             for (Py_ssize_t i = 0; i < child->text_len; i++) {
-                if (!md_is_ws(text[i])) {
+                if (!is_space(text[i])) {
                     return 1;
                 }
             }
@@ -461,7 +461,7 @@ static void text_block_children(text_ctx *ctx, th_node *node) {
             if (only_ws) {
                 const Py_UCS4 *text = need_text(ctx->tree, child);
                 for (Py_ssize_t i = 0; i < child->text_len; i++) {
-                    if (!md_is_ws(text[i])) {
+                    if (!is_space(text[i])) {
                         only_ws = 0;
                         break;
                     }

--- a/src/turbohtml/_c/tokenizer/statemachine.h
+++ b/src/turbohtml/_c/tokenizer/statemachine.h
@@ -39,6 +39,21 @@ typedef struct {
     int kind; /* PyUnicode_{1,2,4}BYTE_KIND */
 } th_buf;
 
+/* The storage width a code point needs; matches the PyUnicode kind values. Kept
+   with th_buf (not in the Python-free core/ascii.h) because it reads the CPython
+   PyUnicode kind constants the width-tagged buffers are stored at. */
+static inline int ucs_width(Py_UCS4 ch) {
+    return ch < 0x100 ? PyUnicode_1BYTE_KIND : ch < 0x10000 ? PyUnicode_2BYTE_KIND : PyUnicode_4BYTE_KIND;
+}
+
+static inline Py_UCS4 buf_read(const th_buf *buf, Py_ssize_t index) {
+    return PyUnicode_READ(buf->kind, buf->data, index);
+}
+
+static inline void buf_write(th_buf *buf, Py_ssize_t index, Py_UCS4 ch) {
+    PyUnicode_WRITE(buf->kind, buf->data, index, ch);
+}
+
 typedef struct {
     th_buf name;
     th_buf value;

--- a/tests/features/test_extract_dates_parser.py
+++ b/tests/features/test_extract_dates_parser.py
@@ -298,6 +298,33 @@ def test_date_url_reads_the_path_date(url: str, expected: tuple[int, int, int] |
     assert _date_url(url) == expected
 
 
+_WIDE_STORAGE = [
+    pytest.param("★", id="ucs2"),
+    pytest.param("\U0001f600", id="ucs4"),
+]
+"""A BMP star and an astral emoji force the argument to 2- and 4-byte storage; the plain-ASCII
+cases only exercise the 1-byte code-point read. Re-running them at each width pins that a date
+reads the same whatever storage the surrounding text forces."""
+
+
+@pytest.mark.parametrize("wide", _WIDE_STORAGE)
+@pytest.mark.parametrize(("text", "expected"), _SCAN_CASES)
+def test_date_scan_is_storage_width_agnostic(text: str, expected: tuple[int, int, int] | None, wide: str) -> None:
+    assert _date_scan(text + wide, _YEAR) == expected
+
+
+@pytest.mark.parametrize("wide", _WIDE_STORAGE)
+@pytest.mark.parametrize(("text", "expected"), _SCAN_ALL_CASES)
+def test_date_scan_all_is_storage_width_agnostic(text: str, expected: list[tuple[int, int, int]], wide: str) -> None:
+    assert _date_scan_all(text + wide, _YEAR) == expected
+
+
+@pytest.mark.parametrize("wide", _WIDE_STORAGE)
+@pytest.mark.parametrize(("url", "expected"), _URL_CASES)
+def test_date_url_is_storage_width_agnostic(url: str, expected: tuple[int, int, int] | None, wide: str) -> None:
+    assert _date_url(url + wide) == expected
+
+
 def test_date_url_rejects_non_str() -> None:
     with pytest.raises(TypeError):
         _date_url(123)  # ty: ignore[invalid-argument-type]  # non-str on purpose

--- a/tests/features/test_extract_dates_parser.py
+++ b/tests/features/test_extract_dates_parser.py
@@ -201,6 +201,9 @@ _SCAN_ALL_CASES = [
     pytest.param("Il 4 luglio 2016 qui.", [(2016, 7, 4)], id="italian-day-first"),
     pytest.param("Posted 4th of July 2016.", [(2016, 7, 4)], id="english-ordinal-of"),
     pytest.param("25th December 2020", [(2020, 12, 25)], id="day-first-ordinal"),
+    # The date grammar's inter-token whitespace is the Perl \s the ported regex used, which keeps the
+    # vertical tab (0x0B) that HTML "ASCII whitespace" drops; a VT between tokens still separates them.
+    pytest.param("25th\x0bDecember\x0b2020", [(2020, 12, 25)], id="vertical-tab-separated"),
     pytest.param("July 4th 2016", [(2016, 7, 4)], id="month-first-ordinal"),
     pytest.param("1st January 2000", [(2000, 1, 1)], id="ordinal-st"),
     pytest.param("22nd March 2020", [(2020, 3, 22)], id="ordinal-nd"),

--- a/tests/features/test_links_enumerate.py
+++ b/tests/features/test_links_enumerate.py
@@ -23,6 +23,12 @@ def test_value_is_reported_with_surrounding_whitespace_trimmed() -> None:
     assert _urls('<a href="  a/b.html  ">x</a>') == [("a", "href", "a/b.html")]
 
 
+def test_carriage_return_from_char_ref_is_trimmed() -> None:
+    # &#13; injects a real U+000D past the input preprocessor's CR->LF fold, and CR is
+    # HTML ASCII whitespace, so "strip leading/trailing ASCII whitespace" must drop it.
+    assert _urls('<a href="&#13;a/b.html&#13;">x</a>') == [("a", "href", "a/b.html")]
+
+
 def test_whitespace_only_url_attribute_is_skipped() -> None:
     assert _urls('<a href="   ">x</a>') == []
 

--- a/tests/serialize/test_tree_main_content.py
+++ b/tests/serialize/test_tree_main_content.py
@@ -86,6 +86,14 @@ def test_main_text_renders_the_winner() -> None:
     assert "Home" not in text
 
 
+def test_main_text_collapses_carriage_return_runs() -> None:
+    # &#13; injects a real U+000D past the CR->LF preprocessor fold; CR is HTML
+    # whitespace, so read_normalize must fold it into a single space, not keep it.
+    text = parse(f"<article class=post><p>{PROSE}&#13;&#13;tail of the article body here.</p></article>").main_text()
+    assert "\r" not in text
+    assert "around it. tail of the article body here." in text
+
+
 @pytest.mark.parametrize(
     "html",
     [

--- a/tests/serialize/test_tree_markdown.py
+++ b/tests/serialize/test_tree_markdown.py
@@ -46,6 +46,9 @@ def test_headings(html: str, expected: str) -> None:
         pytest.param("<p>one</p><p>two</p>", "one\n\ntwo", id="two-paragraphs"),
         pytest.param("<div>a</div><div>b</div>", "a\n\nb", id="divs"),
         pytest.param("<p>a\n  b\t c</p>", "a b c", id="collapse-whitespace"),
+        # &#13; injects a real U+000D past the CR->LF preprocessor fold; CR is HTML
+        # whitespace, so it collapses and trims like the rest of the set.
+        pytest.param("<p>a&#13;&#13;b</p>", "a b", id="collapse-carriage-return"),
         pytest.param("<p>  leading trailing  </p>", "leading trailing", id="trim-edges"),
         pytest.param("<section><p>x</p></section>", "x", id="transparent-container"),
         pytest.param("<p>x<svg><style>.c{fill:red}</style></svg>y</p>", "xy", id="svg-style-suppressed"),

--- a/tests/serialize/test_tree_text.py
+++ b/tests/serialize/test_tree_text.py
@@ -29,6 +29,9 @@ def to_text(html: str, opts: PlainText) -> str:
         pytest.param("<p>a <b>bold</b> <i>x</i> c</p>", PlainText(), "a bold x c", id="inline-markup-stripped"),
         pytest.param("<p>one</p><p>two</p>", PlainText(), "one\n\ntwo", id="paragraphs"),
         pytest.param("<div>a\n  b\tc</div>", PlainText(), "a b c", id="collapse-whitespace"),
+        # &#13; injects a real U+000D past the CR->LF preprocessor fold; CR is HTML
+        # whitespace, so a text-node run of it must collapse like any other run.
+        pytest.param("<div>a&#13;&#13;b</div>", PlainText(), "a b", id="collapse-carriage-return"),
         pytest.param("<p>a<br>b</p>", PlainText(), "a\nb", id="line-break"),
         pytest.param("<p>a<wbr>b</p>", PlainText(), "ab", id="wbr"),
         pytest.param("<section><p>x</p></section>", PlainText(), "x", id="transparent-container"),


### PR DESCRIPTION
Part of #478, the `ascii.h` remainder of the C-consolidation work. The core had the same handful of ASCII questions written by hand in about forty-five places across the tokenizer, tree builder, selector and XPath parsers, encoding sniffer, and the link, date, sanitize, markdown, and readability scanners: whether a code point is an ASCII letter, a digit, a hex digit, or HTML whitespace, and what its ASCII-lowercase form is. 🧹

This routes them through one Python-free header, `core/ascii.h`, styled after `core/vec.h` from #511. It holds `lower_ascii`, `is_ascii_alpha`, `is_ascii_digit`, `is_ascii_hexdigit`, and `is_space` as `static inline` helpers over a `uint32_t`, so every call site inlines the comparison it used to spell out and the css/js engines compile the header in their `JM_STANDALONE` builds. The width-tagged buffer helpers (`ucs_width`, `buf_read`, `buf_write`) move next to `th_buf` in `tokenizer/statemachine.h`, which keeps `ascii.h` clear of any CPython dependency.

A byte-identical merge would have been wrong, because several sites had real semantic drift. #511 flagged this, so each one is decided here rather than folded away silently.

| Site | Verdict | Resolution |
| --- | --- | --- |
| `links.c`, `sanitize.c`, `serialize/internal.h`, `readability.c` whitespace, CR omitted | Bug | Route to the shared `is_space`, which includes CR |
| `dates.c` `is_space` includes vertical tab | Intentional | Renamed `is_perl_space`, why-comment, kept local |
| `dates.c` `lower_cp` folds Latin-1 | Intentional | Renamed `lower_month_cp`, noted as wider than ASCII |
| `char` vs `Py_UCS4` case fold in the encoding sniffer | Reconciled | The byte folds call `(char)lower_ascii(ch)` |

Four whitespace scanners dropped U+000D, each commented that the WHATWG input preprocessor folds every carriage return to a line feed, so a parsed value never carries one. A `&#13;` character reference decodes to a real carriage return after preprocessing, which the header's own `is_space` comment already noted, and carriage return is HTML ASCII whitespace. The contexts here run the "strip leading and trailing ASCII whitespace" and "split on ASCII whitespace" steps, so dropping it was a bug: `links()` reported `\rhttp://example.com/\r` for `href="&#13;http://example.com/&#13;"` instead of the trimmed URL, and `to_text()`, `to_markdown()`, and `main_text()` left a `&#13;` run uncollapsed. All four now share `is_space`, and the fix is exercised for the trim, both collapses, and the readability normalize path. 🐛

The intentional keeps stay distinct on purpose. `dates.c` parses arbitrary extracted text, not a tokenizer stream, and its whitespace is the Perl `\s` the ported `_dates.py` regex matched, which keeps the vertical tab that HTML whitespace omits, so `is_perl_space` names that. Its month vocabulary folds accented Latin-1 letters (AOÛT, MÄRZ), so `lower_month_cp` stays wider than the shared ASCII fold. The XPath lexer's `xp_is_space` is a third set again (space, tab, CR, LF, no form feed, the XML `S` production), already distinctly named and left local.

Parsing and serialization produce the same bytes as before apart from the carriage-return fix. Coverage holds at 100% line and branch on both toolchains: macOS llvm-cov over the whole tree, and gcc-13 in ubuntu:24.04 over every changed file, the layout-dependent-branch check that llvm alone can miss. The `warnings` (`-Werror` plus clang-tidy), `type`, `docs`, `prek`, and standalone `asan-js` gates pass, with the JS engine compiling `core/ascii.h` under `-Werror` and running sanitizer-clean; 3.10 through 3.14 are green, and `static inline` keeps codegen identical so CodSpeed stays neutral.
