### PR TITLE
📝 docs(project): present shipped code as turbohtml's own

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,63 @@
+turbohtml
+Copyright (c) 2026 Bernát Gábor and contributors
+
+turbohtml is licensed under the MIT License (see LICENSE). Parts of the
+character-encoding and language detectors are derived from the third-party
+projects below; their copyright notices and license terms are reproduced here
+as those licenses require.
+
+================================================================================
+chardetng
+================================================================================
+
+The content-based character-encoding detector in
+src/turbohtml/_c/encoding/detect.h and the tables generated into
+src/turbohtml/_c/encoding/detect_data.h are derived from chardetng
+<https://github.com/hsivonen/chardetng>, Copyright Mozilla Foundation, made
+available under the MIT or Apache-2.0 license at the recipient's option. The
+MIT terms, exercised here, are:
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+
+================================================================================
+whatlang-rs
+================================================================================
+
+The content-based language detector in src/turbohtml/_c/encoding/language.h and
+the tables generated into src/turbohtml/_c/encoding/language_data.h are derived
+from whatlang-rs <https://github.com/greyblake/whatlang-rs>, Copyright (c) 2017
+Sergey Potapov, made available under the MIT license:
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.

--- a/docs/changelog/315.feature.rst
+++ b/docs/changelog/315.feature.rst
@@ -3,6 +3,6 @@ Detect the character encoding of bytes without parsing them via the new :mod:`tu
 language), :func:`~turbohtml.detect.detect_all` ranks every surviving candidate, and the incremental
 :class:`~turbohtml.detect.EncodingDetector` accumulates a stream chunk by chunk, all configured by a frozen
 :class:`~turbohtml.detect.Detection` options object. The engine is the existing C pipeline
-``parse(detect_encoding=True)`` runs -- the WHATWG sniff, then a port of Firefox's chardetng -- so turbohtml replaces
-``chardet``, ``charset-normalizer``, and ``cchardet``, each with a migration guide and benchmark - by
+``parse(detect_encoding=True)`` runs -- the WHATWG sniff, then a content-based character-frequency detector -- so
+turbohtml replaces ``chardet``, ``charset-normalizer``, and ``cchardet``, each with a migration guide and benchmark - by
 :user:`gaborbernat`.

--- a/docs/changelog/42.doc.rst
+++ b/docs/changelog/42.doc.rst
@@ -1,0 +1,4 @@
+Present the shipped detectors and minifier as turbohtml's own work: the inspiration prose that framed them as ports of
+other projects now describes what each algorithm does, the acknowledgment for the projects that shaped them lives on the
+:doc:`/how-this-was-built` page, and the license-required attribution for the code and data derived from ``chardetng``
+and ``whatlang`` moves into a top-level ``NOTICE`` file. Part of #478.

--- a/docs/changelog/474.feature.rst
+++ b/docs/changelog/474.feature.rst
@@ -1,8 +1,8 @@
 Detect the natural language of text from the :mod:`turbohtml.detect` surface. :func:`~turbohtml.detect.detect_language`
-finds the dominant Unicode script, then ranks the languages that share it by a character-trigram model ported from
-`whatlang <https://github.com/greyblake/whatlang-rs>`_ (its ``Method::Trigram``). It returns a
-:class:`~turbohtml.detect.LanguageMatch` carrying an ISO 639-3 code, a confidence, the script, and the English name, and
-a frozen :class:`~turbohtml.detect.LanguageDetection` adds a confidence floor and allow/deny language constraints. The
-port covers whatlang's 69 languages across nine scripts and reproduces whatlang's own trigram method on every entry of
-its example corpus, matching the language, the confidence, and the script. This closes the content-language-detection
-gap the resiliparse and trafilatura migration guides listed; part of #459 - by :user:`gaborbernat`.
+finds the dominant Unicode script, then ranks the languages that share it by a character-trigram rank model (the
+Cavnar-Trenkle method). It returns a :class:`~turbohtml.detect.LanguageMatch` carrying an ISO 639-3 code, a confidence,
+the script, and the English name, and a frozen :class:`~turbohtml.detect.LanguageDetection` adds a confidence floor and
+allow/deny language constraints. It covers 69 languages across nine scripts and is validated against `whatlang
+<https://github.com/greyblake/whatlang-rs>`_'s ``Method::Trigram`` on every entry of its example corpus, matching the
+language, the confidence, and the script. This closes the content-language-detection gap the resiliparse and trafilatura
+migration guides listed; part of #459 - by :user:`gaborbernat`.

--- a/docs/explanation/parsing.rst
+++ b/docs/explanation/parsing.rst
@@ -32,11 +32,10 @@ For ``bytes`` input the first stage resolves an encoding in the `WHATWG order
 <https://html.spec.whatwg.org/multipage/parsing.html#determining-the-character-encoding>`_: a byte-order mark wins
 outright, then the caller's ``encoding`` argument, then a prescan of the first 1024 bytes for a ``<meta>`` charset
 declaration, and windows-1252 stands in when nothing matched. Passing ``detect_encoding=True`` inserts one step before
-that fallback: a content-based detector ported from Firefox's `chardetng <https://github.com/hsivonen/chardetng>`_,
-which validates UTF-8 structurally and otherwise lets the CJK and single-byte candidates compete on character-pair
-frequencies, where a single decode error or C1 control disqualifies a candidate. The step is opt-in and strictly
-subordinate: a declared encoding always wins, so spec conformance is untouched, and pure ASCII stays windows-1252 (the
-two decode ASCII identically).
+that fallback: a content-based detector that validates UTF-8 structurally and otherwise lets the CJK and single-byte
+candidates compete on character-pair frequencies, where a single decode error or C1 control disqualifies a candidate.
+The step is opt-in and strictly subordinate: a declared encoding always wins, so spec conformance is untouched, and pure
+ASCII stays windows-1252 (the two decode ASCII identically).
 
 The same pipeline, minus the decode and the parse, is the standalone :func:`turbohtml.detect.detect` -- the
 :doc:`chardet and charset-normalizer replacement </reference/detect>` -- which is why a standalone detection and

--- a/docs/how-this-was-built.rst
+++ b/docs/how-this-was-built.rst
@@ -12,3 +12,7 @@ their own test suites. The aim was correctness as much as speed, checked against
 None of this would exist without that prior work. turbohtml stands on the shoulders of the competing libraries across
 those ecosystems and on the specifications for HTML, CSS, and JavaScript and the people who wrote them. The saying about
 standing on the shoulders of giants applies here in full. My thanks to all of them.
+
+Some engines owe a specific debt. The html5lib-tests conformance suite and lexbor shaped the parser and tree builder;
+the encoding and language detectors follow the models chardetng and whatlang published. Where I reused another project's
+code or data, its license requires attribution, which lives in the ``NOTICE`` file at the repository root.

--- a/docs/how-to/tokenizing.rst
+++ b/docs/how-to/tokenizing.rst
@@ -97,7 +97,7 @@ The events map one to one:
 turbohtml differs from ``html.parser`` wherever ``html.parser`` diverges from the WHATWG algorithm browsers implement:
 turbohtml handles the raw-text content models (a ``<b>`` inside ``<script>`` stays text rather than a tag), recovers
 from malformed markup the way a browser would, and never emits ``handle_decl`` for CDATA sections (they only exist in
-foreign content). Code ported from ``html.parser`` sees the same tokens a browser sees, the point of most migrations.
+foreign content). Code migrated from ``html.parser`` sees the same tokens a browser sees, the point of most migrations.
 
 *****************************
  Extract the links of a page

--- a/docs/reference/detect.rst
+++ b/docs/reference/detect.rst
@@ -6,8 +6,8 @@
 
 Detect the character encoding of bytes without parsing them, a successor to ``chardet.detect``, ``cchardet.detect``, and
 ``charset_normalizer.from_bytes``. The pipeline is the one :func:`turbohtml.parse` runs for ``bytes`` input -- the
-WHATWG sniff (byte-order mark, then a ``<meta>`` prescan), the content detector ported from Firefox's `chardetng
-<https://github.com/hsivonen/chardetng>`_, then the spec's windows-1252 fallback -- so a standalone detection and
+WHATWG sniff (byte-order mark, then a ``<meta>`` prescan), a content detector that scores byte-pair frequencies against
+per-encoding character-class models, then the spec's windows-1252 fallback -- so a standalone detection and
 ``parse(data, detect_encoding=True)`` always agree (:doc:`how it decides </explanation/parsing>`).
 
 .. autofunction:: detect
@@ -27,8 +27,7 @@ WHATWG sniff (byte-order mark, then a ``<meta>`` prescan), the content detector 
 
 Detect the natural language of text, a successor to ``whatlang``, ``resiliparse.parse.lang``, and trafilatura's language
 filter. :func:`detect_language` finds the dominant Unicode script and ranks the languages sharing it by a
-character-trigram model ported from `whatlang <https://github.com/greyblake/whatlang-rs>`_, reading the visible text
-rather than an ``<html lang>`` attribute.
+character-trigram model, reading the visible text rather than an ``<html lang>`` attribute.
 
 .. autofunction:: detect_language
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ keywords = [
   "unescape",
 ]
 license = "MIT"
+license-files = [
+  "LICENSE",
+  "NOTICE",
+]
 maintainers = [
   { name = "Bernát Gábor", email = "gaborjbernat@gmail.com" },
 ]

--- a/src/turbohtml/_c/serialize/js/fold.c
+++ b/src/turbohtml/_c/serialize/js/fold.c
@@ -10,7 +10,7 @@
      true / false -> !0 / !1
      undefined    -> void 0        (only when nothing shadows undefined)
 
-   Constant-driven dead-code elimination, modeled on esbuild/terser/tdewolff. A
+   Constant-driven dead-code elimination, the constant-folding pass every optimizing JS minifier runs. A
    transform only drops an operand when it is a *pure* constant (no side effects) or
    the operand is on the never-taken side of a short circuit; and it only drops a
    *statement* subtree when that subtree declares no hoisted `var` or function (which

--- a/src/turbohtml/detect.py
+++ b/src/turbohtml/detect.py
@@ -4,11 +4,11 @@ turbohtml.detect: standalone character-encoding detection over bytes.
 :func:`detect` answers the question ``chardet``, ``charset-normalizer``, and ``cchardet`` exist for -- "what encoding
 are these bytes?" -- without an HTML parser in the call path. It runs the same C pipeline :func:`turbohtml.parse`
 uses for ``bytes`` input: the WHATWG sniff first (a byte-order mark, then a ``<meta>`` prescan of the first 1024
-bytes), then the content detector ported from Firefox's `chardetng <https://github.com/hsivonen/chardetng>`__, then
-the spec's windows-1252 fallback. A non-mark input therefore always yields the same encoding whether you detect it
-standalone or parse it with ``detect_encoding=True``; a byte-order mark is the one divergence, reported here with its
-own label (``UTF-8-SIG`` and the UTF-16/UTF-32 marks) so a caller can strip it, where the spec-locked parse path keeps
-the plain WHATWG name.
+bytes), then a content detector that validates UTF-8 structurally and otherwise scores the CJK and single-byte
+candidates on character-pair frequencies, then the spec's windows-1252 fallback. A non-mark input therefore always
+yields the same encoding whether you detect it standalone or parse it with ``detect_encoding=True``; a byte-order mark
+is the one divergence, reported here with its own label (``UTF-8-SIG`` and the UTF-16/UTF-32 marks) so a caller can
+strip it, where the spec-locked parse path keeps the plain WHATWG name.
 
 A result is an :class:`EncodingMatch` with the WHATWG canonical name, a confidence, and the language the frequency
 model matched, mirroring the ``chardet.detect`` dict shape as a typed record. :func:`detect_all` ranks every
@@ -17,8 +17,8 @@ surviving candidate, :class:`EncodingDetector` accumulates a stream chunk by chu
 encoding/language constraints).
 
 :func:`detect_language` answers the separate question ``whatlang``, ``resiliparse``, and ``trafilatura`` exist for --
-"what natural language is this text?" -- from the visible text rather than an ``<html lang>`` attribute. It runs a C
-port of whatlang's model: find the dominant Unicode script, then rank the languages sharing it by how closely the
+"what natural language is this text?" -- from the visible text rather than an ``<html lang>`` attribute. It runs a
+character-trigram model: find the dominant Unicode script, then rank the languages sharing it by how closely the
 text's most frequent character trigrams match each language's embedded profile. It returns a :class:`LanguageMatch`
 (ISO 639-3 code, confidence, script, English name); a frozen :class:`LanguageDetection` config carries a confidence
 floor and language constraints.
@@ -322,8 +322,8 @@ def detect_language(text: str, options: LanguageDetection | None = None, /) -> L
     Detect the natural language a string is written in, the ``whatlang`` / ``resiliparse`` content-language successor.
 
     The detector finds the dominant Unicode script, then ranks the languages that share it by the similarity between
-    the text's most frequent character trigrams and each language's embedded profile (the whatlang model, ported to
-    C). It reads the visible text only; it does not consult an ``<html lang>`` attribute.
+    the text's most frequent character trigrams and each language's embedded profile. It reads the visible text only;
+    it does not consult an ``<html lang>`` attribute.
 
     :param text: the text to classify; extract it from a document first (e.g. ``node.text``).
     :param options: the detection options; defaults to :class:`LanguageDetection` (always answer, no constraints).

--- a/tests/detect/test_detect_api.py
+++ b/tests/detect/test_detect_api.py
@@ -214,9 +214,9 @@ def test_non_bytes_input_is_rejected() -> None:
         detect("text")  # ty: ignore[invalid-argument-type]  # str exposes no byte buffer
 
 
-# Content-based language detection (roadmap #459) ports whatlang's trigram model (Method::Trigram): the samples below
-# detect their language exactly, and the port reproduces whatlang bit-for-bit, agreeing with whatlang's own
-# Method::Trigram on all 69 entries of whatlang's example corpus, confidence to 1e-6 included.
+# Content-based language detection (roadmap #459) scores a character-trigram rank model: the samples below detect their
+# language exactly, and the detector is validated bit-for-bit against whatlang's own Method::Trigram on all 69 entries
+# of its example corpus, confidence to 1e-6 included.
 _LANGUAGE_CASES: list[tuple[str, str, str]] = [
     ("There is no reason not to learn a new language every single year of your life.", "eng", "Latin"),
     ("Die Ordnung muss für immer in diesem Codebase bleiben und zuverlässig funktionieren.", "deu", "Latin"),

--- a/tests/serialize/test_minify_roundtrip.py
+++ b/tests/serialize/test_minify_roundtrip.py
@@ -1,9 +1,9 @@
-"""Round-trip safety of serialize(layout=Minify(...)) over a borrowed adversarial corpus.
+"""Round-trip safety of serialize(layout=Minify(...)) over an adversarial corpus.
 
 Minification is only correct if the minified bytes reparse to the same tree. This
 suite enforces that property at scale against the html5lib-tests tree-construction
-suite -- 1.7k adversarial snippets borrowed from the html5lib project and already
-vendored for the conformance harness.
+suite -- 1.7k adversarial snippets from the vendored html5lib-tests corpus, already
+in place for the conformance harness.
 
 The check is idempotence under reparse: ``minify(parse(minify(parse(src))))`` must
 equal ``minify(parse(src))``. A tag omission or whitespace fold that changed the


### PR DESCRIPTION
For 1.0, turbohtml should present as its own native work. Several docstrings, docs, changelog fragments, and test comments still framed shipped code as someone else's: the encoding detector "ported from Firefox's `chardetng`", the language detector a "port of `whatlang`", the JS constant folder "modeled on esbuild/terser/tdewolff". That reads as a wrapper around other projects rather than a library in its own right.

This scrub rewords the framing to describe what each algorithm does (a content detector that scores byte-pair frequencies against per-encoding character-class models, a character-trigram rank model for language) while keeping every legitimate reference. 📝 Competitor names stay where they earn their place: as successor positioning (`chardet`, `whatlang`, and `resiliparse` "exist for" the same question) and as validation oracles (the detector is checked against `whatlang`'s own `Method::Trigram` corpus, the minifier against the vendored `html5lib-tests` corpus). Spec links, migration guides, and the `html5lib-tests` data-provenance notes stay as they were. The acknowledgment for the projects that shaped the parser and detectors (`html5lib-tests`, `lexbor`, `chardetng`, and `whatlang`) now lives on the `how-this-was-built` page, its proper home.

Nothing legally required was lost. 🔒 The encoding and language detectors reuse code and data derived from `chardetng` (MIT or Apache-2.0, Copyright Mozilla Foundation) and `whatlang-rs` (MIT, Copyright Sergey Potapov), whose licenses require attribution. That attribution moves out of scattered inline prose into a top-level `NOTICE`, shipped in the sdist and wheel through `project.license-files`; the generated `detect_data.h` and `language_data.h` keep their in-file provenance headers too. The change is prose, one C comment, and packaging metadata, so parser and detector behavior is unchanged.

Part of #478.

closes #42
