### PR TITLE
🧹 chore: whole-tree simp + no-slop sweep

### DIFF
--- a/docs/changelog/50.misc.rst
+++ b/docs/changelog/50.misc.rst
@@ -1,0 +1,5 @@
+Finish the pre-1.0 house-style sweep over the whole tree. Drop the section-divider banners the audit found in eight test
+files, annotate the remaining module-level configuration singletons ``Final`` so every module matches, and rename the
+single-letter loop counters the plain-text renderer, date extractor, and encoding detector had drifted to. Em dashes in
+C comments become ASCII ``--`` to match the rest of the tree, and four documentation sentences lose their filler. Output
+is unchanged; this is style and prose only. Part of #478.

--- a/docs/explanation/stdlib-parity.rst
+++ b/docs/explanation/stdlib-parity.rst
@@ -38,13 +38,13 @@ Python; the filtering walk (the allowlist checks, the URL-scheme parsing, the es
 C against the parsed tree, which is why it sanitizes faster than the Rust nh3.
 
 Enumerating a page's links is the same tree walk from a third angle. :meth:`~turbohtml.Node.links` finds every
-link-bearing location in C (not just ``<a href>`` but the URLs hidden in ``srcset`` candidate lists, a ``<meta
-refresh>`` redirect, and CSS ``url()``/``@import`` in a ``style`` attribute or a ``<style>`` sheet), so the capability
-no hand-rolled ``find_all`` loop reaches comes for free. The walk locates the URL spans and splices replacements back in
-place; the URL resolution itself is :func:`urllib.parse.urljoin` from the standard library, deliberately *not*
-reimplemented in C, because RFC 3986 reference resolution is a solved, standard problem and not where turbohtml's value
-lies. The line between the two is the project's rule in miniature: the HTML-specific, performance-sensitive work is C,
-and a thin typed facade wires it to the stdlib.
+link-bearing location in C: ``<a href>``, the URLs hidden in ``srcset`` candidate lists, a ``<meta refresh>`` redirect,
+and CSS ``url()``/``@import`` in a ``style`` attribute or a ``<style>`` sheet, so the capability no hand-rolled
+``find_all`` loop reaches comes for free. The walk locates the URL spans and splices replacements back in place; the URL
+resolution itself is :func:`urllib.parse.urljoin` from the standard library, deliberately *not* reimplemented in C,
+because RFC 3986 reference resolution is a solved, standard problem and not where turbohtml's value lies. The line
+between the two is the project's rule in miniature: the HTML-specific, performance-sensitive work is C, and a thin typed
+facade wires it to the stdlib.
 
 Generating HTML is the one place a builder helper earns a little Python of its own. :data:`turbohtml.build.E` adds no
 tree mechanics: every ``E.<tag>(...)`` call constructs a real :class:`~turbohtml.Element` and appends its children

--- a/docs/explanation/structured-data.rst
+++ b/docs/explanation/structured-data.rst
@@ -19,12 +19,12 @@ The division of labor is the same one the rest of the read path follows: the *lo
 Python step stays in Python. A pure-C pass under the per-tree critical section walks the document once per format,
 gathering the ``itemscope``/``itemprop``/``itemtype`` structure into nested :class:`~turbohtml.MicrodataItem` records
 and the OpenGraph and Twitter ``<meta>`` pairs into a flat mapping, all holding no reference back into the tree. JSON-LD
-is the exception that proves the rule: the C walk gathers the verbatim text of each ``<script
-type="application/ld+json">`` block into a list of strings, then the critical section is released and a thin facade
-parses them with the standard library :mod:`json`. The JSON grammar is not reinvented in C, and the parse never touches
-the tree, so it cannot race a concurrent mutation -- the snapshot-then-parse split is what keeps the Python call off the
-live structure. A block that is not valid JSON is skipped rather than raising, the robust default for scraping a page
-whose markup the author did not validate.
+is the one exception: the C walk gathers the verbatim text of each ``<script type="application/ld+json">`` block into a
+list of strings, then the critical section is released and a thin facade parses them with the standard library
+:mod:`json`. The JSON grammar is not reinvented in C, and the parse never touches the tree, so it cannot race a
+concurrent mutation -- the snapshot-then-parse split is what keeps the Python call off the live structure. A block that
+is not valid JSON is skipped rather than raising, the safe default for scraping a page whose markup the author did not
+validate.
 
 *******************************
  Microdata, OpenGraph, Twitter

--- a/docs/migration/soupsieve.rst
+++ b/docs/migration/soupsieve.rst
@@ -10,8 +10,7 @@ module-level ``select`` / ``select_one`` / ``iselect`` / ``match`` / ``filter`` 
 queries over bs4 tags. Its scope is deliberately narrow: it interprets a CSS selector against an already-parsed tree of
 BeautifulSoup ``Tag`` objects, one element at a time, in Python. It covers a broad slice of Selectors Level 3 and 4 and
 adds a few proprietary extensions (``:-soup-contains()``, ``[attr!=value]``, custom pseudo-class aliases). Because it is
-the default engine that ``bs4`` reaches for, it is installed on essentially every project that scrapes or queries HTML
-in Python.
+the default engine that ``bs4`` reaches for, it ships with nearly every project that scrapes or queries HTML in Python.
 
 :mod:`turbohtml.query` covers that same ground with the same call shapes over turbohtml's native selector engine. A port
 swaps ``import soupsieve`` for ``from turbohtml import query`` and keeps its structure: the matcher methods and module

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1764,7 +1764,7 @@ static int fill_element_attrs(th_tree *tree, th_node *node, PyObject *attrs, PyO
 }
 
 /* On-stack scratch for ASCII-lowercasing a tag before the atom lookup; a tag
-   whose UTF-8 exceeds this is simply treated as an unknown atom. */
+   whose UTF-8 exceeds this is treated as an unknown atom. */
 #define ELEMENT_TAG_LOWER_STACK_BYTES 64
 
 /* Build an Element wrapper for tag with attrs, without the public constructor's
@@ -1814,7 +1814,7 @@ PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs) {
         }
         atom = th_tag_lookup(stack, utf8_len);
     } else {
-        PyErr_Clear(); /* a surrogate or very long custom tag is simply not in the table */
+        PyErr_Clear(); /* a surrogate or very long custom tag is not in the table */
     }
     th_node *node = th_tree_make_element(tree, tag_points, tag_len, atom, attr_count);
     PyMem_Free(tag_points);

--- a/src/turbohtml/_c/dom/foreign.h
+++ b/src/turbohtml/_c/dom/foreign.h
@@ -430,7 +430,7 @@ static int foreign_step(th_tree *tree, const th_token *token) {
             return 1;
         }
     } /* GCOVR_EXCL_BR_LINE: the walk always reaches the fragment root or an html element first */
-    return 1; /* GCOVR_EXCL_LINE: same — the foreign end-tag walk never falls through */
+    return 1; /* GCOVR_EXCL_LINE: same -- the foreign end-tag walk never falls through */
 }
 
 #endif /* TURBOHTML_DOM_FOREIGN_H */

--- a/src/turbohtml/_c/dom/formatters.c
+++ b/src/turbohtml/_c/dom/formatters.c
@@ -138,7 +138,7 @@ static PyObject *minify_get_minify_js(PyObject *self, void *Py_UNUSED(closure)) 
         Py_RETURN_NONE;
     }
     module_state *state = PyType_GetModuleState(Py_TYPE(self));
-    /* JSMinify(mangle, fold) — positional order matches the dataclass field order */
+    /* JSMinify(mangle, fold) -- positional order matches the dataclass field order */
     return PyObject_CallFunction(state->js_minify_type, "OO", minify->minify_js_mangle ? Py_True : Py_False,
                                  minify->minify_js_fold ? Py_True : Py_False);
 }

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -485,9 +485,9 @@ static int md_resolve_enum(const char *name, PyObject *value, const char *const 
         PyErr_Format(PyExc_TypeError, "%s must be a string", name);
         return -1;
     }
-    for (int i = 0; i < count; i++) {
-        if (strcmp(text, choices[i]) == 0) {
-            *out = i;
+    for (int choice_index = 0; choice_index < count; choice_index++) {
+        if (strcmp(text, choices[choice_index]) == 0) {
+            *out = choice_index;
             return 0;
         }
     }
@@ -914,10 +914,10 @@ static PyObject *node_annotated_render(PyObject *self, PyObject *rules_dict, PyO
     if (text_opts_from_spec(&opt, spec) < 0) {
         return NULL;
     }
-    Py_ssize_t n = PyDict_Size(rules_dict);
-    text_rule *rules = PyMem_Calloc((size_t)(n > 0 ? n : 1), sizeof(text_rule));
-    PyObject **labels = PyMem_Calloc((size_t)(n > 0 ? n : 1), sizeof(PyObject *));
-    Py_UCS4 **values = PyMem_Calloc((size_t)(n > 0 ? n : 1), sizeof(Py_UCS4 *));
+    Py_ssize_t rule_count = PyDict_Size(rules_dict);
+    text_rule *rules = PyMem_Calloc((size_t)(rule_count > 0 ? rule_count : 1), sizeof(text_rule));
+    PyObject **labels = PyMem_Calloc((size_t)(rule_count > 0 ? rule_count : 1), sizeof(PyObject *));
+    Py_UCS4 **values = PyMem_Calloc((size_t)(rule_count > 0 ? rule_count : 1), sizeof(Py_UCS4 *));
     if (rules == NULL || labels == NULL || values == NULL) { /* GCOVR_EXCL_BR_LINE: cannot force an alloc failure */
         PyMem_Free(rules);                                   /* GCOVR_EXCL_LINE: allocation-failure path */
         PyMem_Free(labels);                                  /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -925,14 +925,14 @@ static PyObject *node_annotated_render(PyObject *self, PyObject *rules_dict, PyO
         return PyErr_NoMemory();                             /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     PyObject *key, *value;
-    Py_ssize_t pos = 0, r = 0;
+    Py_ssize_t pos = 0, filled_count = 0;
     int failed = 0;
     while (PyDict_Next(rules_dict, &pos, &key, &value)) {
-        if (text_parse_rule(key, value, &rules[r], &labels[r], &values[r]) < 0) {
+        if (text_parse_rule(key, value, &rules[filled_count], &labels[filled_count], &values[filled_count]) < 0) {
             failed = 1;
             break;
         }
-        r++;
+        filled_count++;
     }
     PyObject *result = NULL;
     if (!failed) {
@@ -940,8 +940,8 @@ static PyObject *node_annotated_render(PyObject *self, PyObject *rules_dict, PyO
         Py_ssize_t span_count = 0, out_len = 0;
         Py_UCS4 *data;
         Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
-        data = th_node_annotated_text(tree_of(self), ((NodeObject *)self)->node, &opt, rules, n, &spans, &span_count,
-                                      &out_len);
+        data = th_node_annotated_text(tree_of(self), ((NodeObject *)self)->node, &opt, rules, rule_count, &spans,
+                                      &span_count, &out_len);
         Py_END_CRITICAL_SECTION();
         if (data == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -950,8 +950,10 @@ static PyObject *node_annotated_render(PyObject *self, PyObject *rules_dict, PyO
         PyObject *text = data != NULL ? ucs4_to_str(data, out_len) : NULL;   /* GCOVR_EXCL_BR_LINE */
         PyObject *label_list = data != NULL ? PyList_New(span_count) : NULL; /* GCOVR_EXCL_BR_LINE */
         if (text != NULL && label_list != NULL) { /* GCOVR_EXCL_BR_LINE: only an alloc failure makes either NULL */
-            for (Py_ssize_t i = 0; i < span_count; i++) {
-                PyList_SET_ITEM(label_list, i, Py_BuildValue("nnO", spans[i].start, spans[i].end, spans[i].label));
+            for (Py_ssize_t span_index = 0; span_index < span_count; span_index++) {
+                PyList_SET_ITEM(
+                    label_list, span_index,
+                    Py_BuildValue("nnO", spans[span_index].start, spans[span_index].end, spans[span_index].label));
             }
             result = PyTuple_Pack(2, text, label_list);
         }
@@ -960,9 +962,9 @@ static PyObject *node_annotated_render(PyObject *self, PyObject *rules_dict, PyO
         PyMem_Free(data);
         PyMem_Free(spans);
     }
-    for (Py_ssize_t i = 0; i < r; i++) {
-        Py_XDECREF(labels[i]);
-        PyMem_Free(values[i]);
+    for (Py_ssize_t rule_index = 0; rule_index < filled_count; rule_index++) {
+        Py_XDECREF(labels[rule_index]);
+        PyMem_Free(values[rule_index]);
     }
     PyMem_Free(rules);
     PyMem_Free(labels);

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -1,12 +1,12 @@
-/* WHATWG HTML tree construction — see dom/tree.h.
+/* WHATWG HTML tree construction -- see dom/tree.h.
 
    Implements the linear document path (initial → before html → before head →
    in head → after head → in body → text → after body), generic nesting, void
    elements, implied end tags, the full in-body block/heading/list end-tag
    rules, active formatting elements with reconstruction and the adoption agency
-   algorithm (misnested <b>/<i>/<a>). The remaining structural modes — table
+   algorithm (misnested <b>/<i>/<a>). The remaining structural modes -- table
    foster-parenting, foreign content (SVG/MathML), select, templates and
-   frameset — fall back to generic insertion for now; each is a follow-up gated
+   frameset -- fall back to generic insertion for now; each is a follow-up gated
    by the html5lib tree-construction suite, whose pass rate this engine grows
    toward 100%. */
 
@@ -464,7 +464,7 @@ static int has_in_list_item_scope(th_tree *tree, uint16_t atom) {
             return 0;
         }
     } /* GCOVR_EXCL_BR_LINE: the stack always bottoms out at an html scope boundary, so the loop never falls through */
-    return 0; /* GCOVR_EXCL_LINE: same — has_in_list_item_scope always returns inside the loop */
+    return 0; /* GCOVR_EXCL_LINE: same -- has_in_list_item_scope always returns inside the loop */
 }
 
 static int is_implied_end_atom(uint16_t atom) {
@@ -542,7 +542,7 @@ static int has_in_table_scope(th_tree *tree, uint16_t atom) {
             return 0;
         }
     } /* GCOVR_EXCL_BR_LINE: the stack always bottoms out at an html table-scope boundary */
-    return 0; /* GCOVR_EXCL_LINE: same — has_in_table_scope always returns inside the loop */
+    return 0; /* GCOVR_EXCL_LINE: same -- has_in_table_scope always returns inside the loop */
 }
 
 /* The appropriate place for inserting a node: normally the current node, but
@@ -3390,9 +3390,9 @@ static void run_drain(th_tree *tree, th_tokenizer *sm, th_run_state *run_state) 
         if (tok->kind == TH_START_TAG && has_in_scope(tree, TH_TAG_SELECT) &&
             (dc->mode == M_IN_TABLE || dc->mode == M_IN_TABLE_BODY || dc->mode == M_IN_ROW || dc->mode == M_IN_CELL ||
              dc->mode == M_IN_CAPTION)) {
-            uint16_t a = tok_atom(tok);
-            if (a == TH_TAG_CAPTION || a == TH_TAG_TABLE || a == TH_TAG_TBODY || a == TH_TAG_TFOOT ||
-                a == TH_TAG_THEAD || a == TH_TAG_TR || a == TH_TAG_TD || a == TH_TAG_TH) {
+            uint16_t atom = tok_atom(tok);
+            if (atom == TH_TAG_CAPTION || atom == TH_TAG_TABLE || atom == TH_TAG_TBODY || atom == TH_TAG_TFOOT ||
+                atom == TH_TAG_THEAD || atom == TH_TAG_TR || atom == TH_TAG_TD || atom == TH_TAG_TH) {
                 pop_until_atom(tree, TH_TAG_SELECT);
                 dc->mode = reset_insertion_mode(tree);
                 goto reprocess;

--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -1,7 +1,7 @@
 /* Tree-builder internals shared between the parser (tree.c) and the standalone
    serialization translation units. The arena, the borrowed-input readers, the
    lazy text-span realization and the void-element predicate live here as
-   `static inline` so every including unit keeps its own inlined copy — the
+   `static inline` so every including unit keeps its own inlined copy -- the
    serialize hot path pays no cross-TU call for need_text() or is_void_atom(). */
 
 #ifndef TURBOHTML_DOM_TREE_INTERNAL_H

--- a/src/turbohtml/_c/encoding/detect.h
+++ b/src/turbohtml/_c/encoding/detect.h
@@ -1007,8 +1007,8 @@ static void th_cjk_score_euc_kr(th_cjk_candidate *cand, uint16_t u) {
 /* Drive one CPython incremental codec a byte at a time, mirroring chardetng's
    decode-and-classify loop. A decode error disqualifies the candidate. */
 static void th_cjk_feed(th_cjk_candidate *cand, const unsigned char *buf, Py_ssize_t len) {
-    for (Py_ssize_t i = 0; i < len; i++) {
-        unsigned char b = buf[i];
+    for (Py_ssize_t byte_index = 0; byte_index < len; byte_index++) {
+        unsigned char b = buf[byte_index];
         PyObject *chunk = PyBytes_FromStringAndSize((const char *)&b, 1);
         if (chunk == NULL) { /* GCOVR_EXCL_START -- single-byte allocation only fails on OOM */
             PyErr_Clear();
@@ -1090,8 +1090,8 @@ static void th_cjk_run(th_cjk_kind kind, const char *label, const unsigned char 
    no high byte, contains an escape, and decodes cleanly as ISO-2022-JP. */
 static int th_iso2022jp_alive(const unsigned char *buf, Py_ssize_t len) {
     int esc = 0;
-    for (Py_ssize_t i = 0; i < len; i++) {
-        if (buf[i] == 0x1B) {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        if (buf[index] == 0x1B) {
             esc = 1;
             break;
         }

--- a/src/turbohtml/_c/features/dates.c
+++ b/src/turbohtml/_c/features/dates.c
@@ -148,27 +148,29 @@ static int iso_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
     if (!year_at(data, kind, len, pos, year)) {
         return 0;
     }
-    Py_ssize_t p = pos + 4;
-    if (p >= len || !(CP(p) == '-' || CP(p) == '/' || CP(p) == '.')) {
+    Py_ssize_t cursor = pos + 4;
+    if (cursor >= len || !(CP(cursor) == '-' || CP(cursor) == '/' || CP(cursor) == '.')) {
         return 0;
     }
-    p++;
-    if (p + 2 < len && month2(CP(p), CP(p + 1), month) && (CP(p + 2) == '-' || CP(p + 2) == '/' || CP(p + 2) == '.')) {
-        p += 2;
-    } else if (p + 1 < len && month1(CP(p), month) && (CP(p + 1) == '-' || CP(p + 1) == '/' || CP(p + 1) == '.')) {
-        p += 1;
+    cursor++;
+    if (cursor + 2 < len && month2(CP(cursor), CP(cursor + 1), month) &&
+        (CP(cursor + 2) == '-' || CP(cursor + 2) == '/' || CP(cursor + 2) == '.')) {
+        cursor += 2;
+    } else if (cursor + 1 < len && month1(CP(cursor), month) &&
+               (CP(cursor + 1) == '-' || CP(cursor + 1) == '/' || CP(cursor + 1) == '.')) {
+        cursor += 1;
     } else {
         return 0;
     }
-    p++;
-    if (p + 1 < len && day2(CP(p), CP(p + 1), day)) {
-        p += 2;
-    } else if (p < len && day1(CP(p), day)) {
-        p += 1;
+    cursor++;
+    if (cursor + 1 < len && day2(CP(cursor), CP(cursor + 1), day)) {
+        cursor += 2;
+    } else if (cursor < len && day1(CP(cursor), day)) {
+        cursor += 1;
     } else {
         return 0;
     }
-    *out_end = p;
+    *out_end = cursor;
     return 1;
 }
 
@@ -209,43 +211,45 @@ static int compact_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos
    The year run is two to four ASCII digits ended by a non-digit. */
 static int dmy_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, int *raw_day, int *raw_month,
                   int *raw_year, Py_ssize_t *out_end) {
-    Py_ssize_t p = pos;
-    if (p + 2 < len && CP(p) >= '0' && CP(p) <= '3' && is_ascii_digit(CP(p + 1)) &&
-        (CP(p + 2) == '-' || CP(p + 2) == '/' || CP(p + 2) == '.')) {
-        *raw_day = (int)(CP(p) - '0') * 10 + (int)(CP(p + 1) - '0');
-        p += 2;
-    } else if (p + 1 < len && is_ascii_digit(CP(p)) && (CP(p + 1) == '-' || CP(p + 1) == '/' || CP(p + 1) == '.')) {
-        *raw_day = (int)(CP(p) - '0');
-        p += 1;
+    Py_ssize_t cursor = pos;
+    if (cursor + 2 < len && CP(cursor) >= '0' && CP(cursor) <= '3' && is_ascii_digit(CP(cursor + 1)) &&
+        (CP(cursor + 2) == '-' || CP(cursor + 2) == '/' || CP(cursor + 2) == '.')) {
+        *raw_day = (int)(CP(cursor) - '0') * 10 + (int)(CP(cursor + 1) - '0');
+        cursor += 2;
+    } else if (cursor + 1 < len && is_ascii_digit(CP(cursor)) &&
+               (CP(cursor + 1) == '-' || CP(cursor + 1) == '/' || CP(cursor + 1) == '.')) {
+        *raw_day = (int)(CP(cursor) - '0');
+        cursor += 1;
     } else {
         return 0;
     }
-    p++;
-    if (p + 2 < len && CP(p) >= '0' && CP(p) <= '1' && is_ascii_digit(CP(p + 1)) &&
-        (CP(p + 2) == '-' || CP(p + 2) == '/' || CP(p + 2) == '.')) {
-        *raw_month = (int)(CP(p) - '0') * 10 + (int)(CP(p + 1) - '0');
-        p += 2;
-    } else if (p + 1 < len && is_ascii_digit(CP(p)) && (CP(p + 1) == '-' || CP(p + 1) == '/' || CP(p + 1) == '.')) {
-        *raw_month = (int)(CP(p) - '0');
-        p += 1;
+    cursor++;
+    if (cursor + 2 < len && CP(cursor) >= '0' && CP(cursor) <= '1' && is_ascii_digit(CP(cursor + 1)) &&
+        (CP(cursor + 2) == '-' || CP(cursor + 2) == '/' || CP(cursor + 2) == '.')) {
+        *raw_month = (int)(CP(cursor) - '0') * 10 + (int)(CP(cursor + 1) - '0');
+        cursor += 2;
+    } else if (cursor + 1 < len && is_ascii_digit(CP(cursor)) &&
+               (CP(cursor + 1) == '-' || CP(cursor + 1) == '/' || CP(cursor + 1) == '.')) {
+        *raw_month = (int)(CP(cursor) - '0');
+        cursor += 1;
     } else {
         return 0;
     }
-    p++;
-    Py_ssize_t start = p;
-    while (p < len && is_ascii_digit(CP(p))) {
-        p++;
+    cursor++;
+    Py_ssize_t start = cursor;
+    while (cursor < len && is_ascii_digit(CP(cursor))) {
+        cursor++;
     }
-    Py_ssize_t run = p - start;
+    Py_ssize_t run = cursor - start;
     if (run < 2 || run > 4) {
         return 0;
     }
     int value = 0;
-    for (Py_ssize_t index = start; index < p; index++) {
+    for (Py_ssize_t index = start; index < cursor; index++) {
         value = value * 10 + (int)(CP(index) - '0');
     }
     *raw_year = value;
-    *out_end = p;
+    *out_end = cursor;
     return 1;
 }
 
@@ -369,23 +373,23 @@ static Py_ssize_t skip_spaces(const void *data, int kind, Py_ssize_t len, Py_ssi
    needs. Returns 1 with the year and end position. */
 static int text_a_tail(const void *data, int kind, Py_ssize_t len, Py_ssize_t start, int *year, Py_ssize_t *out_end) {
     for (int with_ordinal = 1; with_ordinal >= 0; with_ordinal--) {
-        Py_ssize_t p = start;
+        Py_ssize_t cursor = start;
         if (with_ordinal) {
-            int ordinal = match_ordinal(data, kind, len, p);
+            int ordinal = match_ordinal(data, kind, len, cursor);
             if (ordinal == 0) {
                 continue;
             }
-            p += ordinal;
+            cursor += ordinal;
         }
-        if (p < len && CP(p) == ',') {
-            p++;
+        if (cursor < len && CP(cursor) == ',') {
+            cursor++;
         }
-        p = skip_spaces(data, kind, len, p);
-        if (p < 0) {
+        cursor = skip_spaces(data, kind, len, cursor);
+        if (cursor < 0) {
             continue;
         }
-        if (year_at(data, kind, len, p, year)) {
-            *out_end = p + 4;
+        if (year_at(data, kind, len, cursor, year)) {
+            *out_end = cursor + 4;
             return 1;
         }
     }
@@ -401,21 +405,21 @@ static int text_a(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
     if (name_length == 0) {
         return 0;
     }
-    Py_ssize_t p = pos + name_length;
-    if (p < len && CP(p) == '.') {
-        p++;
+    Py_ssize_t cursor = pos + name_length;
+    if (cursor < len && CP(cursor) == '.') {
+        cursor++;
     }
-    p = skip_spaces(data, kind, len, p);
-    if (p < 0) {
+    cursor = skip_spaces(data, kind, len, cursor);
+    if (cursor < 0) {
         return 0;
     }
-    if (p + 1 < len && CP(p) >= '0' && CP(p) <= '3' && is_ascii_digit(CP(p + 1)) &&
-        text_a_tail(data, kind, len, p + 2, year, out_end)) {
-        *day = (int)(CP(p) - '0') * 10 + (int)(CP(p + 1) - '0');
+    if (cursor + 1 < len && CP(cursor) >= '0' && CP(cursor) <= '3' && is_ascii_digit(CP(cursor + 1)) &&
+        text_a_tail(data, kind, len, cursor + 2, year, out_end)) {
+        *day = (int)(CP(cursor) - '0') * 10 + (int)(CP(cursor + 1) - '0');
         return 1;
     }
-    if (p < len && is_ascii_digit(CP(p)) && text_a_tail(data, kind, len, p + 1, year, out_end)) {
-        *day = (int)(CP(p) - '0');
+    if (cursor < len && is_ascii_digit(CP(cursor)) && text_a_tail(data, kind, len, cursor + 1, year, out_end)) {
+        *day = (int)(CP(cursor) - '0');
         return 1;
     }
     return 0;
@@ -427,42 +431,42 @@ static int text_a(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
 static int text_b_tail(const void *data, int kind, Py_ssize_t len, Py_ssize_t start, int *month, int *year,
                        Py_ssize_t *out_end) {
     for (int with_ordinal = 1; with_ordinal >= 0; with_ordinal--) {
-        Py_ssize_t p = start;
+        Py_ssize_t cursor = start;
         if (with_ordinal) {
-            int ordinal = match_ordinal(data, kind, len, p);
+            int ordinal = match_ordinal(data, kind, len, cursor);
             if (ordinal == 0) {
                 continue;
             }
-            p += ordinal;
+            cursor += ordinal;
         }
-        if (p < len && CP(p) == '.') {
-            p++;
+        if (cursor < len && CP(cursor) == '.') {
+            cursor++;
         }
-        p = skip_spaces(data, kind, len, p);
-        if (p < 0) {
+        cursor = skip_spaces(data, kind, len, cursor);
+        if (cursor < 0) {
             continue;
         }
-        if (p + 2 < len && lower_month_cp(CP(p)) == 'o' && lower_month_cp(CP(p + 1)) == 'f' &&
-            is_perl_space(CP(p + 2))) {
-            p = skip_spaces(data, kind, len, p + 2);
+        if (cursor + 2 < len && lower_month_cp(CP(cursor)) == 'o' && lower_month_cp(CP(cursor + 1)) == 'f' &&
+            is_perl_space(CP(cursor + 2))) {
+            cursor = skip_spaces(data, kind, len, cursor + 2);
         }
-        int name_length = match_month_name(data, kind, len, p, month);
+        int name_length = match_month_name(data, kind, len, cursor, month);
         if (name_length == 0) {
             continue;
         }
-        Py_ssize_t q = p + name_length;
-        if (q < len && CP(q) == '.') {
-            q++;
+        Py_ssize_t scan_end = cursor + name_length;
+        if (scan_end < len && CP(scan_end) == '.') {
+            scan_end++;
         }
-        if (q < len && CP(q) == ',') {
-            q++;
+        if (scan_end < len && CP(scan_end) == ',') {
+            scan_end++;
         }
-        q = skip_spaces(data, kind, len, q);
-        if (q < 0) {
+        scan_end = skip_spaces(data, kind, len, scan_end);
+        if (scan_end < 0) {
             continue;
         }
-        if (year_at(data, kind, len, q, year)) {
-            *out_end = q + 4;
+        if (year_at(data, kind, len, scan_end, year)) {
+            *out_end = scan_end + 4;
             return 1;
         }
     }
@@ -619,23 +623,26 @@ static int url_at(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
     if (!year_at(data, kind, len, pos, year)) {
         return 0;
     }
-    Py_ssize_t p = pos + 4;
-    if (p >= len || !(CP(p) == '/' || CP(p) == '_' || CP(p) == '-')) {
+    Py_ssize_t cursor = pos + 4;
+    if (cursor >= len || !(CP(cursor) == '/' || CP(cursor) == '_' || CP(cursor) == '-')) {
         return 0;
     }
-    p++;
-    if (p + 2 < len && month2(CP(p), CP(p + 1), month) && (CP(p + 2) == '/' || CP(p + 2) == '_' || CP(p + 2) == '-')) {
-        p += 2;
-    } else if (p + 1 < len && month1(CP(p), month) && (CP(p + 1) == '/' || CP(p + 1) == '_' || CP(p + 1) == '-')) {
-        p += 1;
+    cursor++;
+    if (cursor + 2 < len && month2(CP(cursor), CP(cursor + 1), month) &&
+        (CP(cursor + 2) == '/' || CP(cursor + 2) == '_' || CP(cursor + 2) == '-')) {
+        cursor += 2;
+    } else if (cursor + 1 < len && month1(CP(cursor), month) &&
+               (CP(cursor + 1) == '/' || CP(cursor + 1) == '_' || CP(cursor + 1) == '-')) {
+        cursor += 1;
     } else {
         return 0;
     }
-    p++;
-    if (p + 1 < len && day2(CP(p), CP(p + 1), day) && (p + 2 >= len || !is_ascii_digit(CP(p + 2)))) {
+    cursor++;
+    if (cursor + 1 < len && day2(CP(cursor), CP(cursor + 1), day) &&
+        (cursor + 2 >= len || !is_ascii_digit(CP(cursor + 2)))) {
         return 1;
     }
-    if (p < len && day1(CP(p), day) && (p + 1 >= len || !is_ascii_digit(CP(p + 1)))) {
+    if (cursor < len && day1(CP(cursor), day) && (cursor + 1 >= len || !is_ascii_digit(CP(cursor + 1)))) {
         return 1;
     }
     return 0;

--- a/src/turbohtml/_c/serialize/document.c
+++ b/src/turbohtml/_c/serialize/document.c
@@ -1,4 +1,4 @@
-/* Renders a parsed tree back to HTML — the round-trippable document/fragment
+/* Renders a parsed tree back to HTML -- the round-trippable document/fragment
    markup, the html5lib "#document" debug dump, and the indented pretty form,
    under the WHATWG, minimal, or named-entity escape policy the caller picks. */
 
@@ -85,7 +85,7 @@ static void serialize_node_line(sbuf *out, th_tree *tree, th_node *node, int dep
         break;
         /* GCOVR_EXCL_STOP */
     case TH_NODE_DOCUMENT: /* GCOVR_EXCL_LINE: the document node is the serialization root, never a line itself */
-        break;             /* GCOVR_EXCL_LINE: same — the document node is never reached as a child */
+        break;             /* GCOVR_EXCL_LINE: same -- the document node is never reached as a child */
     }
     sbuf_putc(out, '\n');
     /* attributes: each on its own deeper line, output in lexicographic name

--- a/src/turbohtml/_c/serialize/internal.h
+++ b/src/turbohtml/_c/serialize/internal.h
@@ -392,7 +392,7 @@ static inline void ser_sort_order(th_tree *tree, const th_node *node, Py_ssize_t
 }
 
 /* The order to emit node's attributes in: NULL means source order (sorting off, or
-   fewer than two attributes), otherwise a filled index array — the caller's stack
+   fewer than two attributes), otherwise a filled index array -- the caller's stack
    buffer for up to MAX_SORTED_ATTRS attributes, else a heap block freed through
    ser_attr_order_free. */
 static inline Py_ssize_t *ser_attr_order(th_tree *tree, const th_node *node, int sort, Py_ssize_t *stack) {
@@ -576,15 +576,15 @@ static inline int is_md_skipped(const th_node *node) {
     return node->ns == TH_NS_HTML && node->atom == TH_TAG_HEAD;
 }
 
-static inline Py_ssize_t md_put_decimal(sbuf *out, Py_ssize_t n) {
+static inline Py_ssize_t md_put_decimal(sbuf *out, Py_ssize_t number) {
     Py_UCS4 digits[20];
     Py_ssize_t count = 0;
     do {
-        digits[count++] = (Py_UCS4)('0' + (int)(n % 10));
-        n /= 10;
-    } while (n > 0);
-    for (Py_ssize_t i = count - 1; i >= 0; i--) {
-        sbuf_putc(out, digits[i]);
+        digits[count++] = (Py_UCS4)('0' + (int)(number % 10));
+        number /= 10;
+    } while (number > 0);
+    for (Py_ssize_t index = count - 1; index >= 0; index--) {
+        sbuf_putc(out, digits[index]);
     }
     return count;
 }

--- a/src/turbohtml/_c/serialize/js/mangle.c
+++ b/src/turbohtml/_c/serialize/js/mangle.c
@@ -1354,7 +1354,7 @@ static int inline_single_use(jm_program *prog, int32_t global) {
 
 /* Replace every read of a qualifying symbol with a copy of its literal, counting the copies; a
    `{ x }` shorthand read first gains its explicit key. The declarator still stands while this
-   runs, so if a key allocation fails mid-walk the untouched reads simply keep the binding -- the
+   runs, so if a key allocation fails mid-walk the untouched reads keep the binding -- the
    caller unlinks it only once every read was replaced. */
 /* One planned propagation: every read of `sym` (its declarator target excluded) becomes a copy of
    the literal at `init`; `replaced` counts the copies so the caller unlinks the declarator only

--- a/src/turbohtml/_c/serialize/markdown.c
+++ b/src/turbohtml/_c/serialize/markdown.c
@@ -1,5 +1,5 @@
-/* Turns a scraped page into clean GitHub-Flavored Markdown — headings, lists,
-   tables, links and emphasis — so a `scrape -> markdown` pipeline needs no
+/* Turns a scraped page into clean GitHub-Flavored Markdown -- headings, lists,
+   tables, links and emphasis -- so a `scrape -> markdown` pipeline needs no
    second dependency.
 
    It shares the sbuf buffer, need_text(), the tag atoms, the attribute lookup,
@@ -14,7 +14,7 @@
    eagerly: a run sets space_pending, and the deferred space is flushed (as one
    space) only just before the next real character, and only when the current
    line already holds content. That one rule collapses runs, drops the space at
-   block and line starts, and — because a closing marker does not flush — moves a
+   block and line starts, and -- because a closing marker does not flush -- moves a
    trailing inner space out of `**bold** ` instead of leaving `**bold **`, which
    is invalid markdown. */
 
@@ -355,8 +355,8 @@ static Py_ssize_t md_escape_line_number(md_ctx *ctx, const Py_UCS4 *text, Py_ssi
 
 /* Emit inline text with normal-flow whitespace collapsing and markdown escaping.
    Prose is mostly plain runs, so after the first character of a word is placed
-   (which resolves the deferred space, markers and escapes) the rest of the run —
-   no whitespace, nothing to escape — is bulk-copied in one memcpy. */
+   (which resolves the deferred space, markers and escapes) the rest of the run --
+   no whitespace, nothing to escape -- is bulk-copied in one memcpy. */
 static void md_emit_text(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
     int translit = ctx->opt->transliterate;
     Py_ssize_t index = 0;

--- a/src/turbohtml/_c/serialize/minify.c
+++ b/src/turbohtml/_c/serialize/minify.c
@@ -1,4 +1,4 @@
-/* Shrinks a parsed document to the smallest equivalent HTML — dropping the
+/* Shrinks a parsed document to the smallest equivalent HTML -- dropping the
    optional tags, quotes, and whitespace the spec lets us fold without changing
    what the bytes reparse to.
 
@@ -447,7 +447,7 @@ static int mini_omit_start_tag(th_tree *tree, th_node *node, int strip_comments)
    empty, "module", or a WHATWG JavaScript MIME type essence. Any other type
    (application/json, importmap, a text/html template, ...) is data, not script, and must
    pass through untouched, so it is never handed to the JS minifier. A type padded with
-   whitespace is treated conservatively as non-JS — rare, and verbatim is always safe. */
+   whitespace is treated conservatively as non-JS -- rare, and verbatim is always safe. */
 static int script_is_js(th_tree *tree, th_node *node) {
     Py_ssize_t type_index = th_node_attr_find(tree, node, "type", 4);
     if (type_index < 0) {
@@ -485,8 +485,8 @@ static int script_is_js(th_tree *tree, th_node *node) {
     return 0;
 }
 
-/* Emit a <script>'s JavaScript content minified, returning 1 when it did. Returns 0 —
-   leaving the caller to emit the content verbatim — for a non-JS script, an empty one, or
+/* Emit a <script>'s JavaScript content minified, returning 1 when it did. Returns 0 --
+   leaving the caller to emit the content verbatim -- for a non-JS script, an empty one, or
    a script the JS minifier cannot parse, so one bad <script> never breaks serialization. */
 static int mini_emit_script_js(sbuf *out, th_tree *tree, th_node *node, const th_minify_opts *opts) {
     if (node->atom != TH_TAG_SCRIPT) {
@@ -523,8 +523,8 @@ static int mini_emit_script_js(sbuf *out, th_tree *tree, th_node *node, const th
     return 1;
 }
 
-/* Emit a <style>'s CSS content minified, returning 1 when it did. Returns 0 — leaving the
-   caller to emit the content verbatim — for a non-style raw-text element or an empty <style>,
+/* Emit a <style>'s CSS content minified, returning 1 when it did. Returns 0 -- leaving the
+   caller to emit the content verbatim -- for a non-style raw-text element or an empty <style>,
    so those cost nothing. A parsed <style> body can hold no </style close sequence (the parser
    would have ended the element there), and the CSS engine never synthesizes one, so the
    minified stylesheet stays inside the element and reparses to the same raw-text node. */

--- a/src/turbohtml/_c/serialize/readability.c
+++ b/src/turbohtml/_c/serialize/readability.c
@@ -1,5 +1,5 @@
-/* Pulls the real article out of a cluttered page — stripping nav, sidebars, and
-   boilerplate — so a reader view or a clean extract keeps only the main content.
+/* Pulls the real article out of a cluttered page -- stripping nav, sidebars, and
+   boilerplate -- so a reader view or a clean extract keeps only the main content.
 
    It scores the DOM by content density -- text length, comma count, tag weight
    and class/id weight, discounted by link density, the well-known readability

--- a/src/turbohtml/_c/serialize/text.c
+++ b/src/turbohtml/_c/serialize/text.c
@@ -1,6 +1,6 @@
-/* Renders a page as readable plain text the way a browser would lay it out —
+/* Renders a page as readable plain text the way a browser would lay it out --
    blocks split by blank lines, lists indented under their bullets, tables drawn
-   as a column-aligned grid — for search indexing, diffing, or a terminal view.
+   as a column-aligned grid -- for search indexing, diffing, or a terminal view.
 
    It shares sbuf, need_text(), the tag atoms, the attribute lookup, and the
    is_space()/is_md_block()/is_md_skipped() predicates from serialize/internal.h.
@@ -118,18 +118,18 @@ static void text_emit_word(text_ctx *ctx, const Py_UCS4 *word, Py_ssize_t len) {
 
 /* Emit inline text with normal-flow whitespace collapsing (no escaping). */
 static void text_emit_text(text_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
-    Py_ssize_t i = 0;
-    while (i < len) {
-        if (is_space(text[i])) {
+    Py_ssize_t pos = 0;
+    while (pos < len) {
+        if (is_space(text[pos])) {
             ctx->space_pending = 1;
-            i++;
+            pos++;
             continue;
         }
-        Py_ssize_t start = i;
-        while (i < len && !is_space(text[i])) {
-            i++;
+        Py_ssize_t start = pos;
+        while (pos < len && !is_space(text[pos])) {
+            pos++;
         }
-        text_emit_word(ctx, &text[start], i - start);
+        text_emit_word(ctx, &text[start], pos - start);
     }
 }
 
@@ -161,9 +161,9 @@ static Py_ssize_t text_add_reference(text_ctx *ctx, const Py_UCS4 *url, Py_ssize
 }
 
 /* Emit a run of ASCII characters (a bracket, a footnote number's punctuation). */
-static void text_emit_ascii(text_ctx *ctx, const char *s) {
-    for (const char *c = s; *c != '\0'; c++) {
-        sbuf_putc(&ctx->out, (Py_UCS4)(unsigned char)*c);
+static void text_emit_ascii(text_ctx *ctx, const char *ascii) {
+    for (const char *cursor = ascii; *cursor != '\0'; cursor++) {
+        sbuf_putc(&ctx->out, (Py_UCS4)(unsigned char)*cursor);
         ctx->column++;
     }
     ctx->line_has_content = 1;
@@ -195,19 +195,19 @@ static int text_rule_matches(text_ctx *ctx, th_node *node, const text_rule *rule
     if (rule->value == NULL) {
         return 1;
     }
-    const Py_UCS4 *av = node->attrs[idx].value;
-    Py_ssize_t avlen = node->attrs[idx].value_len;
-    Py_ssize_t i = 0;
-    while (i < avlen) {
-        while (i < avlen && is_space(av[i])) {
-            i++;
+    const Py_UCS4 *attr_value = node->attrs[idx].value;
+    Py_ssize_t attr_len = node->attrs[idx].value_len;
+    Py_ssize_t pos = 0;
+    while (pos < attr_len) {
+        while (pos < attr_len && is_space(attr_value[pos])) {
+            pos++;
         }
-        Py_ssize_t start = i;
-        while (i < avlen && !is_space(av[i])) {
-            i++;
+        Py_ssize_t start = pos;
+        while (pos < attr_len && !is_space(attr_value[pos])) {
+            pos++;
         }
-        if (i - start == rule->value_len &&
-            memcmp(&av[start], rule->value, (size_t)rule->value_len * sizeof(Py_UCS4)) == 0) {
+        if (pos - start == rule->value_len &&
+            memcmp(&attr_value[start], rule->value, (size_t)rule->value_len * sizeof(Py_UCS4)) == 0) {
             return 1;
         }
     }
@@ -226,8 +226,8 @@ static void text_record_span(text_ctx *ctx, Py_ssize_t start, Py_ssize_t end, Py
     if (start >= end) {
         return; /* an element with no visible text (or only whitespace) gets no span */
     }
-    Py_ssize_t n = PyTuple_GET_SIZE(labels);
-    for (Py_ssize_t i = 0; i < n; i++) {
+    Py_ssize_t label_count = PyTuple_GET_SIZE(labels);
+    for (Py_ssize_t label_index = 0; label_index < label_count; label_index++) {
         if (ctx->span_count == ctx->span_cap) {
             size_t cap;
             size_t bytes;
@@ -247,7 +247,7 @@ static void text_record_span(text_ctx *ctx, Py_ssize_t start, Py_ssize_t end, Py
         }
         ctx->spans[ctx->span_count].start = start;
         ctx->spans[ctx->span_count].end = end;
-        ctx->spans[ctx->span_count].label = PyTuple_GET_ITEM(labels, i);
+        ctx->spans[ctx->span_count].label = PyTuple_GET_ITEM(labels, label_index);
         ctx->span_count++;
     }
 }
@@ -259,8 +259,8 @@ static Py_ssize_t text_open_annotations(text_ctx *ctx, th_node *node) {
         return 0;
     }
     Py_ssize_t opened = 0;
-    for (Py_ssize_t r = 0; r < ctx->n_rules; r++) {
-        if (!text_rule_matches(ctx, node, &ctx->rules[r])) {
+    for (Py_ssize_t rule_index = 0; rule_index < ctx->n_rules; rule_index++) {
+        if (!text_rule_matches(ctx, node, &ctx->rules[rule_index])) {
             continue;
         }
         if (ctx->active_count == ctx->active_cap) {
@@ -281,7 +281,7 @@ static Py_ssize_t text_open_annotations(text_ctx *ctx, th_node *node) {
             ctx->active_cap = (Py_ssize_t)cap;
         }
         ctx->active[ctx->active_count].start = ctx->out.len;
-        ctx->active[ctx->active_count].rule = &ctx->rules[r];
+        ctx->active[ctx->active_count].rule = &ctx->rules[rule_index];
         ctx->active_count++;
         opened++;
     }
@@ -290,10 +290,10 @@ static Py_ssize_t text_open_annotations(text_ctx *ctx, th_node *node) {
 
 /* Close the opened spans, recording each over the text emitted since it opened. */
 static void text_close_annotations(text_ctx *ctx, Py_ssize_t opened) {
-    for (Py_ssize_t i = 0; i < opened; i++) {
+    for (Py_ssize_t index = 0; index < opened; index++) {
         ctx->active_count--;
-        text_active *a = &ctx->active[ctx->active_count];
-        text_record_span(ctx, a->start, ctx->out.len, a->rule->labels);
+        text_active *active = &ctx->active[ctx->active_count];
+        text_record_span(ctx, active->start, ctx->out.len, active->rule->labels);
     }
 }
 
@@ -391,9 +391,9 @@ static void text_render_inline(text_ctx *ctx, th_node *node) {
 
 /* Emit an ASCII option string (a default image alt) through the word machinery
    so it collapses and wraps like any other text. */
-static void text_emit_text2(text_ctx *ctx, const char *s) {
-    for (const char *c = s; *c != '\0'; c++) {
-        Py_UCS4 ch = (Py_UCS4)(unsigned char)*c;
+static void text_emit_text2(text_ctx *ctx, const char *ascii) {
+    for (const char *cursor = ascii; *cursor != '\0'; cursor++) {
+        Py_UCS4 ch = (Py_UCS4)(unsigned char)*cursor;
         if (is_space(ch)) {
             ctx->space_pending = 1;
         } else {
@@ -402,10 +402,10 @@ static void text_emit_text2(text_ctx *ctx, const char *s) {
     }
 }
 
-/* A run of n spaces appended to the continuation prefix; returns the prior len. */
-static Py_ssize_t text_push_indent(text_ctx *ctx, Py_ssize_t n) {
+/* A run of count spaces appended to the continuation prefix; returns the prior len. */
+static Py_ssize_t text_push_indent(text_ctx *ctx, Py_ssize_t count) {
     Py_ssize_t base = ctx->prefix.len;
-    for (Py_ssize_t i = 0; i < n; i++) {
+    for (Py_ssize_t index = 0; index < count; index++) {
         sbuf_putc(&ctx->prefix, ' ');
     }
     return base;
@@ -415,8 +415,8 @@ static int text_leads_with_inline(text_ctx *ctx, th_node *node) {
     for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
         if (child->type == TH_NODE_TEXT) {
             const Py_UCS4 *text = need_text(ctx->tree, child);
-            for (Py_ssize_t i = 0; i < child->text_len; i++) {
-                if (!is_space(text[i])) {
+            for (Py_ssize_t index = 0; index < child->text_len; index++) {
+                if (!is_space(text[index])) {
                     return 1;
                 }
             }
@@ -460,8 +460,8 @@ static void text_block_children(text_ctx *ctx, th_node *node) {
             int only_ws = child->type == TH_NODE_TEXT;
             if (only_ws) {
                 const Py_UCS4 *text = need_text(ctx->tree, child);
-                for (Py_ssize_t i = 0; i < child->text_len; i++) {
-                    if (!is_space(text[i])) {
+                for (Py_ssize_t index = 0; index < child->text_len; index++) {
+                    if (!is_space(text[index])) {
                         only_ws = 0;
                         break;
                     }
@@ -488,8 +488,8 @@ static int text_ordinal_attr(text_ctx *ctx, th_node *node, const char *name, Py_
     }
     Py_ssize_t value = 0;
     int seen = 0;
-    for (Py_ssize_t i = 0; i < len && attr[i] >= '0' && attr[i] <= '9'; i++) {
-        value = value * 10 + (attr[i] - '0');
+    for (Py_ssize_t index = 0; index < len && attr[index] >= '0' && attr[index] <= '9'; index++) {
+        value = value * 10 + (attr[index] - '0');
         seen = 1;
     }
     if (seen) {
@@ -576,8 +576,8 @@ static void text_cell_text(text_ctx *ctx, th_node *node, sbuf *dst) {
     ctx->column = saved_col;
     ctx->space_pending = saved_space;
     ctx->started = saved_started;
-    for (Py_ssize_t i = 0; i < rendered.len; i++) {
-        sbuf_putc(dst, rendered.data[i] == '\n' ? ' ' : rendered.data[i]);
+    for (Py_ssize_t index = 0; index < rendered.len; index++) {
+        sbuf_putc(dst, rendered.data[index] == '\n' ? ' ' : rendered.data[index]);
     }
     PyMem_Free(rendered.data);
 }
@@ -633,46 +633,46 @@ static void text_render_table(text_ctx *ctx, th_node *node) {
         ctx->out.failed = 1;                               /* GCOVR_EXCL_LINE: allocation-failure path */
         return;                                            /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    for (Py_ssize_t r = 0; r < count; r++) {
+    for (Py_ssize_t row_index = 0; row_index < count; row_index++) {
         Py_ssize_t col = 0;
-        for (th_node *cell = rows[r]->first_child; cell != NULL; cell = cell->next_sibling) {
+        for (th_node *cell = rows[row_index]->first_child; cell != NULL; cell = cell->next_sibling) {
             if (cell->type != TH_NODE_ELEMENT || (cell->atom != TH_TAG_TD && cell->atom != TH_TAG_TH)) {
                 continue;
             }
-            text_cell_text(ctx, cell, &grid[r * columns + col]);
-            cells[r * columns + col] = cell;
-            if (grid[r * columns + col].len > widths[col]) {
-                widths[col] = grid[r * columns + col].len;
+            text_cell_text(ctx, cell, &grid[row_index * columns + col]);
+            cells[row_index * columns + col] = cell;
+            if (grid[row_index * columns + col].len > widths[col]) {
+                widths[col] = grid[row_index * columns + col].len;
             }
             col++;
         }
     }
     text_block_line(ctx, 1);
-    for (Py_ssize_t r = 0; r < count; r++) {
-        if (r > 0) {
+    for (Py_ssize_t row_index = 0; row_index < count; row_index++) {
+        if (row_index > 0) {
             text_newline(ctx);
         }
-        for (Py_ssize_t c = 0; c < columns; c++) {
-            if (c > 0) {
+        for (Py_ssize_t col_index = 0; col_index < columns; col_index++) {
+            if (col_index > 0) {
                 text_emit_ascii(ctx, ctx->opt->cell_separator);
             }
-            sbuf *cell = &grid[r * columns + c];
-            th_node *cell_node = cells[r * columns + c];
+            sbuf *cell = &grid[row_index * columns + col_index];
+            th_node *cell_node = cells[row_index * columns + col_index];
             /* annotate the cell element over its placed (not throwaway) text */
             Py_ssize_t opened = cell_node != NULL ? text_open_annotations(ctx, cell_node) : 0;
             sbuf_put_run(&ctx->out, cell->data, cell->len);
             text_close_annotations(ctx, opened);
             /* the last column needs no padding: nothing follows it on the line */
-            if (c + 1 < columns) {
-                for (Py_ssize_t pad = cell->len; pad < widths[c]; pad++) {
+            if (col_index + 1 < columns) {
+                for (Py_ssize_t pad = cell->len; pad < widths[col_index]; pad++) {
                     sbuf_putc(&ctx->out, ' ');
                 }
             }
         }
         ctx->line_has_content = 1;
     }
-    for (Py_ssize_t i = 0; i < count * columns; i++) {
-        PyMem_Free(grid[i].data);
+    for (Py_ssize_t cell_index = 0; cell_index < count * columns; cell_index++) {
+        PyMem_Free(grid[cell_index].data);
     }
     PyMem_Free(grid);
     PyMem_Free(widths);
@@ -692,11 +692,11 @@ static void text_render_pre(text_ctx *ctx, th_node *node) {
         end--;
     }
     text_block_line(ctx, 1);
-    for (Py_ssize_t i = 0; i < end; i++) {
-        if (text[i] == '\n') {
+    for (Py_ssize_t index = 0; index < end; index++) {
+        if (text[index] == '\n') {
             text_newline(ctx);
         } else {
-            sbuf_putc(&ctx->out, text[i]);
+            sbuf_putc(&ctx->out, text[index]);
             ctx->line_has_content = 1;
         }
     }
@@ -755,14 +755,14 @@ static void text_flush_references(text_ctx *ctx) {
         return;
     }
     sbuf_puts(&ctx->out, "\n\n");
-    for (Py_ssize_t i = 0; i < ctx->ref_count; i++) {
-        if (i > 0) {
+    for (Py_ssize_t ref_index = 0; ref_index < ctx->ref_count; ref_index++) {
+        if (ref_index > 0) {
             sbuf_putc(&ctx->out, '\n');
         }
         sbuf_putc(&ctx->out, '[');
-        md_put_decimal(&ctx->out, i + 1);
+        md_put_decimal(&ctx->out, ref_index + 1);
         sbuf_puts(&ctx->out, "] ");
-        sbuf_put_run(&ctx->out, ctx->refs[i].url, ctx->refs[i].url_len);
+        sbuf_put_run(&ctx->out, ctx->refs[ref_index].url, ctx->refs[ref_index].url_len);
     }
 }
 
@@ -808,9 +808,9 @@ Py_UCS4 *th_node_annotated_text(th_tree *tree, th_node *node, const text_opts *o
        same amount; record_span already trimmed each span to non-blank bounds, so
        the trailing strip never lands inside one and no clamping is needed */
     Py_ssize_t front = md_trim(&ctx.out, TH_MD_DOC_STRIP);
-    for (Py_ssize_t i = 0; i < ctx.span_count; i++) {
-        ctx.spans[i].start -= front;
-        ctx.spans[i].end -= front;
+    for (Py_ssize_t span_index = 0; span_index < ctx.span_count; span_index++) {
+        ctx.spans[span_index].start -= front;
+        ctx.spans[span_index].end -= front;
     }
     *out_spans = ctx.spans;
     *out_span_count = ctx.span_count;

--- a/src/turbohtml/_c/tokenizer/statemachine_run.h
+++ b/src/turbohtml/_c/tokenizer/statemachine_run.h
@@ -262,7 +262,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
                 EOF_FLUSH();
             }
 #if TH_UCS1
-            /* '\n' is ordinary text in DATA — the only per-newline work is
+            /* '\n' is ordinary text in DATA -- the only per-newline work is
                line/column tracking, so a single SIMD pass runs straight through
                newlines to the next markup (a paragraph between tags becomes one
                sweep, not one per wrapped line) and folds the newline count and

--- a/src/turbohtml/_c/tokenizer/token.c
+++ b/src/turbohtml/_c/tokenizer/token.c
@@ -113,7 +113,7 @@ PyObject *token_from_record(module_state *state, const th_tokenizer *sm, PyObjec
     } else if (record->kind == TH_TEXT && record->text.len >= 512) {
         self->arena = NULL;
         /* move a large text run instead of copying it; the machine's record
-           simply regrows, which costs far less than duplicating the run */
+           regrows, which costs far less than duplicating the run */
         self->record.kind = TH_TEXT;
         self->record.line = record->line;
         self->record.col = record->col;

--- a/src/turbohtml/_linkify.py
+++ b/src/turbohtml/_linkify.py
@@ -13,32 +13,32 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Final, TypeAlias
 
 from ._html import Element, Text, _linkify_find, _linkify_scan, parse_fragment
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
-_EMAIL_KIND = 1
+_EMAIL_KIND: Final = 1
 
 # A scheme-less match (``tel:+1-800``, ``bitcoin:1abc``) already carries its scheme, so its url is the matched text
 # verbatim; only a bare domain (kind 0 without a ``scheme://``) is prefixed with ``http://``.
-_SCHEME_KIND = 2
+_SCHEME_KIND: Final = 2
 
 # A leading ``scheme://`` tells a matched URL already carries its scheme; a bare domain (``example.com``, ``www.x.com``)
 # does not and is prefixed with ``http://``. Anchoring at the start avoids treating a ``://`` deeper in a bare domain's
 # path (an embedded redirect URL) as the link's own scheme.
-_SCHEME = re.compile(r"[a-zA-Z][a-zA-Z0-9+.\-]*://")
+_SCHEME: Final = re.compile(r"[a-zA-Z][a-zA-Z0-9+.\-]*://")
 
 # The ``scheme://host`` schemes autolinked when a config registers none: the fixed set linkify-it recognizes, so a typo
 # scheme or a ``javascript://`` payload stays plain text. A ``Linkify.schemes`` restricts to its own set (bleach), while
 # a ``LinkDetector``'s ``schemes`` extends this one; the low-level scanner without an allowlist stays permissive.
-_DEFAULT_URL_SCHEMES = ("ftp", "http", "https")
+_DEFAULT_URL_SCHEMES: Final = ("ftp", "http", "https")
 
 # Text inside these never becomes a link: an existing anchor (no nested links) and the raw-text elements whose content
 # is not markup. A caller's skip_tags is added on top.
-_NEVER_LINKIFY = frozenset({"a", "script", "style"})
+_NEVER_LINKIFY: Final = frozenset({"a", "script", "style"})
 
 
 class LinkCandidate:
@@ -120,7 +120,7 @@ def target_blank(link: LinkCandidate) -> LinkCandidate | None:
 
 
 #: The callbacks linkify applies when a caller passes none, matching bleach's default.
-DEFAULT_CALLBACKS = (nofollow,)
+DEFAULT_CALLBACKS: Final = (nofollow,)
 
 
 @dataclass(frozen=True)

--- a/src/turbohtml/_match.py
+++ b/src/turbohtml/_match.py
@@ -21,7 +21,7 @@ and whose namespace discrimination turbohtml does not yet apply -- see the modul
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Final, cast
 
 from ._html import Document, Element, parse
 from ._selectors import SelectorSyntaxError
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 #: The soupsieve ``DEBUG`` flag value, re-exported so a port can pass it without importing soupsieve. turbohtml exposes
 #: no compiled-selector dump, so it is accepted and carried but has no effect.
-DEBUG = 0x1
+DEBUG: Final = 0x1
 
 
 def escape_identifier(ident: str) -> str:
@@ -97,10 +97,10 @@ class Matching:
         return cls(namespaces=namespaces, flags=flags)
 
 
-_DEFAULT = Matching()
+_DEFAULT: Final = Matching()
 # A throwaway element to validate selector syntax at compile time; matching against it parses the selector, raising on
 # a malformed one, without needing the caller's node.
-_PROBE = cast("Element", parse("<x></x>").root)
+_PROBE: Final = cast("Element", parse("<x></x>").root)
 
 
 class Matcher:

--- a/src/turbohtml/_minify.py
+++ b/src/turbohtml/_minify.py
@@ -13,7 +13,7 @@ inline-``<script>`` path are configured the same way.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Final, Literal
 
 from ._html import Minify, _minify_js, parse
 from ._jsminify import JSMinify
@@ -21,7 +21,7 @@ from ._render import Html
 
 __all__ = ["JSMinify", "Minify", "minify", "minify_js"]
 
-_DEFAULT = Minify()
+_DEFAULT: Final = Minify()
 
 
 def minify(html: str, options: Minify | None = None) -> str:

--- a/src/turbohtml/_render.py
+++ b/src/turbohtml/_render.py
@@ -17,7 +17,7 @@ default handling.
 from __future__ import annotations
 
 from dataclasses import dataclass, field, fields
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 from ._html import Formatter, Indent, Minify, _register_render_configs
 
@@ -303,7 +303,7 @@ class Markdown:
         return unpacked
 
 
-_MARKDOWN_DEFAULT = Markdown()
+_MARKDOWN_DEFAULT: Final = Markdown()
 
 
 @dataclass(frozen=True)
@@ -339,7 +339,7 @@ class PlainText:
         }
 
 
-_PLAINTEXT_DEFAULT = PlainText()
+_PLAINTEXT_DEFAULT: Final = PlainText()
 
 
 @dataclass(frozen=True)
@@ -369,7 +369,7 @@ class Html:
         }
 
 
-_HTML_DEFAULT = Html()
+_HTML_DEFAULT: Final = Html()
 
 _register_render_configs(Markdown, PlainText, Html)
 

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from types import MappingProxyType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from ._html import _sanitize, parse_fragment
 
@@ -39,17 +39,30 @@ class OnDisallowed(Enum):
 
 
 #: bleach's default allowed tags, the migration baseline.
-DEFAULT_TAGS = frozenset({"a", "abbr", "acronym", "b", "blockquote", "code", "em", "i", "li", "ol", "strong", "ul"})
+DEFAULT_TAGS: Final = frozenset({
+    "a",
+    "abbr",
+    "acronym",
+    "b",
+    "blockquote",
+    "code",
+    "em",
+    "i",
+    "li",
+    "ol",
+    "strong",
+    "ul",
+})
 #: bleach's default allowed attributes, keyed by tag (``"*"`` would match every tag).
-DEFAULT_ATTRIBUTES: Mapping[str, frozenset[str]] = MappingProxyType({
+DEFAULT_ATTRIBUTES: Final[Mapping[str, frozenset[str]]] = MappingProxyType({
     "a": frozenset({"href", "title"}),
     "abbr": frozenset({"title"}),
     "acronym": frozenset({"title"}),
 })
 #: bleach's default URL schemes.
-DEFAULT_SCHEMES = frozenset({"http", "https", "mailto"})
+DEFAULT_SCHEMES: Final = frozenset({"http", "https", "mailto"})
 #: bleach's default allowed CSS properties (CSS 2.1 safe set plus SVG paint), for scrubbing a ``style`` attribute.
-DEFAULT_CSS_PROPERTIES = frozenset({
+DEFAULT_CSS_PROPERTIES: Final = frozenset({
     "azimuth", "background-color", "border-bottom-color", "border-collapse", "border-color", "border-left-color",
     "border-right-color", "border-top-color", "clear", "color", "cursor", "direction", "display", "elevation",
     "float", "font", "font-family", "font-size", "font-style", "font-variant", "font-weight", "height",
@@ -61,12 +74,12 @@ DEFAULT_CSS_PROPERTIES = frozenset({
 })  # fmt: skip
 
 # A roomier set for the relaxed preset: typical user-generated content (headings, tables, images, figures).
-_RELAXED_TAGS = DEFAULT_TAGS | {
+_RELAXED_TAGS: Final = DEFAULT_TAGS | {
     "p", "br", "hr", "span", "div", "pre", "h1", "h2", "h3", "h4", "h5", "h6",
     "dl", "dt", "dd", "sub", "sup", "del", "ins", "mark", "small", "u", "s", "q", "cite", "img",
     "figure", "figcaption", "table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption", "colgroup", "col",
 }  # fmt: skip
-_RELAXED_ATTRIBUTES: Mapping[str, frozenset[str]] = MappingProxyType({
+_RELAXED_ATTRIBUTES: Final[Mapping[str, frozenset[str]]] = MappingProxyType({
     "*": frozenset({"title", "lang", "dir"}),
     "a": frozenset({"href", "title", "name"}),
     "img": frozenset({"src", "alt", "title", "width", "height"}),

--- a/src/turbohtml/build.py
+++ b/src/turbohtml/build.py
@@ -19,7 +19,7 @@ A call takes its arguments in order: a leading mapping is the element's attribut
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, TypeAlias, TypeGuard
+from typing import TYPE_CHECKING, Final, TypeAlias, TypeGuard
 
 from ._html import Element, Text, _build_document
 
@@ -112,7 +112,7 @@ class ElementMaker:
 
 
 #: The shared builder: ``E.div(...)`` or ``E("div", ...)`` builds a ``<div>`` element.
-E = ElementMaker()
+E: Final = ElementMaker()
 
 
 def document(

--- a/src/turbohtml/query.py
+++ b/src/turbohtml/query.py
@@ -74,7 +74,7 @@ def _unique(elements: Iterable[Element]) -> list[Element]:
 
 
 def _class_list(element: Element) -> list[str]:
-    # the tree stores the class attribute tokenized as a list, or omits it (None)
+    """Read the ``class`` attribute, which the tree stores tokenized as a list or omits entirely."""
     value = element.attrs.get("class")
     return list(value) if isinstance(value, list) else []
 

--- a/tests/dom/test_tree_construct.py
+++ b/tests/dom/test_tree_construct.py
@@ -51,9 +51,6 @@ def test_data_must_be_a_str(node_type: type[Text | Comment]) -> None:
         node_type(123)  # ty: ignore[invalid-argument-type]  # data must be a str
 
 
-# --- Element ---
-
-
 def test_element_bare() -> None:
     div = Element("div")
     assert div.tag == "div"

--- a/tests/dom/test_tree_setters.py
+++ b/tests/dom/test_tree_setters.py
@@ -152,9 +152,6 @@ def test_attrs_round_trips_through_dict() -> None:
     assert dict(_div('<div id="a" class="x">').attrs) == {"id": "a", "class": ["x"]}
 
 
-# --- data setter ---
-
-
 def test_data_setter_replaces_text() -> None:
     text = Text("old")
     text.data = "new & shiny"
@@ -185,9 +182,6 @@ def test_data_cannot_be_deleted() -> None:
         del text.data  # ty: ignore[invalid-assignment]  # data has no deleter
 
 
-# --- text setter ---
-
-
 def test_text_setter_replaces_children() -> None:
     element = parse("<p><b>x</b>y</p>").find("p")
     assert element is not None
@@ -214,9 +208,6 @@ def test_text_cannot_be_deleted() -> None:
     element = _div()
     with pytest.raises(TypeError, match="cannot delete text"):
         del element.text  # ty: ignore[invalid-assignment]  # text has no deleter
-
-
-# --- set_inner_html: parse a fragment in context and replace the children ---
 
 
 @pytest.mark.parametrize(
@@ -299,9 +290,6 @@ def test_set_inner_html_rejects(tag: str, fragment: str, exception: type[Excepti
         Element(tag).set_inner_html(fragment)
 
 
-# --- set_text: replace the children with one verbatim Text node ---
-
-
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
@@ -350,9 +338,6 @@ def test_set_text_on_a_constructed_element() -> None:
 def test_set_text_rejects_non_str(value: str) -> None:
     with pytest.raises(TypeError, match="text must be a str"):
         Element("p").set_text(value)
-
-
-# --- insert_adjacent_html: parse a fragment and splice it at a DOM position ---
 
 
 @pytest.mark.parametrize(

--- a/tests/extract/test_tree_main_content.py
+++ b/tests/extract/test_tree_main_content.py
@@ -298,7 +298,6 @@ def test_landmark_only_body_is_rescued_on_retry() -> None:
     assert "A comet is an icy" in found.text
 
 
-# === article(): the content body plus harvested metadata ===================
 #
 # article() reuses the content scoring above and adds the page-metadata record.
 # The per-field precedence cases below share the BODY content fixture so each one

--- a/tests/query/find/test_tree_find.py
+++ b/tests/query/find/test_tree_find.py
@@ -34,9 +34,6 @@ def _raise(_value: str | None) -> bool:
     raise ZeroDivisionError
 
 
-# --- tag filter kinds ---
-
-
 @pytest.mark.parametrize(
     ("tag_filter", "tags"),
     [
@@ -84,9 +81,6 @@ def test_tag_with_class_filter_uses_the_general_path(class_filter: Filter) -> No
     assert _tags(parse(_DOC).find_all("p", class_=class_filter)) == ["p", "p"]
 
 
-# --- attribute filter kinds ---
-
-
 @pytest.mark.parametrize(
     "id_filter", [pytest.param("t", id="exact-string"), pytest.param(re.compile(r"^t$"), id="regex")]
 )
@@ -123,9 +117,6 @@ def test_attr_callable_on_absent_value_gets_none() -> None:
     seen: list[str | None] = []
     parse("<div id=x><span></span></div>").find_all(id=lambda value: bool(seen.append(value)))
     assert None in seen  # the <span> has no id, so the callable saw None
-
-
-# --- class_ is member-wise with a whole-value fallback ---
 
 
 @pytest.mark.parametrize("class_filter", [pytest.param("big", id="token"), pytest.param(True, id="true-is-presence")])
@@ -172,9 +163,6 @@ def test_class_token_scan_handles_surrounding_whitespace() -> None:
     assert parse('<p class=" a b ">').find("p", class_="c") is None
 
 
-# --- filters that resolve to no match return None ---
-
-
 @pytest.mark.parametrize(
     ("html", "class_filter"),
     [
@@ -204,9 +192,6 @@ def test_filter_on_valueless_attribute_no_match(disabled_filter: Filter) -> None
 
 def test_filter_on_present_valueless_attribute() -> None:
     assert _el(parse("<input disabled>").find("input", disabled=True)).tag == "input"
-
-
-# --- axes ---
 
 
 def test_axis_children() -> None:
@@ -242,9 +227,6 @@ def test_axis_preceding_excludes_ancestors() -> None:
     assert _el(link.find("h2", axis=Axis.PRECEDING)).tag == "h2"
 
 
-# --- limit ---
-
-
 @pytest.mark.parametrize(
     ("limit", "count"),
     [
@@ -267,9 +249,6 @@ def test_limit_on_the_general_path() -> None:
     assert len(parse(_DOC).find_all(True, limit=1)) == 1  # noqa: FBT003
 
 
-# --- dynamic (non-common) attribute names ---
-
-
 def test_dynamic_attr_name() -> None:
     assert _el(parse('<div data-x="v">').find("div", attrs={"data-x": "v"})).tag == "div"
 
@@ -283,9 +262,6 @@ def test_dynamic_attr_name() -> None:
 )
 def test_attrs_dict_matches_nothing(attrs: dict[str, Filter]) -> None:
     assert parse("<div>").find_all("div", attrs=attrs) == []
-
-
-# --- a list filter propagates an error from a member, as does a direct callable ---
 
 
 @pytest.mark.parametrize(
@@ -306,9 +282,6 @@ def test_callable_error_propagates(id_filter: Filter) -> None:
 def test_indexed_tag_filter_error_propagates(query: Callable[[Document], object]) -> None:
     with pytest.raises(ZeroDivisionError):
         query(parse("<p>x</p>"))
-
-
-# --- argument errors ---
 
 
 @pytest.mark.parametrize(
@@ -333,7 +306,6 @@ def test_type_errors(call: Callable[[], object]) -> None:
         call()
 
 
-# --- text predicate: match an element by its collected text -------------------
 # The text= filter runs against the element's collected subtree text (what .text returns):
 # an exact str, a searched regex, or a callable. It composes with the structural filters,
 # and -- because a regex/callable runs Python mid-walk -- the C side snapshots candidates

--- a/tests/query/xpath/test_xpath_eval.py
+++ b/tests/query/xpath/test_xpath_eval.py
@@ -242,8 +242,6 @@ def test_non_string_argument(doc: turbohtml.Node) -> None:
         doc.xpath_one(123)  # ty: ignore[invalid-argument-type]  # non-str exercises the TypeError path
 
 
-# --- The precompiled, reusable turbohtml.XPath object (issue #267) ---
-
 TABLE_HTML = (
     '<table><tr><td class="num">1</td><td>2</td></tr><tr><td class="num">3</td><td class="num">4</td></tr></table>'
 )

--- a/tests/query/xpath/test_xpath_exslt.py
+++ b/tests/query/xpath/test_xpath_exslt.py
@@ -62,9 +62,6 @@ def texts(result: list[Element | str]) -> list[str]:
     return [node.text for node in result if isinstance(node, Element)]
 
 
-# --- re: regular-expression functions -------------------------------------- #
-
-
 @pytest.mark.parametrize(
     ("expr", "expected"),
     [
@@ -106,9 +103,6 @@ def test_re_test_malformed_pattern_propagates_python_error(doc: turbohtml.Node) 
 def test_re_replace_malformed_pattern_propagates_python_error(doc: turbohtml.Node) -> None:
     with pytest.raises(re.error):
         doc.xpath("re:replace('x', '(', '', 'y')")
-
-
-# --- set: node-set functions ----------------------------------------------- #
 
 
 @pytest.mark.parametrize(
@@ -191,9 +185,6 @@ def test_set_distinct_mixed_lengths() -> None:
     assert ids(doc.xpath("set:distinct(//li)")) == ["a", "b"]
 
 
-# --- str: string functions ------------------------------------------------- #
-
-
 @pytest.mark.parametrize(
     ("expr", "expected"),
     [
@@ -226,9 +217,6 @@ def test_str_functions(doc: turbohtml.Node, expr: str, expected: str) -> None:
 def test_str_concat_non_nodeset_argument_raises(doc: turbohtml.Node) -> None:
     with pytest.raises(TypeError, match="non-node-set"):
         doc.xpath("str:concat('x')")
-
-
-# --- math: numeric and node-set functions ---------------------------------- #
 
 
 @pytest.mark.parametrize(
@@ -283,9 +271,6 @@ def test_math_select(doc: turbohtml.Node, expr: str, expected: list[str]) -> Non
 def test_math_non_nodeset_argument_raises(doc: turbohtml.Node, expr: str) -> None:
     with pytest.raises(TypeError, match="non-node-set"):
         doc.xpath(expr)
-
-
-# --- date: field-extraction functions -------------------------------------- #
 
 
 @pytest.mark.parametrize(

--- a/tests/serialize/test_serialize_output_options.py
+++ b/tests/serialize/test_serialize_output_options.py
@@ -6,8 +6,6 @@ import pytest
 
 from turbohtml import Element, Html, Indent, Markdown, Minify, parse
 
-# ----------------------------------------------------------------- sort_attributes
-
 
 @pytest.mark.parametrize(
     ("markup", "selector", "expected"),
@@ -58,9 +56,6 @@ def test_sort_attributes_composes_with_minify() -> None:
     node = parse("<p z=1 a=2>x").select_one("p")
     assert node is not None
     assert node.serialize(Html(layout=Minify(), sort_attributes=True)) == "<p a=2 z=1>x</p>"
-
-
-# ------------------------------------------------------------------- meta_charset
 
 
 def test_meta_charset_injects_into_empty_head() -> None:
@@ -170,9 +165,6 @@ def test_meta_charset_reparses_to_one_declaration() -> None:
     assert metas[0].attrs["charset"] == "utf-8"
 
 
-# ------------------------------------------------------------- meta_charset layouts
-
-
 def test_meta_charset_with_indent_indents_injected_meta() -> None:
     out = parse("<p>x").serialize(Html(layout=Indent(2), meta_charset=True))
     assert out == (
@@ -215,9 +207,6 @@ def test_meta_charset_with_minify_normalizes_existing_meta() -> None:
     assert len(metas) == 1
     assert metas[0].attrs["charset"] == "utf-8"
     assert 'charset="utf-8"' in out
-
-
-# ------------------------------------------------------------------- encode wiring
 
 
 def test_encode_meta_charset_uses_target_encoding() -> None:

--- a/tests/serialize/test_tree_markdown.py
+++ b/tests/serialize/test_tree_markdown.py
@@ -441,8 +441,6 @@ def test_kitchen_sink() -> None:
     assert "\n".join(line.rstrip() for line in md(html).splitlines()) == expected
 
 
-# --------------------------------------------------------- round-trip differential
-
 _WORD = re.compile(r"[0-9a-z]+")
 
 


### PR DESCRIPTION
The last quality pass over the tree before the 1.0 benchmark, closing out the house-style work `#478` tracks. 🧹 An audit of every subsystem found drift the earlier consistency sweeps left behind, all of it cosmetic.

Eight test files still carried section-divider banner comments; those come out, since the test names already carry the structure the banners labeled. The config modules `_linkify`, `_match`, `_minify`, `_render`, `_sanitizer`, and `build` gain the `Final` annotations on their module-level singletons that the newer modules already had. The plain-text renderer, the date extractor, and the encoding detector get descriptive loop-counter names in place of the `i`/`r`/`p` their newer code had drifted to; `idna.c` keeps its RFC 3492 punycode names, which are spec-normative and already cited in the surrounding comments. C comments switch their em dashes to ASCII `--` to match the rest of the tree, three `simply` crutches go, and four documentation sentences lose their filler.

Output is byte-identical; this touches style and prose only. Local gates pass on `tox` `3.14` and `3.10` at 100% Python and C coverage, plus `type`, `docs`, and `pre-commit`.

part of #478
closes #50
