### PR TITLE
📦 perf(build): shrink the release wheel

### DIFF
--- a/docs/changelog/52.packaging.rst
+++ b/docs/changelog/52.packaging.rst
@@ -1,0 +1,3 @@
+Release wheels strip the compiled extension's local symbol table at link time, cutting about 65 KB from the Linux
+``.so`` and 46 KB from the macOS bundle with no behavior change; the source distribution keeps every test, tool, and
+generated table needed to build from source. Part of :issue:`478`.

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,24 @@ meson.add_dist_script('tools/prune_dist.py')
 
 py = import('python').find_installation(pure: false)
 
+# Strip the shipped object's local .symtab at link time. The release wheels pass -Dstrip=true, but meson-python
+# packages straight from the build directory and never runs the install-time strip that option drives, so we do
+# it in the link instead. extension_module already defaults to -fvisibility=hidden (only PyInit__html stays
+# dynamic) and -Db_lto has dropped the unreachable internals, so .symtab is the last slack: ~65 KB off the Linux
+# .so, ~46 KB off the macOS bundle. Gating on -Dstrip keeps every local symbol in the coverage, sanitizer, tsan,
+# codspeed, and warnings builds, which never set it, for gdb/gcov/valgrind/CodSpeed. The flag is applied
+# directly, not via get_supported_link_arguments: ld64 warns on -Wl,-x and meson's probe misreads the warning as
+# unsupported. -Dstrip fires only on the cibuildwheel toolchains (GNU ld/lld, ld64, MSVC), so the branch is safe.
+release_link_args = []
+if get_option('strip')
+    strip_system = host_machine.system()
+    if strip_system == 'darwin'
+        release_link_args = ['-Wl,-x']
+    elif strip_system != 'windows'  # MSVC's release .pyd carries no symbol table to strip
+        release_link_args = ['-Wl,--strip-all']
+    endif
+endif
+
 py.extension_module(
     '_html',
     [
@@ -68,6 +86,7 @@ py.extension_module(
         'src/turbohtml/_c/features/dates.c',
     ],
     include_directories: include_directories('src/turbohtml/_c'),
+    link_args: release_link_args,
     install: true,
     subdir: 'turbohtml',
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,11 +189,17 @@ linux.config-settings.build-dir = "/tmp/turbohtml-pgo"
 # selector/tokenizer bodies moved out of their monolith translation units, and LTO is what re-inlines them at link
 # time so the split is perf-neutral. It layers on top of PGO (the profile the use build reads is LTO-consistent
 # because pgo_build.py trains the generate phase with the same flag).
-linux.config-settings.setup-args = [ "-Dbuildtype=release", "-Db_pgo=use", "-Db_lto=true" ]
+# -Dstrip arms meson.build's link-time strip of the shipped .so's symbol table (meson-python ignores the
+# install-time strip this option normally drives, so meson.build does it at link instead). Release wheels only;
+# the sdist keeps every source. Visibility is already hidden by extension_module's default, so PyInit__html is
+# the sole dynamic symbol and this only trims the ~65 KB local .symtab that -Db_lto cannot touch.
+linux.config-settings.setup-args = [ "-Dbuildtype=release", "-Db_pgo=use", "-Db_lto=true", "-Dstrip=true" ]
 macos.archs = [ "arm64" ]  # Apple silicon only; x86_64 macOS is end-of-life
+macos.config-settings.setup-args = [ "-Dstrip=true" ]
 windows.archs = [ "AMD64" ]  # 64-bit only; skip the 32-bit x86 build
-# force the MSVC toolchain: meson otherwise picks up MinGW from the runner's PATH
-windows.config-settings.setup-args = "--vsenv"
+# force the MSVC toolchain: meson otherwise picks up MinGW from the runner's PATH (the strip flag is a no-op on
+# MSVC, whose release .pyd carries no symbol table and which exports nothing without dllexport)
+windows.config-settings.setup-args = [ "--vsenv", "-Dstrip=true" ]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
The shipped release wheels carried the compiled extension's full local symbol table (`.symtab`), which nothing at runtime reads. Strip it at link time, gated on the `-Dstrip=true` the cibuildwheel release blocks already pass.

Measured (release + LTO):

- Linux `.so` 2,438,488 -> 2,373,144 bytes (-65,344, -2.7%); wheel -20,030 bytes
- macOS bundle 2,006,584 -> 1,960,520 bytes (-46,064, -2.3%); wheel -15,891 bytes

Getting there turned up two wrinkles. meson-python packages the object straight from the build directory and never runs the install-time strip that `-Dstrip` drives, so the strip has to happen in the link. And `extension_module` already defaults to `-fvisibility=hidden`, so `PyInit__html` is the only exported symbol and LTO has already dropped the unreachable internals, which leaves `.symtab` as the last slack. The dead-code GC flags the plan floated buy nothing on top of LTO (measured identical), so I left them out.

The gate is `-Dstrip`, which only the release wheel builds set. The coverage, sanitizer, tsan, codspeed, and warnings builds never set it, so they keep every local symbol for gdb, gcov, valgrind, and CodSpeed. The sdist is untouched and stays complete for from-source development.

closes #52
