### PR TITLE
🐛 fix(serialize): skip null memcpy on empty run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,9 @@ repos:
     rev: "v6.0.0" # v6.0.0
     hooks:
       - id: end-of-file-fixer
-        exclude: ^tests/url/data/IdnaTestV2\.txt$ # vendored verbatim from unicode.org
+        exclude: ^(tests/url/data/IdnaTestV2\.txt|tools/fuzz/corpus/.*)$ # vendored verbatim / byte-exact crash inputs
       - id: trailing-whitespace
-        exclude: ^tests/url/data/IdnaTestV2\.txt$ # vendored verbatim from unicode.org
+        exclude: ^(tests/url/data/IdnaTestV2\.txt|tools/fuzz/corpus/.*)$ # vendored verbatim / byte-exact crash inputs
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: "0.37.3" # 0.37.2
     hooks:

--- a/src/turbohtml/_c/serialize/internal.h
+++ b/src/turbohtml/_c/serialize/internal.h
@@ -57,6 +57,9 @@ static inline void sbuf_putc(sbuf *out, Py_UCS4 character) {
 
 /* Append a run of code points in one bulk copy after a single capacity check. */
 static inline void sbuf_put_run(sbuf *out, const Py_UCS4 *text, Py_ssize_t len) {
+    if (len == 0) { /* an empty run carries a NULL text pointer, and memcpy declares its source non-null even for 0 */
+        return;
+    }
     sbuf_reserve(out, len);
     if (out->failed) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return;        /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */

--- a/tests/serialize/test_tree_serialize.py
+++ b/tests/serialize/test_tree_serialize.py
@@ -294,3 +294,20 @@ def test_serialize_iter_joins_to_serialize_over_corpus(filename: str, layout: In
     assert not mismatches, f"{filename}: {len(mismatches)} chunked outputs differ\n\n" + "\n\n".join(
         repr(source) for source in mismatches[:5]
     )
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param("<!---->", "<!----><html><head></head><body></body></html>", id="empty-comment"),
+        pytest.param(
+            "<img sc<a.png alt=pic><br><hr><input>\n<!--",
+            '<html><head></head><body><img sc<a.png="" alt="pic"><br><hr><input>\n<!----></body></html>',
+            id="fuzz-empty-run",
+        ),
+    ],
+)
+def test_serialize_empty_run(html: str, expected: str) -> None:
+    # An empty comment (or an unclosed <!-- the parser closes) serializes a zero-length run whose text pointer is
+    # NULL; the run must be skipped rather than handed to memcpy, whose source is declared non-null even for length 0.
+    assert parse(html).serialize() == expected

--- a/tools/fuzz/corpus/roundtrip/empty-run-null-src.html
+++ b/tools/fuzz/corpus/roundtrip/empty-run-null-src.html
@@ -1,0 +1,2 @@
+<img sc<a.png alt=pic><br><hr><input>
+<!--


### PR DESCRIPTION
The scheduled deep-fuzz job on `main` aborted under UndefinedBehaviorSanitizer on a 42-byte input. `sbuf_put_run` passed a NULL source pointer to `memcpy` while serializing a zero-length code-point run. glibc annotates `memcpy` as taking a non-null source even when the length is zero, so the call is undefined behavior. 🕳️ macOS clang leaves `memcpy` unannotated, so only the Linux job caught it.

A zero-length run appears whenever the serializer emits an empty comment: `<!---->`, or an unclosed `<!--` the parser closes at end of input. That run carries a NULL text pointer, harmless to pass around but not to feed to `memcpy`. `sbuf_put_run` now returns before the copy when the run is empty.

The exact 42-byte reproducer joins the roundtrip fuzz corpus as a byte-exact seed, so the Linux smoke gate covers it on every run. ✅ Fuzz seeds are held past the whitespace fixers to keep crash inputs verbatim.

Part of #478.