### PR TITLE
📝 docs(changelog): fold the last fragment into the 1.0 overview

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -102,6 +102,9 @@ Packaging updates - 1.0.0
 - Pin every network-sourced C data table (IANA TLDs, the Public Suffix List, and the Unicode IDNA and NFC tables) to a
   named source commit and a SHA-256 checksum, so a rebuild is reproducible and aborts on a poisoned upstream.
   (:issue:`478`)
+- Strip the compiled extension's local symbol table from the release wheels at link time, trimming about 65 KB from the
+  Linux ``.so`` and 46 KB from the macOS bundle; the source distribution still carries every test, tool, and generated
+  table needed to build from source. (:issue:`478`)
 
 Miscellaneous internal changes - 1.0.0
 ======================================

--- a/docs/changelog/52.packaging.rst
+++ b/docs/changelog/52.packaging.rst
@@ -1,3 +1,0 @@
-Release wheels strip the compiled extension's local symbol table at link time, cutting about 65 KB from the Linux
-``.so`` and 46 KB from the macOS bundle with no behavior change; the source distribution keeps every test, tool, and
-generated table needed to build from source. Part of :issue:`478`.


### PR DESCRIPTION
The `v1.0.0` changelog is a hand-written overview that folds the whole 0.4.0 to 1.0.0 span into one themed section under the six towncrier categories. One news fragment, `52.packaging` (the release-wheel symbol strip), was still sitting outside it, so a `towncrier build` at release time would consume it and insert a second, stub `v1.0.0` heading above the overview.

This adds that packaging note to the overview and removes the fragment. 📦 The section now carries all three 1.0 packaging changes (PGO/LTO wheels, pinned-and-checksummed C data tables, and the symbol strip), and no fragments remain to re-expand.

With the overview complete, the 1.0.0 release is cut by tagging the finished changelog directly rather than running `towncrier build` over an empty fragment set.

Part of #478.