### PR TITLE
✨ feat(sanitize): add SAFE_FOR_TEMPLATES marker stripping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ venv*
 docs_out
 src/turbohtml/_version.py
 tools/.bench_data/
+
+# bench Node competitor deps (regenerated with npm install in tools/bench/node)
+tools/bench/node/node_modules/

--- a/docs/_ext/bench_table.py
+++ b/docs/_ext/bench_table.py
@@ -56,6 +56,7 @@ _HOMEPAGES: Final = {
     "csscompressor": "https://github.com/sprymix/csscompressor",
     "cssmin": "https://github.com/zacharyvoase/cssmin",
     "dominate": "https://github.com/Knio/dominate",
+    "DOMPurify": "https://github.com/cure53/DOMPurify",
     "extruct": "https://github.com/scrapinghub/extruct",
     "fast-html": "https://github.com/pcarbonn/fast_html",
     "faust-cchardet": "https://github.com/faust-streaming/cChardet",

--- a/docs/changelog/527.feature.rst
+++ b/docs/changelog/527.feature.rst
@@ -1,0 +1,3 @@
+:class:`~turbohtml.clean.Policy` gained ``strip_template_markers``: with it on, sanitizing collapses template-engine
+expressions (``{{ }}``, ``${ }``, ``<% %>``) in kept text and attribute values to a single space, so the output cannot
+re-inject when a template engine renders it. This matches DOMPurify's ``SAFE_FOR_TEMPLATES``.

--- a/docs/development/bench/sanitize-templates.json
+++ b/docs/development/bench/sanitize-templates.json
@@ -1,0 +1,15 @@
+{
+  "label": "input",
+  "parties": [
+    "turbohtml",
+    "DOMPurify"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "templated 4 KiB",
+      0.00014190855371351872,
+      0.2589921527703862
+    ]
+  ]
+}

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -96,6 +96,15 @@ an allowlist, since a blocklist passes anything it did not think to name.
 .. bench-table::
     :file: bench/sanitize.json
 
+Template-safe sanitizing (``Policy.strip_template_markers``, collapsing ``{{ }}``/``${ }``/``<% %>`` so the output
+cannot re-inject through a template engine) has no allowlist-sanitizer analog in Python; the reference is DOMPurify's
+``SAFE_FOR_TEMPLATES``, which runs in JavaScript. Reaching it from Python means shelling out to Node, where each call
+spins up a DOM before it sanitizes, so the figure below is that end-to-end per-document cost, not a pure-algorithm
+comparison. turbohtml folds the same transform into its C walk and pays neither the process nor the DOM.
+
+.. bench-table::
+    :file: bench/sanitize-templates.json
+
 **********
  Markdown
 **********

--- a/docs/how-to/sanitizing.rst
+++ b/docs/how-to/sanitizing.rst
@@ -23,6 +23,24 @@ non-overridable baseline drops scripting and ``javascript:`` URLs no matter what
 
     <p>Hi <a>link</a></p>&lt;script&gt;evil()&lt;/script&gt;
 
+*************************************
+ Keep the output safe for a template
+*************************************
+
+When sanitized HTML is later rendered through a client-side template engine (Angular, Vue, Mustache, EJS, ERB), a
+surviving ``{{ ... }}``, ``${ ... }``, or ``<% ... %>`` is a second injection point: the engine evaluates it after the
+sanitizer has passed. Set ``strip_template_markers`` to collapse every such run, in kept text and attribute values, to a
+single space, matching DOMPurify's ``SAFE_FOR_TEMPLATES``.
+
+.. code-block:: python
+
+    from turbohtml.clean import sanitize, Policy
+
+    policy = Policy.relaxed()
+    policy = Policy(tags=policy.tags, attributes=policy.attributes, strip_template_markers=True)
+    print(sanitize("<p title='{{x}}'>Hi {{ user.name }}</p>", policy))
+    # <p title=" ">Hi  </p>
+
 **************************************
  Trust the first pass, do not reparse
 **************************************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,8 +264,8 @@ builtin = "clear,usage,en-GB_to_en-US"
 ignore-words-list = "caf,notin,afe,hava,vave,grey,forin,opps,fo,nd,te,januar,februar,juni,juli,oktober,dezember,tha,shttp"
 skip = """\
   */html_entities.h,*/tag_atom.h,*/entity_names.h,*/tld_table.h,*/psl_table.h,*/css_colors.h,*/language_data.h,*/idna_t\
-  able.h,*/IdnaTestV2.txt,*/dompurify_expect.mjs\
-  """  # generated tables of HTML5 / IANA / CSS / PSL / language names, the Unicode IDNA table + vectors, and the DOMPurify XSS fixtures
+  able.h,*/IdnaTestV2.txt,*/dompurify_expect.mjs,*/package-lock.json\
+  """  # generated tables of HTML5 / IANA / CSS / PSL / language names, the Unicode IDNA table + vectors, the DOMPurify XSS fixtures, and the npm lockfile
 count = true
 quiet-level = 3
 

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -967,8 +967,8 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             th_node_attr_del(s->tree, element, name, name_len);
             continue; /* the next attribute shifted into this slot */
         }
-        if (s->strip_templates && strip_attr_templates(s, element, attr) < 0) {
-            return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+        if (s->strip_templates && strip_attr_templates(s, element, attr) < 0) { /* GCOVR_EXCL_BR_LINE: only alloc fail */
+            return -1;                                                          /* GCOVR_EXCL_LINE: alloc-failure path */
         }
         if (name_len == 5 && memcmp(name, "style", 5) == 0) {
             Py_ssize_t before = element->attr_count;
@@ -1274,8 +1274,8 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
                 th_node_remove(child);
             }
         } else if (child->type == TH_NODE_TEXT) {
-            if (s->strip_templates && strip_text_templates(s, child) < 0) {
-                return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+            if (s->strip_templates && strip_text_templates(s, child) < 0) { /* GCOVR_EXCL_BR_LINE: only alloc failure */
+                return -1;                                                  /* GCOVR_EXCL_LINE: allocation-failure path */
             }
         } else {
             th_node_remove(child); /* doctype, processing instruction, CDATA: never valid in a sanitized fragment */

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -967,9 +967,9 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             th_node_attr_del(s->tree, element, name, name_len);
             continue; /* the next attribute shifted into this slot */
         }
-        if (s->strip_templates &&
-            strip_attr_templates(s, element, attr) < 0) { /* GCOVR_EXCL_BR_LINE: only alloc fail */
-            return -1;                                    /* GCOVR_EXCL_LINE: alloc-failure path */
+        /* strip_attr_templates only fails on allocation, which no test can force */
+        if (s->strip_templates && strip_attr_templates(s, element, attr) < 0) { /* GCOVR_EXCL_BR_LINE */
+            return -1;                                                          /* GCOVR_EXCL_LINE */
         }
         if (name_len == 5 && memcmp(name, "style", 5) == 0) {
             Py_ssize_t before = element->attr_count;
@@ -1275,8 +1275,9 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
                 th_node_remove(child);
             }
         } else if (child->type == TH_NODE_TEXT) {
-            if (s->strip_templates && strip_text_templates(s, child) < 0) { /* GCOVR_EXCL_BR_LINE: only alloc failure */
-                return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+            /* strip_text_templates only fails on allocation, which no test can force */
+            if (s->strip_templates && strip_text_templates(s, child) < 0) { /* GCOVR_EXCL_BR_LINE */
+                return -1;                                                  /* GCOVR_EXCL_LINE */
             }
         } else {
             th_node_remove(child); /* doctype, processing instruction, CDATA: never valid in a sanitized fragment */

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -36,6 +36,8 @@ typedef struct {
     int allow_relative;
     int on_disallowed;
     int strip_comments;
+    int strip_templates; /* SAFE_FOR_TEMPLATES: collapse {{ }}, ${ }, <% %> runs so kept text/attrs stay template-safe
+                          */
 } sanitizer;
 
 /* Elements removed regardless of the allowlist: scripting, plugin, and raw-text containers. (frame and frameset need
@@ -837,6 +839,74 @@ static int sanitize_style_body(sanitizer *s, th_node *element) {
     return status;
 }
 
+/* SAFE_FOR_TEMPLATES. A template engine (Angular, Vue, Mustache, EJS, ERB) evaluates {{ }}, ${ }, and <% %> in the
+   strings it later renders, so a sanitized value that still carries one can re-inject once the output is fed through
+   that engine. Copy `in` to `out` -- caller-sized to `len`, since a run only ever shrinks -- replacing every such run,
+   its opening delimiter through the nearest matching close (or through the end when the run is left unclosed), with a
+   single space, matching DOMPurify's SAFE_FOR_TEMPLATES. Returns the written length and sets *changed when a run was
+   collapsed, so a caller rewrites the node only when the value held a marker. */
+static Py_ssize_t strip_template_markers(const Py_UCS4 *in, Py_ssize_t len, Py_UCS4 *out, int *changed) {
+    Py_ssize_t write = 0;
+    *changed = 0;
+    Py_ssize_t read = 0;
+    while (read < len) {
+        Py_UCS4 opener = in[read];
+        Py_UCS4 next = read + 1 < len ? in[read + 1] : 0;
+        Py_UCS4 close_lead;
+        Py_UCS4 close_tail;
+        if (opener == '{' && next == '{') {
+            close_lead = '}';
+            close_tail = '}';
+        } else if (opener == '$' && next == '{') {
+            close_lead = '}';
+            close_tail = 0;
+        } else if (opener == '<' && next == '%') {
+            close_lead = '%';
+            close_tail = '>';
+        } else {
+            out[write++] = opener;
+            read++;
+            continue;
+        }
+        Py_ssize_t scan = read + 2;
+        int closed = 0;
+        while (scan < len && !closed) {
+            if (in[scan] == close_lead && close_tail == 0) {
+                scan++; /* ${ ... } closes on the single } */
+                closed = 1;
+            } else if (in[scan] == close_lead && scan + 1 < len && in[scan + 1] == close_tail) {
+                scan += 2; /* {{ ... }} and <% ... %> close on the two-char delimiter */
+                closed = 1;
+            } else {
+                scan++; /* an ordinary character, or a lead byte that is not the full close */
+            }
+        }
+        out[write++] = ' ';
+        *changed = 1;
+        read = scan;
+    }
+    return write;
+}
+
+/* Collapse the template markers in one kept attribute's value, rewriting it in place when SAFE_FOR_TEMPLATES is on and
+   the value held a marker. Returns 0, or -1 on allocation failure. */
+static int strip_attr_templates(sanitizer *s, th_node *element, th_node_attr *attr) {
+    Py_UCS4 *out = PyMem_New(Py_UCS4, attr->value_len > 0 ? attr->value_len : 1);
+    if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int changed = 0;
+    Py_ssize_t out_len = strip_template_markers(attr->value, attr->value_len, out, &changed);
+    int status = 0;
+    if (changed) {
+        Py_ssize_t name_len = 0;
+        const char *name = th_attr_name(s->tree, attr->name_atom, &name_len);
+        status = th_node_attr_set(s->tree, element, name, name_len, out, out_len, 1);
+    }
+    PyMem_Free(out);
+    return status;
+}
+
 static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
     Py_ssize_t index = 0;
     while (index < element->attr_count) {
@@ -896,6 +966,9 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
         if (drop) {
             th_node_attr_del(s->tree, element, name, name_len);
             continue; /* the next attribute shifted into this slot */
+        }
+        if (s->strip_templates && strip_attr_templates(s, element, attr) < 0) {
+            return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
         }
         if (name_len == 5 && memcmp(name, "style", 5) == 0) {
             Py_ssize_t before = element->attr_count;
@@ -1163,6 +1236,30 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
     return status;
 }
 
+/* Rewrite one text node in place with its template markers collapsed, when SAFE_FOR_TEMPLATES is on and the node held a
+   marker. Returns 0, or -1 on allocation failure. */
+static int strip_text_templates(sanitizer *s, th_node *node) {
+    Py_ssize_t len = 0;
+    Py_UCS4 *data = th_node_data(s->tree, node, &len);
+    if (data == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    Py_UCS4 *out = PyMem_New(Py_UCS4, len); /* a text node always carries at least one code point, so len >= 1 */
+    if (out == NULL) {                      /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        PyMem_Free(data);                   /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;                          /* GCOVR_EXCL_LINE */
+    }
+    int changed = 0;
+    Py_ssize_t out_len = strip_template_markers(data, len, out, &changed);
+    int status = 0;
+    if (changed) {
+        status = th_node_set_data(s->tree, node, out, out_len);
+    }
+    PyMem_Free(out);
+    PyMem_Free(data);
+    return status;
+}
+
 /* Walk an element's children, applying the policy; capturing the next sibling keeps the loop safe across edits. */
 static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
     th_node *child = parent->first_child;
@@ -1176,7 +1273,11 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
             if (s->strip_comments) {
                 th_node_remove(child);
             }
-        } else if (child->type != TH_NODE_TEXT) {
+        } else if (child->type == TH_NODE_TEXT) {
+            if (s->strip_templates && strip_text_templates(s, child) < 0) {
+                return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+        } else {
             th_node_remove(child); /* doctype, processing instruction, CDATA: never valid in a sanitized fragment */
         }
         child = next;
@@ -1225,14 +1326,14 @@ static int require_prefixes(PyObject *prefixes) {
 
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
    attribute_filter, set_attributes, remove_with_content, css_properties, attribute_prefixes, attribute_values,
-   media_hosts) -> None. Filters the fragment in place; sanitizer.py serializes it. */
+   media_hosts, strip_templates) -> None. Filters the fragment in place; sanitizer.py serializes it. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOp:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
                           &s.set_attributes, &s.remove_with_content, &s.css_properties, &s.attribute_prefixes,
-                          &s.attribute_values, &s.media_hosts)) {
+                          &s.attribute_values, &s.media_hosts, &s.strip_templates)) {
         return NULL;
     }
     if (require_anyset(s.tags, "tags") < 0 || require_anyset(s.url_schemes, "url_schemes") < 0 ||

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -852,8 +852,8 @@ static Py_ssize_t strip_template_markers(const Py_UCS4 *in, Py_ssize_t len, Py_U
     while (read < len) {
         Py_UCS4 opener = in[read];
         Py_UCS4 next = read + 1 < len ? in[read + 1] : 0;
-        Py_UCS4 close_lead;
-        Py_UCS4 close_tail;
+        Py_UCS4 close_lead = 0;
+        Py_UCS4 close_tail = 0;
         if (opener == '{' && next == '{') {
             close_lead = '}';
             close_tail = '}';
@@ -891,7 +891,7 @@ static Py_ssize_t strip_template_markers(const Py_UCS4 *in, Py_ssize_t len, Py_U
 /* Collapse the template markers in one kept attribute's value, rewriting it in place when SAFE_FOR_TEMPLATES is on and
    the value held a marker. Returns 0, or -1 on allocation failure. */
 static int strip_attr_templates(sanitizer *s, th_node *element, th_node_attr *attr) {
-    Py_UCS4 *out = PyMem_New(Py_UCS4, attr->value_len > 0 ? attr->value_len : 1);
+    Py_UCS4 *out = PyMem_Malloc((size_t)(attr->value_len > 0 ? attr->value_len : 1) * sizeof(Py_UCS4));
     if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
     }
@@ -1244,10 +1244,10 @@ static int strip_text_templates(sanitizer *s, th_node *node) {
     if (data == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    Py_UCS4 *out = PyMem_New(Py_UCS4, len); /* a text node always carries at least one code point, so len >= 1 */
-    if (out == NULL) {                      /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        PyMem_Free(data);                   /* GCOVR_EXCL_LINE: allocation-failure path */
-        return -1;                          /* GCOVR_EXCL_LINE */
+    Py_UCS4 *out = PyMem_Malloc((size_t)len * sizeof(Py_UCS4)); /* a text node carries >= 1 point, so len >= 1 */
+    if (out == NULL) {    /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        PyMem_Free(data); /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;        /* GCOVR_EXCL_LINE */
     }
     int changed = 0;
     Py_ssize_t out_len = strip_template_markers(data, len, out, &changed);

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -967,8 +967,9 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             th_node_attr_del(s->tree, element, name, name_len);
             continue; /* the next attribute shifted into this slot */
         }
-        if (s->strip_templates && strip_attr_templates(s, element, attr) < 0) { /* GCOVR_EXCL_BR_LINE: only alloc fail */
-            return -1;                                                          /* GCOVR_EXCL_LINE: alloc-failure path */
+        if (s->strip_templates &&
+            strip_attr_templates(s, element, attr) < 0) { /* GCOVR_EXCL_BR_LINE: only alloc fail */
+            return -1;                                    /* GCOVR_EXCL_LINE: alloc-failure path */
         }
         if (name_len == 5 && memcmp(name, "style", 5) == 0) {
             Py_ssize_t before = element->attr_count;
@@ -1275,7 +1276,7 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
             }
         } else if (child->type == TH_NODE_TEXT) {
             if (s->strip_templates && strip_text_templates(s, child) < 0) { /* GCOVR_EXCL_BR_LINE: only alloc failure */
-                return -1;                                                  /* GCOVR_EXCL_LINE: allocation-failure path */
+                return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
             }
         } else {
             th_node_remove(child); /* doctype, processing instruction, CDATA: never valid in a sanitized fragment */

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -123,6 +123,9 @@ class Policy:
         already admits and cannot admit a new one.
     :param media_hosts: allowed hosts for an embedded-media ``src`` (``audio``, ``video``, ``source``, ``track``); a
         ``src`` whose URL host is not one of these lowercase entries is dropped. Empty means no host restriction.
+    :param strip_template_markers: collapse template-engine expressions (``{{ }}``, ``${ }``, ``<% %>``) in kept text
+        and attribute values to a single space, so sanitized output cannot re-inject when a template engine (Angular,
+        Vue, Mustache, EJS, ERB) later renders it. DOMPurify's ``SAFE_FOR_TEMPLATES``; off by default.
     """
 
     tags: frozenset[str] = DEFAULT_TAGS
@@ -140,6 +143,7 @@ class Policy:
     attribute_prefixes: frozenset[str] = frozenset()
     attribute_values: Mapping[str, Mapping[str, frozenset[str]]] = field(default_factory=dict)
     media_hosts: frozenset[str] = frozenset()
+    strip_template_markers: bool = False
 
     @classmethod
     def strict(cls) -> Policy:
@@ -220,6 +224,7 @@ class Sanitizer:
             policy.attribute_prefixes,
             self._attribute_values,
             policy.media_hosts,
+            policy.strip_template_markers,
         )
         return root.inner_html
 

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -58,6 +58,7 @@ def _sanitize(
     attribute_prefixes: frozenset[str],
     attribute_values: Mapping[str, Mapping[str, frozenset[str]]],
     media_hosts: frozenset[str],
+    strip_templates: bool,
     /,
 ) -> None: ...
 def annotation_surface(text: str, spans: Iterable[tuple[int, int, str]], /) -> dict[str, list[str]]: ...

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -731,10 +731,10 @@ def test_strip_propagates_a_child_filter_error() -> None:
 def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
-    # the fourteen policy arguments after the element; only the non-element first argument matters to this guard
+    # the fifteen policy arguments after the element; only the non-element first argument matters to this guard
     policy_args = (
         frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset(), frozenset(), frozenset(), {},
-        frozenset(),
+        frozenset(), False,
     )  # fmt: skip
     with pytest.raises(TypeError):
         _sanitize("not an element", *policy_args)  # ty: ignore[invalid-argument-type]

--- a/tests/clean/test_sanitizer_namespace.py
+++ b/tests/clean/test_sanitizer_namespace.py
@@ -38,11 +38,12 @@ def _sanitize_tree(root: Element, tags: frozenset[str]) -> str:
     """Run the C sanitizer in place over a pre-built tree, removing every disallowed node's subtree."""
     # named to keep the boolean positional arguments off the FBT003 lint, not to document them
     allow_relative = strip_comments = True
+    strip_templates = False
     empty: frozenset[str] = frozenset()
     schemes = frozenset({"http", "https", "mailto"})
     _sanitize(
         root, tags, {}, schemes, allow_relative, OnDisallowed.REMOVE.value, strip_comments, None, None, {}, empty,
-        empty, empty, {}, empty,
+        empty, empty, {}, empty, strip_templates,
     )  # fmt: skip
     return root.inner_html
 

--- a/tests/clean/test_sanitizer_templates.py
+++ b/tests/clean/test_sanitizer_templates.py
@@ -1,0 +1,60 @@
+"""``Policy.strip_template_markers`` (DOMPurify's ``SAFE_FOR_TEMPLATES``): collapse ``{{ }}``/``${ }``/``<% %>`` runs.
+
+A template engine (Angular, Vue, Mustache, EJS, ERB) evaluates these markers in the strings it renders, so a sanitized
+value that still carries one can re-inject once the output is fed through that engine. With the flag on, every run --
+its opening delimiter through the nearest matching close, or through the end when unclosed -- collapses to a single
+space, in kept text and in kept attribute values alike.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml.clean import Policy, sanitize
+
+_ON = Policy(
+    tags=frozenset({"p", "a", "input"}),
+    attributes={"a": frozenset({"href", "title"}), "input": frozenset({"disabled"})},
+    strip_template_markers=True,
+)
+
+
+@pytest.mark.parametrize(
+    ("fragment", "expected"),
+    [
+        pytest.param("<p>a{{x}}b</p>", "<p>a b</p>", id="mustache-closed"),
+        pytest.param("<p>a${x}b</p>", "<p>a b</p>", id="tmplit-closed"),
+        pytest.param("<p>a<%x%>b</p>", "<p>a b</p>", id="erb-closed"),
+        pytest.param("<p>a{{x</p>", "<p>a </p>", id="mustache-unclosed"),
+        pytest.param("<p>a${x</p>", "<p>a </p>", id="tmplit-unclosed"),
+        pytest.param("<p>a<%x</p>", "<p>a </p>", id="erb-unclosed"),
+        pytest.param("<p>x{{a}b}}y</p>", "<p>x y</p>", id="inner-close-lead-then-full-close"),
+        pytest.param("<p>{{a}</p>", "<p> </p>", id="close-lead-at-last-char-stays-unclosed"),
+        pytest.param("<p>a{b}c</p>", "<p>a{b}c</p>", id="brace-without-second-brace-kept"),
+        pytest.param("<p>a$b c</p>", "<p>a$b c</p>", id="dollar-without-brace-kept"),
+        pytest.param("<p>3 &lt; 5</p>", "<p>3 &lt; 5</p>", id="lt-without-percent-kept"),
+        pytest.param("<p>a{</p>", "<p>a{</p>", id="brace-at-end-of-text-kept"),
+        pytest.param("<p>a$</p>", "<p>a$</p>", id="dollar-at-end-of-text-kept"),
+        pytest.param("<p>a&lt;</p>", "<p>a&lt;</p>", id="lt-at-end-of-text-kept"),
+        pytest.param("<p>{{a}}{{b}}</p>", "<p>  </p>", id="two-runs-collapse-independently"),
+    ],
+)
+def test_templates_text_run_collapses(fragment: str, expected: str) -> None:
+    assert sanitize(fragment, _ON) == expected
+
+
+def test_templates_attribute_value_with_marker_collapses() -> None:
+    assert sanitize('<a href="/x" title="{{t}}">k</a>', _ON) == '<a href="/x" title=" ">k</a>'
+
+
+def test_templates_attribute_value_without_marker_unchanged() -> None:
+    assert sanitize('<a href="/x" title="plain">k</a>', _ON) == '<a href="/x" title="plain">k</a>'
+
+
+def test_templates_valueless_attribute_survives() -> None:
+    assert sanitize("<input disabled>", _ON) == '<input disabled="">'
+
+
+def test_templates_off_by_default_keeps_markers() -> None:
+    keep = Policy(tags=frozenset({"p"}))
+    assert sanitize("<p>a{{x}}b</p>", keep) == "<p>a{{x}}b</p>"

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -106,6 +106,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "socialcard": ("socialcard-spec", _spec),
     "structured": ("structured-spec", _spec),
     "sanitize": ("sanitize-spec", _spec),
+    "sanitize-templates": ("sanitize-templates-spec", _spec),
     "linkify": ("linkify-spec", _spec),
     "markdown-google": ("markdown-google-spec", _spec),
     "article": ("article-spec", _spec),

--- a/tools/bench/competitors/dompurify.py
+++ b/tools/bench/competitors/dompurify.py
@@ -1,0 +1,24 @@
+"""
+DOMPurify (via isomorphic-dompurify): the reference SAFE_FOR_TEMPLATES sanitizer, run as a Node subprocess.
+
+DOMPurify is JavaScript, so it runs through a small committed Node runner over stdin, the way the JS minifiers do. Its
+``SAFE_FOR_TEMPLATES`` mode is the oracle turbohtml's ``strip_template_markers`` matches; here it is the speed baseline.
+Regenerating the table needs ``npm install`` in ``tools/bench/node`` first (dompurify is a library, not a CLI).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REQUIREMENTS = ()
+
+_RUNNER = str(Path(__file__).resolve().parent.parent / "node" / "dompurify_runner.js")
+
+
+def sanitize_templates(text: str) -> str:
+    """Sanitize a document with DOMPurify's SAFE_FOR_TEMPLATES on, piping it through the Node runner."""
+    return subprocess.run(["node", _RUNNER], input=text, capture_output=True, text=True, check=True).stdout
+
+
+OPERATIONS = {"sanitize-templates": (sanitize_templates, "DOMPurify")}

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import functools
 import re
+from dataclasses import replace
 from typing import TYPE_CHECKING, cast
 
 import turbohtml
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 _SANITIZER = _clean.Sanitizer(_clean.Policy.relaxed())
+_SANITIZER_TEMPLATES = _clean.Sanitizer(replace(_clean.Policy.relaxed(), strip_template_markers=True))
 _LINKS_BASE = "https://example.com/base/"
 _URL_HINT_BASE = "http://site.com/"
 _FIND_TEXT_PATTERN = re.compile(r"test")  # ubiquitous in the wpt corpus, so the predicate does real work
@@ -242,6 +244,11 @@ def microdata(text: str) -> None:
 def sanitize(text: str) -> None:
     """Sanitize with turbohtml's relaxed policy, reusing a prebuilt sanitizer."""
     _SANITIZER.sanitize(text)
+
+
+def sanitize_templates(text: str) -> None:
+    """Sanitize with SAFE_FOR_TEMPLATES on, collapsing template markers as the C walk keeps each node."""
+    _SANITIZER_TEMPLATES.sanitize(text)
 
 
 def markup(text: str) -> None:
@@ -519,6 +526,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "structured": (structured, "turbohtml"),
     "microdata": (microdata, "turbohtml"),
     "sanitize": (sanitize, "turbohtml"),
+    "sanitize-templates": (sanitize_templates, "turbohtml"),
     "markup": (markup, "turbohtml"),
     "markup-op": (markup_op, "turbohtml"),
     "linkify": (linkify, "turbohtml"),

--- a/tools/bench/node/dompurify_runner.js
+++ b/tools/bench/node/dompurify_runner.js
@@ -1,0 +1,12 @@
+// Sanitize stdin with DOMPurify's SAFE_FOR_TEMPLATES on, the competitor for turbohtml's strip_template_markers.
+// The bench (tools/bench/competitors/dompurify.py) pipes one document in and reads the sanitized result back.
+const DOMPurify = require("isomorphic-dompurify");
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  process.stdout.write(DOMPurify.sanitize(input, { SAFE_FOR_TEMPLATES: true }));
+});

--- a/tools/bench/node/package-lock.json
+++ b/tools/bench/node/package-lock.json
@@ -1,0 +1,548 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "isomorphic-dompurify": "^3.18.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.18.0.tgz",
+      "integrity": "sha512-ajp0D8laIHeoYlhBTevpE2HUhqWaqLXFk6K/wV3Ok8kDraBZpZsifwVWaY8IfJntMRIo1VSksgKV+lXyet9Q7A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.11",
+        "jsdom": "^29.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.6.tgz",
+      "integrity": "sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.6"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.6.tgz",
+      "integrity": "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/bench/node/package.json
+++ b/tools/bench/node/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "isomorphic-dompurify": "^3.18.0"
+  }
+}

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -54,6 +54,17 @@ _STRUCTURED_PAGE = dedent("""\
       </div>
     </body>""")
 
+_SANITIZE_TEMPLATES = dedent("""\
+    <article class=card>
+      <h1>{{ post.title }}</h1>
+      <p data-id="${post.id}">By {{ author.name }} on <% post.date %> in {{ post.section }}.</p>
+      <ul>
+        <li>{{ item.label }}: ${item.value}</li>
+        <li>Rating <% stars %> out of {{ max }}</li>
+      </ul>
+    </article>
+""")
+
 _SANITIZE_POST = dedent("""\
     <div class=post>
       <h1>Title</h1>
@@ -109,6 +120,7 @@ OPERATIONS: dict[str, Operation] = {
     "structured": Operation("structured-data extraction", "us"),
     "microdata": Operation("Microdata item extraction", "us"),
     "sanitize": Operation("sanitize", "us"),
+    "sanitize-templates": Operation("sanitize (template-safe)", "us"),
     "markup": Operation("markupsafe-compatible escape", "ns"),
     "markup-op": Operation("Markup operations", "ns"),
     "linkify": Operation("linkify HTML", "us"),
@@ -387,6 +399,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("comment", "<p>Thanks for the <a href='http://example.com'>link</a>! <script>evil()</script></p>"),
         ("post 4 KiB", _SANITIZE_POST * 20),
     ),
+    "sanitize-templates": lambda: (("templated 4 KiB", _SANITIZE_TEMPLATES * 20),),
     "markup": lambda: _MARKUP_ESCAPE_CASES,
     "markup-op": lambda: (
         ("striptags", ("striptags", _MARKUP_OPS_HTML)),


### PR DESCRIPTION
Sanitized HTML that still carries a template expression is a second injection point. A client-side template engine (Angular, Vue, Mustache, EJS, ERB) evaluates `{{ }}`, `${ }`, or `<% %>` after the sanitizer has passed, so a string that the sanitizer kept as inert text runs once the page renders it. 🔐 bleach, `nh3`, and `html-sanitizer` have no equivalent, so this closes a real gap against DOMPurify, whose `SAFE_FOR_TEMPLATES` this matches.

`Policy.strip_template_markers`, off by default, collapses every such run to a single space, in kept text and attribute values alike. A run spans its opening delimiter through the nearest matching close, or through the end when it is left unclosed, so no marker survives even in malformed input. The scan runs inside the existing C walk beside the keep/escape/strip pass, so a template-safe sanitize stays one parse with no extra tree traversal.

A new `sanitize-templates` benchmark gates the flag-on path under CodSpeed, and the vendored DOMPurify XSS corpus stays the sanitizer's security oracle.

Closes #527
