### PR TITLE
✨ feat(clean): report what the sanitizer dropped

### DIFF
--- a/docs/changelog/528.feature.rst
+++ b/docs/changelog/528.feature.rst
@@ -1,0 +1,3 @@
+:func:`turbohtml.clean.sanitize_report` (and :meth:`turbohtml.clean.Sanitizer.sanitize_report`) sanitize a fragment and
+return what the policy dropped alongside the cleaned HTML: one :class:`turbohtml.clean.Removed` record per removed
+element or stripped attribute, in walk order. This matches DOMPurify's ``DOMPurify.removed``.

--- a/docs/how-to/sanitizing.rst
+++ b/docs/how-to/sanitizing.rst
@@ -53,3 +53,22 @@ HTML parsing is not a fixpoint: serialize a tree and reparse it, and you can get
 later parse breaks *out* of it; a raw carriage return in text also becomes a newline on reparse. ``sanitize`` resolves
 all of that in its one pass, so the string it returns is inert. Reparsing and reserializing that string can yield a
 different string that is still inert. The guarantee is inertness, not byte-stable output across a round trip.
+
+*****************************
+ See what the policy dropped
+*****************************
+
+:func:`turbohtml.clean.sanitize_report` sanitizes and also hands back what it removed, the way DOMPurify populates
+``DOMPurify.removed``. Each dropped element or stripped attribute becomes one :class:`~turbohtml.clean.Removed` record,
+in the order the walk reached it, so a policy can be tuned against evidence instead of guesswork.
+
+.. testcode::
+
+    from turbohtml.clean import sanitize_report, Policy
+
+    html, removed = sanitize_report('<p onmouseover="x">Hi <b onclick="y">there</b></p>', Policy.relaxed())
+    print(removed)
+
+.. testoutput::
+
+    [Removed(tag='p', attribute='onmouseover'), Removed(tag='b', attribute='onclick')]

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -13,8 +13,15 @@ in ``<a>`` links, HTML-aware so it never links inside an existing ``<a>``, a raw
 
 .. autofunction:: sanitize
 
+:func:`sanitize_report` sanitizes and also returns what the policy dropped, one :class:`Removed` record per removed
+element or stripped attribute, the way DOMPurify populates ``DOMPurify.removed``.
+
+.. autofunction:: sanitize_report
+
+.. autoclass:: Removed
+
 .. autoclass:: Sanitizer
-    :members: sanitize
+    :members: sanitize, sanitize_report
 
 .. autoclass:: Policy
     :members: strict, basic, relaxed

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -33,12 +33,35 @@ typedef struct {
     PyObject *attribute_prefixes;  /* frozenset[str]: allow any attribute whose name starts with one of these */
     PyObject *attribute_values;    /* dict[str, dict[str, frozenset[str]]]: per (tag, attr) literal value allowlist */
     PyObject *media_hosts; /* frozenset[str]: allowed hosts for an embedded-media (audio/video/source/track) src */
+    PyObject
+        *removed; /* list to append (tag, attr_or_None) records to as the walk drops things, or NULL to not report */
     int allow_relative;
     int on_disallowed;
     int strip_comments;
     int strip_templates; /* SAFE_FOR_TEMPLATES: collapse {{ }}, ${ }, <% %> runs so kept text/attrs stay template-safe
                           */
 } sanitizer;
+
+/* Append one dropped item to the audit list when reporting is on: (tag, None) for a removed or escaped element, (tag,
+   attribute_name) for a stripped attribute. A no-op when s->removed is NULL, the common non-reporting path. Returns 0,
+   or -1 on error. */
+static int record_removed(sanitizer *s, PyObject *tag, const char *attr, Py_ssize_t attr_len) {
+    if (s->removed == NULL) {
+        return 0;
+    }
+    PyObject *name = attr == NULL ? Py_NewRef(Py_None) : PyUnicode_FromStringAndSize(attr, attr_len);
+    if (name == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *record = PyTuple_Pack(2, tag, name);
+    Py_DECREF(name);
+    if (record == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;        /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int status = PyList_Append(s->removed, record);
+    Py_DECREF(record);
+    return status;
+}
 
 /* Elements removed regardless of the allowlist: scripting, plugin, and raw-text containers. (frame and frameset need
    no entry: the parser drops them outside a frameset document, so a fragment can never contain one to neutralize.) */
@@ -952,6 +975,9 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             url_disallowed = !ok; /* a disallowed host drops every src occurrence, like a disallowed scheme */
         }
         if (url_disallowed) {
+            if (record_removed(s, tag, name, name_len) < 0) { /* GCOVR_EXCL_BR_LINE: record only fails on alloc */
+                return -1;                                    /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
             /* A duplicate URL attribute desyncs the per-value scheme check from the
                single value a re-parsing browser keeps (WHATWG keeps the first): dropping
                only this occurrence deletes the first match by name, which may be a benign
@@ -964,6 +990,9 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             continue;
         }
         if (drop) {
+            if (record_removed(s, tag, name, name_len) < 0) { /* GCOVR_EXCL_BR_LINE: record only fails on alloc */
+                return -1;                                    /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
             th_node_attr_del(s->tree, element, name, name_len);
             continue; /* the next attribute shifted into this slot */
         }
@@ -1213,6 +1242,11 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
     }
     /* only disallowed elements consult remove_with_content, so a kept element never pays the set lookup */
     int remove_content = allowed > 0 ? 0 : PySet_Contains(s->remove_with_content, tag);
+    /* a disallowed element is about to be removed, stripped, or escaped; note it before the disposition splits */
+    if (allowed == 0 && record_removed(s, tag, NULL, 0) < 0) { /* GCOVR_EXCL_BR_LINE: record only fails on alloc */
+        Py_DECREF(tag);                                        /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;                                             /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
     int status = 0;
     if (allowed < 0 || remove_content < 0) { /* GCOVR_EXCL_BR_LINE: PySet_Contains never fails on a str key */
         status = -1;                         /* GCOVR_EXCL_LINE */
@@ -1328,16 +1362,19 @@ static int require_prefixes(PyObject *prefixes) {
 
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
    attribute_filter, set_attributes, remove_with_content, css_properties, attribute_prefixes, attribute_values,
-   media_hosts, strip_templates) -> None. Filters the fragment in place; sanitizer.py serializes it. */
+   media_hosts, strip_templates, removed) -> None. Filters the fragment in place; sanitizer.py serializes it.
+   `removed` is a list the walk appends (tag, attr_or_None) records to, or None to skip the audit. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
+    PyObject *removed = NULL;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOp:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOpO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
                           &s.set_attributes, &s.remove_with_content, &s.css_properties, &s.attribute_prefixes,
-                          &s.attribute_values, &s.media_hosts, &s.strip_templates)) {
+                          &s.attribute_values, &s.media_hosts, &s.strip_templates, &removed)) {
         return NULL;
     }
+    s.removed = removed == Py_None ? NULL : removed;
     if (require_anyset(s.tags, "tags") < 0 || require_anyset(s.url_schemes, "url_schemes") < 0 ||
         require_anyset(s.remove_with_content, "remove_with_content") < 0 ||
         require_anyset(s.css_properties, "css_properties") < 0 ||

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from itertools import starmap
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Final
 
@@ -23,6 +24,21 @@ from ._html import _sanitize, parse_fragment
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
+
+    from ._html import Element
+
+
+@dataclass(frozen=True, slots=True)
+class Removed:
+    """
+    One item a policy dropped, the shape :meth:`Sanitizer.sanitize_report` returns.
+
+    :param tag: the tag name of the dropped element, or of the element a dropped attribute was on.
+    :param attribute: the dropped attribute's name, or ``None`` when the element itself was dropped.
+    """
+
+    tag: str
+    attribute: str | None = None
 
 
 class OnDisallowed(Enum):
@@ -206,6 +222,27 @@ class Sanitizer:
             or ``attribute_prefixes`` contains a non-string.
         :raises ValueError: if ``attribute_prefixes`` contains an empty string, which would match every attribute.
         """
+        return self._filter(html, None).inner_html
+
+    def sanitize_report(self, html: str) -> tuple[str, list[Removed]]:
+        """
+        Sanitize a fragment and report what the policy dropped, the way DOMPurify populates ``DOMPurify.removed``.
+
+        Every disallowed element (removed, stripped, or escaped) and every stripped attribute becomes one
+        :class:`Removed` record, in the order the walk reached it, so a caller can log or tune a policy against
+        evidence instead of guessing.
+
+        :param html: the untrusted HTML fragment.
+        :returns: the sanitized HTML paired with the list of dropped items.
+        :raises TypeError: like :meth:`sanitize`, on a mistyped set-valued policy field.
+        :raises ValueError: like :meth:`sanitize`, on an empty ``attribute_prefixes`` entry.
+        """
+        removed: list[tuple[str, str | None]] = []
+        html_out = self._filter(html, removed).inner_html
+        return html_out, list(starmap(Removed, removed))
+
+    def _filter(self, html: str, removed: list[tuple[str, str | None]] | None) -> Element:
+        """Run the C walk over a freshly parsed fragment, appending drops to ``removed`` when it is not None."""
         policy = self.policy
         root = parse_fragment(html)
         _sanitize(
@@ -225,8 +262,9 @@ class Sanitizer:
             self._attribute_values,
             policy.media_hosts,
             policy.strip_template_markers,
+            removed,
         )
-        return root.inner_html
+        return root
 
 
 def sanitize(html: str, options: Policy | None = None) -> str:
@@ -244,6 +282,19 @@ def sanitize(html: str, options: Policy | None = None) -> str:
     return Sanitizer(options).sanitize(html)
 
 
+def sanitize_report(html: str, options: Policy | None = None) -> tuple[str, list[Removed]]:
+    """
+    Sanitize a fragment and report what the policy dropped, like DOMPurify's ``DOMPurify.removed``.
+
+    :param html: the untrusted HTML fragment.
+    :param options: the policy to enforce; None uses bleach's default allowlist.
+    :returns: the sanitized HTML paired with one :class:`Removed` record per dropped element or attribute.
+    :raises TypeError: like :func:`sanitize`, on a mistyped set-valued policy field.
+    :raises ValueError: like :func:`sanitize`, on an empty ``attribute_prefixes`` entry.
+    """
+    return Sanitizer(options).sanitize_report(html)
+
+
 __all__ = [
     "DEFAULT_ATTRIBUTES",
     "DEFAULT_CSS_PROPERTIES",
@@ -251,6 +302,8 @@ __all__ = [
     "DEFAULT_TAGS",
     "OnDisallowed",
     "Policy",
+    "Removed",
     "Sanitizer",
     "sanitize",
+    "sanitize_report",
 ]

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -59,6 +59,7 @@ def _sanitize(
     attribute_values: Mapping[str, Mapping[str, frozenset[str]]],
     media_hosts: frozenset[str],
     strip_templates: bool,
+    removed: list[tuple[str, str | None]] | None,
     /,
 ) -> None: ...
 def annotation_surface(text: str, spans: Iterable[tuple[int, int, str]], /) -> dict[str, list[str]]: ...

--- a/src/turbohtml/clean.py
+++ b/src/turbohtml/clean.py
@@ -37,8 +37,10 @@ from ._sanitizer import (
     DEFAULT_TAGS,
     OnDisallowed,
     Policy,
+    Removed,
     Sanitizer,
     sanitize,
+    sanitize_report,
 )
 
 __all__ = [
@@ -58,6 +60,7 @@ __all__ = [
     "Minify",
     "OnDisallowed",
     "Policy",
+    "Removed",
     "Sanitizer",
     "linkify",
     "minify",
@@ -66,5 +69,6 @@ __all__ = [
     "minify_js",
     "nofollow",
     "sanitize",
+    "sanitize_report",
     "target_blank",
 ]

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -11,8 +11,10 @@ from turbohtml.clean import (
     DEFAULT_TAGS,
     OnDisallowed,
     Policy,
+    Removed,
     Sanitizer,
     sanitize,
+    sanitize_report,
 )
 
 if TYPE_CHECKING:
@@ -731,10 +733,10 @@ def test_strip_propagates_a_child_filter_error() -> None:
 def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
-    # the fifteen policy arguments after the element; only the non-element first argument matters to this guard
+    # the sixteen policy arguments after the element; only the non-element first argument matters to this guard
     policy_args = (
         frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset(), frozenset(), frozenset(), {},
-        frozenset(), False,
+        frozenset(), False, None,
     )  # fmt: skip
     with pytest.raises(TypeError):
         _sanitize("not an element", *policy_args)  # ty: ignore[invalid-argument-type]
@@ -966,3 +968,35 @@ def test_media_host_ipv6_literal_rejected_even_when_listed() -> None:
     # bracketed host admits no media src -- the pre-unification behavior, kept so routing never weakens the allowlist
     policy = _media_policy(frozenset({"youtube.com", "::1"}))
     assert "src=" not in sanitize('<video src="https://[::1]/x">', policy)
+
+
+def test_report_records_a_removed_element() -> None:
+    out, removed = sanitize_report("<p>ok <script>evil()</script> done</p>")
+    assert Removed("script", None) in removed
+    assert "evil" in out
+    assert "<script>" not in out
+
+
+def test_report_records_a_dropped_attribute() -> None:
+    _, removed = sanitize_report('<a href="http://x" onclick="bad()">k</a>')
+    assert removed == [Removed("a", "onclick")]
+
+
+def test_report_records_a_disallowed_url_attribute() -> None:
+    _, removed = sanitize_report('<a href="javascript:alert(1)">x</a>')
+    assert removed == [Removed("a", "href")]
+
+
+def test_report_orders_records_as_the_walk_reaches_them() -> None:
+    _, removed = sanitize_report('<a class="c" title="t" href="ftp://x">k</a>')
+    assert removed == [Removed("a", "class"), Removed("a", "href")]
+
+
+def test_report_is_empty_when_nothing_is_dropped() -> None:
+    out, removed = sanitize_report('<a href="http://x" title="t">ok</a>')
+    assert removed == []
+    assert out == '<a href="http://x" title="t">ok</a>'
+
+
+def test_report_default_attribute_is_none() -> None:
+    assert Removed("div") == Removed("div", None)

--- a/tests/clean/test_sanitizer_namespace.py
+++ b/tests/clean/test_sanitizer_namespace.py
@@ -43,7 +43,7 @@ def _sanitize_tree(root: Element, tags: frozenset[str]) -> str:
     schemes = frozenset({"http", "https", "mailto"})
     _sanitize(
         root, tags, {}, schemes, allow_relative, OnDisallowed.REMOVE.value, strip_comments, None, None, {}, empty,
-        empty, empty, {}, empty, strip_templates,
+        empty, empty, {}, empty, strip_templates, None,
     )  # fmt: skip
     return root.inner_html
 

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -107,6 +107,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "structured": ("structured-spec", _spec),
     "sanitize": ("sanitize-spec", _spec),
     "sanitize-templates": ("sanitize-templates-spec", _spec),
+    "sanitize-report": ("sanitize-report-spec", _spec),
     "linkify": ("linkify-spec", _spec),
     "markdown-google": ("markdown-google-spec", _spec),
     "article": ("article-spec", _spec),

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -252,6 +252,11 @@ def sanitize_templates(text: str) -> None:
     _SANITIZER_TEMPLATES.sanitize(text)
 
 
+def sanitize_report(text: str) -> None:
+    """Sanitize with the audit trail on, exercising the removed-node collection."""
+    _SANITIZER.sanitize_report(text)
+
+
 def markup(text: str) -> None:
     """Escape a string into a Markup with turbohtml's markupsafe-compatible escape."""
     _markup_escape(text)
@@ -533,6 +538,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "microdata": (microdata, "turbohtml"),
     "sanitize": (sanitize, "turbohtml"),
     "sanitize-templates": (sanitize_templates, "turbohtml"),
+    "sanitize-report": (sanitize_report, "turbohtml"),
     "markup": (markup, "turbohtml"),
     "markup-op": (markup_op, "turbohtml"),
     "linkify": (linkify, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -121,6 +121,7 @@ OPERATIONS: dict[str, Operation] = {
     "microdata": Operation("Microdata item extraction", "us"),
     "sanitize": Operation("sanitize", "us"),
     "sanitize-templates": Operation("sanitize (template-safe)", "us"),
+    "sanitize-report": Operation("sanitize with audit trail", "us"),
     "markup": Operation("markupsafe-compatible escape", "ns"),
     "markup-op": Operation("Markup operations", "ns"),
     "linkify": Operation("linkify HTML", "us"),
@@ -401,6 +402,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("post 4 KiB", _SANITIZE_POST * 20),
     ),
     "sanitize-templates": lambda: (("templated 4 KiB", _SANITIZE_TEMPLATES * 20),),
+    "sanitize-report": lambda: (("post 4 KiB", _SANITIZE_POST * 20),),
     "markup": lambda: _MARKUP_ESCAPE_CASES,
     "markup-op": lambda: (
         ("striptags", ("striptags", _MARKUP_OPS_HTML)),


### PR DESCRIPTION
A caller tuning a sanitizer policy could see only the cleaned string, never which tags or attributes the policy removed, so narrowing or widening an allowlist meant guessing. bleach, `nh3`, and `html-sanitizer` expose no such report; DOMPurify does, through `DOMPurify.removed`. 🔍

`sanitize_report()` (and `Sanitizer.sanitize_report()`) return the cleaned HTML paired with one `Removed` record per dropped element or stripped attribute, in the order the walk reached them: `Removed(tag="a", attribute="onclick")` for a stripped attribute, `Removed(tag="script", attribute=None)` for a removed, stripped, or escaped element. Clean input gives an empty list.

The audit runs inside the existing C walk. Each drop appends to a caller-owned list only when reporting is on, so the plain `sanitize()` path pays one `NULL` check and nothing else. A `sanitize-report` benchmark gates the reporting path under CodSpeed.

Closes #528
