### PR TITLE
✨ feat(clean): per-property inline-style value allowlist

### DIFF
--- a/docs/changelog/533.feature.rst
+++ b/docs/changelog/533.feature.rst
@@ -1,0 +1,4 @@
+``turbohtml.clean.Policy`` gains ``allowed_styles``, a per-element, per-property value allowlist for the ``style``
+attribute keyed ``{tag: {property: [pattern, ...]}}`` with ``"*"`` matching every tag. A declaration survives only when
+its value matches one of the property's patterns, porting sanitize-html's ``allowedStyles``. It narrows
+``css_properties`` by value and never weakens the baseline that drops ``expression()`` and disallowed-scheme ``url()``.

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -44,4 +44,5 @@ It is the wrong tool in a few honest cases:
     serialization
     main-content
     mutation
+    sanitizing
     free-threading

--- a/docs/explanation/sanitizing.rst
+++ b/docs/explanation/sanitizing.rst
@@ -1,0 +1,26 @@
+####################
+ Layered sanitizing
+####################
+
+Sanitizing is subtractive and layered: each configurable allowlist can only *remove* more than the layer below it, and
+under all of them sits a baseline no policy can reach. The order matters, so read a kept ``style`` attribute as the
+worked example.
+
+A style declaration passes through three gates in turn. First the non-configurable safety baseline: ``expression()``
+runs script in old IE, and ``url(javascript:...)`` carries a disallowed scheme, so either drops the whole declaration no
+matter what the policy says. Then ``css_properties``, the property-*name* allowlist: a property outside the set is gone
+even if its value is harmless. Only a declaration that clears both reaches ``allowed_styles``, the property-*value*
+allowlist, which keeps it only when its value matches one of the patterns listed for the element's tag (or ``"*"``).
+
+The layering is deliberately one-directional. ``allowed_styles`` *narrows* -- it can reject a value the earlier layers
+would have kept, but it can never re-admit one they dropped. A caller who writes ``{"color": [r".*"]}`` has not opened a
+hole: ``.*`` matches ``expression(alert(1))`` as a string, but the baseline already discarded that declaration two gates
+earlier, so the pattern never sees it. This is why the value patterns are a *validation* step, not an *authorization*
+one: they answer "is this known-good?", and the answer only ever shrinks what survives.
+
+Keeping the dangerous-value baseline unconditional -- rather than folding it into ``css_properties`` or
+``allowed_styles`` -- is what makes a permissive policy safe by construction. A caller tuning an allowlist is reasoning
+about which benign values to accept; they are never one regex away from re-enabling script execution, because that
+decision was taken out of the policy's hands entirely. The same shape governs the rest of the sanitizer: ``on*`` event
+handlers, ``<script>``, and ``javascript:`` URLs are dropped below the allowlists, so no combination of ``tags``,
+``attributes``, or ``attribute_filter`` settings can bring them back.

--- a/docs/how-to/sanitizing.rst
+++ b/docs/how-to/sanitizing.rst
@@ -41,6 +41,33 @@ single space, matching DOMPurify's ``SAFE_FOR_TEMPLATES``.
     print(sanitize("<p title='{{x}}'>Hi {{ user.name }}</p>", policy))
     # <p title=" ">Hi  </p>
 
+*********************************************
+ Restrict inline styles to known-good values
+*********************************************
+
+``css_properties`` allowlists property *names*; ``allowed_styles`` narrows further by *value*, the way sanitize-html's
+``allowedStyles`` does. Key it ``{tag: {property: [pattern, ...]}}``, with ``"*"`` as a tag matching every element. A
+declaration survives only when its property is listed for the element's tag or ``"*"`` and its value matches one of the
+patterns (an unanchored :func:`re.search`). This runs on top of ``css_properties`` and the dangerous-value baseline: a
+property must still be in ``css_properties``, and ``expression()`` or a ``url()`` with a disallowed scheme is dropped
+even if a pattern would admit it.
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy
+
+    policy = Policy(
+        tags=frozenset({"p"}),
+        attributes={"p": frozenset({"style"})},
+        css_properties=frozenset({"color", "text-align"}),
+        allowed_styles={"*": {"color": [r"^#[0-9a-f]{3,6}$"], "text-align": [r"^left$|^center$|^right$"]}},
+    )
+    print(sanitize('<p style="color: #ff0000; text-align: justify; font-size: 40px">Hi</p>', policy))
+
+.. testoutput::
+
+    <p style="color: #ff0000">Hi</p>
+
 **************************************
  Trust the first pass, do not reparse
 **************************************

--- a/docs/migration/html-sanitizer.rst
+++ b/docs/migration/html-sanitizer.rst
@@ -69,6 +69,10 @@ What turbohtml adds
 - ``Policy.remove_with_content`` and a fixed safety baseline that drops ``<script>``, ``on*`` event handlers, and
   ``javascript:`` URLs by construction, so no allowlist can re-admit them and script text never leaks into the output.
 - ``Policy.css_properties``: when ``style`` is allowed, its declarations are scrubbed against a safe property set.
+- ``Policy.allowed_styles``: a per-element, per-property value allowlist for the ``style`` attribute, keyed ``{tag:
+  {property: [pattern, ...]}}`` with ``"*"`` matching every tag. It ports sanitize-html's ``allowedStyles`` -- a
+  declaration survives only when its value matches one of the property's patterns -- narrowing ``css_properties`` by
+  value without weakening the dangerous-value baseline.
 - ``Policy.attribute_filter`` to rewrite or drop any surviving attribute value, and ``Policy.set_attributes`` to force
   attribute values onto every kept instance of a tag.
 - ``Policy.add_link_rel`` generalizes ``add_nofollow`` to any ``rel`` token set (for example ``noopener``,

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -26,6 +26,29 @@ element or stripped attribute, the way DOMPurify populates ``DOMPurify.removed``
 .. autoclass:: Policy
     :members: strict, basic, relaxed
 
+``Policy.css_properties`` allowlists style property *names*; ``Policy.allowed_styles`` narrows further by *value*, the
+way sanitize-html's ``allowedStyles`` does. Key it ``{tag: {property: [pattern, ...]}}`` (``"*"`` matches every tag); a
+``style`` declaration survives only when its property is listed for the element's tag or ``"*"`` and its value matches
+one of the patterns via an unanchored :func:`re.search`. It runs on top of ``css_properties`` and the dangerous-value
+baseline -- the property must still be in ``css_properties``, and ``expression()`` or a disallowed-scheme ``url()`` is
+dropped even when a pattern would admit it:
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy
+
+    policy = Policy(
+        tags=frozenset({"p"}),
+        attributes={"p": frozenset({"style"})},
+        css_properties=frozenset({"color"}),
+        allowed_styles={"*": {"color": [r"^#[0-9a-f]{3,6}$"]}},
+    )
+    print(sanitize('<p style="color: #0a0; color: red">ok</p>', policy))
+
+.. testoutput::
+
+    <p style="color: #0a0">ok</p>
+
 .. autoclass:: OnDisallowed
     :members:
 

--- a/docs/tutorials/getting-started.rst
+++ b/docs/tutorials/getting-started.rst
@@ -86,5 +86,31 @@ plus a combining mark, so ``"café"`` need not equal ``"café"`` even though the
     False
     True
 
-Reach for ``NFC`` before you compare or store text; the :doc:`/how-to/encoding` guide covers the other three forms. With
-the string helpers in hand, continue to :doc:`tokenizing` to break whole documents into tokens.
+Reach for ``NFC`` before you compare or store text; the :doc:`/how-to/encoding` guide covers the other three forms.
+
+*************************
+ Sanitize untrusted HTML
+*************************
+
+When the input is already HTML rather than plain text, clean it against an allowlist with
+:func:`turbohtml.clean.sanitize`. A :class:`~turbohtml.clean.Policy` says what to keep; here it allows a ``<p>`` with a
+``style`` attribute and, through ``allowed_styles``, keeps a ``color`` only when it is a hex value. A non-overridable
+baseline still drops dangerous CSS, so the ``url(javascript:...)`` goes even though the property name is allowed:
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy
+
+    policy = Policy(
+        tags=frozenset({"p"}),
+        attributes={"p": frozenset({"style"})},
+        css_properties=frozenset({"color"}),
+        allowed_styles={"*": {"color": [r"^#[0-9a-f]{3,6}$"]}},
+    )
+    print(sanitize('<p style="color: #0a0; color: url(javascript:x)">Hi</p>', policy))
+
+.. testoutput::
+
+    <p style="color: #0a0">Hi</p>
+
+With the string helpers in hand, continue to :doc:`tokenizing` to break whole documents into tokens.

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -32,6 +32,10 @@ typedef struct {
     PyObject *css_properties;      /* frozenset[str]: CSS property names kept when scrubbing a `style` attribute */
     PyObject *attribute_prefixes;  /* frozenset[str]: allow any attribute whose name starts with one of these */
     PyObject *attribute_values;    /* dict[str, dict[str, frozenset[str]]]: per (tag, attr) literal value allowlist */
+    PyObject *allowed_styles;      /* dict[str, dict[str, tuple[re.Pattern, ...]]]: per (tag or "*") allowed style
+                                      properties, each mapped to the compiled patterns its value must match, or an empty
+                                      dict when no per-property value allowlist is in force */
+    PyObject *re_search; /* the interned "search" method name, for calling re.Pattern.search from the style scrubber */
     PyObject *media_hosts; /* frozenset[str]: allowed hosts for an embedded-media (audio/video/source/track) src */
     PyObject
         *removed; /* list to append (tag, attr_or_None) records to as the walk drops things, or NULL to not report */
@@ -451,24 +455,84 @@ static int apply_set_attributes(sanitizer *s, th_node *element, PyObject *tag) {
     return 0;
 }
 
-/* A CSS property name is ASCII letters, digits, and '-', so an ASCII lowercase is enough to look it up. Returns 1
-   allow, 0 drop, -1 error. */
-static int css_property_allowed(sanitizer *s, const Py_UCS4 *name, Py_ssize_t len) {
+/* A CSS property name is ASCII letters, digits, and '-', so an ASCII lowercase key is enough to look it up. Callers
+   guarantee 0 < len < 64 (a real property name), so the fixed buffer never overflows. Returns a new str, or NULL on
+   allocation failure. */
+static PyObject *css_property_key(const Py_UCS4 *name, Py_ssize_t len) {
     char lowered[64];
-    if (len == 0 || len >= (Py_ssize_t)sizeof(lowered)) {
+    for (Py_ssize_t index = 0; index < len; index++) {
+        lowered[index] = (char)(lower_ascii(name[index]));
+    }
+    return PyUnicode_FromStringAndSize(lowered, len);
+}
+
+/* Is the CSS property `name[0:len]` in the name allowlist? Returns 1 allow, 0 drop, -1 error. */
+static int css_property_allowed(sanitizer *s, const Py_UCS4 *name, Py_ssize_t len) {
+    if (len == 0 || len >= 64) {
         return 0; /* empty, or longer than any real property name */
     }
-    for (Py_ssize_t index = 0; index < len; index++) {
-        Py_UCS4 c = name[index];
-        lowered[index] = (char)(lower_ascii(c));
-    }
-    PyObject *key = PyUnicode_FromStringAndSize(lowered, len);
+    PyObject *key = css_property_key(name, len);
     if (key == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     int allowed = PySet_Contains(s->css_properties, key);
     Py_DECREF(key);
     return allowed;
+}
+
+/* The per-element resolution of Policy.allowed_styles: the allowlist keyed by the element's own tag and the one keyed
+   by the "*" wildcard, either borrowed or NULL when absent. A NULL styles pointer means allowed_styles imposes nothing
+   on this declaration list (the `<style>` body, and any element no rule applies to), keeping that path branch-free. */
+typedef struct {
+    PyObject *tag_rule;  /* allowed_styles[tag], borrowed, or NULL */
+    PyObject *star_rule; /* allowed_styles["*"], borrowed, or NULL */
+} style_allowlist;
+
+/* Does `value_obj` match one of the patterns `rule` lists for `prop_key`? Following sanitize-html's allowedStyles, a
+   declaration survives only when its property is listed and its value matches a pattern (an unanchored `re.search`,
+   like JavaScript's `RegExp.test`). Returns 1 a pattern matched, 0 the property is absent or no pattern matched, -1
+   error. A NULL rule (the wildcard or tag entry not present) contributes no match. */
+static int css_style_patterns_match(sanitizer *s, PyObject *rule, PyObject *prop_key, PyObject *value_obj) {
+    if (rule == NULL) {
+        return 0;
+    }
+    PyObject *patterns = PyDict_GetItemWithError(rule, prop_key);
+    if (patterns == NULL) {
+        return PyErr_Occurred() ? -1 : 0; /* GCOVR_EXCL_BR_LINE: the str-key lookup cannot itself error */
+    }
+    Py_ssize_t count = PyTuple_GET_SIZE(patterns);
+    for (Py_ssize_t index = 0; index < count; index++) {
+        /* gcc pins the search call's untaken exception edge to this loop-body opening; a compiled re.Pattern.search
+           over a str cannot raise, so that edge is uncoverable */
+        PyObject *pattern = PyTuple_GET_ITEM(patterns, index); /* GCOVR_EXCL_BR_LINE */
+        PyObject *result = PyObject_CallMethodOneArg(pattern, s->re_search, value_obj);
+        if (result == NULL) { /* GCOVR_EXCL_BR_LINE: only a caller-supplied broken pattern could reach here */
+            return -1;        /* GCOVR_EXCL_LINE: allocation/exception-failure path */
+        }
+        int matched = result != Py_None;
+        Py_DECREF(result);
+        if (matched) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Narrow a name-allowlisted declaration through Policy.allowed_styles: the property `name[start:end]` must be listed
+   for the element's own tag or the "*" wildcard (their pattern lists union, so either can admit it) and its value
+   `value_obj` must match one of that property's patterns. Returns 1 keep, 0 drop, -1 error. */
+static int css_style_declaration_allowed(sanitizer *s, const style_allowlist *styles, const Py_UCS4 *name,
+                                         Py_ssize_t name_len, PyObject *value_obj) {
+    PyObject *prop_key = css_property_key(name, name_len);
+    if (prop_key == NULL) { /* GCOVR_EXCL_BR_LINE: the property already passed the name allowlist, so len < 64 */
+        return -1;          /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int matched = css_style_patterns_match(s, styles->tag_rule, prop_key, value_obj);
+    if (matched == 0) {
+        matched = css_style_patterns_match(s, styles->star_rule, prop_key, value_obj);
+    }
+    Py_DECREF(prop_key);
+    return matched;
 }
 
 /* Bytes that continue a CSS identifier, so `expression`/`url` is only recognized as a function name at a token boundary
@@ -555,12 +619,14 @@ static int css_value_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t star
 }
 
 /* Decide whether the declaration `value[start:end)`, split at `colon` into property and value, survives the policy:
-   its property name must be allowlisted and its value free of expression()/url(disallowed-scheme). On a keep, the
-   trimmed declaration span (property start through the value's last non-whitespace byte) is returned in *name_start
-   and *decl_end. Returns 1 keep, 0 drop, -1 error. Shared by the `style` attribute and `<style>` body scrubbers so the
-   safety rules stay identical across both. */
-static int css_declaration_kept(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_ssize_t colon,
-                                Py_ssize_t *name_start_out, Py_ssize_t *decl_end_out) {
+   its property name must be allowlisted and its value free of expression()/url(disallowed-scheme). When `styles` is
+   non-NULL, Policy.allowed_styles narrows further -- the property must be listed and its value match a pattern -- on
+   top of that baseline, never weakening it. On a keep, the trimmed declaration span (property start through the value's
+   last non-whitespace byte) is returned in *name_start and *decl_end. Returns 1 keep, 0 drop, -1 error. Shared by the
+   `style` attribute and `<style>` body scrubbers so the safety rules stay identical across both. */
+static int css_declaration_kept(sanitizer *s, const style_allowlist *styles, const Py_UCS4 *value, Py_ssize_t start,
+                                Py_ssize_t end, Py_ssize_t colon, Py_ssize_t *name_start_out,
+                                Py_ssize_t *decl_end_out) {
     if (colon < start) {
         return 0; /* no property:value split in this declaration, so drop it */
     }
@@ -590,6 +656,25 @@ static int css_declaration_kept(sanitizer *s, const Py_UCS4 *value, Py_ssize_t s
     while (decl_end > colon + 1 && is_space(value[decl_end - 1])) {
         decl_end--;
     }
+    if (styles != NULL) {
+        Py_ssize_t value_start = colon + 1;
+        while (value_start < decl_end && is_space(value[value_start])) {
+            value_start++;
+        }
+        PyObject *value_obj =
+            PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, value + value_start, decl_end - value_start);
+        if (value_obj == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;           /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        int narrowed = css_style_declaration_allowed(s, styles, value + name_start, name_end - name_start, value_obj);
+        Py_DECREF(value_obj);
+        if (narrowed < 0) { /* GCOVR_EXCL_BR_LINE: css_style_declaration_allowed only fails on allocation failure */
+            return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        if (!narrowed) {
+            return 0; /* an unlisted property, or a value no pattern admits, is dropped */
+        }
+    }
     *name_start_out = name_start;
     *decl_end_out = decl_end;
     return 1;
@@ -597,11 +682,11 @@ static int css_declaration_kept(sanitizer *s, const Py_UCS4 *value, Py_ssize_t s
 
 /* Append the declaration `value[start:end)` to `out` if it survives the policy, trimming surrounding whitespace and
    joining kept declarations with "; " (the `style` attribute's declaration-list form). Returns 0, or -1 on error. */
-static int css_flush_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end, Py_ssize_t colon,
-                                 Py_UCS4 *out, Py_ssize_t *out_len) {
+static int css_flush_declaration(sanitizer *s, const style_allowlist *styles, const Py_UCS4 *value, Py_ssize_t start,
+                                 Py_ssize_t end, Py_ssize_t colon, Py_UCS4 *out, Py_ssize_t *out_len) {
     Py_ssize_t name_start = 0;
     Py_ssize_t decl_end = 0;
-    int kept = css_declaration_kept(s, value, start, end, colon, &name_start, &decl_end);
+    int kept = css_declaration_kept(s, styles, value, start, end, colon, &name_start, &decl_end);
     if (kept <= 0) { /* GCOVR_EXCL_BR_LINE: the -1 half is css_declaration_kept's allocation-failure path */
         return kept;
     }
@@ -615,11 +700,27 @@ static int css_flush_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssize_t 
     return 0;
 }
 
-/* Scrub a kept `style` attribute: keep only declarations whose property name is allowlisted. The value is a CSS
-   declaration list; split it on top-level ';' and ':' while skipping strings, comments, and parenthesised groups so a
-   separator inside url()/quotes/comments is not mistaken for one. Rewrites the attribute, deleting it if nothing
-   survives. Returns 0 on success, -1 on error. */
-static int sanitize_style(sanitizer *s, th_node *element, th_node_attr *attr) {
+/* Scrub a kept `style` attribute: keep only declarations whose property name is allowlisted, and, when a
+   Policy.allowed_styles rule applies to `tag` (its own entry or the "*" wildcard), whose value matches one of that
+   property's patterns too. The value is a CSS declaration list; split it on top-level ';' and ':' while skipping
+   strings, comments, and parenthesised groups so a separator inside url()/quotes/comments is not mistaken for one.
+   Rewrites the attribute, deleting it if nothing survives. Returns 0 on success, -1 on error. */
+static int sanitize_style(sanitizer *s, th_node *element, th_node_attr *attr, PyObject *tag) {
+    style_allowlist rules = {NULL, NULL};
+    const style_allowlist *styles = NULL;
+    if (PyDict_GET_SIZE(s->allowed_styles) > 0) {
+        rules.tag_rule = PyDict_GetItemWithError(s->allowed_styles, tag);
+        if (rules.tag_rule == NULL && PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: the tag lookup cannot itself error */
+            return -1;                                    /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        rules.star_rule = PyDict_GetItemWithError(s->allowed_styles, s->star);
+        if (rules.star_rule == NULL && PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: the "*" lookup cannot itself error */
+            return -1;                                     /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        if (rules.tag_rule != NULL || rules.star_rule != NULL) {
+            styles = &rules; /* a rule applies to this element, so its declarations are narrowed */
+        }
+    }
     const Py_UCS4 *value = attr->value;
     Py_ssize_t len = attr->value_len;
     Py_UCS4 *out = PyMem_Malloc((size_t)(2 * len + 2) * sizeof(Py_UCS4));
@@ -680,7 +781,7 @@ static int sanitize_style(sanitizer *s, th_node *element, th_node_attr *attr) {
                 continue;
             }
         }
-        int flushed = css_flush_declaration(s, value, decl_start, index, colon, out, &out_len);
+        int flushed = css_flush_declaration(s, styles, value, decl_start, index, colon, out, &out_len);
         if (flushed < 0) {   /* GCOVR_EXCL_BR_LINE: css_flush_declaration only fails on allocation failure */
             PyMem_Free(out); /* GCOVR_EXCL_LINE: allocation-failure path */
             return -1;       /* GCOVR_EXCL_LINE */
@@ -721,7 +822,7 @@ static int css_emit_block_declaration(sanitizer *s, const Py_UCS4 *value, Py_ssi
                                       Py_ssize_t colon, Py_UCS4 *out, Py_ssize_t *out_len) {
     Py_ssize_t name_start = 0;
     Py_ssize_t decl_end = 0;
-    int kept = css_declaration_kept(s, value, start, end, colon, &name_start, &decl_end);
+    int kept = css_declaration_kept(s, NULL, value, start, end, colon, &name_start, &decl_end);
     if (kept <= 0) { /* GCOVR_EXCL_BR_LINE: the -1 half is css_declaration_kept's allocation-failure path */
         return kept;
     }
@@ -1002,8 +1103,8 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
         }
         if (name_len == 5 && memcmp(name, "style", 5) == 0) {
             Py_ssize_t before = element->attr_count;
-            if (sanitize_style(s, element, attr) < 0) { /* GCOVR_EXCL_BR_LINE: only on allocation failure */
-                return -1;                              /* GCOVR_EXCL_LINE: allocation-failure path */
+            if (sanitize_style(s, element, attr, tag) < 0) { /* GCOVR_EXCL_BR_LINE: only on allocation failure */
+                return -1;                                   /* GCOVR_EXCL_LINE: allocation-failure path */
             }
             if (element->attr_count < before) {
                 continue; /* the style scrubbed to empty and was deleted */
@@ -1362,16 +1463,16 @@ static int require_prefixes(PyObject *prefixes) {
 
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
    attribute_filter, set_attributes, remove_with_content, css_properties, attribute_prefixes, attribute_values,
-   media_hosts, strip_templates, removed) -> None. Filters the fragment in place; sanitizer.py serializes it.
-   `removed` is a list the walk appends (tag, attr_or_None) records to, or None to skip the audit. */
+   media_hosts, strip_templates, removed, allowed_styles) -> None. Filters the fragment in place; sanitizer.py
+   serializes it. `removed` is a list the walk appends (tag, attr_or_None) records to, or None to skip the audit. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
     PyObject *removed = NULL;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOpO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOpOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
                           &s.set_attributes, &s.remove_with_content, &s.css_properties, &s.attribute_prefixes,
-                          &s.attribute_values, &s.media_hosts, &s.strip_templates, &removed)) {
+                          &s.attribute_values, &s.media_hosts, &s.strip_templates, &removed, &s.allowed_styles)) {
         return NULL;
     }
     s.removed = removed == Py_None ? NULL : removed;
@@ -1390,12 +1491,19 @@ PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     if (s.star == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }
+    s.re_search = PyUnicode_InternFromString("search"); /* interned once; the style scrubber calls Pattern.search */
+    if (s.re_search == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(s.star);     /* GCOVR_EXCL_LINE */
+        return NULL;           /* GCOVR_EXCL_LINE */
+    }
     s.wildcard_attrs = PyDict_GetItemWithError(s.attributes, s.star);
     if (s.wildcard_attrs == NULL && PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: the "*" lookup cannot itself error */
         Py_DECREF(s.star);                              /* GCOVR_EXCL_LINE */
+        Py_DECREF(s.re_search);                         /* GCOVR_EXCL_LINE */
         return NULL;                                    /* GCOVR_EXCL_LINE */
     }
     int failed = sanitize_children(&s, root, 1) < 0; /* the fragment root is kept context */
     Py_DECREF(s.star);
+    Py_DECREF(s.re_search);
     return failed ? NULL : Py_NewRef(Py_None);
 }

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -14,6 +14,7 @@ This module is the policy facade only; the walk that keeps, escapes, strips, or 
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from itertools import starmap
@@ -23,7 +24,7 @@ from typing import TYPE_CHECKING, Final
 from ._html import _sanitize, parse_fragment
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Mapping, Sequence
 
     from ._html import Element
 
@@ -137,6 +138,14 @@ class Policy:
     :param attribute_values: restrict a kept attribute to literal values, keyed ``{tag: {attribute: allowed_values}}``;
         a surviving attribute whose value is outside its set is dropped. This narrows an attribute ``attributes``
         already admits and cannot admit a new one.
+    :param allowed_styles: a per-property value allowlist for the ``style`` attribute, keyed
+        ``{tag: {property: [pattern, ...]}}`` with ``"*"`` as a tag matching every element (sanitize-html's
+        ``allowedStyles``). A declaration survives only when its property is listed for the element's tag or ``"*"``
+        (their pattern lists union) and its value matches one of the patterns (an unanchored :func:`re.search`).
+        Patterns are strings or precompiled :class:`re.Pattern`. This narrows on top of ``css_properties`` and the
+        non-configurable dangerous-value baseline: a property this admits is still dropped unless ``css_properties``
+        lists it too, and ``expression()`` or a ``url()`` with a disallowed scheme is dropped even if a pattern would
+        match it. Empty (the default) leaves ``css_properties`` as the only ``style`` filter.
     :param media_hosts: allowed hosts for an embedded-media ``src`` (``audio``, ``video``, ``source``, ``track``); a
         ``src`` whose URL host is not one of these lowercase entries is dropped. Empty means no host restriction.
     :param strip_template_markers: collapse template-engine expressions (``{{ }}``, ``${ }``, ``<% %>``) in kept text
@@ -160,6 +169,7 @@ class Policy:
     attribute_values: Mapping[str, Mapping[str, frozenset[str]]] = field(default_factory=dict)
     media_hosts: frozenset[str] = frozenset()
     strip_template_markers: bool = False
+    allowed_styles: Mapping[str, Mapping[str, Sequence[str | re.Pattern[str]]]] = field(default_factory=dict)
 
     @classmethod
     def strict(cls) -> Policy:
@@ -209,6 +219,13 @@ class Sanitizer:
         self._attribute_values = {
             tag: {attr: frozenset(values) for attr, values in attrs.items()}
             for tag, attrs in self.policy.attribute_values.items()
+        }
+        self._allowed_styles = {
+            tag: {
+                prop.lower(): tuple(p if isinstance(p, re.Pattern) else re.compile(p) for p in patterns)
+                for prop, patterns in props.items()
+            }
+            for tag, props in self.policy.allowed_styles.items()
         }
 
     def sanitize(self, html: str) -> str:
@@ -263,6 +280,7 @@ class Sanitizer:
             policy.media_hosts,
             policy.strip_template_markers,
             removed,
+            self._allowed_styles,
         )
         return root
 

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -1,4 +1,5 @@
 # Subsystem: features (_c/features) — sanitizing, linkify scanning, annotation, and type registration.
+import re
 from collections.abc import Callable, Iterable, Mapping
 
 from turbohtml._structured_data import JSONValue, MicrodataItem, OpenGraph, RdfaItem, StructuredData
@@ -60,6 +61,7 @@ def _sanitize(
     media_hosts: frozenset[str],
     strip_templates: bool,
     removed: list[tuple[str, str | None]] | None,
+    allowed_styles: Mapping[str, Mapping[str, tuple[re.Pattern[str], ...]]],
     /,
 ) -> None: ...
 def annotation_surface(text: str, spans: Iterable[tuple[int, int, str]], /) -> dict[str, list[str]]: ...

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -18,7 +19,7 @@ from turbohtml.clean import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping, Sequence
 
 
 def _style_policy(
@@ -358,6 +359,105 @@ def test_style_double_quoted_url_scheme_is_stripped() -> None:
     assert "style=" not in sanitize("""<p style='color: url("javascript:x")'>y</p>""", _style_policy())
 
 
+_COLOR_ALIGN = {"color": [r"^#[0-9a-f]{3,6}$", r"^rgb\("], "text-align": [r"^left$|^right$|^center$"]}
+
+
+def _allowed_styles_policy(
+    allowed_styles: Mapping[str, Mapping[str, Sequence[str | re.Pattern[str]]]],
+    *,
+    css_properties: frozenset[str] = frozenset({"color", "text-align", "width"}),
+) -> Policy:
+    """A <p style> / <span style> policy carrying a per-property value allowlist for exercising allowed_styles."""
+    return Policy(
+        tags=frozenset({"p", "span"}),
+        attributes={"*": frozenset({"style"})},
+        css_properties=css_properties,
+        allowed_styles=allowed_styles,
+    )
+
+
+@pytest.mark.parametrize(
+    ("style", "expected"),
+    [
+        pytest.param("color: #fff", 'style="color: #fff"', id="value-matches-pattern"),
+        pytest.param("color: red", None, id="value-fails-every-pattern"),
+        pytest.param("text-align: center", 'style="text-align: center"', id="second-property-matches"),
+        pytest.param("width: 5px", None, id="property-not-listed-dropped"),
+        pytest.param("color: #fff; width: 5px", 'style="color: #fff"', id="listed-kept-unlisted-dropped"),
+        pytest.param("color: rgb(1,2,3)", 'style="color: rgb(1,2,3)"', id="second-pattern-of-a-property"),
+        pytest.param("color:", None, id="empty-value-no-pattern-matches"),
+    ],
+)
+def test_allowed_styles_narrows_by_value(style: str, expected: str | None) -> None:
+    out = sanitize(f'<p style="{style}">x</p>', _allowed_styles_policy({"*": _COLOR_ALIGN}))
+    if expected is None:
+        assert "style=" not in out
+    else:
+        assert expected in out
+
+
+def test_allowed_styles_wildcard_applies_to_every_tag() -> None:
+    # the "*" tag key matches any element, so a <span> is narrowed the same as a <p>
+    policy = _allowed_styles_policy({"*": {"color": [r"^blue$"]}})
+    assert sanitize('<span style="color: blue">x</span>', policy) == '<span style="color: blue">x</span>'
+    assert "style=" not in sanitize('<span style="color: green">x</span>', policy)
+
+
+def test_allowed_styles_tag_specific_leaves_other_tags_to_name_allowlist() -> None:
+    # a rule keyed only by "span" narrows <span>; a <p> keeps the css_properties baseline (no value narrowing)
+    policy = _allowed_styles_policy({"span": {"color": [r"^blue$"]}})
+    assert "style=" not in sanitize('<span style="color: red; width: 5px">x</span>', policy)
+    assert sanitize('<p style="color: red; width: 5px">x</p>', policy) == '<p style="color: red; width: 5px">x</p>'
+
+
+def test_allowed_styles_merges_tag_and_wildcard() -> None:
+    # a property listed by the tag and by "*" unions both pattern lists; distinct properties from each both apply
+    policy = _allowed_styles_policy({
+        "p": {"color": [r"^red$"]},
+        "*": {"color": [r"^blue$"], "text-align": [r"^left$"]},
+    })
+    assert sanitize('<p style="color: red">x</p>', policy) == '<p style="color: red">x</p>'
+    assert sanitize('<p style="color: blue">x</p>', policy) == '<p style="color: blue">x</p>'
+    assert sanitize('<p style="text-align: left">x</p>', policy) == '<p style="text-align: left">x</p>'
+    assert "style=" not in sanitize('<p style="color: green">x</p>', policy)
+
+
+def test_allowed_styles_accepts_precompiled_patterns() -> None:
+    policy = _allowed_styles_policy({"*": {"color": [re.compile(r"^teal$")]}})
+    assert sanitize('<p style="color: teal">x</p>', policy) == '<p style="color: teal">x</p>'
+
+
+def test_allowed_styles_patterns_search_unanchored() -> None:
+    # a pattern is applied with re.search, so an unanchored one matches anywhere in the value, like sanitize-html
+    policy = _allowed_styles_policy({"*": {"color": [r"e"]}})
+    assert sanitize('<p style="color: red">x</p>', policy) == '<p style="color: red">x</p>'
+
+
+def test_allowed_styles_still_requires_the_name_allowlist() -> None:
+    # allowed_styles narrows on top of css_properties; a property it lists but css_properties omits stays dropped
+    policy = _allowed_styles_policy({"*": {"color": [r"^red$"]}}, css_properties=frozenset({"width"}))
+    assert "style=" not in sanitize('<p style="color: red">x</p>', policy)
+
+
+@pytest.mark.parametrize(
+    "style",
+    [
+        pytest.param("color: expression(alert(1))", id="expression"),
+        pytest.param("color: url(javascript:alert(1))", id="javascript-url"),
+    ],
+)
+def test_allowed_styles_cannot_admit_dangerous_values(style: str) -> None:
+    # the safety baseline runs before the value patterns, so a permissive pattern cannot re-admit dangerous CSS
+    policy = _allowed_styles_policy({"*": {"color": [r".*"]}})
+    assert "style=" not in sanitize(f'<p style="{style}">x</p>', policy)
+
+
+def test_allowed_styles_empty_is_a_noop() -> None:
+    # the default empty mapping leaves css_properties as the only style filter
+    policy = _allowed_styles_policy({})
+    assert sanitize('<p style="color: red; width: 5px">x</p>', policy) == '<p style="color: red; width: 5px">x</p>'
+
+
 def _style_element_policy(*, css_properties: frozenset[str] = DEFAULT_CSS_PROPERTIES) -> Policy:
     """A policy that allowlists the <style> element, so its stylesheet body is scrubbed rather than dropped."""
     return Policy(tags=frozenset({"style"}), attributes={}, css_properties=css_properties)
@@ -398,6 +498,17 @@ def _style_element_policy(*, css_properties: frozenset[str] = DEFAULT_CSS_PROPER
 def test_style_element_body_scrubbed(css: str, expected_body: str) -> None:
     # an allowlisted <style> keeps its element and structure; each declaration is vetted like a style attribute
     assert sanitize(f"<style>{css}</style>", _style_element_policy()) == f"<style>{expected_body}</style>"
+
+
+def test_allowed_styles_does_not_narrow_style_element_body() -> None:
+    # allowed_styles targets inline style attributes; a <style> body stays governed by css_properties alone
+    policy = Policy(
+        tags=frozenset({"style"}),
+        attributes={},
+        css_properties=frozenset({"color"}),
+        allowed_styles={"*": {"color": [r"^blue$"]}},
+    )
+    assert sanitize("<style>p{color:red}</style>", policy) == "<style>p{color:red;}</style>"
 
 
 @pytest.mark.parametrize("css", ["", "  "], ids=["no-text-child", "whitespace-only"])
@@ -733,10 +844,10 @@ def test_strip_propagates_a_child_filter_error() -> None:
 def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
-    # the sixteen policy arguments after the element; only the non-element first argument matters to this guard
+    # the seventeen policy arguments after the element; only the non-element first argument matters to this guard
     policy_args = (
         frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset(), frozenset(), frozenset(), {},
-        frozenset(), False, None,
+        frozenset(), False, None, {},
     )  # fmt: skip
     with pytest.raises(TypeError):
         _sanitize("not an element", *policy_args)  # ty: ignore[invalid-argument-type]

--- a/tests/clean/test_sanitizer_namespace.py
+++ b/tests/clean/test_sanitizer_namespace.py
@@ -43,7 +43,7 @@ def _sanitize_tree(root: Element, tags: frozenset[str]) -> str:
     schemes = frozenset({"http", "https", "mailto"})
     _sanitize(
         root, tags, {}, schemes, allow_relative, OnDisallowed.REMOVE.value, strip_comments, None, None, {}, empty,
-        empty, empty, {}, empty, strip_templates, None,
+        empty, empty, {}, empty, strip_templates, None, {},
     )  # fmt: skip
     return root.inner_html
 

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -109,6 +109,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "sanitize": ("sanitize-spec", _spec),
     "sanitize-templates": ("sanitize-templates-spec", _spec),
     "sanitize-report": ("sanitize-report-spec", _spec),
+    "sanitize-styles": ("sanitize-styles-spec", _spec),
     "linkify": ("linkify-spec", _spec),
     "markdown-google": ("markdown-google-spec", _spec),
     "article": ("article-spec", _spec),

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -40,6 +40,14 @@ if TYPE_CHECKING:
 
 _SANITIZER = _clean.Sanitizer(_clean.Policy.relaxed())
 _SANITIZER_TEMPLATES = _clean.Sanitizer(replace(_clean.Policy.relaxed(), strip_template_markers=True))
+_SANITIZER_STYLES = _clean.Sanitizer(
+    replace(
+        _clean.Policy.relaxed(),
+        attributes={"*": frozenset({"style", "title", "lang", "dir"})},
+        css_properties=frozenset({"color", "text-align", "font-size"}),
+        allowed_styles={"*": {"color": [r"^#[0-9a-f]{3,6}$", r"^rgb\("], "text-align": [r"^left$|^center$|^right$"]}},
+    )
+)
 _LINKS_BASE = "https://example.com/base/"
 _URL_HINT_BASE = "http://site.com/"
 _FIND_TEXT_PATTERN = re.compile(r"test")  # ubiquitous in the wpt corpus, so the predicate does real work
@@ -256,6 +264,11 @@ def sanitize_templates(text: str) -> None:
 def sanitize_report(text: str) -> None:
     """Sanitize with the audit trail on, exercising the removed-node collection."""
     _SANITIZER.sanitize_report(text)
+
+
+def sanitize_styles(text: str) -> None:
+    """Sanitize with a per-property style value allowlist, exercising the allowed_styles scrub path."""
+    _SANITIZER_STYLES.sanitize(text)
 
 
 def markup(text: str) -> None:
@@ -550,6 +563,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "sanitize": (sanitize, "turbohtml"),
     "sanitize-templates": (sanitize_templates, "turbohtml"),
     "sanitize-report": (sanitize_report, "turbohtml"),
+    "sanitize-styles": (sanitize_styles, "turbohtml"),
     "markup": (markup, "turbohtml"),
     "markup-op": (markup_op, "turbohtml"),
     "linkify": (linkify, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -74,6 +74,15 @@ _SANITIZE_POST = dedent("""\
       <ul><li>one</li><li>two</li></ul>
     </div>""")
 
+# rich in style attributes with a mix of pattern-matching and rejected values, so the allowed_styles scrub does real
+# per-declaration regex work rather than short-circuiting on an empty rule
+_SANITIZE_STYLES = dedent("""\
+    <div style="color: #ff0000; text-align: center; position: fixed">
+      <p style="color: rgb(1, 2, 3); font-size: 40px">Styled
+        <span style="text-align: left; color: green">inline</span> text.</p>
+      <p style="color: #abc; text-align: justify">More <b style="color: #123456">bold</b> content.</p>
+    </div>""")
+
 
 @dataclass(frozen=True)
 class Operation:
@@ -123,6 +132,7 @@ OPERATIONS: dict[str, Operation] = {
     "sanitize": Operation("sanitize", "us"),
     "sanitize-templates": Operation("sanitize (template-safe)", "us"),
     "sanitize-report": Operation("sanitize with audit trail", "us"),
+    "sanitize-styles": Operation("sanitize (style allowlist)", "us"),
     "markup": Operation("markupsafe-compatible escape", "ns"),
     "markup-op": Operation("Markup operations", "ns"),
     "linkify": Operation("linkify HTML", "us"),
@@ -426,6 +436,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     ),
     "sanitize-templates": lambda: (("templated 4 KiB", _SANITIZE_TEMPLATES * 20),),
     "sanitize-report": lambda: (("post 4 KiB", _SANITIZE_POST * 20),),
+    "sanitize-styles": lambda: (("styled 4 KiB", _SANITIZE_STYLES * 20),),
     "markup": lambda: _MARKUP_ESCAPE_CASES,
     "markup-op": lambda: (
         ("striptags", ("striptags", _MARKUP_OPS_HTML)),


### PR DESCRIPTION
Adds `Policy.allowed_styles`, a per-element, per-property value allowlist for the `style` attribute, porting sanitize-html's `allowedStyles`.

Key it `{tag: {property: [pattern, ...]}}`, with `"*"` as a tag matching every element. A declaration survives only when its property is listed for the element's own tag or `"*"` (their pattern lists union, so either can admit it) and its value matches one of the patterns, using an unanchored `re.search` — the same semantics as sanitize-html's `RegExp.test`. Patterns are strings or precompiled `re.Pattern`, compiled once in `Sanitizer.__init__`.

Precedence: this narrows on top of the existing `css_properties` name allowlist and the non-configurable dangerous-value baseline, and never weakens it. A property still has to be in `css_properties`, and `expression()` or a `url()` with a disallowed scheme is dropped even when a caller's pattern would match it. When no rule applies to an element (its tag and `"*"` both absent), `allowed_styles` imposes nothing extra. The `<style>` element body stays governed by `css_properties` alone, since sanitize-html's `allowedStyles` targets inline styles.

The narrowing runs inside the existing style-scrub walk; the non-`allowed_styles` path keeps its current zero-overhead scrub.

```python
from turbohtml.clean import sanitize, Policy

policy = Policy(
    tags=frozenset({"p"}),
    attributes={"p": frozenset({"style"})},
    css_properties=frozenset({"color", "text-align"}),
    allowed_styles={"*": {"color": [r"^#[0-9a-f]{3,6}$"], "text-align": [r"^left$|^center$|^right$"]}},
)
sanitize('<p style="color: #ff0000; text-align: justify; font-size: 40px">Hi</p>', policy)
# <p style="color: #ff0000">Hi</p>
```

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)
