### PR TITLE
✨ feat(sanitize): rename tags during sanitize

### DIFF
--- a/docs/_ext/bench_table.py
+++ b/docs/_ext/bench_table.py
@@ -103,6 +103,7 @@ _HOMEPAGES: Final = {
     "pyquery": "https://pyquery.readthedocs.io/",
     "rcssmin": "https://opensource.perlig.de/rcssmin/",
     "rjsmin": "https://opensource.perlig.de/rjsmin/",
+    "sanitize-html": "https://github.com/apostrophecms/sanitize-html",
     "readability-lxml": "https://github.com/buriy/python-readability",
     "readabilipy": "https://readabilipy.readthedocs.io/",
     "resiliparse": "https://resiliparse.chatnoir.eu/",

--- a/docs/changelog/531.feature.rst
+++ b/docs/changelog/531.feature.rst
@@ -1,0 +1,5 @@
+:class:`turbohtml.clean.Policy` gains ``transform_tags``: a map that renames elements while sanitizing, sanitize-html's
+``transformTags``. Map a source tag to a string to rename it, or to a :class:`turbohtml.clean.Transform` to rename it and
+add attributes (sanitize-html's ``simpleTransform``). The rename runs before the allowlist in the same C walk, so the
+renamed element is re-checked from scratch -- a transform decides an element's name but never its safety: mapping a tag
+to ``script`` still drops it, and an added attribute is scrubbed like the element's own.

--- a/docs/changelog/531.feature.rst
+++ b/docs/changelog/531.feature.rst
@@ -1,5 +1,5 @@
 :class:`turbohtml.clean.Policy` gains ``transform_tags``: a map that renames elements while sanitizing, sanitize-html's
-``transformTags``. Map a source tag to a string to rename it, or to a :class:`turbohtml.clean.Transform` to rename it and
-add attributes (sanitize-html's ``simpleTransform``). The rename runs before the allowlist in the same C walk, so the
-renamed element is re-checked from scratch -- a transform decides an element's name but never its safety: mapping a tag
-to ``script`` still drops it, and an added attribute is scrubbed like the element's own.
+``transformTags``. Map a source tag to a string to rename it, or to a :class:`turbohtml.clean.Transform` to rename it
+and add attributes (sanitize-html's ``simpleTransform``). The rename runs before the allowlist in the same C walk, so
+the renamed element is re-checked from scratch -- a transform decides an element's name but never its safety: mapping a
+tag to ``script`` still drops it, and an added attribute is scrubbed like the element's own.

--- a/docs/explanation/sanitizing.rst
+++ b/docs/explanation/sanitizing.rst
@@ -24,3 +24,12 @@ about which benign values to accept; they are never one regex away from re-enabl
 decision was taken out of the policy's hands entirely. The same shape governs the rest of the sanitizer: ``on*`` event
 handlers, ``<script>``, and ``javascript:`` URLs are dropped below the allowlists, so no combination of ``tags``,
 ``attributes``, or ``attribute_filter`` settings can bring them back.
+
+``transform_tags`` is the one step that *adds* rather than removes -- it renames an element and can inject attributes --
+so its placement is what keeps the model intact. The rename runs at the very top, before the allowlist reads the tag,
+and then the walk continues on the renamed element as if the author had written the target: the allowlist decides its
+disposition, the unsafe-tag baseline still escapes a ``script`` or ``iframe`` target, and every injected attribute joins
+the element's own to be scrubbed by the same gates below. A transform therefore chooses an element's *name* while every
+gate underneath still governs its *safety*. Putting the additive step above the subtractive stack, instead of letting it
+write past the allowlist, is why ``{"b": "script"}`` cannot smuggle a live ``<script>`` and an injected ``href`` cannot
+carry a ``javascript:`` URL -- the transform hands its output back to the pipeline rather than around it.

--- a/docs/how-to/sanitizing.rst
+++ b/docs/how-to/sanitizing.rst
@@ -68,6 +68,32 @@ even if a pattern would admit it.
 
     <p style="color: #ff0000">Hi</p>
 
+******************************
+ Rename tags while sanitizing
+******************************
+
+To rewrite a tag as it is cleaned -- ``<b>`` to ``<strong>``, or the deprecated ``<center>`` to a ``<div>`` -- set
+``transform_tags``, sanitize-html's ``transformTags``. Key it by source tag: a bare string renames, and a
+:class:`~turbohtml.clean.Transform` renames and adds attributes. The rename runs before the allowlist, so the renamed
+element is re-checked from scratch; a transform sets an element's name, never its safety. Mapping a tag to a disallowed
+or unsafe target (``script``) still drops it, and an added attribute is scrubbed with the element's own, so it must be
+allowlisted to survive.
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy, Transform
+
+    policy = Policy(
+        tags=frozenset({"strong", "em", "div"}),
+        attributes={"div": frozenset({"class"})},
+        transform_tags={"b": "strong", "i": "em", "center": Transform("div", {"class": "legacy"})},
+    )
+    print(sanitize("<center><b>bold</b> and <i>italic</i></center>", policy))
+
+.. testoutput::
+
+    <div class="legacy"><strong>bold</strong> and <em>italic</em></div>
+
 **************************************
  Trust the first pass, do not reparse
 **************************************

--- a/docs/migration/bench/sanitize-html.json
+++ b/docs/migration/bench/sanitize-html.json
@@ -1,0 +1,15 @@
+{
+  "label": "input",
+  "parties": [
+    "turbohtml",
+    "sanitize-html"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "legacy 4 KiB",
+      5.40419714525342e-05,
+      0.0564835419645533
+    ]
+  ]
+}

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -315,6 +315,15 @@ JavaScript with :func:`~turbohtml.clean.minify_js` -- every minifier value-safe.
       - .. image:: https://static.pepy.tech/badge/lightningcss
             :alt: lightningcss total downloads
             :target: https://pepy.tech/project/lightningcss
+    - - 14
+      - :doc:`sanitize-html <sanitize-html>`
+      - `docs <https://github.com/apostrophecms/sanitize-html>`__
+      - .. image:: https://img.shields.io/npm/dm/sanitize-html
+            :alt: sanitize-html monthly downloads
+            :target: https://www.npmjs.com/package/sanitize-html
+      - .. image:: https://img.shields.io/npm/dt/sanitize-html
+            :alt: sanitize-html total downloads
+            :target: https://www.npmjs.com/package/sanitize-html
 
 *********
  Convert
@@ -694,6 +703,7 @@ GitHub-Flavored Markdown, and :meth:`turbohtml.Node.to_text` extracts rendered t
     linkify-it-py
     bleach
     nh3
+    sanitize-html
     lxml-html-clean
     rcssmin
     rjsmin

--- a/docs/migration/sanitize-html.rst
+++ b/docs/migration/sanitize-html.rst
@@ -1,0 +1,114 @@
+####################
+ From sanitize-html
+####################
+
+`sanitize-html <https://github.com/apostrophecms/sanitize-html>`_ is the standard Node HTML sanitizer: you declare the
+tags, attributes, URL schemes, and CSS properties you trust, and everything else is stripped. Its distinguishing feature
+is ``transformTags`` -- a map that renames an element (and optionally rewrites its attributes) during the sanitize pass,
+with a ``simpleTransform(tagName, attribs, merge)`` helper for the common rename-and-add case. Projects that ran
+sanitization in a Node service, or in a Python service shelling out to Node, reach for it because bleach and its
+successors historically had no equivalent rename step.
+
+turbohtml's :mod:`turbohtml.clean` sanitizer covers the same allowlist surface behind a frozen, thread-safe
+:class:`~turbohtml.clean.Policy`, and ``Policy.transform_tags`` is the direct port of ``transformTags``: it renames HTML
+elements during the same single C walk, with :class:`~turbohtml.clean.Transform` playing the role of ``simpleTransform``.
+Moving the sanitize step into Python drops the Node subprocess, and the second language with it.
+
+****************************
+ turbohtml vs sanitize-html
+****************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 22 39 39
+
+    - - Dimension
+      - turbohtml
+      - sanitize-html
+    - - Runtime
+      - Python, filtering in a C extension
+      - Node.js, filtering in JavaScript over htmlparser2
+    - - Rename step
+      - ``Policy.transform_tags`` map, ``Transform`` for rename-and-add
+      - ``transformTags`` map, ``simpleTransform`` for rename-and-add
+    - - Rename safety
+      - Renamed element re-checked against the allowlist and the unconditional baseline
+      - Renamed element re-checked against ``allowedTags``/``allowedAttributes``
+    - - Configuration
+      - One frozen ``Policy``, reusable across threads
+      - A plain options object per call
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - TypeScript definitions
+    - - Dependencies
+      - None (self-contained C extension)
+      - htmlparser2, and its transitive tree
+
+Feature overlap
+===============
+
+The transform surface ports one-to-one:
+
+- ``transformTags: { b: 'strong' }`` (rename) -> ``transform_tags={"b": "strong"}``.
+- ``transformTags: { center: sanitizeHtml.simpleTransform('div', { class: 'x' }) }`` (rename and add attributes) ->
+  ``transform_tags={"center": Transform("div", {"class": "x"})}``.
+- ``allowedTags`` / ``allowedAttributes`` -> ``Policy.tags`` / ``Policy.attributes``.
+- ``allowedSchemes`` -> ``Policy.url_schemes``; ``allowedStyles`` -> ``Policy.allowed_styles``.
+
+Both apply the rename before the allowlist, so a transform decides an element's name but never its safety: mapping a tag
+to ``script`` still drops it, and an attribute added by a transform is scrubbed like the element's own. turbohtml keeps
+that guarantee under an *unconditional* baseline -- ``on*`` handlers, scripting elements, and ``javascript:`` URLs are
+removed regardless of the policy -- so a transform can smuggle neither a disallowed tag nor an unscrubbed attribute.
+
+The one shape difference: ``transformTags`` also accepts an arbitrary callback returning ``{ tagName, attribs, text }``,
+and a ``'*'`` entry that runs on every tag. ``transform_tags`` is a declarative per-tag map (a string or a
+:class:`~turbohtml.clean.Transform`); it renames and adds attributes without running caller code mid-walk, and per-tag
+rules cover the presentational-tag modernization ``simpleTransform`` was built for. Only HTML elements are transformed.
+
+Porting a transform
+===================
+
+A sanitize-html config that modernizes legacy presentational tags:
+
+.. code-block:: javascript
+
+    const clean = sanitizeHtml(dirty, {
+      allowedTags: ["strong", "em", "div"],
+      allowedAttributes: { div: ["class"] },
+      transformTags: {
+        b: "strong",
+        i: "em",
+        center: sanitizeHtml.simpleTransform("div", { class: "legacy" }),
+      },
+    });
+
+ports to:
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy, Transform
+
+    policy = Policy(
+        tags=frozenset({"strong", "em", "div"}),
+        attributes={"div": frozenset({"class"})},
+        transform_tags={
+            "b": "strong",
+            "i": "em",
+            "center": Transform("div", {"class": "legacy"}),
+        },
+    )
+    print(sanitize("<center><b>bold</b> and <i>italic</i></center>", policy))
+
+.. testoutput::
+
+    <div class="legacy"><strong>bold</strong> and <em>italic</em></div>
+
+Performance
+===========
+
+turbohtml renames in the same C walk that sanitizes, so a transform adds no extra pass. The table times both libraries
+end-to-end on a document dense in the presentational tags a transform rewrites; the sanitize-html figure is its Node
+runner over stdin, the cost a Python service pays to reach it as a subprocess.
+
+.. bench-table::
+    :file: bench/sanitize-html.json

--- a/docs/migration/sanitize-html.rst
+++ b/docs/migration/sanitize-html.rst
@@ -11,8 +11,8 @@ successors historically had no equivalent rename step.
 
 turbohtml's :mod:`turbohtml.clean` sanitizer covers the same allowlist surface behind a frozen, thread-safe
 :class:`~turbohtml.clean.Policy`, and ``Policy.transform_tags`` is the direct port of ``transformTags``: it renames HTML
-elements during the same single C walk, with :class:`~turbohtml.clean.Transform` playing the role of ``simpleTransform``.
-Moving the sanitize step into Python drops the Node subprocess, and the second language with it.
+elements during the same single C walk, with :class:`~turbohtml.clean.Transform` playing the role of
+``simpleTransform``. Moving the sanitize step into Python drops the Node subprocess, and the second language with it.
 
 ****************************
  turbohtml vs sanitize-html

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -49,6 +49,29 @@ dropped even when a pattern would admit it:
 
     <p style="color: #0a0">ok</p>
 
+``Policy.transform_tags`` renames elements during the same walk, sanitize-html's ``transformTags``. Key it by source
+tag: map to a bare string to rename, or to a :class:`Transform` to rename and add attributes. The rename runs *before*
+the allowlist, so the renamed element is re-checked from scratch -- a transform decides an element's name but never its
+safety. Mapping a tag to ``script`` still drops it, and an added attribute is scrubbed like the element's own, so it
+must be allowlisted to survive:
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy, Transform
+
+    policy = Policy(
+        tags=frozenset({"strong", "div"}),
+        attributes={"div": frozenset({"class"})},
+        transform_tags={"b": "strong", "center": Transform("div", {"class": "center"})},
+    )
+    print(sanitize("<b>bold</b> and <center>middle</center>", policy))
+
+.. testoutput::
+
+    <strong>bold</strong> and <div class="center">middle</div>
+
+.. autoclass:: Transform
+
 .. autoclass:: OnDisallowed
     :members:
 

--- a/docs/tutorials/editing.rst
+++ b/docs/tutorials/editing.rst
@@ -64,6 +64,26 @@ edit without touching the original:
 
     False
 
+Reshaping is not limited to trees you built. When you clean untrusted markup, the sanitizer can rename tags in the same
+pass: a :class:`~turbohtml.clean.Policy` with ``transform_tags`` rewrites a source tag to a target (a
+:class:`~turbohtml.clean.Transform` also adds attributes). The rename runs before the allowlist, so the result is
+re-checked -- modernizing legacy tags while the safety baseline still applies:
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy, Transform
+
+    policy = Policy(
+        tags=frozenset({"strong", "em", "div"}),
+        attributes={"div": frozenset({"class"})},
+        transform_tags={"b": "strong", "i": "em", "center": Transform("div", {"class": "center"})},
+    )
+    print(sanitize("<center><b>Old</b> <i>markup</i></center>", policy))
+
+.. testoutput::
+
+    <div class="center"><strong>Old</strong> <em>markup</em></div>
+
 When you serialize, set an ``Html`` config's ``layout`` to a :class:`~turbohtml.Minify` to shrink the output without
 changing what it means: it folds insignificant whitespace, omits optional tags, unquotes safe attributes, and strips
 comments, and the result reparses to the same tree. Here the ``</li>`` tags stay because real whitespace separates the

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -36,7 +36,9 @@ typedef struct {
                                       properties, each mapped to the compiled patterns its value must match, or an empty
                                       dict when no per-property value allowlist is in force */
     PyObject *re_search; /* the interned "search" method name, for calling re.Pattern.search from the style scrubber */
-    PyObject *media_hosts; /* frozenset[str]: allowed hosts for an embedded-media (audio/video/source/track) src */
+    PyObject *media_hosts;    /* frozenset[str]: allowed hosts for an embedded-media (audio/video/source/track) src */
+    PyObject *transform_tags; /* dict[str, tuple[str, dict[str, str]]]: source tag -> (target tag, added attributes),
+                                 applied before the allowlist so the renamed element is re-checked, or an empty dict */
     PyObject
         *removed; /* list to append (tag, attr_or_None) records to as the walk drops things, or NULL to not report */
     int allow_relative;
@@ -1315,6 +1317,58 @@ static int namespace_reachable(const th_node *element) {
     return is_mathml_text_point(parent) || is_html_integration_point(parent);
 }
 
+/* Rename an element to a transform's target tag and add its extra attributes when the policy maps the element's current
+   name (sanitize-html's transformTags / simpleTransform). The rename happens before the allowlist and safety checks and
+   re-points *tag at the target, so the renamed element is re-checked as if the author had written the target: the
+   allowlist decides its disposition, is_unsafe_tag still neutralizes a target like `script`, and the added attributes
+   join the element's own to be scrubbed with them, so a transform can smuggle neither a disallowed tag nor an
+   unscrubbed attribute. Only HTML elements transform, matched by serialized name. Returns 1 when a transform applied, 0
+   when none did, -1 on error. */
+static int apply_transform(sanitizer *s, th_node *element, PyObject **tag) {
+    PyObject *entry = PyDict_GetItemWithError(s->transform_tags, *tag);
+    if (entry == NULL) {
+        return PyErr_Occurred() ? -1 : 0; /* GCOVR_EXCL_BR_LINE: the str-key lookup cannot itself error */
+    }
+    PyObject *target = PyTuple_GET_ITEM(entry, 0);
+    Py_ssize_t target_utf8_len = 0;
+    const char *target_utf8 = PyUnicode_AsUTF8AndSize(target, &target_utf8_len);
+    if (target_utf8 == NULL) { /* GCOVR_EXCL_BR_LINE: the target is a non-empty str validated at setup */
+        return -1;             /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    Py_UCS4 *points = PyUnicode_AsUCS4Copy(target);
+    if (points == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;        /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int renamed = th_node_set_data(s->tree, element, points, PyUnicode_GET_LENGTH(target));
+    PyMem_Free(points);
+    if (renamed < 0) { /* GCOVR_EXCL_BR_LINE: th_node_set_data only fails on allocation failure */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    element->atom = th_tag_lookup(target_utf8, target_utf8_len);
+    element->tag_flags = (uint8_t)(th_tag_flags(element->atom) | (element->tag_flags & TH_ELEM_CLOSED_BY_END_TAG));
+    PyObject *added_name, *added_value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(PyTuple_GET_ITEM(entry, 1), &pos, &added_name, &added_value)) {
+        Py_ssize_t name_len = 0;
+        const char *name_bytes = PyUnicode_AsUTF8AndSize(added_name, &name_len);
+        if (name_bytes == NULL) { /* GCOVR_EXCL_BR_LINE: attribute names are str validated at setup */
+            return -1;            /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        Py_UCS4 *value_points = PyUnicode_AsUCS4Copy(added_value);
+        if (value_points == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;              /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        int status = th_node_attr_set(s->tree, element, name_bytes, name_len, value_points,
+                                      PyUnicode_GET_LENGTH(added_value), 1);
+        PyMem_Free(value_points);
+        if (status < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;    /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    Py_SETREF(*tag, Py_NewRef(target));
+    return 1;
+}
+
 /* Keep, escape, strip, or remove one element according to the policy. parent_kept is
    1 when the element's parent is itself being kept; an allowlisted foreign (SVG/MathML)
    element is kept only then, so it never outlives its namespace context (e.g. an svg
@@ -1324,6 +1378,12 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
     PyObject *tag = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, element->text, element->text_len);
     if (tag == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    if (is_html && PyDict_GET_SIZE(s->transform_tags) > 0) {
+        if (apply_transform(s, element, &tag) < 0) { /* GCOVR_EXCL_BR_LINE: apply_transform only fails on allocation */
+            Py_DECREF(tag);                          /* GCOVR_EXCL_LINE: allocation-failure path */
+            return -1;                               /* GCOVR_EXCL_LINE */
+        }
     }
     /* an allowlisted element matches by its serialized name (a foreign element by
        e.g. "svg"/"foreignObject"); the unsafe-tag set still escapes scripting and
@@ -1463,16 +1523,18 @@ static int require_prefixes(PyObject *prefixes) {
 
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
    attribute_filter, set_attributes, remove_with_content, css_properties, attribute_prefixes, attribute_values,
-   media_hosts, strip_templates, removed, allowed_styles) -> None. Filters the fragment in place; sanitizer.py
-   serializes it. `removed` is a list the walk appends (tag, attr_or_None) records to, or None to skip the audit. */
+   media_hosts, strip_templates, removed, allowed_styles, transform_tags) -> None. Filters the fragment in place;
+   sanitizer.py serializes it. `removed` is a list the walk appends (tag, attr_or_None) records to, or None to skip the
+   audit. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
     PyObject *removed = NULL;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOpOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOpOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
                           &s.set_attributes, &s.remove_with_content, &s.css_properties, &s.attribute_prefixes,
-                          &s.attribute_values, &s.media_hosts, &s.strip_templates, &removed, &s.allowed_styles)) {
+                          &s.attribute_values, &s.media_hosts, &s.strip_templates, &removed, &s.allowed_styles,
+                          &s.transform_tags)) {
         return NULL;
     }
     s.removed = removed == Py_None ? NULL : removed;

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -42,6 +42,24 @@ class Removed:
     attribute: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class Transform:
+    """
+    A rename rule for ``Policy.transform_tags``, sanitize-html's ``simpleTransform``.
+
+    Mapping a source tag to a bare string renames it; mapping it to a ``Transform`` renames it and adds attributes. The
+    added attributes are not trusted: they join the element's own attributes and go through the same allowlist and
+    URL/style scrubbing, so a transform cannot add an attribute the policy would otherwise strip.
+
+    :param tag: the target tag name to rename to.
+    :param attributes: attribute name/value pairs to add to the renamed element (added if absent, overwritten if
+        present).
+    """
+
+    tag: str
+    attributes: Mapping[str, str] = field(default_factory=dict)
+
+
 class OnDisallowed(Enum):
     """
     What to do with an element the policy does not allow.
@@ -138,6 +156,12 @@ class Policy:
     :param attribute_values: restrict a kept attribute to literal values, keyed ``{tag: {attribute: allowed_values}}``;
         a surviving attribute whose value is outside its set is dropped. This narrows an attribute ``attributes``
         already admits and cannot admit a new one.
+    :param transform_tags: rename rules applied before the allowlist, keyed by source tag (sanitize-html's
+        ``transformTags``). A value that is a plain string renames the element to it; a :class:`Transform` renames it
+        and adds attributes. The rename runs first, then the renamed element is re-checked from scratch, so a transform
+        decides an element's *name* but never its safety: the allowlist still governs the target tag (mapping to
+        ``script`` still drops it), and any added attributes are scrubbed like the element's own. Only HTML elements are
+        transformed, matched by tag name. Empty (the default) renames nothing.
     :param allowed_styles: a per-property value allowlist for the ``style`` attribute, keyed
         ``{tag: {property: [pattern, ...]}}`` with ``"*"`` as a tag matching every element (sanitize-html's
         ``allowedStyles``). A declaration survives only when its property is listed for the element's tag or ``"*"``
@@ -170,6 +194,7 @@ class Policy:
     media_hosts: frozenset[str] = frozenset()
     strip_template_markers: bool = False
     allowed_styles: Mapping[str, Mapping[str, Sequence[str | re.Pattern[str]]]] = field(default_factory=dict)
+    transform_tags: Mapping[str, Transform | str] = field(default_factory=dict)
 
     @classmethod
     def strict(cls) -> Policy:
@@ -227,6 +252,22 @@ class Sanitizer:
             }
             for tag, props in self.policy.allowed_styles.items()
         }
+        self._transform_tags = dict(starmap(self._compile_transform, self.policy.transform_tags.items()))
+
+    @staticmethod
+    def _compile_transform(source: str, target: Transform | str) -> tuple[str, tuple[str, dict[str, str]]]:
+        """Normalize one transform rule into ``(source, (target_tag, added_attributes))`` for the C walk."""
+        if isinstance(target, str):
+            name, attributes = target, {}
+        elif isinstance(target, Transform):
+            name, attributes = target.tag, dict(target.attributes)
+        else:
+            msg = f"transform_tags[{source!r}] must be a str or Transform, got {type(target).__name__}"
+            raise TypeError(msg)
+        if not name:
+            msg = f"transform_tags[{source!r}] target tag must be a non-empty string"
+            raise ValueError(msg)
+        return source, (name, attributes)
 
     def sanitize(self, html: str) -> str:
         """
@@ -281,6 +322,7 @@ class Sanitizer:
             policy.strip_template_markers,
             removed,
             self._allowed_styles,
+            self._transform_tags,
         )
         return root
 
@@ -322,6 +364,7 @@ __all__ = [
     "Policy",
     "Removed",
     "Sanitizer",
+    "Transform",
     "sanitize",
     "sanitize_report",
 ]

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -64,6 +64,7 @@ def _sanitize(
     strip_templates: bool,
     removed: list[tuple[str, str | None]] | None,
     allowed_styles: Mapping[str, Mapping[str, tuple[re.Pattern[str], ...]]],
+    transform_tags: Mapping[str, tuple[str, Mapping[str, str]]],
     /,
 ) -> None: ...
 def annotation_surface(text: str, spans: Iterable[tuple[int, int, str]], /) -> dict[str, list[str]]: ...

--- a/src/turbohtml/clean.py
+++ b/src/turbohtml/clean.py
@@ -39,6 +39,7 @@ from ._sanitizer import (
     Policy,
     Removed,
     Sanitizer,
+    Transform,
     sanitize,
     sanitize_report,
 )
@@ -62,6 +63,7 @@ __all__ = [
     "Policy",
     "Removed",
     "Sanitizer",
+    "Transform",
     "linkify",
     "minify",
     "minify_css",

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -844,10 +844,10 @@ def test_strip_propagates_a_child_filter_error() -> None:
 def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
-    # the seventeen policy arguments after the element; only the non-element first argument matters to this guard
+    # the eighteen policy arguments after the element; only the non-element first argument matters to this guard
     policy_args = (
         frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset(), frozenset(), frozenset(), {},
-        frozenset(), False, None, {},
+        frozenset(), False, None, {}, {},
     )  # fmt: skip
     with pytest.raises(TypeError):
         _sanitize("not an element", *policy_args)  # ty: ignore[invalid-argument-type]

--- a/tests/clean/test_sanitizer_namespace.py
+++ b/tests/clean/test_sanitizer_namespace.py
@@ -43,7 +43,7 @@ def _sanitize_tree(root: Element, tags: frozenset[str]) -> str:
     schemes = frozenset({"http", "https", "mailto"})
     _sanitize(
         root, tags, {}, schemes, allow_relative, OnDisallowed.REMOVE.value, strip_comments, None, None, {}, empty,
-        empty, empty, {}, empty, strip_templates, None, {},
+        empty, empty, {}, empty, strip_templates, None, {}, {},
     )  # fmt: skip
     return root.inner_html
 

--- a/tests/clean/test_sanitizer_transform.py
+++ b/tests/clean/test_sanitizer_transform.py
@@ -1,0 +1,109 @@
+"""``Policy.transform_tags`` (sanitize-html's ``transformTags``/``simpleTransform``): rename a tag mid-sanitize.
+
+A transform rewrites an element's name -- and, with a :class:`Transform`, adds attributes -- before the allowlist runs,
+so the renamed element is re-checked as if the author had written the target. The rename decides an element's name, never
+its safety: the allowlist still governs the target tag, and any added attributes are scrubbed like the element's own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml.clean import Policy, Sanitizer, Transform, sanitize, sanitize_report
+
+
+@pytest.mark.parametrize(
+    ("fragment", "transform", "tags", "expected"),
+    [
+        pytest.param("<b>hi</b>", {"b": "strong"}, {"strong"}, "<strong>hi</strong>", id="string-rename"),
+        pytest.param("<i>hi</i>", {"i": Transform("em")}, {"em"}, "<em>hi</em>", id="transform-rename-only"),
+        pytest.param("<b>a</b><i>b</i>", {"b": "strong"}, {"strong", "i"}, "<strong>a</strong><i>b</i>", id="one-of-two"),
+        pytest.param("<b>x</b>", {"b": "strong"}, {"em"}, "&lt;strong&gt;x&lt;/strong&gt;", id="target-not-allowed"),
+        pytest.param("<p>x</p>", {"b": "strong"}, {"p"}, "<p>x</p>", id="no-rule-untouched"),
+    ],
+)
+def test_transform_renames(fragment: str, transform: dict[str, Transform | str], tags: set[str], expected: str) -> None:
+    assert sanitize(fragment, Policy(tags=frozenset(tags), transform_tags=transform)) == expected
+
+
+def test_transform_nests_and_recurses() -> None:
+    policy = Policy(tags=frozenset({"strong", "em"}), transform_tags={"b": "strong", "i": "em"})
+    assert sanitize("<b>a<i>b</i>c</b>", policy) == "<strong>a<em>b</em>c</strong>"
+
+
+def test_transform_adds_allowlisted_attribute() -> None:
+    policy = Policy(
+        tags=frozenset({"div"}),
+        attributes={"div": frozenset({"class"})},
+        transform_tags={"center": Transform("div", {"class": "center"})},
+    )
+    assert sanitize("<center>x</center>", policy) == '<div class="center">x</div>'
+
+
+def test_transform_added_attribute_still_needs_allowlist() -> None:
+    policy = Policy(tags=frozenset({"div"}), transform_tags={"center": Transform("div", {"class": "c"})})
+    assert sanitize("<center>x</center>", policy) == "<div>x</div>"
+
+
+def test_transform_added_attribute_overwrites_existing() -> None:
+    policy = Policy(
+        tags=frozenset({"div"}),
+        attributes={"div": frozenset({"class"})},
+        transform_tags={"div": Transform("div", {"class": "safe"})},
+    )
+    assert sanitize('<div class="danger">x</div>', policy) == '<div class="safe">x</div>'
+
+
+@pytest.mark.parametrize(
+    ("target", "fragment", "expected"),
+    [
+        pytest.param("script", "<b>evil</b>", "&lt;script&gt;evil&lt;/script&gt;", id="script"),
+        pytest.param("iframe", "<b>x</b>", "&lt;iframe&gt;x&lt;/iframe&gt;", id="iframe"),
+    ],
+)
+def test_transform_cannot_smuggle_unsafe_tag(target: str, fragment: str, expected: str) -> None:
+    policy = Policy(tags=frozenset({"strong", target}), transform_tags={"b": target})
+    assert sanitize(fragment, policy) == expected
+
+
+def test_transform_added_url_attribute_is_scheme_scrubbed() -> None:
+    policy = Policy(
+        tags=frozenset({"a"}),
+        attributes={"a": frozenset({"href"})},
+        transform_tags={"b": Transform("a", {"href": "javascript:alert(1)"})},
+    )
+    assert sanitize("<b>x</b>", policy) == "<a>x</a>"
+
+
+def test_transform_target_never_bypasses_on_handler_scrub() -> None:
+    policy = Policy(
+        tags=frozenset({"div"}),
+        attributes={"div": frozenset({"onclick"})},
+        transform_tags={"b": Transform("div", {"onclick": "steal()"})},
+    )
+    assert sanitize("<b>x</b>", policy) == "<div>x</div>"
+
+
+def test_transform_reports_target_name() -> None:
+    policy = Policy(tags=frozenset({"strong"}), transform_tags={"b": "script"})
+    html, removed = sanitize_report("<b>e</b>", policy)
+    assert html == "&lt;script&gt;e&lt;/script&gt;"
+    assert [(item.tag, item.attribute) for item in removed] == [("script", None)]
+
+
+def test_transform_skips_foreign_elements() -> None:
+    policy = Policy(tags=frozenset({"svg", "strong"}), transform_tags={"b": "strong"})
+    assert sanitize("<svg></svg><b>x</b>", policy) == "<svg></svg><strong>x</strong>"
+
+
+@pytest.mark.parametrize(
+    ("target", "error", "message"),
+    [
+        pytest.param(5, TypeError, "must be a str or Transform, got int", id="wrong-type"),
+        pytest.param("", ValueError, "must be a non-empty string", id="empty-string"),
+        pytest.param(Transform(""), ValueError, "must be a non-empty string", id="empty-transform-tag"),
+    ],
+)
+def test_transform_rejects_bad_rule(target: Transform | str | int, error: type[Exception], message: str) -> None:
+    with pytest.raises(error, match=message):
+        Sanitizer(Policy(transform_tags={"b": target}))  # ty: ignore[invalid-argument-type]

--- a/tests/clean/test_sanitizer_transform.py
+++ b/tests/clean/test_sanitizer_transform.py
@@ -1,8 +1,9 @@
 """``Policy.transform_tags`` (sanitize-html's ``transformTags``/``simpleTransform``): rename a tag mid-sanitize.
 
 A transform rewrites an element's name -- and, with a :class:`Transform`, adds attributes -- before the allowlist runs,
-so the renamed element is re-checked as if the author had written the target. The rename decides an element's name, never
-its safety: the allowlist still governs the target tag, and any added attributes are scrubbed like the element's own.
+so the renamed element is re-checked as if the author had written the target. The rename decides an element's name,
+never its safety: the allowlist still governs the target tag, and any added attributes are scrubbed like the element's
+own.
 """
 
 from __future__ import annotations

--- a/tests/clean/test_sanitizer_transform.py
+++ b/tests/clean/test_sanitizer_transform.py
@@ -17,7 +17,9 @@ from turbohtml.clean import Policy, Sanitizer, Transform, sanitize, sanitize_rep
     [
         pytest.param("<b>hi</b>", {"b": "strong"}, {"strong"}, "<strong>hi</strong>", id="string-rename"),
         pytest.param("<i>hi</i>", {"i": Transform("em")}, {"em"}, "<em>hi</em>", id="transform-rename-only"),
-        pytest.param("<b>a</b><i>b</i>", {"b": "strong"}, {"strong", "i"}, "<strong>a</strong><i>b</i>", id="one-of-two"),
+        pytest.param(
+            "<b>a</b><i>b</i>", {"b": "strong"}, {"strong", "i"}, "<strong>a</strong><i>b</i>", id="one-of-two"
+        ),
         pytest.param("<b>x</b>", {"b": "strong"}, {"em"}, "&lt;strong&gt;x&lt;/strong&gt;", id="target-not-allowed"),
         pytest.param("<p>x</p>", {"b": "strong"}, {"p"}, "<p>x</p>", id="no-rule-untouched"),
     ],

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -113,6 +113,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "sanitize-templates": ("sanitize-templates-spec", _spec),
     "sanitize-report": ("sanitize-report-spec", _spec),
     "sanitize-styles": ("sanitize-styles-spec", _spec),
+    "sanitize-transform": ("sanitize-transform-spec", _spec),
     "linkify": ("linkify-spec", _spec),
     "markdown-google": ("markdown-google-spec", _spec),
     "article": ("article-spec", _spec),

--- a/tools/bench/competitors/sanitize_html.py
+++ b/tools/bench/competitors/sanitize_html.py
@@ -1,0 +1,25 @@
+"""
+sanitize-html: the standard Node HTML sanitizer, run as a subprocess for the tag-transform comparison.
+
+sanitize-html is JavaScript, so it runs through a small committed Node runner over stdin, the way the JS minifiers and
+DOMPurify do. Its ``transformTags``/``simpleTransform`` is the API turbohtml's :attr:`Policy.transform_tags` mirrors;
+here it is the speed baseline. Regenerating the table needs ``npm install`` in ``tools/bench/node`` first (sanitize-html
+is a library, not a CLI).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REQUIREMENTS = ()
+
+_RUNNER = str(Path(__file__).resolve().parent.parent / "node" / "sanitize_html_runner.js")
+
+
+def sanitize_transform(text: str) -> str:
+    """Sanitize a document while renaming deprecated presentational tags, piping it through the Node runner."""
+    return subprocess.run(["node", _RUNNER], input=text, capture_output=True, text=True, check=True).stdout
+
+
+OPERATIONS = {"sanitize-transform": (sanitize_transform, "sanitize-html")}

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -48,6 +48,24 @@ _SANITIZER_STYLES = _clean.Sanitizer(
         allowed_styles={"*": {"color": [r"^#[0-9a-f]{3,6}$", r"^rgb\("], "text-align": [r"^left$|^center$|^right$"]}},
     )
 )
+# rename the deprecated presentational tags a real feed still carries to their modern equivalents in the same walk,
+# sanitize-html's transformTags; the added class exercises the attribute-injection path alongside the rename
+_RELAXED = _clean.Policy.relaxed()
+_SANITIZER_TRANSFORM = _clean.Sanitizer(
+    replace(
+        _RELAXED,
+        attributes={**_RELAXED.attributes, "div": frozenset({"class"})},
+        transform_tags={
+            "b": "strong",
+            "i": "em",
+            "big": "span",
+            "tt": "code",
+            "strike": "s",
+            "font": "span",
+            "center": _clean.Transform("div", {"class": "center"}),
+        },
+    )
+)
 _LINKS_BASE = "https://example.com/base/"
 _URL_HINT_BASE = "http://site.com/"
 _FIND_TEXT_PATTERN = re.compile(r"test")  # ubiquitous in the wpt corpus, so the predicate does real work
@@ -279,6 +297,11 @@ def sanitize_report(text: str) -> None:
 def sanitize_styles(text: str) -> None:
     """Sanitize with a per-property style value allowlist, exercising the allowed_styles scrub path."""
     _SANITIZER_STYLES.sanitize(text)
+
+
+def sanitize_transform(text: str) -> None:
+    """Sanitize with a tag-transform map, renaming deprecated presentational tags in the same C walk."""
+    _SANITIZER_TRANSFORM.sanitize(text)
 
 
 def markup(text: str) -> None:
@@ -576,6 +599,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "sanitize-templates": (sanitize_templates, "turbohtml"),
     "sanitize-report": (sanitize_report, "turbohtml"),
     "sanitize-styles": (sanitize_styles, "turbohtml"),
+    "sanitize-transform": (sanitize_transform, "turbohtml"),
     "markup": (markup, "turbohtml"),
     "markup-op": (markup_op, "turbohtml"),
     "linkify": (linkify, "turbohtml"),

--- a/tools/bench/node/package-lock.json
+++ b/tools/bench/node/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "isomorphic-dompurify": "^3.18.0"
+        "isomorphic-dompurify": "^3.18.0",
+        "sanitize-html": "^2.17.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -264,11 +265,79 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
     },
     "node_modules/dompurify": {
       "version": "3.4.11",
@@ -277,6 +346,20 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/entities": {
@@ -291,6 +374,18 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -301,6 +396,46 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -362,6 +497,15 @@
         }
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
@@ -377,6 +521,30 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -387,6 +555,40 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/punycode": {
@@ -405,6 +607,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
       }
     },
     "node_modules/saxes": {

--- a/tools/bench/node/package.json
+++ b/tools/bench/node/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "isomorphic-dompurify": "^3.18.0"
+    "isomorphic-dompurify": "^3.18.0",
+    "sanitize-html": "^2.17.0"
   }
 }

--- a/tools/bench/node/sanitize_html_runner.js
+++ b/tools/bench/node/sanitize_html_runner.js
@@ -1,0 +1,30 @@
+// Sanitize stdin with sanitize-html's transformTags renaming the deprecated presentational tags, the competitor for
+// turbohtml's Policy.transform_tags. The bench (tools/bench/competitors/sanitize_html.py) pipes one document in and
+// reads the sanitized result back. The allowlist and rename map mirror the turbohtml transform op in tools/bench/core.py.
+const sanitizeHtml = require("sanitize-html");
+
+const OPTIONS = {
+  allowedTags: [
+    "a", "abbr", "b", "big", "blockquote", "center", "code", "div", "em", "font", "h1", "h2", "h3", "h4", "h5", "h6",
+    "i", "li", "ol", "p", "s", "span", "strike", "strong", "tt", "ul",
+  ],
+  allowedAttributes: { div: ["class"], a: ["href", "title"] },
+  transformTags: {
+    b: "strong",
+    i: "em",
+    big: "span",
+    tt: "code",
+    strike: "s",
+    font: "span",
+    center: sanitizeHtml.simpleTransform("div", { class: "center" }),
+  },
+};
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  process.stdout.write(sanitizeHtml(input, OPTIONS));
+});

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -98,6 +98,14 @@ _SANITIZE_POST = dedent("""\
       <ul><li>one</li><li>two</li></ul>
     </div>""")
 
+# dense in the deprecated presentational tags a transform map renames (b/i/center/font/tt/big/strike), so the walk hits
+# the rename + attribute-injection path on most elements rather than passing them through unchanged
+_SANITIZE_LEGACY = dedent("""\
+    <center><font size=4><b>Heading</b></font></center>
+    <p><i>Intro</i> with <tt>inline code</tt>, <strike>struck</strike>, and <big>emphatic</big> text.</p>
+    <blockquote><b>Quote</b> from <i>an author</i> with a <font color=red>colored</font> aside.</blockquote>
+    <ul><li><b>one</b></li><li><i>two</i></li><li><tt>three</tt></li></ul>""")
+
 # rich in style attributes with a mix of pattern-matching and rejected values, so the allowed_styles scrub does real
 # per-declaration regex work rather than short-circuiting on an empty rule
 _SANITIZE_STYLES = dedent("""\
@@ -159,6 +167,7 @@ OPERATIONS: dict[str, Operation] = {
     "sanitize-templates": Operation("sanitize (template-safe)", "us"),
     "sanitize-report": Operation("sanitize with audit trail", "us"),
     "sanitize-styles": Operation("sanitize (style allowlist)", "us"),
+    "sanitize-transform": Operation("sanitize (tag transform)", "us"),
     "markup": Operation("markupsafe-compatible escape", "ns"),
     "markup-op": Operation("Markup operations", "ns"),
     "linkify": Operation("linkify HTML", "us"),
@@ -465,6 +474,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "sanitize-templates": lambda: (("templated 4 KiB", _SANITIZE_TEMPLATES * 20),),
     "sanitize-report": lambda: (("post 4 KiB", _SANITIZE_POST * 20),),
     "sanitize-styles": lambda: (("styled 4 KiB", _SANITIZE_STYLES * 20),),
+    "sanitize-transform": lambda: (("legacy 4 KiB", _SANITIZE_LEGACY * 13),),
     "markup": lambda: _MARKUP_ESCAPE_CASES,
     "markup-op": lambda: (
         ("striptags", ("striptags", _MARKUP_OPS_HTML)),


### PR DESCRIPTION
Sanitizing could drop or keep an element but not rewrite it, so migrating a `sanitize-html` config that renames deprecated presentational tags (`<b>`→`<strong>`, `<center>`→`<div>`) had no equivalent. This adds `Policy.transform_tags`, the port of sanitize-html's `transformTags`, so a rename happens inside the single sanitize pass rather than as a second edit over the tree.

Map a source tag to a string to rename it, or to a `Transform` to rename it and add attributes (sanitize-html's `simpleTransform`). The rename runs at the top of the element walk, before the allowlist reads the tag, and the walk then continues on the renamed element as if the author had written the target. 🔒 That ordering is the safety argument: the allowlist still decides the element's disposition, the unconditional baseline still escapes a `script` or `iframe` target, and any injected attribute joins the element's own to be scrubbed by the same gates. `{"b": "script"}` cannot smuggle a live `<script>`, and an injected `href` cannot carry a `javascript:` URL. Only HTML elements are transformed, matched by tag name.

The rename mutates the node in place through the existing tree primitives (rewrite the name, relookup the atom, preserve the source-closed flag), so a transform adds no extra pass over the document. The migration guide benchmarks the transform op end-to-end against sanitize-html's Node runner over stdin, the cost a Python service pays to reach it as a subprocess.

closes #531
