### PR TITLE
✨ feat(serialize): add XML/XHTML output syntax

### DIFF
--- a/docs/changelog/535.feature.rst
+++ b/docs/changelog/535.feature.rst
@@ -1,0 +1,5 @@
+:class:`~turbohtml.Html` gained ``xml``: with ``xml=True``, :meth:`~turbohtml.Node.serialize`,
+:meth:`~turbohtml.Node.encode`, and :meth:`~turbohtml.Node.serialize_iter` emit XML/XHTML instead of HTML -- the
+equivalent of lxml's ``tostring(method="xml")``. Every empty element self-closes (``<br/>``), foreign SVG and MathML
+subtrees carry their namespace declarations, and text and attribute values follow the XML escaping rules, with no HTML
+void-element or raw-text special casing. It composes with ``sort_attributes`` and an :class:`~turbohtml.Indent` layout.

--- a/docs/explanation/serialization.rst
+++ b/docs/explanation/serialization.rst
@@ -36,6 +36,37 @@ otherwise reconstruct one across the gap and shift the tree; and a value is unqu
 re-open it. The transforms that would *not* round-trip (deleting whitespace between block elements, or omitting a tag
 whose reparse changes nesting) are exactly the ones turbohtml declines to make.
 
+***************************
+ HTML vs XML serialization
+***************************
+
+The WHATWG DOM standard defines two ways to turn a node tree into markup: *HTML fragment serialization* and *XML
+serialization*. They are different algorithms, not two escaping levels of one, and the same tree lands in both. The
+``xml`` field on :class:`~turbohtml.Html` selects the XML one -- lxml's ``method="xml"``, libxml2's serializer, and the
+``XMLSerializer`` a browser exposes all target the same form. turbohtml keeps a single tree walk and branches on a flag
+at the four points the algorithms diverge, so the HTML fast path is untouched.
+
+The first divergence is empty elements. HTML has a closed list of *void* elements (``br``, ``img``, ``input``, ...) that
+take a start tag and never an end tag, and every other empty element still writes ``<div></div>``. XML has no such list:
+any element with no children self-closes as ``<div/>`` and a childless ``<br>`` becomes ``<br/>`` for the same reason a
+``<div>`` does, not a special case. The second is raw text. HTML copies a ``<script>`` or ``<style>`` body verbatim,
+because those elements switch the tokenizer into a raw-text state on the way back in; XML has no raw-text elements, so a
+``<`` inside a script escapes like any other text and reparses to the same character. The third is escaping. XML
+predefines only ``&amp; &lt; &gt; &quot; &apos;``, so the HTML no-break-space shortcut ``&nbsp;`` -- undefined without a
+DTD -- cannot appear; turbohtml writes a literal U+00A0 (the output is Unicode), while the whitespace characters XML
+would otherwise normalize away inside an attribute (tab, newline, carriage return) become numeric references so the
+value round-trips.
+
+The fourth is namespaces. turbohtml parses HTML, so an inline ``<svg>`` or ``<math>`` lands in the SVG or MathML
+namespace inside an otherwise-HTML tree, with no namespace prefixes -- HTML has none. XML has no such implicit
+namespaces, so serializing that subtree well-formed means declaring them: the root of a foreign subtree gets the default
+``xmlns`` for its namespace, and an element carrying an ``xlink:``-prefixed attribute gets the ``xlink`` prefix declared
+on itself. Declaring the prefix on the element that uses it (rather than tracking which ancestor already declared it)
+keeps any subtree well-formed on its own, at the cost of a redundant-but-legal redeclaration on a nested user. The
+result parses with any XML reader, which is the whole point: an HTML tree becomes input for an XSLT or XPath 2.0
+pipeline that would reject HTML's unclosed tags. A :class:`~turbohtml.Minify` layout is inherently HTML (its
+optional-tag and unquoted-attribute rules are HTML-parser rules), so it stays HTML even under ``xml=True``.
+
 **********************
  Minifying JavaScript
 **********************

--- a/docs/how-to/serializing.rst
+++ b/docs/how-to/serializing.rst
@@ -76,3 +76,40 @@ as its first child, never a duplicate. ``serialize`` declares ``utf-8`` (the enc
 
     <html><head><meta charset="utf-8"><title>Hi</title></head><body></body></html>
     b'<html><head><meta charset="iso-8859-1"><title>Hi</title></head><body></body></html>'
+
+******************
+ Emit XML / XHTML
+******************
+
+Set ``xml=True`` to switch from HTML syntax to XML/XHTML -- the equivalent of lxml's ``tostring(method="xml")``. Every
+empty element self-closes (``<br/>``, ``<div/>``), a foreign SVG or MathML subtree carries the namespace declaration
+that makes it well-formed, and text and attribute values follow the XML escaping rules: ``&``, ``<`` and ``>`` in text,
+plus ``"`` and the whitespace characters in attribute values, become references, while a no-break space stays literal
+(XML predefines no ``&nbsp;``). The HTML void-element and raw-text special casing does not apply, so a ``<script>`` body
+is escaped like any other text. ``xml`` composes with ``sort_attributes`` and an :class:`~turbohtml.Indent` layout; it
+overrides ``formatter`` (the escaping is fixed by XML), and a :class:`~turbohtml.Minify` layout stays HTML:
+
+.. testcode::
+
+    import turbohtml
+    from turbohtml import Html, Indent
+
+    doc = turbohtml.parse("<div><br><p>if a < b</p><svg><rect></rect></svg></div>").select_one("div")
+    print(doc.serialize(Html(xml=True)))
+    print(doc.serialize(Html(xml=True, layout=Indent(2))))
+
+.. testoutput::
+
+    <div><br/><p>if a &lt; b</p><svg xmlns="http://www.w3.org/2000/svg"><rect/></svg></div>
+    <div>
+      <br/>
+      <p>
+        if a &lt; b
+      </p>
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <rect/>
+      </svg>
+    </div>
+
+The output parses with any XML reader, so it round-trips through :mod:`xml.etree.ElementTree` and hands cleanly to an
+XSLT or XPath 2.0 pipeline that rejects HTML's unclosed tags.

--- a/docs/migration/lxml.rst
+++ b/docs/migration/lxml.rst
@@ -176,6 +176,8 @@ so you iterate :attr:`~turbohtml.Node.children` instead of reading two string fi
       - :class:`turbohtml.IncrementalParser` (``feed`` chunks, ``close`` for the :class:`~turbohtml.Document`)
     - - ``lxml.html.tostring(el)``
       - :attr:`~turbohtml.Node.html`
+    - - ``lxml.etree.tostring(el, method="xml")``, ``tostring(el, method="xhtml")``
+      - :meth:`el.serialize(Html(xml=True)) <turbohtml.Node.serialize>`
 
 A query-and-select flow ports directly:
 
@@ -217,6 +219,22 @@ serialize surface stays available on what you build:
 .. testoutput::
 
     <ul><li class="item">one</li><li class="item">two</li></ul>
+
+Where lxml reaches for ``tostring(el, method="xml")`` (or ``"xhtml"``) to emit well-formed XML, pass
+:class:`~turbohtml.Html` with ``xml=True``. Empty elements self-close, foreign SVG and MathML subtrees carry their
+namespace declarations, and text and attribute values follow the XML escaping rules -- the HTML void-element and
+raw-text special casing does not apply:
+
+.. testcode::
+
+    from turbohtml import Html
+
+    doc = parse("<p>a &amp; b<br><svg><rect></rect></svg></p>")
+    print(doc.select_one("p").serialize(Html(xml=True)))
+
+.. testoutput::
+
+    <p>a &amp; b<br/><svg xmlns="http://www.w3.org/2000/svg"><rect/></svg></p>
 
 **********************
  Gotchas and pitfalls

--- a/docs/reference/serialize.rst
+++ b/docs/reference/serialize.rst
@@ -5,14 +5,15 @@
 .. currentmodule:: turbohtml
 
 Turn a tree back into markup or text. Each renderer takes one configuration object: :meth:`Node.serialize` and
-:meth:`Node.encode` produce HTML under an :class:`Html` config (a :class:`Formatter` picks the escape policy and an
-:class:`Indent` or :class:`Minify` picks the whitespace), and :meth:`Node.serialize_iter` streams the same HTML in
-bounded ``str`` chunks for a large page (every layout but :class:`Minify`, which needs the whole tree);
-:meth:`Node.to_markdown` takes a :class:`Markdown` config; and :meth:`Node.to_text` and :meth:`Node.to_annotated_text`
-take a :class:`PlainText` config. :func:`escape` and :func:`unescape` are the standalone string helpers;
-:func:`annotation_surface` and :func:`annotation_tags` post-process the annotated-text result. A
-:class:`~turbohtml.clean.JSMinify` passed to :class:`Minify` extends HTML minification into inline ``<script>`` content;
-the standalone :func:`~turbohtml.clean.minify_js` lives with the other minifiers in :mod:`turbohtml.clean`.
+:meth:`Node.encode` produce HTML under an :class:`Html` config (a :class:`Formatter` picks the escape policy, an
+:class:`Indent` or :class:`Minify` picks the whitespace, and ``xml=True`` switches to XML/XHTML syntax), and
+:meth:`Node.serialize_iter` streams the same HTML in bounded ``str`` chunks for a large page (every layout but
+:class:`Minify`, which needs the whole tree); :meth:`Node.to_markdown` takes a :class:`Markdown` config; and
+:meth:`Node.to_text` and :meth:`Node.to_annotated_text` take a :class:`PlainText` config. :func:`escape` and
+:func:`unescape` are the standalone string helpers; :func:`annotation_surface` and :func:`annotation_tags` post-process
+the annotated-text result. A :class:`~turbohtml.clean.JSMinify` passed to :class:`Minify` extends HTML minification into
+inline ``<script>`` content; the standalone :func:`~turbohtml.clean.minify_js` lives with the other minifiers in
+:mod:`turbohtml.clean`.
 
 .. autofunction:: escape
 

--- a/docs/tutorials/exporting.rst
+++ b/docs/tutorials/exporting.rst
@@ -82,6 +82,25 @@ JavaScript is minified in the same pass, with local names renamed and constants 
 
     <p>Hi</p> <script>function greet(a){return"hi "+a}</script>
 
+**********************
+ Emit well-formed XML
+**********************
+
+To hand the tree to an XML toolchain instead of a browser, set ``xml=True`` on the :class:`~turbohtml.Html` config.
+Every empty element self-closes, foreign SVG and MathML subtrees carry their namespace declarations, and text and
+attribute values follow the XML escaping rules, so the output parses with any XML reader:
+
+.. testcode::
+
+    from turbohtml import Html
+
+    doc = turbohtml.parse("<p>a &amp; b<br><svg><circle r=5></circle></svg></p>")
+    print(doc.find("p").serialize(Html(xml=True)))
+
+.. testoutput::
+
+    <p>a &amp; b<br/><svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg></p>
+
 That is the whole tree API. Head to the :doc:`/how-to/index` guides for task-focused recipes, the
 :doc:`/migration/index` guide if you are coming from another HTML library, or the :doc:`/reference` for the exact
 signatures.

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -1678,8 +1678,8 @@ static int resolve_layout(module_state *state, PyObject *layout_obj, enum th_lay
    (the str output is conceptually UTF-8 for serialize, the target encoding for
    encode); it is borrowed only for the duration of the call. */
 static PyObject *node_serialize_str(PyObject *self, PyObject *formatter_obj, PyObject *layout_obj, int sort_attributes,
-                                    int meta_charset, const char *charset) {
-    th_serialize_opts opts = {0, sort_attributes, meta_charset, charset, (Py_ssize_t)strlen(charset)};
+                                    int meta_charset, int xml, const char *charset) {
+    th_serialize_opts opts = {0, sort_attributes, meta_charset, charset, (Py_ssize_t)strlen(charset), xml};
     if (resolve_formatter(state_of(self), formatter_obj, &opts.formatter) < 0) {
         return NULL;
     }
@@ -1717,15 +1717,15 @@ static PyObject *node_serialize_str(PyObject *self, PyObject *formatter_obj, PyO
    leaving each unmentioned one at the caller's default. Returns 0 on success, -1 with
    an exception set. */
 static int parse_html_spec(PyObject *spec, PyObject **formatter_obj, PyObject **layout_obj, int *sort_attributes,
-                           int *meta_charset) {
-    static char *keywords[] = {"formatter", "layout", "sort_attributes", "meta_charset", NULL};
+                           int *meta_charset, int *xml) {
+    static char *keywords[] = {"formatter", "layout", "sort_attributes", "meta_charset", "xml", NULL};
     PyObject *empty = PyTuple_New(0);
     if (empty == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
         return -1;        /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    int parsed = PyArg_ParseTupleAndKeywords(empty, spec, "|$OOpp", keywords, formatter_obj, layout_obj,
-                                             sort_attributes, meta_charset);
+    int parsed = PyArg_ParseTupleAndKeywords(empty, spec, "|$OOppp", keywords, formatter_obj, layout_obj,
+                                             sort_attributes, meta_charset, xml);
     Py_DECREF(empty);
     return parsed ? 0 : -1;
 }
@@ -1735,17 +1735,18 @@ static PyObject *node_serialize_from_spec(PyObject *self, PyObject *spec, const 
     PyObject *layout_obj = NULL;
     int sort_attributes = 0;
     int meta_charset = 0;
-    if (parse_html_spec(spec, &formatter_obj, &layout_obj, &sort_attributes, &meta_charset) < 0) {
+    int xml = 0;
+    if (parse_html_spec(spec, &formatter_obj, &layout_obj, &sort_attributes, &meta_charset, &xml) < 0) {
         return NULL;
     }
-    return node_serialize_str(self, formatter_obj, layout_obj, sort_attributes, meta_charset, charset);
+    return node_serialize_str(self, formatter_obj, layout_obj, sort_attributes, meta_charset, xml, charset);
 }
 
 /* Resolve a serialize/encode call's options object to a str rendering under charset.
    None renders the defaults; otherwise the config's _unpack() supplies its keywords. */
 static PyObject *node_serialize_options(PyObject *self, PyObject *options, const char *charset) {
     if (options == NULL || options == Py_None) {
-        return node_serialize_str(self, NULL, NULL, 0, 0, charset);
+        return node_serialize_str(self, NULL, NULL, 0, 0, 0, charset);
     }
     PyObject *spec = config_unpack(options, state_of(self)->html_config_type, "Html");
     if (spec == NULL) {
@@ -1786,9 +1787,9 @@ static PyObject *node_encode(PyObject *self, PyObject *args, PyObject *kwds) {
    A Minify layout is rejected: its transforms analyze the whole tree, so there is no
    per-node stream to resume. */
 static PyObject *node_make_serialize_iter(PyObject *self, PyObject *formatter_obj, PyObject *layout_obj,
-                                          int sort_attributes, int meta_charset) {
+                                          int sort_attributes, int meta_charset, int xml) {
     module_state *state = state_of(self);
-    th_serialize_opts opts = {0, sort_attributes, meta_charset, "utf-8", (Py_ssize_t)strlen("utf-8")};
+    th_serialize_opts opts = {0, sort_attributes, meta_charset, "utf-8", (Py_ssize_t)strlen("utf-8"), xml};
     if (resolve_formatter(state, formatter_obj, &opts.formatter) < 0) {
         return NULL;
     }
@@ -1817,7 +1818,7 @@ static PyObject *node_serialize_iter(PyObject *self, PyObject *args, PyObject *k
         return NULL;
     }
     if (options == NULL || options == Py_None) {
-        return node_make_serialize_iter(self, NULL, NULL, 0, 0);
+        return node_make_serialize_iter(self, NULL, NULL, 0, 0, 0);
     }
     PyObject *spec = config_unpack(options, state_of(self)->html_config_type, "Html");
     if (spec == NULL) {
@@ -1827,10 +1828,11 @@ static PyObject *node_serialize_iter(PyObject *self, PyObject *args, PyObject *k
     PyObject *layout_obj = NULL;
     int sort_attributes = 0;
     int meta_charset = 0;
-    int parsed = parse_html_spec(spec, &formatter_obj, &layout_obj, &sort_attributes, &meta_charset);
+    int xml = 0;
+    int parsed = parse_html_spec(spec, &formatter_obj, &layout_obj, &sort_attributes, &meta_charset, &xml);
     Py_DECREF(spec);
     if (parsed < 0) {
         return NULL;
     }
-    return node_make_serialize_iter(self, formatter_obj, layout_obj, sort_attributes, meta_charset);
+    return node_make_serialize_iter(self, formatter_obj, layout_obj, sort_attributes, meta_charset, xml);
 }

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -314,6 +314,7 @@ typedef struct {
     int inject_meta;     /* ensure <head> declares <meta charset=charset> */
     const char *charset; /* ASCII encoding label for the injected/normalized meta */
     Py_ssize_t charset_len;
+    int xml; /* XML/XHTML syntax: self-close empty elements, XML escaping, foreign namespace decls */
 } th_serialize_opts;
 
 /* Serialize node and its subtree under opts. When indent is non-NULL it is the

--- a/src/turbohtml/_c/serialize/document.c
+++ b/src/turbohtml/_c/serialize/document.c
@@ -201,6 +201,18 @@ static th_node *serialize_compact_step(sbuf *out, th_tree *tree, th_node *node, 
     switch (node->type) { /* GCOVR_EXCL_BR_LINE: th_node_type is exhaustive; the implicit default is unreachable */
     case TH_NODE_ELEMENT:
         ser_open_tag(out, tree, node, opts);
+        if (opts->xml) {
+            /* XML syntax: every empty element self-closes, no void/raw-text special
+               casing, so a childless element ends the tag and a parent descends */
+            if (node->first_child == NULL) {
+                sbuf_puts(out, "/>");
+            } else {
+                sbuf_putc(out, '>');
+                descend = node->first_child;
+            }
+            break;
+        }
+        sbuf_putc(out, '>');
         ser_inject_head_meta(out, tree, node, opts);
         if (node->ns == TH_NS_HTML && is_serialize_void_atom(node->atom)) {
             break; /* void elements have no children or end tag */
@@ -223,7 +235,11 @@ static th_node *serialize_compact_step(sbuf *out, th_tree *tree, th_node *node, 
         }
         break;
     case TH_NODE_TEXT:
-        sbuf_put_text(out, need_text(tree, node), node->text_len, 0, opts->formatter);
+        if (opts->xml) {
+            sbuf_put_xml_text(out, need_text(tree, node), node->text_len, 0);
+        } else {
+            sbuf_put_text(out, need_text(tree, node), node->text_len, 0, opts->formatter);
+        }
         break;
     case TH_NODE_COMMENT:
         sbuf_puts(out, "<!--");
@@ -302,6 +318,19 @@ static th_node *serialize_pretty_step(sbuf *out, th_tree *tree, th_node *node, t
     switch (node->type) { /* GCOVR_EXCL_BR_LINE: th_node_type is exhaustive; the implicit default is unreachable */
     case TH_NODE_ELEMENT: {
         ser_open_tag(out, tree, node, opts->out);
+        if (opts->out->xml) {
+            /* XML pretty form: an empty element self-closes on its line, a parent
+               opens then lays each child out one level deeper (the ascend closes it) */
+            if (node->first_child == NULL) {
+                sbuf_puts(out, "/>");
+            } else {
+                sbuf_putc(out, '>');
+                ser_newline_indent(out, opts, *depth + 1);
+                descend = node->first_child;
+            }
+            break;
+        }
+        sbuf_putc(out, '>');
         if (node->ns == TH_NS_HTML && is_serialize_void_atom(node->atom)) {
             break;
         }
@@ -348,7 +377,11 @@ static th_node *serialize_pretty_step(sbuf *out, th_tree *tree, th_node *node, t
         break;
     }
     case TH_NODE_TEXT:
-        sbuf_put_text(out, need_text(tree, node), node->text_len, 0, opts->out->formatter);
+        if (opts->out->xml) {
+            sbuf_put_xml_text(out, need_text(tree, node), node->text_len, 0);
+        } else {
+            sbuf_put_text(out, need_text(tree, node), node->text_len, 0, opts->out->formatter);
+        }
         break;
     case TH_NODE_COMMENT:
         sbuf_puts(out, "<!--");
@@ -498,7 +531,7 @@ void th_node_collect_text(th_tree *tree, th_node *node, Py_UCS4 *buf) {
 
 /* The WHATWG-conformant defaults the html/inner_html accessors serialize under:
    minimal escaping, source attribute order, no charset injection. */
-static const th_serialize_opts ser_default_opts = {TH_FMT_WHATWG, 0, 0, NULL, 0};
+static const th_serialize_opts ser_default_opts = {TH_FMT_WHATWG, 0, 0, NULL, 0, 0};
 
 Py_UCS4 *th_node_html(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
     sbuf out = {NULL, 0, 0, 0};

--- a/src/turbohtml/_c/serialize/internal.h
+++ b/src/turbohtml/_c/serialize/internal.h
@@ -253,6 +253,56 @@ static inline void sbuf_put_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t len,
     }
 }
 
+/* Whether a code point needs a reference under XML serialization. Structural
+   `& < >` always escape; a double quote, tab and newline escape only inside an
+   attribute value (where XML would otherwise normalize the whitespace away); a
+   carriage return escapes everywhere so a reparse cannot fold it to a newline. */
+static inline int sbuf_xml_special(Py_UCS4 character, int in_attr) {
+    if (character == '&' || character == '<' || character == '>' || character == '\r') {
+        return 1;
+    }
+    return in_attr && (character == '"' || character == '\t' || character == '\n');
+}
+
+/* Emit one flagged character's XML replacement. */
+static inline void sbuf_put_xml_special(sbuf *out, Py_UCS4 character) {
+    if (character == '&') {
+        sbuf_puts(out, "&amp;");
+    } else if (character == '<') {
+        sbuf_puts(out, "&lt;");
+    } else if (character == '>') {
+        sbuf_puts(out, "&gt;");
+    } else if (character == '"') {
+        sbuf_puts(out, "&quot;");
+    } else if (character == '\t') {
+        sbuf_puts(out, "&#9;");
+    } else if (character == '\n') {
+        sbuf_puts(out, "&#10;");
+    } else {
+        sbuf_puts(out, "&#13;"); /* the only remaining flagged character is U+000D */
+    }
+}
+
+/* Append text under XML escaping, bulk-copying each run with nothing to escape and
+   rewriting only the specials between. Unlike the HTML formatter, no-break space is
+   left verbatim (XML predefines no &nbsp;) and `>` escapes in every context. */
+static inline void sbuf_put_xml_text(sbuf *out, const Py_UCS4 *text, Py_ssize_t len, int in_attr) {
+    Py_ssize_t index = 0;
+    while (index < len) {
+        Py_ssize_t start = index;
+        while (index < len && !sbuf_xml_special(text[index], in_attr)) {
+            index++;
+        }
+        if (index > start) {
+            sbuf_put_run(out, &text[start], index - start);
+        }
+        if (index < len) {
+            sbuf_put_xml_special(out, text[index]);
+            index++;
+        }
+    }
+}
+
 /* An element whose text children serialize literally rather than escaped: the
    WHATWG literal set is style/script/xmp/iframe/noembed/noframes/plaintext.
    noscript carries the rawtext flag for tokenization but is raw-text only when the
@@ -448,15 +498,41 @@ static inline void ser_inject_head_meta(sbuf *out, th_tree *tree, const th_node 
     }
 }
 
-/* Write an element's start tag, "<tag attrs...>": attributes in source order, or in
-   name order when opts asks; values double-quoted and escaped under the formatter,
-   with a charset meta's declaration normalized when meta_charset is on. */
+/* Emit the namespace declarations an XML start tag needs to stay well-formed: the
+   default namespace on the root of a foreign (SVG/MathML) subtree -- an element
+   whose parent is in a different namespace -- and the xlink prefix on any element
+   carrying an `xlink:`-prefixed attribute (a redundant redeclaration on a nested
+   element is still well-formed, so no ancestor tracking is needed). */
+static inline void ser_xml_ns_decls(sbuf *out, th_tree *tree, const th_node *node) {
+    if (node->ns != TH_NS_HTML && (node->parent == NULL || node->parent->ns != node->ns)) {
+        sbuf_puts(out, node->ns == TH_NS_SVG ? " xmlns=\"http://www.w3.org/2000/svg\""
+                                             : " xmlns=\"http://www.w3.org/1998/Math/MathML\"");
+    }
+    for (Py_ssize_t position = 0; position < node->attr_count; position++) {
+        Py_ssize_t name_len;
+        const char *name = th_attr_name(tree, node->attrs[position].name_atom, &name_len);
+        if (name_len >= 6 && memcmp(name, "xlink:", 6) == 0) {
+            sbuf_puts(out, " xmlns:xlink=\"http://www.w3.org/1999/xlink\"");
+            break;
+        }
+    }
+}
+
+/* Write an element's start tag up to but not including its closing delimiter,
+   "<tag attrs...": attributes in source order, or in name order when opts asks;
+   values double-quoted and escaped under the formatter (or the XML rules when
+   opts->xml), with a charset meta's declaration normalized when meta_charset is on.
+   The caller appends ">" (or "/>" for an empty XML element) so it can choose the
+   self-closing form after inspecting the children. */
 static inline void ser_open_tag(sbuf *out, th_tree *tree, th_node *node, const th_serialize_opts *opts) {
     sbuf_putc(out, '<');
     sbuf_put_ucs4(out, node->text, node->text_len);
+    if (opts->xml) {
+        ser_xml_ns_decls(out, tree, node);
+    }
     Py_ssize_t stack_order[MAX_SORTED_ATTRS];
     Py_ssize_t *order = ser_attr_order(tree, node, opts->sort_attributes, stack_order);
-    int charset_kind = opts->inject_meta ? ser_meta_charset_kind(tree, node) : 0;
+    int charset_kind = opts->inject_meta && !opts->xml ? ser_meta_charset_kind(tree, node) : 0;
     for (Py_ssize_t position = 0; position < node->attr_count; position++) {
         th_node_attr *attr = &node->attrs[order != NULL ? order[position] : position];
         sbuf_putc(out, ' ');
@@ -467,11 +543,14 @@ static inline void ser_open_tag(sbuf *out, th_tree *tree, th_node *node, const t
             continue;
         }
         sbuf_puts(out, "=\"");
-        sbuf_put_text(out, attr->value, attr->value_len, 1, opts->formatter);
+        if (opts->xml) {
+            sbuf_put_xml_text(out, attr->value, attr->value_len, 1);
+        } else {
+            sbuf_put_text(out, attr->value, attr->value_len, 1, opts->formatter);
+        }
         sbuf_putc(out, '"');
     }
     ser_attr_order_free(order, stack_order);
-    sbuf_putc(out, '>');
 }
 
 static inline void ser_close_tag(sbuf *out, th_node *node) {

--- a/src/turbohtml/_render.py
+++ b/src/turbohtml/_render.py
@@ -352,12 +352,17 @@ class Html:
         :class:`~turbohtml.Minify` minifies.
     :param sort_attributes: emit each element's attributes in name order rather than source order.
     :param meta_charset: normalize (or inject) the ``<meta charset>`` declaration to the output encoding.
+    :param xml: emit XML/XHTML syntax -- every empty element self-closes (``<br/>``), foreign SVG and MathML
+        subtrees carry their namespace declarations, and text and attribute values follow the XML escaping rules.
+        The HTML void-element and raw-text special casing (and the ``formatter``/``meta_charset`` options) do not
+        apply; a :class:`~turbohtml.Minify` layout stays HTML.
     """
 
     formatter: Formatter = Formatter.WHATWG
     layout: Indent | Minify | None = None
     sort_attributes: bool = False
     meta_charset: bool = False
+    xml: bool = False
 
     def _unpack(self) -> dict[str, object]:
         """Flatten to the renderer's keyword names, emitting only values that differ from its defaults."""

--- a/tests/serialize/test_serialize_xml.py
+++ b/tests/serialize/test_serialize_xml.py
@@ -1,0 +1,193 @@
+"""XML/XHTML serialization: the ``Html(xml=True)`` output syntax."""
+
+from __future__ import annotations
+
+from xml.etree import ElementTree as ET  # noqa: S405  # parsing turbohtml's own serialized output, not untrusted input
+
+import pytest
+
+from turbohtml import Element, Formatter, Html, Indent, Minify, Text, parse
+
+_XML = Html(xml=True)
+
+
+def _fragment(markup: str, selector: str) -> Element:
+    node = parse(markup).select_one(selector)
+    assert node is not None
+    return node
+
+
+@pytest.mark.parametrize(
+    ("markup", "selector", "expected"),
+    [
+        pytest.param("<div></div>", "div", "<div/>", id="empty-self-closes"),
+        pytest.param("<br>", "br", "<br/>", id="void-self-closes"),
+        pytest.param("<input name=q value=1>", "input", '<input name="q" value="1"/>', id="void-with-attrs"),
+        pytest.param("<p>x</p>", "p", "<p>x</p>", id="non-empty-keeps-end-tag"),
+        pytest.param("<p><b>y</b></p>", "p", "<p><b>y</b></p>", id="nested-children"),
+        pytest.param("<img src=a>", "img", '<img src="a"/>', id="void-img"),
+    ],
+)
+def test_empty_elements_self_close(markup: str, selector: str, expected: str) -> None:
+    assert _fragment(markup, selector).serialize(_XML) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        pytest.param("a&b", "a&amp;b", id="ampersand"),
+        pytest.param("a<b", "a&lt;b", id="less-than"),
+        pytest.param("a>b", "a&gt;b", id="greater-than"),
+        pytest.param("a\rb", "a&#13;b", id="carriage-return"),
+        pytest.param('a"b', 'a"b', id="quote-stays-literal"),
+        pytest.param("a\tb\nc", "a\tb\nc", id="tab-newline-stay-literal"),
+        pytest.param("a\xa0b", "a\xa0b", id="nbsp-stays-literal"),
+    ],
+)
+def test_text_escaping(text: str, expected: str) -> None:
+    assert Element("p", children=[Text(text)]).serialize(_XML) == f"<p>{expected}</p>"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("a&b", "a&amp;b", id="ampersand"),
+        pytest.param("a<b", "a&lt;b", id="less-than"),
+        pytest.param("a>b", "a&gt;b", id="greater-than"),
+        pytest.param('a"b', "a&quot;b", id="quote"),
+        pytest.param("a\tb", "a&#9;b", id="tab"),
+        pytest.param("a\nb", "a&#10;b", id="newline"),
+        pytest.param("a\rb", "a&#13;b", id="carriage-return"),
+        pytest.param("a\xa0b", "a\xa0b", id="nbsp-stays-literal"),
+    ],
+)
+def test_attribute_escaping(value: str, expected: str) -> None:
+    assert Element("p", {"title": value}).serialize(_XML) == f'<p title="{expected}"/>'
+
+
+def test_script_content_is_escaped_not_raw() -> None:
+    node = _fragment("<script>if(a<b){}</script>", "script")
+    assert node.serialize(_XML) == "<script>if(a&lt;b){}</script>"
+
+
+def test_style_content_is_escaped_not_raw() -> None:
+    node = _fragment("<style>a>b{}</style>", "style")
+    assert node.serialize(_XML) == "<style>a&gt;b{}</style>"
+
+
+def test_svg_root_declares_default_namespace() -> None:
+    node = _fragment("<svg><rect x=1><circle/></rect></svg>", "svg")
+    assert node.serialize(_XML) == '<svg xmlns="http://www.w3.org/2000/svg"><rect x="1"><circle/></rect></svg>'
+
+
+def test_mathml_root_declares_default_namespace() -> None:
+    node = _fragment("<math><mi>x</mi></math>", "math")
+    assert node.serialize(_XML) == '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math>'
+
+
+def test_nested_foreign_element_does_not_redeclare_default() -> None:
+    node = _fragment("<svg><g><rect/></g></svg>", "svg")
+    assert "xmlns=" not in node.serialize(_XML).split("<g", 1)[1]
+
+
+def test_detached_foreign_element_declares_namespace() -> None:
+    svg = _fragment("<svg></svg>", "svg")
+    svg.extract()
+    assert svg.serialize(_XML) == '<svg xmlns="http://www.w3.org/2000/svg"/>'
+
+
+def test_xlink_attribute_declares_prefix() -> None:
+    node = _fragment("<svg xlink:href=x></svg>", "svg")
+    assert node.serialize(_XML) == (
+        '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="x"/>'
+    )
+
+
+def test_foreign_element_without_xlink_omits_prefix() -> None:
+    node = _fragment("<svg width=10></svg>", "svg")
+    assert "xmlns:xlink" not in node.serialize(_XML)
+
+
+def test_html_element_never_carries_namespace_decl() -> None:
+    assert "xmlns" not in _fragment("<p id=a>x</p>", "p").serialize(_XML)
+
+
+def test_sort_attributes_composes_with_xml() -> None:
+    node = _fragment("<p z=1 a=2>x", "p")
+    assert node.serialize(Html(xml=True, sort_attributes=True)) == '<p a="2" z="1">x</p>'
+
+
+def test_formatter_is_ignored_under_xml() -> None:
+    node = Element("p", children=[Text("a\xa0b")])
+    assert node.serialize(Html(xml=True, formatter=Formatter.NAMED_ENTITIES)) == "<p>a\xa0b</p>"
+
+
+def test_meta_charset_is_ignored_under_xml() -> None:
+    out = parse("<p>x").serialize(Html(xml=True, meta_charset=True))
+    assert "meta" not in out
+    assert out == "<html><head/><body><p>x</p></body></html>"
+
+
+def test_document_serialize_self_closes_empty_head() -> None:
+    assert parse("<p>x").serialize(_XML) == "<html><head/><body><p>x</p></body></html>"
+
+
+def test_comment_and_doctype_pass_through() -> None:
+    out = parse("<!doctype html><!--note--><p>x").serialize(_XML)
+    assert out == "<!DOCTYPE html><!--note--><html><head/><body><p>x</p></body></html>"
+
+
+def test_indent_pretty_xml_self_closes_empties() -> None:
+    node = _fragment("<div><p>hi</p><br></div>", "div")
+    assert node.serialize(Html(xml=True, layout=Indent(2))) == ("<div>\n  <p>\n    hi\n  </p>\n  <br/>\n</div>")
+
+
+def test_indent_pretty_xml_escapes_text() -> None:
+    node = _fragment("<p>a&lt;b</p>", "p")
+    assert node.serialize(Html(xml=True, layout=Indent(2))) == "<p>\n  a&lt;b\n</p>"
+
+
+def test_indent_pretty_xml_empty_root_self_closes() -> None:
+    assert _fragment("<div></div>", "div").serialize(Html(xml=True, layout=Indent(2))) == "<div/>"
+
+
+def test_serialize_iter_streams_xml() -> None:
+    node = _fragment("<div><br><p>x</p></div>", "div")
+    assert "".join(node.serialize_iter(_XML)) == "<div><br/><p>x</p></div>"
+
+
+def test_serialize_iter_streams_indented_xml() -> None:
+    node = _fragment("<div><br></div>", "div")
+    assert "".join(node.serialize_iter(Html(xml=True, layout=Indent(2)))) == "<div>\n  <br/>\n</div>"
+
+
+def test_encode_emits_xml_bytes() -> None:
+    assert _fragment("<br>", "br").encode(options=_XML) == b"<br/>"
+
+
+def test_minify_layout_stays_html_under_xml() -> None:
+    node = _fragment("<br>", "br")
+    assert node.serialize(Html(xml=True, layout=Minify())) == "<br>"
+
+
+@pytest.mark.parametrize(
+    "markup",
+    [
+        pytest.param("<div><br><p class='a&b<c'>x&amp;<b>y</b></p></div>", id="mixed"),
+        pytest.param("<svg xlink:href=x><a xlink:title=t><rect/></a></svg>", id="foreign-xlink"),
+        pytest.param("<math><mi mathvariant=bold>x</mi></math>", id="mathml"),
+        pytest.param("<p title='a\tb\nc'>t&lt;u</p>", id="whitespace-attrs"),
+        pytest.param("<script>if(a<b&&c>d){}</script>", id="script"),
+    ],
+)
+def test_output_is_well_formed_xml(markup: str) -> None:
+    node = parse(markup).select_one("div,svg,math,script,p")
+    assert node is not None
+    ET.fromstring(node.serialize(_XML))  # noqa: S314  # our own serialized output, parsed only to assert well-formedness
+
+
+def test_round_trip_reparses_to_same_html() -> None:
+    node = _fragment("<div><br><p>x&amp;y</p></div>", "div")
+    reparsed = parse(node.serialize(_XML)).select_one("div")
+    assert reparsed is not None
+    assert reparsed.serialize() == node.serialize()

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -53,6 +53,7 @@ _DOCUMENT_OPS = (
     "find-text",
     "text-content",
     "serialize",
+    "serialize-xml",
     "minify",
     "edit",
     "class-edit",

--- a/tools/bench/competitors/lxml.py
+++ b/tools/bench/competitors/lxml.py
@@ -101,6 +101,11 @@ def serialize(text: str) -> None:
     lxml_html.tostring(_parsed(text))
 
 
+def serialize_xml(text: str) -> None:
+    """Serialize a parsed document to XML with lxml's tostring(method='xml')."""
+    lxml_html.tostring(_parsed(text), method="xml")
+
+
 def extract_attr(text: str) -> None:
     """Read every anchor's href with lxml's XPath attribute selection."""
     _parsed(text).xpath("//a/@href")
@@ -307,6 +312,7 @@ OPERATIONS = {
     "select-has": (select_has, "lxml"),
     "text-content": (text_content, "lxml"),
     "serialize": (serialize, "lxml"),
+    "serialize-xml": (serialize_xml, "lxml method=xml"),
     "extract-attr": (extract_attr, "lxml"),
     "extract-text": (extract_text, "lxml"),
     "strip-remove": (strip_remove, "lxml"),

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -58,6 +58,7 @@ _SET_HTML = "<p>Updated <a href='/x'>link</a> and <b>bold</b>.</p><ul><li>one</l
 _SET_TEXT = "Replacement text, escaped & verbatim."
 _DETECTOR = _LinkDetector()
 _ANNOTATION_RULES = {"h1": ["heading"], "b": ["emphasis"], "a": ["link"]}
+_XML = turbohtml.Html(xml=True)  # the XML/XHTML serialization config, reused across the timed calls
 
 
 def build(count: int) -> None:
@@ -171,6 +172,11 @@ def text_content(text: str) -> None:
 def serialize(text: str) -> None:
     """Serialize a parsed document back to HTML with turbohtml's html property."""
     _ = _parsed(text).html
+
+
+def serialize_xml(text: str) -> None:
+    """Serialize a parsed document to well-formed XML/XHTML with turbohtml's Html(xml=True) option."""
+    _ = _parsed(text).serialize(_XML)
 
 
 def minify(text: str) -> str:
@@ -556,6 +562,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "find-text": (find_text, "turbohtml"),
     "text-content": (text_content, "turbohtml"),
     "serialize": (serialize, "turbohtml"),
+    "serialize-xml": (serialize_xml, "turbohtml"),
     "minify": (minify, "turbohtml"),
     "edit": (Mutating(turbohtml.parse, edit), "turbohtml"),
     "class-edit": (class_edit, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -139,6 +139,7 @@ OPERATIONS: dict[str, Operation] = {
     "find-text": Operation("find by text content", "us"),
     "text-content": Operation("collect visible text", "us"),
     "serialize": Operation("serialize a parsed tree", "us"),
+    "serialize-xml": Operation("serialize a parsed tree to XML", "us"),
     "minify": Operation("minify a document", "us"),
     "edit": Operation("tag every link rel=nofollow", "us"),
     "class-edit": Operation("class add/remove on every link", "us"),
@@ -450,6 +451,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "find-text": _readpath_cases,
     "text-content": _readpath_cases,
     "serialize": _readpath_cases,
+    "serialize-xml": _readpath_cases,
     "minify": _readpath_cases,
     "socialcard": lambda: (
         ("head", _SOCIAL_HEAD),


### PR DESCRIPTION
turbohtml serialized HTML syntax only, so a tree bound for an XML toolchain (an XSLT or XPath 2.0 pipeline, an `XMLSerializer` consumer, anything that rejects HTML's unclosed tags) had to be round-tripped through a second library. This adds an XML/XHTML serialization mode, the equivalent of lxml's `tostring(method="xml")`, so `serialize`, `encode`, and `serialize_iter` can emit well-formed XML from the same parsed tree.

`Html` gained an `xml` field. With `xml=True` the WHATWG XML serialization rules apply: every empty element self-closes (`<br/>`, `<div/>`), a foreign SVG or MathML subtree carries the namespace declaration that makes it well-formed (`xmlns` on the subtree root, `xmlns:xlink` on any element bearing an `xlink:` attribute), and text and attribute values follow the XML escaping rules (`&`, `<`, `>` in text, plus `"` and the whitespace characters in attributes, with a no-break space left literal since XML predefines no `&nbsp;`). The HTML void-element and raw-text special casing does not apply, so a `<script>` body is escaped like any other text.

The serializer keeps its single tree walk and branches on the flag at the four points where the HTML and XML algorithms diverge, so the HTML fast path stays intact. 🚀 The flag composes with `sort_attributes` and an `Indent` layout; a `Minify` layout stays HTML, since its optional-tag and unquoted-attribute rules are HTML-parser rules.

The `docs/migration/lxml.rst` guide maps `tostring(method="xml"|"xhtml")` onto `serialize(Html(xml=True))`, and a `serialize-xml` benchmark op compares turbohtml against lxml's `method="xml"` head to head.

closes #535
