### PR TITLE
✨ feat(sanitize): add DOM-clobbering isolation

### DIFF
--- a/docs/changelog/534.feature.rst
+++ b/docs/changelog/534.feature.rst
@@ -1,5 +1,5 @@
 :class:`~turbohtml.clean.Policy` gained ``isolate_named_props``: with it on, sanitizing prefixes every kept ``id`` and
 ``name`` value with ``user-content-``, moving it out of the property namespace so it cannot shadow a built-in
 ``document`` or form property through named access (DOM clobbering, where ``<input name="attributes">`` makes
-``form.attributes`` resolve to the input and ``<img name="body">`` hides ``document.body``). An already-prefixed value is
-left alone, so re-sanitizing is a fixpoint. This matches DOMPurify's ``SANITIZE_NAMED_PROPS``.
+``form.attributes`` resolve to the input and ``<img name="body">`` hides ``document.body``). An already-prefixed value
+is left alone, so re-sanitizing is a fixpoint. This matches DOMPurify's ``SANITIZE_NAMED_PROPS``.

--- a/docs/changelog/534.feature.rst
+++ b/docs/changelog/534.feature.rst
@@ -1,0 +1,5 @@
+:class:`~turbohtml.clean.Policy` gained ``isolate_named_props``: with it on, sanitizing prefixes every kept ``id`` and
+``name`` value with ``user-content-``, moving it out of the property namespace so it cannot shadow a built-in
+``document`` or form property through named access (DOM clobbering, where ``<input name="attributes">`` makes
+``form.attributes`` resolve to the input and ``<img name="body">`` hides ``document.body``). An already-prefixed value is
+left alone, so re-sanitizing is a fixpoint. This matches DOMPurify's ``SANITIZE_NAMED_PROPS``.

--- a/docs/explanation/sanitizing.rst
+++ b/docs/explanation/sanitizing.rst
@@ -33,3 +33,18 @@ the element's own to be scrubbed by the same gates below. A transform therefore 
 gate underneath still governs its *safety*. Putting the additive step above the subtractive stack, instead of letting it
 write past the allowlist, is why ``{"b": "script"}`` cannot smuggle a live ``<script>`` and an injected ``href`` cannot
 carry a ``javascript:`` URL -- the transform hands its output back to the pipeline rather than around it.
+
+``isolate_named_props`` is the other rewriting step, and its design turns on a constraint the layered model does not:
+turbohtml has no live DOM. DOM clobbering exploits *named access* -- an ``id`` or ``name`` whose value matches a
+built-in property makes that property resolve to the attacker's element (``<input name="attributes">`` shadows
+``form.attributes``, ``<img name="body">`` shadows ``document.body``). Nothing about such an attribute is malformed, so
+the allowlist keeps it; only a defense aimed at the collision itself removes it. DOMPurify offers two: ``SANITIZE_DOM``
+tests ``value in document`` and drops a real collision, and ``SANITIZE_NAMED_PROPS`` prefixes every ``id``/``name``
+value with ``user-content-``. The first needs the running engine's property set, which only a live DOM can enumerate;
+the second is a pure string transform. turbohtml sanitizes a parsed tree with no DOM to probe, so it takes the second
+design: prefixing is unconditional and complete, where a static reimplementation of the ``in document`` check would be a
+hand-maintained name list that silently misses whatever property a future engine adds. Applying the prefix *after*
+``attribute_filter`` -- the last configurable gate -- rather than before, means no filter can hand back a clobbering
+value the isolation then fails to namespace; like the dangerous-value baseline, the guarantee sits below the caller's
+reach. Idempotence closes the loop: a value already carrying the prefix is left untouched, so sanitizing sanitized
+output is a fixpoint rather than a growing stack of ``user-content-user-content-`` markers.

--- a/docs/how-to/sanitizing.rst
+++ b/docs/how-to/sanitizing.rst
@@ -41,6 +41,32 @@ single space, matching DOMPurify's ``SAFE_FOR_TEMPLATES``.
     print(sanitize("<p title='{{x}}'>Hi {{ user.name }}</p>", policy))
     # <p title=" ">Hi  </p>
 
+***************************
+ Neutralize DOM clobbering
+***************************
+
+When you allow ``id`` or ``name`` on kept elements, an attacker can set a value that collides with a built-in
+``document`` or form property and shadow it through named access -- ``<input name="attributes">`` makes
+``form.attributes`` resolve to the input, ``<img name="body">`` hides ``document.body``. The allowlist keeps the
+attribute because it is otherwise ordinary. Set ``isolate_named_props`` to prefix every kept ``id`` and ``name`` value
+with ``user-content-``, moving it out of the property namespace so no value can collide, matching DOMPurify's
+``SANITIZE_NAMED_PROPS``. An already-prefixed value is left alone, so re-sanitizing is a fixpoint.
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy
+
+    policy = Policy(
+        tags=frozenset({"a", "input"}),
+        attributes={"a": frozenset({"id", "href"}), "input": frozenset({"name"})},
+        isolate_named_props=True,
+    )
+    print(sanitize('<a id="location" href="http://x/">x</a><input name="attributes">', policy))
+
+.. testoutput::
+
+    <a id="user-content-location" href="http://x/">x</a><input name="user-content-attributes">
+
 *********************************************
  Restrict inline styles to known-good values
 *********************************************

--- a/docs/migration/bench/dompurify.json
+++ b/docs/migration/bench/dompurify.json
@@ -1,0 +1,20 @@
+{
+  "label": "operation",
+  "parties": [
+    "turbohtml",
+    "DOMPurify"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "sanitize (template-safe) — templated 4 KiB",
+      3.4542055800557137e-05,
+      0.2417227909900248
+    ],
+    [
+      "sanitize (named-prop isolation) — clobbering 4 KiB",
+      3.062502946704626e-05,
+      0.24151520803570747
+    ]
+  ]
+}

--- a/docs/migration/dompurify.rst
+++ b/docs/migration/dompurify.rst
@@ -1,0 +1,105 @@
+################
+ From DOMPurify
+################
+
+`DOMPurify <https://github.com/cure53/DOMPurify>`_ is the reference client-side HTML sanitizer: it parses untrusted
+markup, walks it against a hardened allowlist, and hands back a string safe to assign to ``innerHTML``. It runs in a
+browser or, server-side, on ``jsdom`` through ``isomorphic-dompurify``. Two of its options harden against attacks the
+allowlist alone does not stop: ``SAFE_FOR_TEMPLATES`` neutralizes template-engine expressions left in the output, and
+``SANITIZE_NAMED_PROPS`` defuses DOM clobbering by namespacing ``id`` and ``name`` values.
+
+turbohtml's :mod:`turbohtml.clean` sanitizer covers the same ground behind a frozen, thread-safe
+:class:`~turbohtml.clean.Policy`, without a JavaScript runtime. ``Policy.strip_template_markers`` is the port of
+``SAFE_FOR_TEMPLATES``, and ``Policy.isolate_named_props`` the port of ``SANITIZE_NAMED_PROPS``. Both run inside the
+single C sanitize walk, so a Python service sanitizes in-process instead of shelling out to Node.
+
+************************
+ turbohtml vs DOMPurify
+************************
+
+.. list-table::
+    :header-rows: 1
+    :widths: 24 38 38
+
+    - - Dimension
+      - turbohtml
+      - DOMPurify
+    - - Runtime
+      - Python, filtering in a C extension
+      - JavaScript, filtering over a browser DOM or ``jsdom``
+    - - Configuration
+      - One frozen ``Policy``, reusable across threads
+      - A config object per ``sanitize`` call
+    - - Template safety
+      - ``Policy.strip_template_markers``
+      - ``SAFE_FOR_TEMPLATES``
+    - - Clobbering defense
+      - ``Policy.isolate_named_props`` (static ``user-content-`` prefix)
+      - ``SANITIZE_NAMED_PROPS`` (static prefix) or ``SANITIZE_DOM`` (live-DOM probe)
+    - - Typing
+      - Fully annotated, ``py.typed``
+      - TypeScript definitions
+    - - Dependencies
+      - None (self-contained C extension)
+      - A DOM: a browser, or ``jsdom`` server-side
+
+DOM clobbering
+==============
+
+An attacker-controlled ``id`` or ``name`` whose value matches a built-in ``document`` or form property shadows that
+property through *named access*. ``<input name="attributes">`` inside a form makes ``form.attributes`` resolve to the
+input rather than the real attribute map; ``<img name="body">`` hides ``document.body``; ``<a id="location">`` can
+stand in for ``document.location`` in code that reads it by name. Sanitizing against an allowlist keeps the element --
+``id`` and ``name`` are ordinary attributes -- so the collision survives the allowlist and only a dedicated defense
+removes it.
+
+DOMPurify's ``SANITIZE_NAMED_PROPS`` moves the value out of the property namespace by prefixing every kept ``id`` and
+``name`` with the constant string ``user-content-``; a value already carrying the prefix is left alone, so re-running
+the sanitizer is a fixpoint. ``Policy.isolate_named_props`` is the same transform, applied in the same C walk that
+enforces the allowlist:
+
+.. code-block:: javascript
+
+    DOMPurify.sanitize(dirty, { SANITIZE_NAMED_PROPS: true });
+
+ports to:
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy
+
+    policy = Policy(
+        tags=frozenset({"form", "input"}),
+        attributes={"form": frozenset({"id"}), "input": frozenset({"name"})},
+        isolate_named_props=True,
+    )
+    print(sanitize('<form id="settings"><input name="attributes"></form>', policy))
+
+.. testoutput::
+
+    <form id="user-content-settings"><input name="user-content-attributes"></form>
+
+The prefix is unconditional on ``id`` and ``name`` -- turbohtml namespaces every kept value rather than probing a live
+DOM for a real collision, so it needs no browser and cannot miss a property the running engine happens to expose.
+DOMPurify's other mode, ``SANITIZE_DOM``, instead *drops* a colliding attribute after testing ``value in document`` at
+sanitize time; that check needs the DOM turbohtml does without, so ``isolate_named_props`` follows the static
+``SANITIZE_NAMED_PROPS`` design. The safety baseline is unaffected either way: ``on*`` handlers, scripting
+elements, and ``javascript:`` URLs are removed regardless of the policy, so isolation is one more layer, never the only
+one.
+
+Template safety
+===============
+
+``SAFE_FOR_TEMPLATES`` collapses ``{{ }}``, ``${ }``, and ``<% %>`` runs so a sanitized value cannot re-inject once a
+template engine renders it. ``Policy.strip_template_markers`` is the direct port; see :doc:`the how-to
+</how-to/sanitizing>` for a worked example. Both options can be on at once, and both run in the same walk.
+
+Performance
+===========
+
+turbohtml isolates and collapses markers in the same C walk that enforces the allowlist, so neither option adds a pass.
+The table times both libraries end-to-end; the DOMPurify figure is its Node runner over stdin on ``isomorphic-dompurify``,
+the cost a Python service pays to reach it as a subprocess, DOM startup included.
+
+.. bench-table::
+    :file: bench/dompurify.json

--- a/docs/migration/dompurify.rst
+++ b/docs/migration/dompurify.rst
@@ -48,10 +48,9 @@ DOM clobbering
 
 An attacker-controlled ``id`` or ``name`` whose value matches a built-in ``document`` or form property shadows that
 property through *named access*. ``<input name="attributes">`` inside a form makes ``form.attributes`` resolve to the
-input rather than the real attribute map; ``<img name="body">`` hides ``document.body``; ``<a id="location">`` can
-stand in for ``document.location`` in code that reads it by name. Sanitizing against an allowlist keeps the element --
-``id`` and ``name`` are ordinary attributes -- so the collision survives the allowlist and only a dedicated defense
-removes it.
+input rather than the real attribute map; ``<img name="body">`` hides ``document.body``; ``<a id="location">`` can stand
+in for ``document.location`` in code that reads it by name. Sanitizing against an allowlist keeps the element -- ``id``
+and ``name`` are ordinary attributes -- so the collision survives the allowlist and only a dedicated defense removes it.
 
 DOMPurify's ``SANITIZE_NAMED_PROPS`` moves the value out of the property namespace by prefixing every kept ``id`` and
 ``name`` with the constant string ``user-content-``; a value already carrying the prefix is left alone, so re-running
@@ -83,9 +82,8 @@ The prefix is unconditional on ``id`` and ``name`` -- turbohtml namespaces every
 DOM for a real collision, so it needs no browser and cannot miss a property the running engine happens to expose.
 DOMPurify's other mode, ``SANITIZE_DOM``, instead *drops* a colliding attribute after testing ``value in document`` at
 sanitize time; that check needs the DOM turbohtml does without, so ``isolate_named_props`` follows the static
-``SANITIZE_NAMED_PROPS`` design. The safety baseline is unaffected either way: ``on*`` handlers, scripting
-elements, and ``javascript:`` URLs are removed regardless of the policy, so isolation is one more layer, never the only
-one.
+``SANITIZE_NAMED_PROPS`` design. The safety baseline is unaffected either way: ``on*`` handlers, scripting elements, and
+``javascript:`` URLs are removed regardless of the policy, so isolation is one more layer, never the only one.
 
 Template safety
 ===============
@@ -98,8 +96,8 @@ Performance
 ===========
 
 turbohtml isolates and collapses markers in the same C walk that enforces the allowlist, so neither option adds a pass.
-The table times both libraries end-to-end; the DOMPurify figure is its Node runner over stdin on ``isomorphic-dompurify``,
-the cost a Python service pays to reach it as a subprocess, DOM startup included.
+The table times both libraries end-to-end; the DOMPurify figure is its Node runner over stdin on
+``isomorphic-dompurify``, the cost a Python service pays to reach it as a subprocess, DOM startup included.
 
 .. bench-table::
     :file: bench/dompurify.json

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -332,6 +332,15 @@ JavaScript with :func:`~turbohtml.clean.minify_js` -- every minifier value-safe.
       - .. image:: https://img.shields.io/npm/dt/sanitize-html
             :alt: sanitize-html total downloads
             :target: https://www.npmjs.com/package/sanitize-html
+    - - 15
+      - :doc:`DOMPurify <dompurify>`
+      - `docs <https://github.com/cure53/DOMPurify>`__
+      - .. image:: https://img.shields.io/npm/dm/dompurify
+            :alt: DOMPurify monthly downloads
+            :target: https://www.npmjs.com/package/dompurify
+      - .. image:: https://img.shields.io/npm/dt/dompurify
+            :alt: DOMPurify total downloads
+            :target: https://www.npmjs.com/package/dompurify
 
 *********
  Convert
@@ -713,6 +722,7 @@ GitHub-Flavored Markdown, and :meth:`turbohtml.Node.to_text` extracts rendered t
     bleach
     nh3
     sanitize-html
+    dompurify
     lxml-html-clean
     rcssmin
     rjsmin

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -70,6 +70,27 @@ must be allowlisted to survive:
 
     <strong>bold</strong> and <div class="center">middle</div>
 
+``Policy.isolate_named_props`` prefixes every kept ``id`` and ``name`` value with ``user-content-``, DOMPurify's
+``SANITIZE_NAMED_PROPS``. It stops DOM clobbering -- an ``id`` or ``name`` whose value matches a built-in ``document``
+or form property shadows that property through named access -- by moving the value out of the property namespace. An
+already-prefixed value is left alone, so re-sanitizing is a fixpoint. The isolation is applied after
+``attribute_filter``, so the value a filter returns is the one that gets namespaced:
+
+.. testcode::
+
+    from turbohtml.clean import sanitize, Policy
+
+    policy = Policy(
+        tags=frozenset({"input"}),
+        attributes={"input": frozenset({"name"})},
+        isolate_named_props=True,
+    )
+    print(sanitize('<input name="attributes">', policy))
+
+.. testoutput::
+
+    <input name="user-content-attributes">
+
 .. autoclass:: Transform
 
 .. autoclass:: OnDisallowed

--- a/docs/tutorials/editing.rst
+++ b/docs/tutorials/editing.rst
@@ -84,6 +84,24 @@ re-checked -- modernizing legacy tags while the safety baseline still applies:
 
     <div class="center"><strong>Old</strong> <em>markup</em></div>
 
+The same pass can defuse DOM clobbering. An ``id`` or ``name`` whose value matches a built-in property
+(``form.attributes``, ``document.body``) shadows it through named access, and the allowlist keeps such an attribute
+because it is otherwise ordinary. Turn on ``isolate_named_props`` to prefix every kept ``id`` and ``name`` value with
+``user-content-``, moving it out of the property namespace:
+
+.. testcode::
+
+    policy = Policy(
+        tags=frozenset({"form", "input"}),
+        attributes={"form": frozenset({"id"}), "input": frozenset({"name"})},
+        isolate_named_props=True,
+    )
+    print(sanitize('<form id="settings"><input name="attributes"></form>', policy))
+
+.. testoutput::
+
+    <form id="user-content-settings"><input name="user-content-attributes"></form>
+
 When you serialize, set an ``Html`` config's ``layout`` to a :class:`~turbohtml.Minify` to shrink the output without
 changing what it means: it folds insignificant whitespace, omits optional tags, unquotes safe attributes, and strips
 comments, and the result reparses to the same tree. Here the ``</li>`` tags stay because real whitespace separates the

--- a/src/turbohtml/_c/features/sanitize.c
+++ b/src/turbohtml/_c/features/sanitize.c
@@ -44,8 +44,10 @@ typedef struct {
     int allow_relative;
     int on_disallowed;
     int strip_comments;
-    int strip_templates; /* SAFE_FOR_TEMPLATES: collapse {{ }}, ${ }, <% %> runs so kept text/attrs stay template-safe
-                          */
+    int strip_templates;     /* SAFE_FOR_TEMPLATES: collapse {{ }}, ${ }, <% %> runs so kept text/attrs stay
+                                template-safe */
+    int isolate_named_props; /* SANITIZE_NAMED_PROPS: prefix kept id/name values with "user-content-" so they cannot
+                                shadow a document/form named property (DOM clobbering) */
 } sanitizer;
 
 /* Append one dropped item to the audit list when reporting is on: (tag, None) for a removed or escaped element, (tag,
@@ -1033,6 +1035,47 @@ static int strip_attr_templates(sanitizer *s, th_node *element, th_node_attr *at
     return status;
 }
 
+/* DOMPurify's SANITIZE_NAMED_PROPS. An attacker-controlled id or name whose value matches a built-in document or form
+   property name shadows that property through named access -- DOM clobbering, where `<input name="attributes">` makes
+   `form.attributes` resolve to the input and `<img name="body">` hides `document.body`. Prefixing every kept id/name
+   value with "user-content-" moves it out of the property namespace, so no value can collide with a real property
+   name; the prefix is left in place when already present, so re-sanitizing is a fixpoint. A bare id/name carries no
+   value to shadow with, but is prefixed all the same so the isolation is unconditional on the two attributes.
+   Returns 0, or -1 on allocation failure. */
+static int prefix_named_prop(sanitizer *s, th_node *element, const th_node_attr *attr) {
+    Py_ssize_t name_len = 0;
+    const char *name = th_attr_name(s->tree, attr->name_atom, &name_len);
+    if (!((name_len == 2 && memcmp(name, "id", 2) == 0) || (name_len == 4 && memcmp(name, "name", 4) == 0))) {
+        return 0; /* only id and name expose named-property access, so no other attribute is isolated */
+    }
+    static const char prefix[] = "user-content-";
+    Py_ssize_t prefix_len = (Py_ssize_t)(sizeof(prefix) - 1);
+    const Py_UCS4 *value = attr->value;
+    Py_ssize_t len = value == NULL ? 0 : attr->value_len;
+    if (len >= prefix_len) {
+        int already = 1;
+        for (Py_ssize_t index = 0; already && index < prefix_len; index++) {
+            already = value[index] == (Py_UCS4)prefix[index];
+        }
+        if (already) {
+            return 0; /* already isolated, so re-prefixing would double the marker and corrupt the value */
+        }
+    }
+    Py_UCS4 *out = PyMem_Malloc((size_t)(prefix_len + len) * sizeof(Py_UCS4));
+    if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    for (Py_ssize_t index = 0; index < prefix_len; index++) {
+        out[index] = (Py_UCS4)prefix[index];
+    }
+    if (len > 0) { /* a bare id/name has no value to copy; the prefix alone becomes its value */
+        memcpy(out + prefix_len, value, (size_t)len * sizeof(Py_UCS4));
+    }
+    int status = th_node_attr_set(s->tree, element, name, name_len, out, prefix_len + len, 1);
+    PyMem_Free(out);
+    return status;
+}
+
 static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
     Py_ssize_t index = 0;
     while (index < element->attr_count) {
@@ -1120,6 +1163,13 @@ static int sanitize_attributes(sanitizer *s, th_node *element, PyObject *tag) {
             if (element->attr_count < before) {
                 continue; /* the filter deleted it */
             }
+        }
+        /* Isolate last, after the filter has had its say, so the value it returns is what gets namespaced and no
+           attribute_filter can leave a clobbering value un-prefixed. Re-fetch the slot: a set above may have
+           reallocated the attribute array. prefix_named_prop only fails on allocation, which no test can force. */
+        th_node_attr *slot = &element->attrs[index];
+        if (s->isolate_named_props && prefix_named_prop(s, element, slot) < 0) { /* GCOVR_EXCL_BR_LINE */
+            return -1;                                                           /* GCOVR_EXCL_LINE */
         }
         index++;
     }
@@ -1523,18 +1573,18 @@ static int require_prefixes(PyObject *prefixes) {
 
 /* _sanitize(element, tags, attributes, url_schemes, allow_relative, on_disallowed, strip_comments, add_link_rel,
    attribute_filter, set_attributes, remove_with_content, css_properties, attribute_prefixes, attribute_values,
-   media_hosts, strip_templates, removed, allowed_styles, transform_tags) -> None. Filters the fragment in place;
-   sanitizer.py serializes it. `removed` is a list the walk appends (tag, attr_or_None) records to, or None to skip the
-   audit. */
+   media_hosts, strip_templates, removed, allowed_styles, transform_tags, isolate_named_props) -> None. Filters the
+   fragment in place; sanitizer.py serializes it. `removed` is a list the walk appends (tag, attr_or_None) records to,
+   or None to skip the audit. */
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args) {
     PyObject *element;
     PyObject *removed = NULL;
     sanitizer s = {0};
-    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOpOOO:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
+    if (!PyArg_ParseTuple(args, "OOOOpipOOOOOOOOpOOOp:_sanitize", &element, &s.tags, &s.attributes, &s.url_schemes,
                           &s.allow_relative, &s.on_disallowed, &s.strip_comments, &s.add_link_rel, &s.attribute_filter,
                           &s.set_attributes, &s.remove_with_content, &s.css_properties, &s.attribute_prefixes,
                           &s.attribute_values, &s.media_hosts, &s.strip_templates, &removed, &s.allowed_styles,
-                          &s.transform_tags)) {
+                          &s.transform_tags, &s.isolate_named_props)) {
         return NULL;
     }
     s.removed = removed == Py_None ? NULL : removed;

--- a/src/turbohtml/_sanitizer.py
+++ b/src/turbohtml/_sanitizer.py
@@ -175,6 +175,11 @@ class Policy:
     :param strip_template_markers: collapse template-engine expressions (``{{ }}``, ``${ }``, ``<% %>``) in kept text
         and attribute values to a single space, so sanitized output cannot re-inject when a template engine (Angular,
         Vue, Mustache, EJS, ERB) later renders it. DOMPurify's ``SAFE_FOR_TEMPLATES``; off by default.
+    :param isolate_named_props: prefix every kept ``id`` and ``name`` value with ``user-content-`` so it cannot shadow
+        a built-in ``document`` or form property through named access (DOM clobbering: ``<input name="attributes">``
+        makes ``form.attributes`` resolve to the input, ``<img name="body">`` hides ``document.body``). The prefix is
+        left alone when already present, so re-sanitizing is a fixpoint. DOMPurify's ``SANITIZE_NAMED_PROPS``; off by
+        default.
     """
 
     tags: frozenset[str] = DEFAULT_TAGS
@@ -195,6 +200,7 @@ class Policy:
     strip_template_markers: bool = False
     allowed_styles: Mapping[str, Mapping[str, Sequence[str | re.Pattern[str]]]] = field(default_factory=dict)
     transform_tags: Mapping[str, Transform | str] = field(default_factory=dict)
+    isolate_named_props: bool = False
 
     @classmethod
     def strict(cls) -> Policy:
@@ -323,6 +329,7 @@ class Sanitizer:
             removed,
             self._allowed_styles,
             self._transform_tags,
+            policy.isolate_named_props,
         )
         return root
 

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -66,6 +66,7 @@ def _sanitize(
     removed: list[tuple[str, str | None]] | None,
     allowed_styles: Mapping[str, Mapping[str, tuple[re.Pattern[str], ...]]],
     transform_tags: Mapping[str, tuple[str, Mapping[str, str]]],
+    isolate_named_props: bool,
     /,
 ) -> None: ...
 def annotation_surface(text: str, spans: Iterable[tuple[int, int, str]], /) -> dict[str, list[str]]: ...

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -844,10 +844,10 @@ def test_strip_propagates_a_child_filter_error() -> None:
 def test_sanitize_rejects_non_element() -> None:
     from turbohtml._html import _sanitize  # noqa: PLC0415  # exercising the C argument guard directly
 
-    # the eighteen policy arguments after the element; only the non-element first argument matters to this guard
+    # the nineteen policy arguments after the element; only the non-element first argument matters to this guard
     policy_args = (
         frozenset(), {}, frozenset(), True, 0, True, None, None, {}, frozenset(), frozenset(), frozenset(), {},
-        frozenset(), False, None, {}, {},
+        frozenset(), False, None, {}, {}, False,
     )  # fmt: skip
     with pytest.raises(TypeError):
         _sanitize("not an element", *policy_args)  # ty: ignore[invalid-argument-type]

--- a/tests/clean/test_sanitizer_named_props.py
+++ b/tests/clean/test_sanitizer_named_props.py
@@ -1,0 +1,94 @@
+"""``Policy.isolate_named_props`` (DOMPurify's ``SANITIZE_NAMED_PROPS``): namespace id/name to stop DOM clobbering.
+
+An attacker-set ``id`` or ``name`` whose value matches a built-in ``document`` or form property shadows it through
+named access -- ``<input name="attributes">`` makes ``form.attributes`` resolve to the input, ``<img name="body">``
+hides ``document.body``. With the flag on, every kept id/name value is prefixed with ``user-content-``, moving it out
+of the property namespace so no value can collide; an already-prefixed value is left alone, so re-sanitizing is a
+fixpoint. The flag is off by default and never weakens the safety baseline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml.clean import Policy, Removed, sanitize, sanitize_report
+
+_ALLOW = {
+    "a": frozenset({"id", "href", "hx"}),
+    "form": frozenset({"name"}),
+    "input": frozenset({"name", "id"}),
+    "img": frozenset({"name", "src"}),
+    "p": frozenset({"id", "class"}),
+}
+_TAGS = frozenset({"a", "form", "input", "img", "p"})
+_ON = Policy(tags=_TAGS, attributes=_ALLOW, isolate_named_props=True)
+_OFF = Policy(tags=_TAGS, attributes=_ALLOW)
+
+
+@pytest.mark.parametrize(
+    ("fragment", "expected"),
+    [
+        pytest.param(
+            '<a id="location" href="http://x/">x</a>',
+            '<a id="user-content-location" href="http://x/">x</a>',
+            id="id-collision-prefixed",
+        ),
+        pytest.param(
+            '<input name="attributes">', '<input name="user-content-attributes">', id="name-collision-prefixed"
+        ),
+        pytest.param(
+            '<img name="body" src="http://x/i.png">',
+            '<img name="user-content-body" src="http://x/i.png">',
+            id="name-prefixed-url-kept",
+        ),
+        pytest.param('<a id="user-content-foo">y</a>', '<a id="user-content-foo">y</a>', id="already-prefixed-untouched"),
+        pytest.param(
+            '<a id="user-shortmismatch">y</a>',
+            '<a id="user-content-user-shortmismatch">y</a>',
+            id="shares-lead-then-differs",
+        ),
+        pytest.param('<a id="x">y</a>', '<a id="user-content-x">y</a>', id="short-value-prefixed"),
+        pytest.param('<a id="">y</a>', '<a id="user-content-">y</a>', id="empty-value-prefixed"),
+        pytest.param('<a id>y</a>', '<a id="user-content-">y</a>', id="bare-attribute-prefixed"),
+        pytest.param('<a href="http://x/">y</a>', '<a href="http://x/">y</a>', id="href-not-a-named-prop"),
+        pytest.param('<a hx="q">y</a>', '<a hx="q">y</a>', id="two-char-non-id-untouched"),
+        pytest.param(
+            '<p class="c" id="menu">t</p>', '<p class="c" id="user-content-menu">t</p>', id="only-id-among-siblings"
+        ),
+    ],
+)
+def test_isolate_named_props_on(fragment: str, expected: str) -> None:
+    assert sanitize(fragment, _ON) == expected
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        pytest.param('<a id="location" href="http://x/">x</a>', id="id"),
+        pytest.param('<input name="attributes">', id="name"),
+        pytest.param('<a hx="q">y</a>', id="other-attribute"),
+    ],
+)
+def test_isolate_named_props_off_by_default(fragment: str) -> None:
+    assert sanitize(fragment, _OFF) == fragment
+
+
+def test_isolate_named_props_is_a_fixpoint() -> None:
+    once = sanitize('<input name="attributes"><a id="location">x</a>', _ON)
+    assert sanitize(once, _ON) == once
+
+
+def test_isolate_named_props_runs_after_attribute_filter() -> None:
+    policy = Policy(
+        tags=frozenset({"a"}),
+        attributes={"a": frozenset({"id"})},
+        attribute_filter=lambda _tag, name, value: value.upper() if name == "id" else value,
+        isolate_named_props=True,
+    )
+    assert sanitize('<a id="menu">x</a>', policy) == '<a id="user-content-MENU">x</a>'
+
+
+def test_isolate_named_props_keeps_safety_baseline() -> None:
+    html, removed = sanitize_report('<a id="x" onclick="e()">t</a><script>bad()</script>', _ON)
+    assert html == '<a id="user-content-x">t</a>&lt;script&gt;bad()&lt;/script&gt;'
+    assert removed == [Removed("a", "onclick"), Removed("script")]

--- a/tests/clean/test_sanitizer_named_props.py
+++ b/tests/clean/test_sanitizer_named_props.py
@@ -41,7 +41,9 @@ _OFF = Policy(tags=_TAGS, attributes=_ALLOW)
             '<img name="user-content-body" src="http://x/i.png">',
             id="name-prefixed-url-kept",
         ),
-        pytest.param('<a id="user-content-foo">y</a>', '<a id="user-content-foo">y</a>', id="already-prefixed-untouched"),
+        pytest.param(
+            '<a id="user-content-foo">y</a>', '<a id="user-content-foo">y</a>', id="already-prefixed-untouched"
+        ),
         pytest.param(
             '<a id="user-shortmismatch">y</a>',
             '<a id="user-content-user-shortmismatch">y</a>',
@@ -49,7 +51,7 @@ _OFF = Policy(tags=_TAGS, attributes=_ALLOW)
         ),
         pytest.param('<a id="x">y</a>', '<a id="user-content-x">y</a>', id="short-value-prefixed"),
         pytest.param('<a id="">y</a>', '<a id="user-content-">y</a>', id="empty-value-prefixed"),
-        pytest.param('<a id>y</a>', '<a id="user-content-">y</a>', id="bare-attribute-prefixed"),
+        pytest.param("<a id>y</a>", '<a id="user-content-">y</a>', id="bare-attribute-prefixed"),
         pytest.param('<a href="http://x/">y</a>', '<a href="http://x/">y</a>', id="href-not-a-named-prop"),
         pytest.param('<a hx="q">y</a>', '<a hx="q">y</a>', id="two-char-non-id-untouched"),
         pytest.param(

--- a/tests/clean/test_sanitizer_namespace.py
+++ b/tests/clean/test_sanitizer_namespace.py
@@ -38,12 +38,12 @@ def _sanitize_tree(root: Element, tags: frozenset[str]) -> str:
     """Run the C sanitizer in place over a pre-built tree, removing every disallowed node's subtree."""
     # named to keep the boolean positional arguments off the FBT003 lint, not to document them
     allow_relative = strip_comments = True
-    strip_templates = False
+    strip_templates = isolate_named_props = False
     empty: frozenset[str] = frozenset()
     schemes = frozenset({"http", "https", "mailto"})
     _sanitize(
         root, tags, {}, schemes, allow_relative, OnDisallowed.REMOVE.value, strip_comments, None, None, {}, empty,
-        empty, empty, {}, empty, strip_templates, None, {}, {},
+        empty, empty, {}, empty, strip_templates, None, {}, {}, isolate_named_props,
     )  # fmt: skip
     return root.inner_html
 

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -113,6 +113,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "structured": ("structured-spec", _spec),
     "sanitize": ("sanitize-spec", _spec),
     "sanitize-templates": ("sanitize-templates-spec", _spec),
+    "sanitize-named-props": ("sanitize-named-props-spec", _spec),
     "sanitize-report": ("sanitize-report-spec", _spec),
     "sanitize-styles": ("sanitize-styles-spec", _spec),
     "sanitize-transform": ("sanitize-transform-spec", _spec),

--- a/tools/bench/competitors/dompurify.py
+++ b/tools/bench/competitors/dompurify.py
@@ -1,9 +1,11 @@
 """
-DOMPurify (via isomorphic-dompurify): the reference SAFE_FOR_TEMPLATES sanitizer, run as a Node subprocess.
+DOMPurify (via isomorphic-dompurify): the reference HTML sanitizer, run as a Node subprocess.
 
 DOMPurify is JavaScript, so it runs through a small committed Node runner over stdin, the way the JS minifiers do. Its
-``SAFE_FOR_TEMPLATES`` mode is the oracle turbohtml's ``strip_template_markers`` matches; here it is the speed baseline.
-Regenerating the table needs ``npm install`` in ``tools/bench/node`` first (dompurify is a library, not a CLI).
+``SAFE_FOR_TEMPLATES`` mode is the oracle turbohtml's ``strip_template_markers`` matches, and its
+``SANITIZE_NAMED_PROPS`` mode the oracle ``isolate_named_props`` matches; here each is the speed baseline for its
+turbohtml counterpart. Regenerating the table needs ``npm install`` in ``tools/bench/node`` first (dompurify is a
+library, not a CLI).
 """
 
 from __future__ import annotations
@@ -16,9 +18,22 @@ REQUIREMENTS = ()
 _RUNNER = str(Path(__file__).resolve().parent.parent / "node" / "dompurify_runner.js")
 
 
+def _run(mode: str, text: str) -> str:
+    """Pipe ``text`` through the Node runner in ``mode`` and read the sanitized result back."""
+    return subprocess.run(["node", _RUNNER, mode], input=text, capture_output=True, text=True, check=True).stdout
+
+
 def sanitize_templates(text: str) -> str:
-    """Sanitize a document with DOMPurify's SAFE_FOR_TEMPLATES on, piping it through the Node runner."""
-    return subprocess.run(["node", _RUNNER], input=text, capture_output=True, text=True, check=True).stdout
+    """Sanitize a document with DOMPurify's SAFE_FOR_TEMPLATES on."""
+    return _run("templates", text)
 
 
-OPERATIONS = {"sanitize-templates": (sanitize_templates, "DOMPurify")}
+def sanitize_named_props(text: str) -> str:
+    """Sanitize a document with DOMPurify's SANITIZE_NAMED_PROPS on, prefixing id/name with ``user-content-``."""
+    return _run("named-props", text)
+
+
+OPERATIONS = {
+    "sanitize-templates": (sanitize_templates, "DOMPurify"),
+    "sanitize-named-props": (sanitize_named_props, "DOMPurify"),
+}

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -66,6 +66,16 @@ _SANITIZER_TRANSFORM = _clean.Sanitizer(
         },
     )
 )
+# allow id/name broadly and keep the form controls that carry the clobbering-prone values, so isolation prefixes most
+# attributes rather than skipping a value it never touches
+_SANITIZER_NAMED_PROPS = _clean.Sanitizer(
+    replace(
+        _RELAXED,
+        attributes={**_RELAXED.attributes, "*": frozenset({"id", "name", "title", "lang", "dir"})},
+        tags=_RELAXED.tags | {"form", "input"},
+        isolate_named_props=True,
+    )
+)
 _LINKS_BASE = "https://example.com/base/"
 _URL_HINT_BASE = "http://site.com/"
 _FIND_TEXT_PATTERN = re.compile(r"test")  # ubiquitous in the wpt corpus, so the predicate does real work
@@ -298,6 +308,11 @@ def sanitize(text: str) -> None:
 def sanitize_templates(text: str) -> None:
     """Sanitize with SAFE_FOR_TEMPLATES on, collapsing template markers as the C walk keeps each node."""
     _SANITIZER_TEMPLATES.sanitize(text)
+
+
+def sanitize_named_props(text: str) -> None:
+    """Sanitize with SANITIZE_NAMED_PROPS on, prefixing each kept id/name value in the same C walk."""
+    _SANITIZER_NAMED_PROPS.sanitize(text)
 
 
 def sanitize_report(text: str) -> None:
@@ -610,6 +625,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "syndication": (syndication, "turbohtml"),
     "sanitize": (sanitize, "turbohtml"),
     "sanitize-templates": (sanitize_templates, "turbohtml"),
+    "sanitize-named-props": (sanitize_named_props, "turbohtml"),
     "sanitize-report": (sanitize_report, "turbohtml"),
     "sanitize-styles": (sanitize_styles, "turbohtml"),
     "sanitize-transform": (sanitize_transform, "turbohtml"),

--- a/tools/bench/node/dompurify_runner.js
+++ b/tools/bench/node/dompurify_runner.js
@@ -1,6 +1,14 @@
-// Sanitize stdin with DOMPurify's SAFE_FOR_TEMPLATES on, the competitor for turbohtml's strip_template_markers.
-// The bench (tools/bench/competitors/dompurify.py) pipes one document in and reads the sanitized result back.
+// Sanitize stdin with DOMPurify, the competitor for turbohtml's sanitizer. The mode (argv[2]) picks the config the
+// bench (tools/bench/competitors/dompurify.py) is timing: "templates" turns on SAFE_FOR_TEMPLATES (the oracle for
+// strip_template_markers), "named-props" turns on SANITIZE_NAMED_PROPS (the oracle for isolate_named_props). One
+// document is piped in and the sanitized result is read back.
 const DOMPurify = require("isomorphic-dompurify");
+
+const CONFIGS = {
+  templates: { SAFE_FOR_TEMPLATES: true },
+  "named-props": { SANITIZE_NAMED_PROPS: true },
+};
+const config = CONFIGS[process.argv[2] || "templates"];
 
 let input = "";
 process.stdin.setEncoding("utf8");
@@ -8,5 +16,5 @@ process.stdin.on("data", (chunk) => {
   input += chunk;
 });
 process.stdin.on("end", () => {
-  process.stdout.write(DOMPurify.sanitize(input, { SAFE_FOR_TEMPLATES: true }));
+  process.stdout.write(DOMPurify.sanitize(input, config));
 });

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -106,6 +106,16 @@ _SANITIZE_LEGACY = dedent("""\
     <blockquote><b>Quote</b> from <i>an author</i> with a <font color=red>colored</font> aside.</blockquote>
     <ul><li><b>one</b></li><li><i>two</i></li><li><tt>three</tt></li></ul>""")
 
+# dense in id/name attributes whose values collide with document/form properties (DOM clobbering), so the named-prop
+# isolation prefixes most attributes rather than skipping past a value it never touches
+_SANITIZE_NAMED = dedent("""\
+    <form name="config" id="settings">
+      <input name="attributes" id="body"><input name="method" id="location">
+      <input name="submit" id="cookie"><input name="nodeName" id="documentElement">
+      <a id="forms" name="images" href="http://example.com/x">links</a>
+      <a id="anchors" name="scripts" href="http://example.com/y">scripts</a>
+    </form>""")
+
 # rich in style attributes with a mix of pattern-matching and rejected values, so the allowed_styles scrub does real
 # per-declaration regex work rather than short-circuiting on an empty rule
 _SANITIZE_STYLES = dedent("""\
@@ -167,6 +177,7 @@ OPERATIONS: dict[str, Operation] = {
     "syndication": Operation("RSS/Atom feed parsing", "us"),
     "sanitize": Operation("sanitize", "us"),
     "sanitize-templates": Operation("sanitize (template-safe)", "us"),
+    "sanitize-named-props": Operation("sanitize (named-prop isolation)", "us"),
     "sanitize-report": Operation("sanitize with audit trail", "us"),
     "sanitize-styles": Operation("sanitize (style allowlist)", "us"),
     "sanitize-transform": Operation("sanitize (tag transform)", "us"),
@@ -476,6 +487,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("post 4 KiB", _SANITIZE_POST * 20),
     ),
     "sanitize-templates": lambda: (("templated 4 KiB", _SANITIZE_TEMPLATES * 20),),
+    "sanitize-named-props": lambda: (("clobbering 4 KiB", _SANITIZE_NAMED * 11),),
     "sanitize-report": lambda: (("post 4 KiB", _SANITIZE_POST * 20),),
     "sanitize-styles": lambda: (("styled 4 KiB", _SANITIZE_STYLES * 20),),
     "sanitize-transform": lambda: (("legacy 4 KiB", _SANITIZE_LEGACY * 13),),


### PR DESCRIPTION
Sanitizing against an allowlist keeps `id` and `name` attributes because nothing about them is malformed, so a value an attacker picks to match a built-in property survives the walk. That value then shadows the property through named access: `<input name="attributes">` makes `form.attributes` resolve to the input, `<img name="body">` hides `document.body`, and `<a id="location">` can stand in for `document.location`. 🛡️ DOMPurify hardens against this with `SANITIZE_NAMED_PROPS`; turbohtml had no equivalent, so a policy that allowed `id`/`name` on kept elements left the collision in place.

`Policy.isolate_named_props` closes the gap by prefixing every kept `id` and `name` value with `user-content-`, moving it out of the property namespace so no value can collide. turbohtml sanitizes a parsed tree with no DOM to probe, so it takes the static `SANITIZE_NAMED_PROPS` design rather than `SANITIZE_DOM`'s live `value in document` check: the prefix is unconditional and complete, where a static reimplementation of that check would be a hand-maintained name list that misses whatever property a future engine adds. A value already carrying the prefix is left alone, so re-sanitizing is a fixpoint.

The prefix runs in the existing single C walk, after `attribute_filter` has had its say, so the value a filter returns is what gets namespaced and no filter can hand back a clobbering value the isolation then fails to prefix. 🔒 The option is off by default and the safety baseline stays unconditional: `on*` handlers, scripting elements, and `javascript:` URLs are removed regardless of the policy, so isolation is one more layer rather than the only one.

closes #534
