### PR TITLE
✨ feat(parser): declarative Shadow DOM (`<template shadowrootmode>`)

### DIFF
--- a/docs/changelog/549.feature.rst
+++ b/docs/changelog/549.feature.rst
@@ -1,8 +1,9 @@
-Added declarative Shadow DOM to the parser. When the tree builder meets a ``<template>`` carrying a ``shadowrootmode`` of
-``open`` or ``closed`` on a valid shadow host, it attaches a shadow root to the template's parent and parses the
+Added declarative Shadow DOM to the parser. When the tree builder meets a ``<template>`` carrying a ``shadowrootmode``
+of ``open`` or ``closed`` on a valid shadow host, it attaches a shadow root to the template's parent and parses the
 template's content into it, reusing the Shadow DOM tree model -- the template element never joins the light tree.
 ``shadowrootdelegatesfocus`` and ``shadowrootclonable`` set the matching flags, readable as the new
-:attr:`~turbohtml.ShadowRoot.delegates_focus` and :attr:`~turbohtml.ShadowRoot.clonable` properties. Following the WHATWG
-per-document flag, :func:`turbohtml.parse` honors declarative shadow roots by default (a browser navigation) while
-:func:`turbohtml.parse_fragment` does not (an ``innerHTML`` assignment); the new ``allow_declarative_shadow_roots``
-argument flips either default, matching ``setHTMLUnsafe`` when turned on for a fragment.
+:attr:`~turbohtml.ShadowRoot.delegates_focus` and :attr:`~turbohtml.ShadowRoot.clonable` properties. Following the
+WHATWG per-document flag, :func:`turbohtml.parse` honors declarative shadow roots by default (a browser navigation)
+while :func:`turbohtml.parse_fragment` does not (an ``innerHTML`` assignment); the new
+``allow_declarative_shadow_roots`` argument flips either default, matching ``setHTMLUnsafe`` when turned on for a
+fragment.

--- a/docs/changelog/549.feature.rst
+++ b/docs/changelog/549.feature.rst
@@ -1,0 +1,8 @@
+Added declarative Shadow DOM to the parser. When the tree builder meets a ``<template>`` carrying a ``shadowrootmode`` of
+``open`` or ``closed`` on a valid shadow host, it attaches a shadow root to the template's parent and parses the
+template's content into it, reusing the Shadow DOM tree model -- the template element never joins the light tree.
+``shadowrootdelegatesfocus`` and ``shadowrootclonable`` set the matching flags, readable as the new
+:attr:`~turbohtml.ShadowRoot.delegates_focus` and :attr:`~turbohtml.ShadowRoot.clonable` properties. Following the WHATWG
+per-document flag, :func:`turbohtml.parse` honors declarative shadow roots by default (a browser navigation) while
+:func:`turbohtml.parse_fragment` does not (an ``innerHTML`` assignment); the new ``allow_declarative_shadow_roots``
+argument flips either default, matching ``setHTMLUnsafe`` when turned on for a fragment.

--- a/docs/explanation/shadow-dom.rst
+++ b/docs/explanation/shadow-dom.rst
@@ -43,12 +43,35 @@ assigned (or fallback) nodes, and an ordinary node yields its own children with 
 recursively to compose a whole subtree. Nested shadow slots forward correctly: a slot whose fallback is another shadow
 slot expands through both.
 
+**************************
+ Declarative shadow roots
+**************************
+
+Shadow trees also arrive in the markup. A ``<template shadowrootmode>`` is *declarative shadow DOM*: the server writes
+the shadow tree inline, and the parser -- not a script -- attaches it, so the encapsulation is in place the moment the
+document is parsed. turbohtml implements the WHATWG tree-construction steps directly in the C tree builder. When a
+``<template>`` start tag carries a ``shadowrootmode`` of ``open`` or ``closed`` and its parent is a valid shadow host,
+the builder attaches a shadow root to that parent (reusing the same off-tree shadow node and host table as
+:meth:`Element.attach_shadow`) and redirects the template's content into it. The template element is created only on the
+stack of open elements, never inserted into the light tree, so it vanishes once its content is parsed -- leaving just
+the populated shadow root. ``shadowrootdelegatesfocus`` and ``shadowrootclonable`` set the corresponding flags, readable
+as :attr:`ShadowRoot.delegates_focus` and :attr:`ShadowRoot.clonable`.
+
+The spec gates this on a per-document *allow declarative shadow roots* flag, and turbohtml follows it: whole-document
+:func:`parse` sets it on, matching a browser navigating to the page, while :func:`parse_fragment` leaves it off,
+matching an ``innerHTML`` assignment. The ``allow_declarative_shadow_roots`` argument on each flips that default --
+turning it off for a document treats a stray ``shadowrootmode`` as an ordinary template, and turning it on for a
+fragment matches the browser's ``setHTMLUnsafe``. Two guards keep the transform faithful: the host must be a valid
+shadow host (a flow-content element or a hyphenated custom-element name, the DOM's *valid shadow host name*), and a
+parent that already hosts a shadow root keeps its first one, so a second declarative template stays a plain template
+rather than replacing it.
+
 ****************
  What it is not
 ****************
 
 This is the tree model, not a rendering or scripting engine. There are no lifecycle callbacks, no ``slotchange`` events,
-and no style scoping -- turbohtml has no layout or CSS cascade across the boundary to scope. Declarative shadow DOM (the
-``<template shadowrootmode>`` parser sugar) builds on this model separately. What you get is the structural core: attach
-open and closed roots, assign named and default slots, read the assignment both ways, and flatten the composed tree --
-enough to build, inspect, and transform shadow-DOM markup with the same typed, C-backed API as the rest of the tree.
+and no style scoping -- turbohtml has no layout or CSS cascade across the boundary to scope. What you get is the
+structural core: attach open and closed roots (imperatively or declaratively from markup), assign named and default
+slots, read the assignment both ways, and flatten the composed tree -- enough to build, inspect, and transform
+shadow-DOM markup with the same typed, C-backed API as the rest of the tree.

--- a/docs/how-to/shadow-dom.rst
+++ b/docs/how-to/shadow-dom.rst
@@ -81,6 +81,49 @@ The named child lands in the ``title`` slot; the plain paragraph lands in the un
 back to its own children instead, and ``assigned_nodes(flatten=True)`` returns that fallback (expanding any nested
 shadow slots along the way).
 
+*********************************
+ Parse a declarative shadow root
+*********************************
+
+A server can ship a shadow tree in the markup itself with a ``<template shadowrootmode>``. When :func:`parse` meets one,
+it attaches a shadow root to the template's parent and parses the template's content into it, exactly as a browser does
+on navigation -- so the shadow tree is there before any script runs. The template element is consumed: it never joins
+the light tree. ``shadowrootmode`` is ``"open"`` or ``"closed"``, and ``shadowrootdelegatesfocus`` /
+``shadowrootclonable`` set the matching flags:
+
+.. testcode::
+
+    from turbohtml import parse
+
+    doc = parse(
+        "<article id=post>"
+        '<template shadowrootmode="open" shadowrootclonable>'
+        "<h1><slot name=title></slot></h1><slot></slot>"
+        "</template>"
+        '<span slot="title">Hello</span><p>World</p>'
+        "</article>"
+    )
+    post = doc.find(id="post")
+    root = post.shadow_root
+    print(root.mode, root.clonable)
+    print(root.html)
+    print(post.html)
+
+.. testoutput::
+
+    open True
+    <h1><slot name="title"></slot></h1><slot></slot>
+    <article id="post"><span slot="title">Hello</span><p>World</p></article>
+
+The shadow root's slots compose the host's light children just like a scripted one, so ``assigned_nodes`` and
+``flattened_children`` work unchanged. A closed root reads ``None`` from :attr:`Element.shadow_root`, but its content is
+still reachable through :attr:`Node.flattened_children`.
+
+Only a valid shadow host (a flow-content element such as ``div``, ``section``, ``span``, or a custom element with a
+hyphenated name) takes a declarative root; on any other parent the template stays an ordinary template. Whole-document
+:func:`parse` allows declarative shadow roots by default; :func:`parse_fragment` does not -- pass
+``allow_declarative_shadow_roots=True`` to opt in, matching the browser's ``setHTMLUnsafe`` rather than ``innerHTML``.
+
 *************************
  Read the flattened tree
 *************************

--- a/docs/migration/parse5.rst
+++ b/docs/migration/parse5.rst
@@ -82,6 +82,32 @@ faster than parse5 measured in-process (Node startup excluded):
 .. bench-table::
     :file: bench/parse5.json
 
+************************
+ Declarative shadow DOM
+************************
+
+parse5 has no shadow-tree model: it builds a plain ``<template>`` element with a content fragment for a ``<template
+shadowrootmode>`` and leaves the shadow-root attachment to its consumer (jsdom does it in its own layer; a custom
+``treeAdapter`` would do it in yours). turbohtml attaches the shadow root in the parser itself and hands it back on the
+host, so there is nothing extra to wire up:
+
+.. testcode::
+
+    from turbohtml import parse
+
+    host = parse("<section id=h><template shadowrootmode=open><slot></slot></template><p>x</p></section>").find(id="h")
+    print(host.shadow_root.mode)
+
+.. testoutput::
+
+    open
+
+The switch maps to the ``allow_declarative_shadow_roots`` option, which follows the WHATWG per-document flag: on by
+default for whole-document :func:`~turbohtml.parse` (a browser navigation), off for :func:`~turbohtml.parse_fragment`
+(an ``innerHTML`` assignment). Read the attached tree through :attr:`~turbohtml.Element.shadow_root`,
+:meth:`~turbohtml.Element.assigned_nodes`, and :attr:`~turbohtml.Node.flattened_children` -- the same API a scripted
+:meth:`~turbohtml.Element.attach_shadow` produces.
+
 ****************
  How to migrate
 ****************
@@ -133,3 +159,7 @@ with plain offsets:
 - **No pluggable tree adapter.** parse5's ``treeAdapter`` lets you build a custom node shape; turbohtml always builds
   its own :class:`~turbohtml.Document`. To feed another toolchain, serialize with :attr:`~turbohtml.Node.html` and
   reparse there.
+- **Declarative shadow is on for documents.** Unlike parse5, turbohtml attaches a shadow root for a ``<template
+  shadowrootmode>`` during a whole-document :func:`~turbohtml.parse`, so such templates leave the light tree. Pass
+  ``allow_declarative_shadow_roots=False`` to keep parse5's plain-template behavior, or opt a fragment in with
+  ``parse_fragment(..., allow_declarative_shadow_roots=True)``.

--- a/docs/reference/parsing.rst
+++ b/docs/reference/parsing.rst
@@ -11,8 +11,10 @@ parses a fragment in a context element; :class:`IncrementalParser` builds a docu
 Both :func:`parse` and :func:`parse_fragment` take keyword options: ``encoding`` and ``detect_encoding`` steer decoding
 of ``bytes`` input, ``strict`` turns the first recovered parse error into an exception, ``positions`` records each
 element's source line and column, ``source_locations`` additionally records the granular :class:`SourceLocation` spans
-(read via :attr:`Node.source_location`), and ``scripting`` sets the WHATWG scripting flag so ``<noscript>`` parses as a
-raw-text element. Each is described on the function below.
+(read via :attr:`Node.source_location`), ``scripting`` sets the WHATWG scripting flag so ``<noscript>`` parses as a
+raw-text element, and ``allow_declarative_shadow_roots`` honors a ``<template shadowrootmode>`` by attaching a shadow
+root to its parent (on by default for :func:`parse`, off for :func:`parse_fragment`). Each is described on the function
+below.
 
 .. autofunction:: parse
 

--- a/docs/tutorials/tokenizing.rst
+++ b/docs/tutorials/tokenizing.rst
@@ -144,6 +144,29 @@ The ``<tbody>`` no one wrote is there, and ``stray`` was moved out ahead of the 
 builds, delivered as events rather than nodes. If you prefer callbacks over a loop, subclass
 :class:`~turbohtml.saxparse.SaxHandler` and pass it to :func:`~turbohtml.saxparse.sax_parse`.
 
+The tree builder does more than fill in implied elements while it consumes the token stream. When it meets a
+``<template>`` carrying a ``shadowrootmode``, it attaches a *declarative shadow root* to the template's parent and
+parses the template's content into that shadow tree instead of a template content fragment -- the same markup a browser
+turns into a shadow root. The template element itself never lands in the light tree, so the parent serializes without
+it:
+
+.. testcode::
+
+    from turbohtml import parse
+
+    card = parse("<div id=card><template shadowrootmode=open><slot></slot></template><p>Body</p></div>").find(id="card")
+    print(card.shadow_root.mode)
+    print(card.html)
+
+.. testoutput::
+
+    open
+    <div id="card"><p>Body</p></div>
+
+Declarative shadow roots are honored for whole-document :func:`~turbohtml.parse` by default; pass
+``allow_declarative_shadow_roots=False`` to keep such templates as ordinary elements. See :doc:`/how-to/shadow-dom` for
+working with the shadow tree the parser built.
+
 That is the whole tokenizer API. If you are porting an existing :class:`python:html.parser.HTMLParser` subclass,
 :class:`turbohtml.migration.stdlib.HTMLParser` keeps the same ``handle_*`` callbacks over this tokenizer, so the
 migration is changing the base class. Head to the :doc:`/how-to/index` guides for task-focused recipes or the

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -74,7 +74,7 @@ PyDoc_STRVAR(tokenize_doc, "tokenize(s, /, *, resolve_references=True, capture_s
                            ":raises TypeError: if s is not a str.");
 
 PyDoc_STRVAR(parse_doc, "parse(markup, *, encoding=None, strict=False, detect_encoding=False, positions=True, "
-                        "source_locations=False, scripting=False)\n"
+                        "source_locations=False, scripting=False, allow_declarative_shadow_roots=True)\n"
                         "--\n\n"
                         "Parse a whole HTML document with the WHATWG tree-construction algorithm and\n"
                         "return a navigable Document.\n\n"
@@ -95,6 +95,11 @@ PyDoc_STRVAR(parse_doc, "parse(markup, *, encoding=None, strict=False, detect_en
                         "    raw-text element -- its content is raw text, not markup, and serializes\n"
                         "    unescaped -- reproducing the tree a scripting browser builds. Off by\n"
                         "    default so <noscript> content stays parsed and accessible.\n"
+                        ":param allow_declarative_shadow_roots: honor a <template shadowrootmode>, which\n"
+                        "    attaches a shadow root to its parent element and parses the template's\n"
+                        "    content into it (Element.shadow_root). On by default, matching a browser\n"
+                        "    navigating to the document; pass False to keep such templates as ordinary\n"
+                        "    template elements.\n"
                         ":returns: the parsed Document.\n"
                         ":raises TypeError: if markup is neither a str nor a bytes-like object.\n"
                         ":raises LookupError: if encoding names a codec Python does not know.\n"
@@ -119,7 +124,8 @@ PyDoc_STRVAR(parse_xml_doc, "parse_xml(markup)\n--\n\n"
                             "    ParseError (code, line, col).");
 
 PyDoc_STRVAR(parse_fragment_doc,
-             "parse_fragment(html, context='div', *, positions=True, source_locations=False, scripting=False)\n--\n\n"
+             "parse_fragment(html, context='div', *, positions=True, source_locations=False, scripting=False, "
+             "allow_declarative_shadow_roots=False)\n--\n\n"
              "Parse an HTML fragment as the innerHTML of a context element.\n\n"
              ":param html: the fragment markup.\n"
              ":param context: the context element's tag name, optionally namespaced\n"
@@ -130,6 +136,9 @@ PyDoc_STRVAR(parse_fragment_doc,
              "    per-attribute spans, read via Element.source_location. Implies positions.\n"
              ":param scripting: set the WHATWG scripting flag on, making <noscript> a\n"
              "    raw-text element (see parse). Off by default.\n"
+             ":param allow_declarative_shadow_roots: honor a <template shadowrootmode> by\n"
+             "    attaching a shadow root to its parent (see parse). Off by default, matching\n"
+             "    the innerHTML fragment case; the setHTMLUnsafe path turns it on.\n"
              ":returns: the context Element with the parsed nodes as its children.\n"
              ":raises TypeError: if html or context is not a str.\n"
              ":raises ValueError: if context is not a known element tag.");

--- a/src/turbohtml/_c/dom/binding.c
+++ b/src/turbohtml/_c/dom/binding.c
@@ -16,7 +16,7 @@ PyObject *turbohtml_parse_tree(PyObject *Py_UNUSED(module), PyObject *args) {
     const void *data = PyUnicode_DATA(arg);
     Py_ssize_t length = PyUnicode_GET_LENGTH(arg);
 
-    th_tree *tree = th_tree_parse(kind, data, length, 0, 0, scripting);
+    th_tree *tree = th_tree_parse(kind, data, length, 0, 0, scripting, 1);
     if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: only an allocation failure returns NULL */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
@@ -39,7 +39,7 @@ PyObject *turbohtml_parse_only(PyObject *Py_UNUSED(module), PyObject *arg) {
         PyErr_SetString(PyExc_TypeError, "_parse_only() argument must be str");
         return NULL;
     }
-    th_tree *tree = th_tree_parse(PyUnicode_KIND(arg), PyUnicode_DATA(arg), PyUnicode_GET_LENGTH(arg), 0, 0, 0);
+    th_tree *tree = th_tree_parse(PyUnicode_KIND(arg), PyUnicode_DATA(arg), PyUnicode_GET_LENGTH(arg), 0, 0, 0, 1);
     if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: only an allocation failure returns NULL */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
@@ -56,7 +56,7 @@ PyObject *turbohtml_parse_fragment(PyObject *Py_UNUSED(module), PyObject *args) 
         return NULL;
     }
     th_tree *tree = th_tree_parse_fragment(PyUnicode_KIND(text), PyUnicode_DATA(text), PyUnicode_GET_LENGTH(text),
-                                           context, context_len, 0, 0, scripting);
+                                           context, context_len, 0, 0, scripting, 0);
     if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -677,7 +677,7 @@ static PyObject *decode_windows_1252(const unsigned char *bytes, Py_ssize_t len)
    prescan, then windows-1252), decode with that codec replacing malformed bytes,
    and parse the resulting str. The decoded str is retained as the tree's source. */
 static PyObject *parse_bytes(module_state *state, PyObject *markup, const char *enc_arg, Py_ssize_t enc_len, int strict,
-                             int detect, int positions, int locations, int scripting) {
+                             int detect, int positions, int locations, int scripting, int declarative) {
     Py_buffer view;
     if (PyObject_GetBuffer(markup, &view, PyBUF_SIMPLE) < 0) { /* GCOVR_EXCL_BR_LINE: bytes expose a simple buffer */
         return NULL;                                           /* GCOVR_EXCL_LINE: buffer-acquisition failure */
@@ -738,7 +738,7 @@ static PyObject *parse_bytes(module_state *state, PyObject *markup, const char *
         return NULL;       /* GCOVR_EXCL_LINE: decode failure */
     }
     th_tree *tree = th_tree_parse(PyUnicode_KIND(decoded), PyUnicode_DATA(decoded), PyUnicode_GET_LENGTH(decoded),
-                                  positions, locations, scripting);
+                                  positions, locations, scripting, declarative);
     if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: only an allocation failure returns NULL */
         Py_DECREF(decoded);      /* GCOVR_EXCL_LINE: allocation-failure path */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -858,7 +858,8 @@ PyObject *turbohtml_detect_language(PyObject *module, PyObject *args) {
 
 PyObject *turbohtml_parse(PyObject *module, PyObject *args, PyObject *kwargs) {
     static char *keywords[] = {"markup",    "encoding",         "strict",    "detect_encoding",
-                               "positions", "source_locations", "scripting", NULL};
+                               "positions", "source_locations", "scripting", "allow_declarative_shadow_roots",
+                               NULL};
     PyObject *markup;
     const char *enc_arg = NULL;
     Py_ssize_t enc_len = 0;
@@ -867,14 +868,15 @@ PyObject *turbohtml_parse(PyObject *module, PyObject *args, PyObject *kwargs) {
     int positions = 1;
     int locations = 0;
     int scripting = 0;
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$z#ppppp:parse", keywords, &markup, &enc_arg, &enc_len, &strict,
-                                     &detect, &positions, &locations, &scripting)) {
+    int declarative = 1;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$z#pppppp:parse", keywords, &markup, &enc_arg, &enc_len, &strict,
+                                     &detect, &positions, &locations, &scripting, &declarative)) {
         return NULL;
     }
     module_state *state = PyModule_GetState(module);
     if (PyUnicode_Check(markup)) {
         th_tree *tree = th_tree_parse(PyUnicode_KIND(markup), PyUnicode_DATA(markup), PyUnicode_GET_LENGTH(markup),
-                                      positions, locations, scripting);
+                                      positions, locations, scripting, declarative);
         if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: only an allocation failure returns NULL */
             return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
         }
@@ -887,7 +889,7 @@ PyObject *turbohtml_parse(PyObject *module, PyObject *args, PyObject *kwargs) {
         PyErr_SetString(PyExc_TypeError, "parse() argument must be str or a bytes-like object");
         return NULL;
     }
-    return parse_bytes(state, markup, enc_arg, enc_len, strict, detect, positions, locations, scripting);
+    return parse_bytes(state, markup, enc_arg, enc_len, strict, detect, positions, locations, scripting, declarative);
 }
 
 PyObject *turbohtml_parse_xml(PyObject *module, PyObject *args, PyObject *kwargs) {
@@ -908,15 +910,17 @@ PyObject *turbohtml_parse_xml(PyObject *module, PyObject *args, PyObject *kwargs
 }
 
 PyObject *turbohtml_tree_parse_fragment(PyObject *module, PyObject *args, PyObject *kwargs) {
-    static char *keywords[] = {"html", "context", "positions", "source_locations", "scripting", NULL};
+    static char *keywords[] = {
+        "html", "context", "positions", "source_locations", "scripting", "allow_declarative_shadow_roots", NULL};
     PyObject *text;
     PyObject *context_obj = NULL;
     int positions = 1;
     int locations = 0;
     int scripting = 0;
+    int declarative = 0;
     /* require str: the "s#" format also accepts bytes, which would decode as latin-1 garbage */
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "U|U$ppp:parse_fragment", keywords, &text, &context_obj, &positions,
-                                     &locations, &scripting)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "U|U$pppp:parse_fragment", keywords, &text, &context_obj, &positions,
+                                     &locations, &scripting, &declarative)) {
         return NULL;
     }
     const char *context = "div";
@@ -934,7 +938,7 @@ PyObject *turbohtml_tree_parse_fragment(PyObject *module, PyObject *args, PyObje
         }
     }
     th_tree *tree = th_tree_parse_fragment(PyUnicode_KIND(text), PyUnicode_DATA(text), PyUnicode_GET_LENGTH(text),
-                                           context, context_len, positions, locations, scripting);
+                                           context, context_len, positions, locations, scripting, declarative);
     if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -2576,7 +2576,7 @@ static th_tree *parse_fragment_in_context(th_node *context, PyObject *html, int 
     name[name_len] = '\0';
     Py_DECREF(tag);
     th_tree *fragment = th_tree_parse_fragment(PyUnicode_KIND(html), PyUnicode_DATA(html), PyUnicode_GET_LENGTH(html),
-                                               name, name_len, 0, 0, scripting);
+                                               name, name_len, 0, 0, scripting, 0);
     PyMem_Free(name);
     if (fragment == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         PyErr_NoMemory();   /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/src/turbohtml/_c/dom/shadow.c
+++ b/src/turbohtml/_c/dom/shadow.c
@@ -331,9 +331,22 @@ PyObject *node_get_flattened_children(PyObject *self, void *Py_UNUSED(closure)) 
 
 PyDoc_STRVAR(shadow_root_mode_doc, "the shadow root's mode: 'open' or 'closed'");
 PyDoc_STRVAR(shadow_root_host_doc, "the Element this shadow root is attached to");
+PyDoc_STRVAR(shadow_root_delegates_focus_doc,
+             "whether the shadow root delegates focus, from a declarative shadow root's\n"
+             "shadowrootdelegatesfocus attribute (always False otherwise)");
+PyDoc_STRVAR(shadow_root_clonable_doc, "whether the shadow root is clonable, from a declarative shadow root's\n"
+                                       "shadowrootclonable attribute (always False otherwise)");
 
 static PyObject *shadow_root_get_mode(PyObject *self, void *Py_UNUSED(closure)) {
     return PyUnicode_FromString(th_shadow_mode(((NodeObject *)self)->node) != 0 ? "closed" : "open");
+}
+
+static PyObject *shadow_root_get_delegates_focus(PyObject *self, void *Py_UNUSED(closure)) {
+    return PyBool_FromLong((((NodeObject *)self)->node->tag_flags & TH_SHADOW_DELEGATES_FOCUS) != 0);
+}
+
+static PyObject *shadow_root_get_clonable(PyObject *self, void *Py_UNUSED(closure)) {
+    return PyBool_FromLong((((NodeObject *)self)->node->tag_flags & TH_SHADOW_CLONABLE) != 0);
 }
 
 static PyObject *shadow_root_get_host(PyObject *self, void *Py_UNUSED(closure)) {
@@ -349,6 +362,8 @@ static PyObject *shadow_root_get_host(PyObject *self, void *Py_UNUSED(closure)) 
 static PyGetSetDef shadow_root_getset[] = {
     {"mode", shadow_root_get_mode, NULL, shadow_root_mode_doc, NULL},
     {"host", shadow_root_get_host, NULL, shadow_root_host_doc, NULL},
+    {"delegates_focus", shadow_root_get_delegates_focus, NULL, shadow_root_delegates_focus_doc, NULL},
+    {"clonable", shadow_root_get_clonable, NULL, shadow_root_clonable_doc, NULL},
     {NULL, NULL, NULL, NULL, NULL},
 };
 
@@ -387,7 +402,7 @@ static PyObject *shadow_root_set_inner_html(PyObject *self, PyObject *html) {
     }
     int scripting = th_tree_scripting(tree_of(self));
     th_tree *fragment = th_tree_parse_fragment(PyUnicode_KIND(html), PyUnicode_DATA(html), PyUnicode_GET_LENGTH(html),
-                                               "div", 3, 0, 0, scripting);
+                                               "div", 3, 0, 0, scripting, 1);
     if (fragment == NULL) {      /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -645,7 +645,11 @@ static th_src_loc *build_source_location(th_tree *tree, th_node *node, const th_
     return loc;
 }
 
-static th_node *insert_element(th_tree *tree, const th_token *token) {
+/* Build an element node from a start-tag token -- atom, category flags, source
+   position/spans, name and attributes -- without placing it in the tree. insert_element
+   appends it at the appropriate place; the declarative-shadow path keeps it off the
+   light tree, only on the stack of open elements. NULL on allocation failure. */
+static th_node *build_element(th_tree *tree, const th_token *token) {
     th_node *node = node_new(tree, TH_NODE_ELEMENT);
     if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
@@ -680,6 +684,14 @@ static th_node *insert_element(th_tree *tree, const th_token *token) {
                 dst->value_len = 0;
             }
         }
+    }
+    return node;
+}
+
+static th_node *insert_element(th_tree *tree, const th_token *token) {
+    th_node *node = build_element(tree, token);
+    if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
     }
     th_node *parent, *before;
     insertion_location(tree, &parent, &before);
@@ -840,9 +852,154 @@ static int input_is_hidden(const th_token *token) {
     return 0;
 }
 
-/* Insert a <template> element and give it a content document-fragment child
-   that subsequent insertions are redirected into. */
+/* The start tag's attribute with this lowercased ASCII name (tokenizer names are
+   already lowercased), or NULL. Used for the boolean shadowroot* attributes and to
+   read shadowrootmode's value. A wider-kind name of the same length holds interleaved
+   zero bytes for its ASCII runs, so the byte compare against an all-ASCII literal can
+   never spuriously match. */
+static const th_attr *token_attr(const th_token *token, const char *name, Py_ssize_t name_len) {
+    for (Py_ssize_t index = 0; index < token->attr_count; index++) {
+        const th_attr *attr = &token->attrs[index];
+        if (attr->name.len == name_len && memcmp(attr->name.data, name, (size_t)name_len) == 0) {
+            return attr;
+        }
+    }
+    return NULL;
+}
+
+/* Whether a token buffer equals an ASCII literal, ASCII case-insensitively (an
+   enumerated attribute value like shadowrootmode's matches case-insensitively). */
+static int buf_iequals_ascii(const th_buf *buf, const char *ascii, Py_ssize_t ascii_len) {
+    if (buf->len != ascii_len) {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < ascii_len; index++) {
+        Py_UCS4 ch = buf_read(buf, index);
+        if (ch >= 'A' && ch <= 'Z') {
+            ch += 32;
+        }
+        if (ch != (Py_UCS4)(unsigned char)ascii[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* The shadowrootmode enumerated state of a <template> start tag: 0 none (absent or an
+   invalid value), 1 open, 2 closed. Only open/closed make a declarative shadow root. */
+static int shadowrootmode_state(const th_token *token) {
+    const th_attr *attr = token_attr(token, "shadowrootmode", 14);
+    if (attr == NULL || !attr->has_value) {
+        return 0;
+    }
+    if (buf_iequals_ascii(&attr->value, "open", 4)) {
+        return 1;
+    }
+    if (buf_iequals_ascii(&attr->value, "closed", 6)) {
+        return 2;
+    }
+    return 0;
+}
+
+/* Whether an element may host a shadow root (DOM: a valid shadow host name -- one of
+   the flow-content elements attachShadow accepts, or a custom element name, which the
+   parser lowercases so an interior hyphen is the whole remaining test). host_atom is
+   passed separately so the fragment root can be tested under its context element's
+   atom rather than the html it stands in for. */
+static int is_valid_shadow_host(const th_node *host, uint16_t host_atom) {
+    if (host->ns != TH_NS_HTML) {
+        return 0;
+    }
+    static const uint16_t hostable[] = {
+        TH_TAG_ARTICLE, TH_TAG_ASIDE, TH_TAG_BLOCKQUOTE, TH_TAG_BODY, TH_TAG_DIV,     TH_TAG_FOOTER,
+        TH_TAG_H1,      TH_TAG_H2,    TH_TAG_H3,         TH_TAG_H4,   TH_TAG_H5,      TH_TAG_H6,
+        TH_TAG_HEADER,  TH_TAG_MAIN,  TH_TAG_NAV,        TH_TAG_P,    TH_TAG_SECTION, TH_TAG_SPAN,
+    };
+    for (size_t index = 0; index < sizeof(hostable) / sizeof(hostable[0]); index++) {
+        if (host_atom == hostable[index]) {
+            return 1;
+        }
+    }
+    if (host_atom != TH_TAG_UNKNOWN) {
+        return 0;
+    }
+    /* a valid custom element name has an interior hyphen; the parser has already
+       lowercased the tag name, so a hyphen past the first byte is the whole test */
+    for (Py_ssize_t index = 1; index < host->text_len; index++) {
+        if (host->text[index] == '-') {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* The host a declarative `<template shadowrootmode>` attaches its shadow root to, per
+   the tree-construction steps: the tree must allow declarative shadow roots, the token
+   must carry an open/closed shadowrootmode, and the adjusted current node must be a
+   shadow-hostable element other than the topmost open element that does not already host
+   a shadow root. Sets *closed from the mode; returns NULL to insert a normal template. */
+static th_node *declarative_shadow_host(th_tree *tree, const th_token *token, int *closed) {
+    if (!tree->declarative_shadow) {
+        return NULL;
+    }
+    int state = shadowrootmode_state(token);
+    if (state == 0) {
+        return NULL;
+    }
+    /* The adjusted current node is the host: the context element in the single-element
+       fragment case (the root only stands in for it, so test it under the context atom),
+       otherwise the current node. The spec's "not the topmost element" guard needs no
+       separate test here -- a document's topmost open element is always <html>, which
+       is not a valid shadow host, and the fragment's topmost is handled above. */
+    th_node *host = current_node(tree);
+    uint16_t host_atom = host->atom;
+    if (tree->fragment_root != NULL && tree->open_len == 1) {
+        host = tree->fragment_root;
+        host_atom = tree->ctx_atom;
+    }
+    if (!is_valid_shadow_host(host, host_atom) || th_element_shadow_root(tree, host) != NULL) {
+        return NULL;
+    }
+    *closed = state == 2;
+    return host;
+}
+
+/* Build the template element off the light tree (only on the stack of open elements),
+   attach a shadow root to host carrying the shadowrootdelegatesfocus / shadowrootclonable
+   flags, and redirect the template's content into that shadow root so subsequent
+   insertions populate the shadow tree. NULL on allocation failure. */
+static th_node *insert_declarative_template(th_tree *tree, const th_token *token, th_node *host, int closed) {
+    th_node *tmpl = build_element(tree, token);
+    if (tmpl == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
+    }
+    th_node *shadow = th_element_attach_shadow(tree, host, closed);
+    if (shadow == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
+    }
+    if (token_attr(token, "shadowrootdelegatesfocus", 24) != NULL) {
+        shadow->tag_flags |= TH_SHADOW_DELEGATES_FOCUS;
+    }
+    if (token_attr(token, "shadowrootclonable", 18) != NULL) {
+        shadow->tag_flags |= TH_SHADOW_CLONABLE;
+    }
+    /* the shadow root is the template's content: content parses straight into it, while
+       it stays parentless (off the light tree) so the flattened-tree walks still root
+       every shadow node at the shadow root rather than the discarded template */
+    tmpl->first_child = shadow;
+    tmpl->last_child = shadow;
+    return tmpl;
+}
+
+/* Insert a <template> element. A declarative `<template shadowrootmode>` attaches a
+   shadow root to its parent; every other template gets a content document-fragment
+   child that subsequent insertions are redirected into. */
 static th_node *insert_template(th_tree *tree, const th_token *token) {
+    int closed = 0;
+    th_node *host = declarative_shadow_host(tree, token, &closed);
+    if (host != NULL) {
+        return insert_declarative_template(tree, token, host, closed);
+    }
     th_node *node = insert_element(tree, token);
     if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
@@ -3677,12 +3834,14 @@ static th_tree *tree_new_document(int positions, int locations) {
     return tree;
 }
 
-th_tree *th_tree_parse(int kind, const void *data, Py_ssize_t length, int positions, int locations, int scripting) {
+th_tree *th_tree_parse(int kind, const void *data, Py_ssize_t length, int positions, int locations, int scripting,
+                       int declarative_shadow) {
     th_tree *tree = tree_new_document(positions, locations);
     if (tree == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
     }
     tree->scripting = scripting;
+    tree->declarative_shadow = declarative_shadow;
     tree->kind = kind;
     tree->data = data;
     tree->length = length;
@@ -3743,12 +3902,14 @@ static enum mode fragment_mode(uint16_t ctx) {
 #define MAX_CONTEXT_NAME 32
 
 th_tree *th_tree_parse_fragment(int kind, const void *data, Py_ssize_t length, const char *context,
-                                Py_ssize_t context_len, int positions, int locations, int scripting) {
+                                Py_ssize_t context_len, int positions, int locations, int scripting,
+                                int declarative_shadow) {
     th_tree *tree = PyMem_Calloc(1, sizeof(th_tree));
     if (tree == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
     }
     tree->scripting = scripting;
+    tree->declarative_shadow = declarative_shadow;
     tree->kind = kind;
     tree->data = data;
     tree->length = length;
@@ -3916,6 +4077,7 @@ th_stream *th_stream_new(int positions, int locations) {
         th_stream_free(stream);                       /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;                                  /* GCOVR_EXCL_LINE: allocation-failure path */
     }
+    stream->tree->declarative_shadow = 1; /* a streaming document parse navigates like the browser */
     th_tok_capture_locations(stream->sm, locations);
     run_state_init(&stream->run_state, M_INITIAL);
     return stream;

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -76,6 +76,12 @@ enum th_node_type {
 #define TH_SHADOW_ROOT 0x01u
 #define TH_SHADOW_CLOSED 0x02u
 
+/* Two further content-node bits carry a declarative shadow root's flags, set by the
+   tree builder from a `<template shadowrootmode>` element's shadowrootdelegatesfocus /
+   shadowrootclonable attributes; both clear on a shadow root the mutation API creates. */
+#define TH_SHADOW_DELEGATES_FOCUS 0x04u
+#define TH_SHADOW_CLONABLE 0x08u
+
 /* A comment node the parser built from a `<?` bogus comment (a comment carries no
    element category bits, so this bit is free on it, disjoint from the content-node
    shadow bits above). The SAX walk reads it to report the node as a processing
@@ -159,9 +165,12 @@ typedef struct {
    the granular start/end-tag and per-attribute spans (read via
    th_node_source_location) and implies positions. scripting is the WHATWG
    scripting flag: when set, noscript is a raw-text element (its content is raw
-   text, serialized unescaped). Returns NULL only on allocation failure (no Python
-   error is set). */
-th_tree *th_tree_parse(int kind, const void *data, Py_ssize_t length, int positions, int locations, int scripting);
+   text, serialized unescaped). declarative_shadow is the WHATWG "allow declarative
+   shadow roots" flag: when set, a `<template shadowrootmode>` attaches a shadow root
+   to its parent instead of building a normal template content fragment. Returns NULL
+   only on allocation failure (no Python error is set). */
+th_tree *th_tree_parse(int kind, const void *data, Py_ssize_t length, int positions, int locations, int scripting,
+                       int declarative_shadow);
 
 /* Parse a whole document under XML 1.0 well-formedness rather than the HTML tree
    builder: self-closing honored on every element, case-sensitive names, CDATA
@@ -272,10 +281,12 @@ void th_node_normalize(th_tree *tree, th_node *root);
 /* Parse an HTML fragment as if set as the innerHTML of the given context element
    (e.g. "td", or "svg path"). The returned tree serializes the context root's
    children. context is a NUL-free ASCII name; context_len its length. positions
-   records element source line/column, and scripting sets the WHATWG scripting flag,
-   both as in th_tree_parse. */
+   records element source line/column, scripting sets the WHATWG scripting flag, and
+   declarative_shadow allows `<template shadowrootmode>` to attach a shadow root to the
+   context element, all as in th_tree_parse. */
 th_tree *th_tree_parse_fragment(int kind, const void *data, Py_ssize_t length, const char *context,
-                                Py_ssize_t context_len, int positions, int locations, int scripting);
+                                Py_ssize_t context_len, int positions, int locations, int scripting,
+                                int declarative_shadow);
 
 /* Whether context names a real element the public parse_fragment() accepts: a known
    HTML tag, or any explicitly namespaced (svg/math) foreign element. */

--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -62,14 +62,15 @@ struct th_tree {
        element it closes with TH_ELEM_CLOSED_BY_END_TAG so the sanitizer can tell a
        source-closed element from a parser-closed one */
     const th_token *closing_end_tag;
-    int quirks;          /* quirks mode: a <table> no longer closes an open <p> */
-    int scripting;       /* the WHATWG scripting flag: noscript is a rawtext element when set */
-    int has_nul;         /* the input contains a U+0000; otherwise text needs no NUL filtering */
-    int can_span;        /* input is borrowed and outlives the tree: text nodes may be
-                            zero-copy spans into it instead of materialized copies */
-    int track_positions; /* record each element's source line/col in trailing node slots */
-    int track_locations; /* record each element's granular source spans (implies track_positions) */
-    int kind;            /* borrowed input storage */
+    int quirks;             /* quirks mode: a <table> no longer closes an open <p> */
+    int scripting;          /* the WHATWG scripting flag: noscript is a rawtext element when set */
+    int declarative_shadow; /* allow a <template shadowrootmode> to attach a shadow root to its parent */
+    int has_nul;            /* the input contains a U+0000; otherwise text needs no NUL filtering */
+    int can_span;           /* input is borrowed and outlives the tree: text nodes may be
+                               zero-copy spans into it instead of materialized copies */
+    int track_positions;    /* record each element's source line/col in trailing node slots */
+    int track_locations;    /* record each element's granular source spans (implies track_positions) */
+    int kind;               /* borrowed input storage */
     const void *data;
     Py_ssize_t length;
     int failed; /* an allocation failed; abandon the parse */

--- a/src/turbohtml/_c/tokenizer/sax.c
+++ b/src/turbohtml/_c/tokenizer/sax.c
@@ -254,7 +254,7 @@ PyObject *turbohtml_sax_events(PyObject *module, PyObject *arg) {
         return NULL;
     }
     module_state *state = PyModule_GetState(module);
-    th_tree *tree = th_tree_parse(PyUnicode_KIND(arg), PyUnicode_DATA(arg), PyUnicode_GET_LENGTH(arg), 0, 0, 0);
+    th_tree *tree = th_tree_parse(PyUnicode_KIND(arg), PyUnicode_DATA(arg), PyUnicode_GET_LENGTH(arg), 0, 0, 0, 1);
     if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: only an allocation failure returns NULL */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -356,6 +356,10 @@ class ShadowRoot(Node):
     def mode(self) -> str: ...
     @property
     def host(self) -> Element: ...
+    @property
+    def delegates_focus(self) -> bool: ...
+    @property
+    def clonable(self) -> bool: ...
     def append(self, child: Node, /) -> None: ...
     def set_inner_html(self, html: str, /) -> None: ...
 
@@ -429,10 +433,17 @@ def parse(
     positions: bool = True,
     source_locations: bool = False,
     scripting: bool = False,
+    allow_declarative_shadow_roots: bool = True,
 ) -> Document: ...
 def parse_xml(markup: str) -> Document: ...
 def parse_fragment(
-    html: str, context: str = "div", *, positions: bool = True, source_locations: bool = False, scripting: bool = False
+    html: str,
+    context: str = "div",
+    *,
+    positions: bool = True,
+    source_locations: bool = False,
+    scripting: bool = False,
+    allow_declarative_shadow_roots: bool = False,
 ) -> Element: ...
 def _build_document(
     head: list[Node],

--- a/tests/dom/test_declarative_shadow.py
+++ b/tests/dom/test_declarative_shadow.py
@@ -29,7 +29,7 @@ def test_open_shadowrootmode_attaches_a_shadow_root() -> None:
 def test_declarative_template_is_off_the_light_tree() -> None:
     host = _element(parse("<div id=h><template shadowrootmode=open><p>x</p></template><b>light</b></div>").find(id="h"))
     assert host.find("template") is None
-    assert host.html == "<div id=\"h\"><b>light</b></div>"
+    assert host.html == '<div id="h"><b>light</b></div>'
 
 
 def test_closed_shadowrootmode_hides_the_root_but_keeps_its_content() -> None:
@@ -53,7 +53,9 @@ def test_delegates_focus_and_clonable_flags_are_set() -> None:
 
 
 def test_flags_default_off_without_the_attributes() -> None:
-    root = _shadow(_element(parse("<div id=h><template shadowrootmode=open>x</template></div>").find(id="h")).shadow_root)
+    root = _shadow(
+        _element(parse("<div id=h><template shadowrootmode=open>x</template></div>").find(id="h")).shadow_root
+    )
     assert root.delegates_focus is False
     assert root.clonable is False
 
@@ -110,8 +112,15 @@ def test_foreign_integration_point_is_not_a_shadow_host() -> None:
     assert host.find("template") is not None
 
 
-@pytest.mark.parametrize("markup", ["<template>x</template>", "<template shadowrootmode>x</template>",
-                                    "<template shadowrootmode=off>x</template>", "<template shadowrootmode=ope1>x</template>"])
+@pytest.mark.parametrize(
+    "markup",
+    [
+        "<template>x</template>",
+        "<template shadowrootmode>x</template>",
+        "<template shadowrootmode=off>x</template>",
+        "<template shadowrootmode=ope1>x</template>",
+    ],
+)
 def test_non_declarative_template_makes_a_content_fragment(markup: str) -> None:
     host = _element(parse(f"<div id=h>{markup}</div>").find(id="h"))
     assert host.shadow_root is None
@@ -139,7 +148,9 @@ def test_document_parsing_can_disable_declarative_shadow() -> None:
 
 
 def test_fragment_parsing_defaults_to_no_declarative_shadow() -> None:
-    host = _element(parse_fragment("<section><template shadowrootmode=open>x</template></section>", "body").find("section"))
+    host = _element(
+        parse_fragment("<section><template shadowrootmode=open>x</template></section>", "body").find("section")
+    )
     assert host.shadow_root is None
     assert host.find("template") is not None
 
@@ -159,8 +170,6 @@ def test_fragment_context_element_is_the_shadow_host() -> None:
 
 
 def test_fragment_context_that_is_not_a_valid_host_keeps_a_template() -> None:
-    fragment = parse_fragment(
-        "<template shadowrootmode=open>x</template>", "html", allow_declarative_shadow_roots=True
-    )
+    fragment = parse_fragment("<template shadowrootmode=open>x</template>", "html", allow_declarative_shadow_roots=True)
     assert fragment.shadow_root is None
     assert _element(fragment.find("template")) is not None

--- a/tests/dom/test_declarative_shadow.py
+++ b/tests/dom/test_declarative_shadow.py
@@ -1,0 +1,166 @@
+"""Declarative Shadow DOM: a `<template shadowrootmode>` attaches a shadow root to its parent."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Element, ShadowRoot, parse, parse_fragment
+
+
+def _element(node: object) -> Element:
+    """Narrow a find result to a non-None Element."""
+    assert isinstance(node, Element)
+    return node
+
+
+def _shadow(node: object) -> ShadowRoot:
+    """Narrow a shadow_root result to a non-None ShadowRoot."""
+    assert isinstance(node, ShadowRoot)
+    return node
+
+
+def test_open_shadowrootmode_attaches_a_shadow_root() -> None:
+    host = _element(parse("<div id=h><template shadowrootmode=open><p>shadow</p></template></div>").find(id="h"))
+    root = _shadow(host.shadow_root)
+    assert root.mode == "open"
+    assert root.html == "<p>shadow</p>"
+
+
+def test_declarative_template_is_off_the_light_tree() -> None:
+    host = _element(parse("<div id=h><template shadowrootmode=open><p>x</p></template><b>light</b></div>").find(id="h"))
+    assert host.find("template") is None
+    assert host.html == "<div id=\"h\"><b>light</b></div>"
+
+
+def test_closed_shadowrootmode_hides_the_root_but_keeps_its_content() -> None:
+    host = _element(parse("<div id=h><template shadowrootmode=closed><b>secret</b></template></div>").find(id="h"))
+    assert host.shadow_root is None  # a closed root is not exposed, like the mutation API
+    assert host.find("template") is None
+    assert [node.tag for node in host.flattened_children if isinstance(node, Element)] == ["b"]
+
+
+@pytest.mark.parametrize("mode", ["open", "closed"])
+def test_shadowrootmode_value_is_case_insensitive(mode: str) -> None:
+    host = _element(parse(f"<div id=h><template shadowrootmode={mode.upper()}>x</template></div>").find(id="h"))
+    assert host.find("template") is None  # OPEN / CLOSED still make a declarative root
+
+
+def test_delegates_focus_and_clonable_flags_are_set() -> None:
+    markup = "<div id=h><template shadowrootmode=open shadowrootdelegatesfocus shadowrootclonable>x</template></div>"
+    root = _shadow(_element(parse(markup).find(id="h")).shadow_root)
+    assert root.delegates_focus is True
+    assert root.clonable is True
+
+
+def test_flags_default_off_without_the_attributes() -> None:
+    root = _shadow(_element(parse("<div id=h><template shadowrootmode=open>x</template></div>").find(id="h")).shadow_root)
+    assert root.delegates_focus is False
+    assert root.clonable is False
+
+
+def test_mutation_attached_shadow_has_no_declarative_flags() -> None:
+    root = Element("div").attach_shadow("open")
+    assert root.delegates_focus is False
+    assert root.clonable is False
+
+
+def test_a_slot_in_the_shadow_assigns_light_children() -> None:
+    markup = "<div id=h><template shadowrootmode=open><slot></slot></template><p>light</p></div>"
+    host = _element(parse(markup).find(id="h"))
+    slot = _element(_shadow(host.shadow_root).find("slot"))
+    assert [node.tag for node in slot.assigned_nodes() if isinstance(node, Element)] == ["p"]
+
+
+def test_nested_declarative_shadow_roots() -> None:
+    markup = (
+        "<div id=o><template shadowrootmode=open>"
+        "<section id=i><template shadowrootmode=open><b>deep</b></template></section>"
+        "</template></div>"
+    )
+    outer = _shadow(_element(parse(markup).find(id="o")).shadow_root)
+    inner = _shadow(_element(outer.find(id="i")).shadow_root)
+    assert inner.html == "<b>deep</b>"
+
+
+def test_second_template_under_a_host_stays_a_normal_template() -> None:
+    markup = "<div id=h><template shadowrootmode=open>a</template><template shadowrootmode=open>b</template></div>"
+    host = _element(parse(markup).find(id="h"))
+    assert _shadow(host.shadow_root).html == "a"
+    assert _element(host.find("template")) is not None  # the host already had a shadow root
+
+
+@pytest.mark.parametrize("tag", ["div", "span", "section", "article", "h1", "body", "my-widget"])
+def test_valid_shadow_host_elements_attach(tag: str) -> None:
+    host = _element(parse(f"<body><{tag} id=h><template shadowrootmode=open>x</template></{tag}></body>").find(id="h"))
+    assert host.shadow_root is not None
+
+
+@pytest.mark.parametrize("tag", ["b", "ul", "foo"])
+def test_invalid_shadow_host_elements_keep_a_normal_template(tag: str) -> None:
+    host = _element(parse(f"<body><{tag} id=h><template shadowrootmode=open>x</template></{tag}></body>").find(id="h"))
+    assert host.shadow_root is None
+    assert host.find("template") is not None
+
+
+def test_foreign_integration_point_is_not_a_shadow_host() -> None:
+    # foreignObject runs HTML rules while the current node is SVG-namespaced, so it is no host
+    doc = parse("<div><svg><foreignObject id=h><template shadowrootmode=open>x</template></foreignObject></svg></div>")
+    host = _element(doc.find(id="h"))
+    assert host.shadow_root is None
+    assert host.find("template") is not None
+
+
+@pytest.mark.parametrize("markup", ["<template>x</template>", "<template shadowrootmode>x</template>",
+                                    "<template shadowrootmode=off>x</template>", "<template shadowrootmode=ope1>x</template>"])
+def test_non_declarative_template_makes_a_content_fragment(markup: str) -> None:
+    host = _element(parse(f"<div id=h>{markup}</div>").find(id="h"))
+    assert host.shadow_root is None
+    template = _element(host.find("template"))
+    assert template.inner_html == "x"  # a normal template content fragment, not a shadow root
+
+
+def test_a_dummy_same_length_attribute_is_not_shadowrootmode() -> None:
+    # the 14-char attribute matches shadowrootmode's length but not its bytes
+    markup = "<div id=h><template aaaaaaaaaaaaaa=1 shadowrootmode=open>x</template></div>"
+    assert _element(parse(markup).find(id="h")).shadow_root is not None
+
+
+def test_template_at_the_document_root_is_not_declarative() -> None:
+    # the adjusted current node is the topmost element, so it makes a normal template
+    doc = parse("<template shadowrootmode=open>x</template>")
+    assert _element(doc.find("template")) is not None
+
+
+def test_document_parsing_can_disable_declarative_shadow() -> None:
+    markup = "<div id=h><template shadowrootmode=open>x</template></div>"
+    host = _element(parse(markup, allow_declarative_shadow_roots=False).find(id="h"))
+    assert host.shadow_root is None
+    assert host.find("template") is not None
+
+
+def test_fragment_parsing_defaults_to_no_declarative_shadow() -> None:
+    host = _element(parse_fragment("<section><template shadowrootmode=open>x</template></section>", "body").find("section"))
+    assert host.shadow_root is None
+    assert host.find("template") is not None
+
+
+def test_fragment_parsing_opts_in_to_declarative_shadow() -> None:
+    fragment = parse_fragment(
+        "<section><template shadowrootmode=open>x</template></section>", "body", allow_declarative_shadow_roots=True
+    )
+    assert _element(fragment.find("section")).shadow_root is not None
+
+
+def test_fragment_context_element_is_the_shadow_host() -> None:
+    fragment = parse_fragment(
+        "<template shadowrootmode=open><p>x</p></template>", "div", allow_declarative_shadow_roots=True
+    )
+    assert _shadow(fragment.shadow_root).html == "<p>x</p>"
+
+
+def test_fragment_context_that_is_not_a_valid_host_keeps_a_template() -> None:
+    fragment = parse_fragment(
+        "<template shadowrootmode=open>x</template>", "html", allow_declarative_shadow_roots=True
+    )
+    assert fragment.shadow_root is None
+    assert _element(fragment.find("template")) is not None

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -177,6 +177,11 @@ def parse_locations(text: str) -> None:
     turbohtml.parse(text, source_locations=True)
 
 
+def parse_shadow(text: str) -> None:
+    """Parse a document whose <template shadowrootmode> elements attach declarative shadow roots to their parents."""
+    turbohtml.parse(text)
+
+
 def fragment(text: str) -> None:
     """Parse a fragment in its container context with turbohtml.parse_fragment."""
     turbohtml.parse_fragment(text, context="tbody")
@@ -680,6 +685,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "parse-xml": (parse_xml, "turbohtml"),
     "parse-scripting": (parse_scripting, "turbohtml"),
     "parse-locations": (parse_locations, "turbohtml"),
+    "parse-shadow": (parse_shadow, "turbohtml"),
     "fragment": (fragment, "turbohtml"),
     "escape": (escape, "turbohtml"),
     "unescape": (unescape, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -99,6 +99,26 @@ _XML_DOC = (
     + "</catalog>"
 )
 
+_SHADOW_CARD = (
+    '<article class="card">'
+    '<template shadowrootmode="open" shadowrootclonable shadowrootdelegatesfocus>'
+    '<style>:host{{display:block}}</style><header><slot name="title">Untitled {index}</slot></header>'
+    '<section><slot>No description</slot></section><footer><slot name="meta"></slot></footer>'
+    "</template>"
+    '<span slot="title">Card {index}</span>'
+    '<p>Body copy for card number {index} with some inline <a href="/item/{index}">detail</a> text.</p>'
+    '<span slot="meta">tag-{index}</span>'
+    "</article>"
+)
+
+# A document of declarative shadow hosts: 200 web-component cards whose <template shadowrootmode> attaches an open
+# shadow root (with slots and the delegatesfocus/clonable flags) to each host, sized to clear the CodSpeed jitter floor.
+_SHADOW_DOC = (
+    "<!doctype html><html><head><title>Component gallery</title></head><body><main>"
+    + "".join(_SHADOW_CARD.format(index=index) for index in range(200))
+    + "</main></body></html>"
+)
+
 _SANITIZE_TEMPLATES = dedent("""\
     <article class=card>
       <h1>{{ post.title }}</h1>
@@ -178,6 +198,7 @@ OPERATIONS: dict[str, Operation] = {
     "parse-xml": Operation("parse XML to a tree", "us"),
     "parse-scripting": Operation("parse to a tree (scripting on)", "us"),
     "parse-locations": Operation("parse to a tree (source locations)", "us"),
+    "parse-shadow": Operation("parse declarative shadow roots", "us"),
     "fragment": Operation("parse a fragment", "us"),
     "escape": Operation("escape", "us"),
     "unescape": Operation("unescape", "us"),
@@ -521,6 +542,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "parse-xml": lambda: (("catalog XML", _XML_DOC),),
     "parse-scripting": _readpath_cases,  # the real pages carry <noscript>, so the scripting rawtext path runs
     "parse-locations": _readpath_cases,  # real attribute-dense pages exercise the per-attribute span stamping
+    "parse-shadow": lambda: (("component gallery", _SHADOW_DOC),),
     "fragment": lambda: (("table-row fragment (2 kB)", _FRAGMENT_HTML),),
     "escape": corpus.escape_cases,
     "unescape": corpus.unescape_cases,

--- a/tools/pgo_corpus.py
+++ b/tools/pgo_corpus.py
@@ -212,7 +212,7 @@ def _scripts() -> list[object]:
 
 
 _HTML_DOCUMENT_OPS: Final = frozenset({
-    "parse", "tokenize", "sax", "fragment", "serialize", "minify", "htmlparser", "path", "path-xpath",
+    "parse", "parse-shadow", "tokenize", "sax", "fragment", "serialize", "minify", "htmlparser", "path", "path-xpath",
     "find", "select", "select-has", "match", "find-text", "text-content",
     "edit", "class-edit", "strip-remove", "strip-tags", "set-html", "set-text", "navigate", "chain",
     "links-extract", "links-absolutize", "links-rewrite", "extract-attr", "extract-text", "links-filter",


### PR DESCRIPTION
Servers ship shadow trees inline with a `<template shadowrootmode>`, and a browser attaches them during parsing so the encapsulation is in place before any script runs. turbohtml parsed such a template as an ordinary template element, leaving the shadow tree unbuilt and the markup misrepresented. This wires declarative shadow DOM into the C tree builder so `parse` reproduces what a navigating browser produces, closes #549.

The tree builder follows the WHATWG tree-construction steps for the `template` start tag directly. 🌱 When a `<template>` carries a `shadowrootmode` of `open` or `closed` and its parent is a valid shadow host, it attaches a shadow root to that parent, reusing the #573 Shadow DOM primitives (`attach_shadow`, the off-tree shadow node, the per-tree host table) rather than a new tree model, and redirects the template's content into the shadow root. The template element is created only on the stack of open elements, so it never joins the light tree and disappears once its content is parsed. `shadowrootdelegatesfocus` and `shadowrootclonable` set flags surfaced as `ShadowRoot.delegates_focus` and `ShadowRoot.clonable`. Two guards keep the transform faithful to the DOM: the host must be a valid shadow host name (a flow-content element or a hyphenated custom-element name), and a parent that already hosts a shadow root keeps its first one.

The feature honors the spec's per-document `allow declarative shadow roots` flag. Whole-document `parse` sets it on, matching a browser navigation, while `parse_fragment` leaves it off, matching an `innerHTML` assignment; the new `allow_declarative_shadow_roots` argument on each flips that default, turning a fragment into the `setHTMLUnsafe` case. 📦 This changes the default document parse: a stray `<template shadowrootmode>` now leaves the light tree, so pass `allow_declarative_shadow_roots=False` to keep the old plain-template behavior.
