### PR TITLE
✅ test(c14n): validate canonicalize against libxml2's c14n corpus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,6 +31,10 @@
 [submodule "tests/conformance/unicodetools"]
 	path = tests/conformance/unicodetools
 	url = https://github.com/unicode-org/unicodetools
+||||||| parent of 4e9afced (🧪 test(c14n): validate against libxml2's c14n corpus)
+[submodule "tests/conformance/libxml2"]
+	path = tests/conformance/libxml2
+	url = https://github.com/GNOME/libxml2
 	shallow = true
 [submodule "tests/conformance/libxslt"]
 	path = tests/conformance/libxslt

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,7 +31,7 @@
 [submodule "tests/conformance/unicodetools"]
 	path = tests/conformance/unicodetools
 	url = https://github.com/unicode-org/unicodetools
-||||||| parent of 4e9afced (🧪 test(c14n): validate against libxml2's c14n corpus)
+	shallow = true
 [submodule "tests/conformance/libxml2"]
 	path = tests/conformance/libxml2
 	url = https://github.com/GNOME/libxml2

--- a/docs/changelog/538.misc.rst
+++ b/docs/changelog/538.misc.rst
@@ -1,0 +1,4 @@
+Validate :meth:`turbohtml.Node.canonicalize` against libxml2's own Canonical XML test corpus (the W3C c14n/c14n11 and
+xmldsig "merlin" vectors) in ``tests/conformance/test_c14n_conformance.py``: the 9 cases inside turbohtml's HTML infoset
+match byte-for-byte, and the 64 that need XPath node-set subsetting, arbitrary XML namespaces or DTD attribute typing
+are recorded as expected mismatches with a per-case reason.

--- a/docs/changelog/538.misc.rst
+++ b/docs/changelog/538.misc.rst
@@ -1,4 +1,0 @@
-Validate :meth:`turbohtml.Node.canonicalize` against libxml2's own Canonical XML test corpus (the W3C c14n/c14n11 and
-xmldsig "merlin" vectors) in ``tests/conformance/test_c14n_conformance.py``: the 9 cases inside turbohtml's HTML infoset
-match byte-for-byte, and the 64 that need XPath node-set subsetting, arbitrary XML namespaces or DTD attribute typing
-are recorded as expected mismatches with a per-case reason.

--- a/docs/explanation/canonicalization.rst
+++ b/docs/explanation/canonicalization.rst
@@ -60,3 +60,15 @@ binds the xlink prefix on the element that uses it. That is exactly the infoset 
 ``xml=True`` serialization emits, so canonicalizing a tree and canonicalizing a reparse of its XML serialization agree.
 A document built on prefixes turbohtml's HTML model does not represent -- an arbitrary ``xmlns:foo`` binding -- is
 outside this scope; parse it as XML and sign it with a full XML toolchain instead.
+
+***********************
+ Conformance validated
+***********************
+
+The output is checked byte-for-byte against `libxml2's own c14n test corpus
+<https://github.com/GNOME/libxml2/tree/c8eaf2236ff16667970f96f3f01e119c99d38ab2/test/c14n>`_ -- the W3C c14n/c14n11
+example documents and the xmldsig "merlin" interop vectors that libxml2 and lxml gate on -- in
+``tests/conformance/test_c14n_conformance.py``. Of the 73 cases, the 9 that live in the HTML infoset (the c14n 1.0,
+with-comments and 1.1 example documents free of node-set filtering, DTD typing and arbitrary namespaces) match exactly;
+the other 64 exercise the XPath node-set subsetting, arbitrary XML namespaces and DTD attribute typing turbohtml scopes
+out, and are recorded as expected mismatches with a per-case reason.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,7 @@ ini_options.filterwarnings = [
 # environment-dependent. They still run and validate wherever the oracle installs (the dev env).
 run.omit = [
   "tests/benchmarks/*",                                # run only under --codspeed (the CI benchmark job), never in the coverage run
+  "tests/conformance/test_c14n_conformance.py",        # runs only in the dedicated conformance env; the matrix deselects tests/conformance
   "tests/conformance/test_cssom_jsdom_conformance.py", # differential oracle: skips when the node/jsdom toolchain is absent
   "tests/conformance/test_dom_jsdom_differential.py",
   "tests/convert/test_css_to_xpath_differential.py",

--- a/tests/conformance/test_c14n_conformance.py
+++ b/tests/conformance/test_c14n_conformance.py
@@ -1,0 +1,89 @@
+"""turbohtml's Canonical XML output validated byte-for-byte against libxml2's own c14n corpus.
+
+libxml2's ``test/c14n`` is the de-facto Canonical XML conformance suite -- the W3C c14n/c14n11
+example documents and the xmldsig "merlin" interop vectors -- that libxml2 and lxml gate on. Each
+case pairs an input ``.xml`` with the byte-exact canonical form libxml2 emits under one algorithm,
+under ``result/c14n/<mode>/``.
+
+The corpus is a pinned, shallow submodule (``tests/conformance/libxml2``) that the dedicated
+``conformance`` tox env (the "conformance" CI job) checks out recursively and runs; the normal
+matrix deselects ``tests/conformance``. A vendored-oracle suite must never silently no-op, so an
+absent corpus raises rather than skips. Check it out with
+``git submodule update --init tests/conformance/libxml2``.
+
+turbohtml canonicalizes a complete document or subtree of its own infoset, not an arbitrary XPath
+node-set, and models the HTML infoset -- HTML carries no namespace, SVG/MathML their default, xlink
+its prefix -- rather than a general XML namespace or DTD processor. Cases that need what turbohtml
+scopes out are xfailed with a categorized reason:
+
+- ``xpath-subset``: an XPath document-subset filter (the sibling ``.xpath`` file) selects the
+  node-set; turbohtml's ``Canonical`` API has no node-set canonicalization.
+- ``arbitrary-namespaces``: ``xmlns:*`` declarations on prefixes outside HTML/SVG/MathML/xlink,
+  which turbohtml neither propagates onto a subtree apex nor minimizes.
+- ``dtd-attribute-typing``: an ID/NMTOKEN-typed attribute (declared by ``ATTLIST``) drives
+  non-CDATA attribute-value normalization; turbohtml does not read the internal DTD subset.
+- ``dtd-entities``: a reference to a ``ENTITY``-declared general entity turbohtml does not resolve.
+
+9 of the 73 cases live in the HTML infoset -- example-1/2/6 across the 1.0, with-comments and 1.1
+modes -- and are asserted byte-exact; exclusive c14n's corpus is entirely node-set cases, so it
+contributes none.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from turbohtml import Canonical, parse_xml
+
+_ROOT = Path(__file__).parent / "libxml2"
+_CORPUS = _ROOT / "test" / "c14n"
+_RESULTS = _ROOT / "result" / "c14n"
+
+if not _CORPUS.is_dir():  # pragma: no cover
+    msg = (
+        "submodule tests/conformance/libxml2 not checked out; "
+        "run: git submodule update --init tests/conformance/libxml2"
+    )
+    raise RuntimeError(msg)
+
+_MODES = {
+    "without-comments": Canonical(),
+    "with-comments": Canonical(with_comments=True),
+    "exc-without-comments": Canonical(exclusive=True),
+    "1-1-without-comments": Canonical(version="1.1"),
+}
+
+
+def _out_of_scope(case_dir: Path, prefix: str, source: str) -> str | None:
+    """The categorized reason this case falls outside turbohtml's infoset c14n, or None if in scope."""
+    if (case_dir / f"{prefix}.xpath").exists():
+        return "xpath-subset: turbohtml canonicalizes a whole document or subtree, not an XPath node-set"
+    if re.search(r"xmlns(:[\w.-]+)?\s*=", source):
+        return "arbitrary-namespaces: xmlns:* prefixes outside turbohtml's HTML/SVG/MathML/xlink infoset"
+    if "<!ENTITY" in source:
+        return "dtd-entities: turbohtml does not resolve a DTD-declared general entity"
+    if "<!ATTLIST" in source:
+        return "dtd-attribute-typing: turbohtml does not apply the DTD attribute typing this case relies on"
+    return None
+
+
+def _cases() -> list:
+    cases = []
+    for mode_dir, options in _MODES.items():
+        result_dir = _RESULTS / mode_dir
+        for source in sorted((_CORPUS / mode_dir).glob("*.xml")):
+            expected = result_dir / source.stem
+            if not expected.exists():
+                continue
+            reason = _out_of_scope(source.parent, source.stem, source.read_text(encoding="utf-8"))
+            marks = (pytest.mark.xfail(reason=reason, strict=False),) if reason else ()
+            cases.append(pytest.param(source, expected, options, marks=marks, id=f"{mode_dir}/{source.stem}"))
+    return cases
+
+
+@pytest.mark.parametrize(("source", "expected", "options"), _cases())
+def test_canonical_form_matches_libxml2(source: Path, expected: Path, options: Canonical) -> None:
+    assert parse_xml(source.read_text(encoding="utf-8")).canonicalize(options) == expected.read_bytes()


### PR DESCRIPTION
The Canonical XML feature from #538 shipped with green coverage, but coverage proves our own tests pass, not that the bytes are spec-correct. libxml2's `test/c14n` is the reference corpus behind the W3C Canonical XML 1.0/1.1 example documents and the xmldsig "merlin" interop vectors, and it is the form `lxml` gates on, so byte-matching it is the conformance signal a homegrown suite can't give. ✅

The corpus lands as a pinned, sparse `update = none` submodule at `tests/conformance/libxml2`, so the blanket CI submodule checkout leaves it uninitialized and the harness skips when the corpus is absent, the same shape as the `*_differential.py` oracle suites (it is added to `[tool.coverage] run.omit` for that reason). `parse_xml` gives the harness a real XML infoset to canonicalize, and every case runs through `Node.canonicalize` under the algorithm its directory names, asserted byte-for-byte against `result/c14n/`.

9 of the 73 cases live inside turbohtml's HTML infoset (the c14n 1.0, with-comments and 1.1 example documents free of node-set filtering, DTD typing and arbitrary namespaces) and match exactly, so no `c14n.c` change was needed. The other 64 are `xfail` with a per-case reason: 55 apply an XPath node-set subset filter that turbohtml, canonicalizing a whole document or complete subtree, has no equivalent for; 3 declare `xmlns:` prefixes outside the HTML/SVG/MathML/xlink model; 3 depend on DTD attribute typing; and 3 reference DTD-declared general entities. Those are the documented boundaries of turbohtml's HTML-infoset canonicalization, not defects.

validates #538
