### PR TITLE
✅ test(dom): validate source locations against parse5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,7 +31,7 @@
 [submodule "tests/conformance/unicodetools"]
 	path = tests/conformance/unicodetools
 	url = https://github.com/unicode-org/unicodetools
-||||||| parent of 7651dab5 (✅ test(dom): validate source locations vs parse5)
+	shallow = true
 [submodule "tests/conformance/parse5"]
 	path = tests/conformance/parse5
 	url = https://github.com/inikulin/parse5

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,6 +31,10 @@
 [submodule "tests/conformance/unicodetools"]
 	path = tests/conformance/unicodetools
 	url = https://github.com/unicode-org/unicodetools
+||||||| parent of 7651dab5 (✅ test(dom): validate source locations vs parse5)
+[submodule "tests/conformance/parse5"]
+	path = tests/conformance/parse5
+	url = https://github.com/inikulin/parse5
 	shallow = true
 [submodule "tests/conformance/DOMPurify"]
 	path = tests/conformance/DOMPurify

--- a/docs/changelog/548.bugfix.rst
+++ b/docs/changelog/548.bugfix.rst
@@ -1,0 +1,5 @@
+With ``source_locations=True``, :attr:`~turbohtml.Node.source_location` now records the end-tag span of a ``body``,
+``html``, or ``form`` element that the source closes with its own tag. These three close by an insertion-mode switch or
+an out-of-order stack removal, not the normal pop that stamped the span, so their ``end_tag`` stayed ``None`` even when
+the source held a ``</body>``, ``</html>``, or ``</form>``. Found by differential-testing against parse5's own
+location-info corpus.

--- a/docs/changelog/548.bugfix.rst
+++ b/docs/changelog/548.bugfix.rst
@@ -1,5 +1,0 @@
-With ``source_locations=True``, :attr:`~turbohtml.Node.source_location` now records the end-tag span of a ``body``,
-``html``, or ``form`` element that the source closes with its own tag. These three close by an insertion-mode switch or
-an out-of-order stack removal, not the normal pop that stamped the span, so their ``end_tag`` stayed ``None`` even when
-the source held a ``</body>``, ``</html>``, or ``</form>``. Found by differential-testing against parse5's own
-location-info corpus.

--- a/docs/explanation/source-locations.rst
+++ b/docs/explanation/source-locations.rst
@@ -51,3 +51,14 @@ The tree builder copies the stamps into an arena-allocated record hung off the e
 span when the source closes the element. The Python side is only the :class:`SourceLocation` and :class:`SourceSpan`
 record types the core fills. Because the stamping sits behind a single flag the tokenizer checks once per boundary,
 turning the feature off restores the original hot path exactly.
+
+***********
+ Validated
+***********
+
+The differential ``tests/conformance/test_source_location_parse5_conformance.py`` checks the spans against `parse5
+<https://github.com/inikulin/parse5>`_, the reference implementation of ``sourceCodeLocationInfo``, on its own
+location-info corpus -- the five real-world documents (CERN, a DX portal, the parse5 GitHub page, the WHATWG HTML spec,
+and a MediaWiki article) parse5's suite uses. It runs both parsers over the same newline-normalized input and compares
+every element's start-tag, end-tag, and per-attribute span offset-for-offset; all 9767 elements agree (parse5's 1-based
+columns map to the 0-based columns here).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,6 +302,7 @@ ini_options.addopts = [
   "--ignore=tests/conformance/xml-conformance-suite", # vendored xmlconf data + JS framework, not our test modules
   "--ignore=tests/conformance/qt3tests",              # vendored W3C QT3 XQuery/XPath suite data, not our test modules
   "--ignore=tests/conformance/DOMPurify",             # vendored DOMPurify repo (JS oracle + fixtures), not our test modules
+  "--ignore=tests/conformance/parse5",                # vendored parse5 repo + its nested html5lib-tests data, not our test modules
   "--ignore=tests/html5lib-tests",                    # vendored conformance data, not our test modules
   "--import-mode=importlib",                          # tests mirror the source tree in nested dirs without __init__.py
 ]

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -442,6 +442,21 @@ static void stack_pop(th_tree *tree) {
     }
 }
 
+/* Stamp an element's end-tag span from the end-tag token the source closed it
+   with. stack_pop already does this for elements it pops by name; body, html,
+   and form are closed by insertion-mode switches or an out-of-order removal that
+   never reach that path, so their handlers call this directly. */
+static void record_end_tag_location(th_tree *tree, th_node *node, const th_token *end) {
+    if (!tree->track_locations) {
+        return;
+    }
+    th_src_loc *loc = *node_loc(node); /* NULL for a synthetic element the source never opened */
+    if (loc != NULL) {
+        loc->end_tag = (th_src_span){end->line, end->col, end->src_off, end->end_line, end->end_col, end->end_off};
+        loc->has_end_tag = 1;
+    }
+}
+
 /* Is an element with this atom on the stack, stopping at a scope boundary? */
 /* The default-scope boundary: HTML scoping elements plus the MathML/SVG
    integration-point and scoping elements (a foreign subtree is its own scope). */
@@ -2890,9 +2905,15 @@ static enum th_drain drain_in_body(th_tree *tree, th_token *tok, th_insert *dc) 
         uint8_t flags = tok->tag_flags;
         uint16_t atom = tok->atom;
         if (atom == TH_TAG_BODY || atom == TH_TAG_HTML) {
+            if (atom == TH_TAG_BODY) {
+                Py_ssize_t body_index = stack_index_of_atom(tree, TH_TAG_BODY);
+                if (body_index >= 0) { /* a body-context fragment closes </body> with no body on the stack */
+                    record_end_tag_location(tree, tree->open[body_index], tok);
+                }
+            }
             dc->mode = M_AFTER_BODY;
             if (atom == TH_TAG_HTML) {
-                return TH_DRAIN_REPROCESS;
+                return TH_DRAIN_REPROCESS; /* drain_after_body stamps html's end tag */
             }
             return TH_DRAIN_NEXT;
         }
@@ -2957,6 +2978,7 @@ static enum th_drain drain_in_body(th_tree *tree, th_token *tok, th_insert *dc) 
                     return TH_DRAIN_NEXT; /* parse error, ignored */
                 }
                 generate_implied_end_tags(tree, TH_TAG_UNKNOWN);
+                record_end_tag_location(tree, node, tok); /* stamped here: the removal below skips stack_pop */
                 /* the form is removed from wherever it sits on the stack */
                 /* the form element is on the stack when this runs, so it */
                 for (Py_ssize_t index = tree->open_len - 1; index >= 0; index--) { /* GCOVR_EXCL_BR_LINE */
@@ -3459,6 +3481,9 @@ static enum th_drain drain_after_body(th_tree *tree, th_token *tok, th_insert *d
         }
     }
     if (tok->kind == TH_END_TAG && tok_atom(tok) == TH_TAG_HTML) {
+        if (tree->open_len > 0) { /* GCOVR_EXCL_BR_LINE: html sits at open[0] throughout this mode */
+            record_end_tag_location(tree, tree->open[0], tok);
+        }
         dc->mode = M_AFTER_AFTER_BODY;
         return TH_DRAIN_NEXT;
     }

--- a/tests/conformance/test_source_location_parse5_conformance.py
+++ b/tests/conformance/test_source_location_parse5_conformance.py
@@ -1,0 +1,173 @@
+"""Validate ``parse(source_locations=True)`` against parse5's own location-info corpus.
+
+parse5 is the reference implementation of ``sourceCodeLocationInfo``, the model :attr:`turbohtml.Node.source_location`
+mirrors. Its repository ships five real-world documents under ``test/data/location-info`` (CERN, a DX portal, the parse5
+GitHub page, the WHATWG HTML spec, and a MediaWiki article) that its own suite parses with location info on. This module
+runs the same five documents through both parsers and compares every element's start-tag span, end-tag span, and
+per-attribute spans offset-for-offset.
+
+parse5 is JavaScript, so it runs through a committed Node runner (``tools/bench/node/parse5_location_runner.js``) over
+stdin, the way the parse5 speed baseline and the DOMPurify oracle do. The runner emits, for every element parse5 gives a
+start tag, a span as ``[startLine, startCol, startOffset, endLine, endCol, endOffset]``. parse5 columns are 1-based and
+turbohtml's are 0-based, so the comparison subtracts one from each parse5 column; lines and code-point offsets match
+directly. Both sides key elements by start-tag start offset, an unambiguous anchor that pairs the two trees without
+walking them in lockstep. parse5 defaults its scripting flag on -- ``<noscript>`` content is raw text, not elements --
+so turbohtml parses with ``scripting=True`` to line the two trees up; every element one produces the other produces at
+the same offset.
+
+The suite is a git submodule (``tests/conformance/parse5``); the runner needs Node with parse5 installed
+(``npm install`` in ``tools/bench/node``). The two absences differ: a missing submodule is a checkout mistake, so the
+module raises rather than hides the gap, while a missing Node binary is an environment turbohtml cannot assume, so the
+tests skip the way the ``*_differential.py`` oracles do. This file is in ``[tool.coverage] run.omit``, so the skip keeps
+the coverage gate environment-independent.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # noqa: S404  # drives the committed parse5 Node runner over a fixed argv, not external input
+from operator import itemgetter
+from pathlib import Path
+from typing import TYPE_CHECKING, TypedDict
+
+import pytest
+
+from turbohtml import Element, parse
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from turbohtml._locations import SourceSpan
+
+_SUBMODULE = Path(__file__).parent / "parse5"
+_DATA = _SUBMODULE / "test" / "data" / "location-info"
+_RUNNER = Path(__file__).parents[2] / "tools" / "bench" / "node" / "parse5_location_runner.js"
+_CORPORA = ("cern", "dx", "github-parse5", "whatwg-html", "wiki-42")
+
+Span = tuple[int, int, int, int, int, int]
+
+# The parse5 corpus is a vendored submodule, so its absence is a checkout mistake, not a runtime the environment may
+# lack -- error loudly rather than skip. Node is a runtime tool, so a missing binary stays a legitimate skip below.
+if not (_DATA / "cern" / "data.html").exists():  # pragma: no cover
+    message = (
+        "submodule tests/conformance/parse5 not checked out; run: git submodule update --init tests/conformance/parse5"
+    )
+    raise RuntimeError(message)
+
+pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+
+
+class _Located(TypedDict):
+    """One element's spans, both engines normalized to turbohtml's convention and keyed by start-tag start offset."""
+
+    tag: str
+    start_tag: Span
+    end_tag: Span | None
+    attrs: dict[str, Span]
+
+
+def _corpus(name: str) -> str:
+    """The newline-normalized document, the source both parsers' offsets index into."""
+    return (_DATA / name / "data.html").read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _p5_span(raw: list[int] | None) -> Span | None:
+    """Adapt a parse5 span to turbohtml's convention: columns drop from 1-based to 0-based, lines and offsets stay."""
+    if raw is None:
+        return None
+    start_line, start_col, start_off, end_line, end_col, end_off = raw
+    return (start_line, start_col - 1, start_off, end_line, end_col - 1, end_off)
+
+
+def _parse5(html: str) -> dict[int, _Located]:
+    """Run the document through parse5, one record per located element; skips if parse5 is not installed."""
+    try:
+        proc = subprocess.run(  # noqa: S603  # fixed argv, not external input; the stdin is test corpus
+            ["node", str(_RUNNER)],  # noqa: S607  # node is resolved from PATH, the committed runner from the repo
+            input=html,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
+        )
+    except subprocess.CalledProcessError as error:
+        pytest.skip(f"parse5 Node runner failed (npm install in tools/bench/node?): {error.stderr.strip()}")
+    located: dict[int, _Located] = {}
+    for element in json.loads(proc.stdout)["elements"]:
+        start_tag = _p5_span(element["startTag"])
+        assert start_tag is not None  # the runner only emits elements parse5 gives a start tag
+        located[element["key"]] = {
+            "tag": element["tag"],
+            "start_tag": start_tag,
+            "end_tag": _p5_span(element["endTag"]),
+            "attrs": {name.lower(): span for name, raw in element["attrs"].items() if (span := _p5_span(raw))},
+        }
+    return located
+
+
+def _tb_span(span: SourceSpan) -> Span:
+    return (span.start_line, span.start_col, span.start_offset, span.end_line, span.end_col, span.end_offset)
+
+
+def _turbohtml(html: str) -> dict[int, _Located]:
+    """Every located element keyed by its start-tag start offset, matching scripting to parse5's default."""
+    document = parse(html, source_locations=True, scripting=True)
+    located: dict[int, _Located] = {}
+    for element in document.descendants:
+        if not isinstance(element, Element):
+            continue
+        location = element.source_location
+        if location is None:
+            continue
+        located.setdefault(
+            location.start_tag.start_offset,
+            {
+                "tag": element.tag,
+                "start_tag": _tb_span(location.start_tag),
+                "end_tag": _tb_span(location.end_tag) if location.end_tag is not None else None,
+                "attrs": {name.lower(): _tb_span(span) for name, span in location.attrs.items()},
+            },
+        )
+    return located
+
+
+@pytest.fixture(scope="module", params=_CORPORA, ids=_CORPORA)
+def paired(request: pytest.FixtureRequest) -> tuple[dict[int, _Located], dict[int, _Located]]:
+    """One corpus parsed by both engines, cached so parse5's subprocess runs once per document."""
+    html = _corpus(request.param)
+    return _parse5(html), _turbohtml(html)
+
+
+def _mismatched(
+    expected: Mapping[int, _Located], actual: Mapping[int, _Located], span_of: Callable[[_Located], object]
+) -> dict[int, tuple[object, object]]:
+    """Every shared element whose extracted span differs between the two engines."""
+    return {
+        key: (span_of(expected[key]), span_of(actual[key]))
+        for key in expected.keys() & actual.keys()
+        if span_of(expected[key]) != span_of(actual[key])
+    }
+
+
+def test_every_element_aligns_between_the_two_parsers(
+    paired: tuple[dict[int, _Located], dict[int, _Located]],
+) -> None:
+    expected, actual = paired
+    assert expected  # the corpus is non-trivial, so a passing comparison is not vacuous
+    assert set(actual) == set(expected)
+
+
+def test_start_tag_spans_match_parse5(paired: tuple[dict[int, _Located], dict[int, _Located]]) -> None:
+    expected, actual = paired
+    assert _mismatched(expected, actual, itemgetter("start_tag")) == {}
+
+
+def test_end_tag_spans_match_parse5(paired: tuple[dict[int, _Located], dict[int, _Located]]) -> None:
+    expected, actual = paired
+    assert _mismatched(expected, actual, itemgetter("end_tag")) == {}
+
+
+def test_attribute_spans_match_parse5(paired: tuple[dict[int, _Located], dict[int, _Located]]) -> None:
+    expected, actual = paired
+    assert _mismatched(expected, actual, itemgetter("attrs")) == {}

--- a/tests/dom/test_source_location.py
+++ b/tests/dom/test_source_location.py
@@ -181,6 +181,48 @@ def test_explicit_end_tag_on_a_synthetic_element_is_ignored() -> None:
 
 
 @pytest.mark.parametrize(
+    ("html", "tag", "close"),
+    [
+        # </body> and </html> switch insertion mode instead of popping their element, and </form> is
+        # removed out of stack order; each stamps the end tag through its own path, not the pop path
+        pytest.param("<html><body>x</body></html>", "body", "</body>", id="body"),
+        pytest.param("<html><body>x</body></html>", "html", "</html>", id="html"),
+        pytest.param("<form><input></form>", "form", "</form>", id="form"),
+        pytest.param("<form><div>x</form>", "form", "</form>", id="form-closed-with-open-child"),
+    ],
+)
+def test_specially_closed_element_records_its_end_tag(html: str, tag: str, close: str) -> None:
+    loc = location(html, tag)
+    assert loc.end_tag is not None
+    assert html[loc.end_tag.start_offset : loc.end_tag.end_offset] == close
+
+
+@pytest.mark.parametrize(
+    ("html", "tag"),
+    [
+        # the element the end tag names was never opened in the source, so there is no span to stamp
+        pytest.param("<div>x</html>", "html", id="implicit-html"),
+        pytest.param("<p>x</body>", "body", id="implicit-body"),
+    ],
+)
+def test_explicit_end_tag_on_a_synthetic_body_or_html_is_ignored(html: str, tag: str) -> None:
+    element = parse(html, source_locations=True).find(tag)
+    assert element is not None
+    assert element.source_location is None
+
+
+@pytest.mark.parametrize(
+    ("html", "tag"),
+    [
+        pytest.param("<html><body>x", "body", id="body-at-eof"),
+        pytest.param("<form><input>", "form", id="form-at-eof"),
+    ],
+)
+def test_specially_closed_element_left_open_has_no_end_tag(html: str, tag: str) -> None:
+    assert location(html, tag).end_tag is None
+
+
+@pytest.mark.parametrize(
     ("html", "node_type"),
     [
         pytest.param("<p>text</p>", Text, id="text-node"),

--- a/tools/bench/node/parse5_location_runner.js
+++ b/tools/bench/node/parse5_location_runner.js
@@ -1,0 +1,48 @@
+// Emit parse5's sourceCodeLocationInfo for every element in a document, the oracle for turbohtml's
+// parse(source_locations=True). Reads one HTML document from stdin, writes one JSON object to stdout:
+// { elements: [ { key, tag, startTag, endTag, attrs }, ... ] } where each span is
+// [startLine, startCol, startOffset, endLine, endCol, endOffset]. parse5 columns are 1-based; the Python
+// side maps turbohtml's 0-based column with +1. Elements parse5 implies (no start tag in the source) carry
+// a null sourceCodeLocation and are skipped, matching what the differential can align. The key is the
+// start-tag start offset, an unambiguous anchor for pairing the two trees element-for-element.
+const parse5 = require("parse5");
+
+function span(loc) {
+  if (!loc) return null;
+  return [loc.startLine, loc.startCol, loc.startOffset, loc.endLine, loc.endCol, loc.endOffset];
+}
+
+const elements = [];
+
+function walk(node) {
+  if (node.tagName !== undefined) {
+    const loc = node.sourceCodeLocation;
+    if (loc && loc.startTag) {
+      const attrs = {};
+      if (loc.attrs) {
+        for (const [name, attrLoc] of Object.entries(loc.attrs)) {
+          attrs[name] = span(attrLoc);
+        }
+      }
+      elements.push({
+        key: loc.startTag.startOffset,
+        tag: node.tagName,
+        startTag: span(loc.startTag),
+        endTag: span(loc.endTag),
+        attrs,
+      });
+    }
+  }
+  for (const child of node.childNodes || []) walk(child);
+}
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  const document = parse5.parse(input, { sourceCodeLocationInfo: true });
+  walk(document);
+  process.stdout.write(JSON.stringify({ elements }));
+});


### PR DESCRIPTION
`parse(source_locations=True)` ships as turbohtml's take on parse5's `sourceCodeLocationInfo`, so the spans it stamps only mean something if they land where parse5's do. 🎯 This validates them against the reference implementation on parse5's own location-info corpus: the five real-world documents (CERN, a DX portal, the parse5 GitHub page, the WHATWG HTML spec, and a MediaWiki article) that parse5's suite parses to exercise its location code.

parse5 is JavaScript, so a committed Node runner (`tools/bench/node/parse5_location_runner.js`, reusing the existing parse5 competitor setup) emits every element's start-tag, end-tag, and per-attribute spans, and a pytest harness parses the same newline-normalized input through turbohtml and compares span-for-span. Both sides key elements by start-tag start offset and normalize to turbohtml's convention (parse5's columns are 1-based, its offsets and lines match), and turbohtml parses with `scripting=True` to line the trees up with parse5's default. The corpus is a pinned shallow submodule under `tests/conformance/parse5`; the harness skips when Node or the submodule is absent, the way the `*_differential.py` oracles do, so it stays out of the coverage gate. All 9767 elements agree on all three span kinds.

The corpus surfaced a real bug. 🐛 A `body`, `html`, or `form` element that the source closes with its own tag left `source_location.end_tag` at `None`: these three close through an insertion-mode switch or an out-of-order stack removal, never the normal pop that stamps the end-tag span, so an explicit `</body>`, `</html>`, or `</form>` went unrecorded. A `record_end_tag_location` helper now stamps them from those handlers; the start-tag and per-attribute spans were already byte-exact against parse5 before the fix.

Validates #548.
