### PR TITLE
👷 ci: add dedicated conformance job

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -62,6 +62,38 @@ jobs:
         run: uvx --with tox-uv tox run -e ${{ matrix.tox_env }}
         env:
           UV_PYTHON_PREFERENCE: only-managed
+  conformance:
+    name: 🔬 conformance
+    runs-on: ubuntu-24.04
+    # The tests/conformance/ suites validate each feature against a competitor's or standards body's OWN test suite,
+    # vendored as pinned submodules under tests/conformance/<oracle> (libxml2, unicodetools, xml-conformance-suite,
+    # qt3tests, parse5, DOMPurify, ...) and/or a Node oracle in tools/bench/node (jsdom, DOMPurify, parse5). They must
+    # RUN with those oracles present: a suite whose submodule is absent errors instead of skipping, which is the whole
+    # point of this job. The normal matrix deselects tests/conformance (tox --ignore) so it never runs an oracle suite
+    # without the oracle. This is a pass/fail correctness gate, not a coverage gate -- the 100% line/branch gate stays
+    # on the matrix (env_run_base), deliberately not bolted on here.
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # meson project() derives the version from git history
+          submodules: recursive # every conformance oracle plus the html5lib-tests data; shallow submodules init here too
+          persist-credentials: false
+      - name: 🟢 Install Node
+        # zizmor: ignore[cache-poisoning] no cache: input is set, so setup-node writes no restorable cache
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+      - name: 📦 Install the Node oracle deps (jsdom, DOMPurify, parse5)
+        run: npm ci
+        working-directory: tools/bench/node
+      - name: 🔄 Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: ✅ Run the conformance suites
+        run: uvx --with tox-uv tox run -e conformance
+        env:
+          UV_PYTHON_PREFERENCE: only-managed
   warnings:
     name: 🚨 -Werror (${{ matrix.label }})
     runs-on: ${{ matrix.os }}

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -67,6 +67,32 @@ codspeed`` or ``pytest tests/benchmarks --codspeed``), so the ordinary test run 
   and a comment explaining why it cannot run.
 - Keep the C output byte for byte identical to the standard library where the two overlap.
 
+********************
+ Conformance suites
+********************
+
+A conformance suite validates one feature against a competitor's or a standards body's **own** test suite rather than
+hand-written cases: libxml2, the Unicode ``unicodetools``, the W3C ``xml-conformance-suite`` and ``qt3tests``,
+``parse5``, DOMPurify, and so on. These suites live under ``tests/conformance/`` and vendor each oracle as a pinned git
+submodule at ``tests/conformance/<oracle>`` (and/or drive a Node oracle in ``tools/bench/node`` -- jsdom, DOMPurify,
+parse5). The convention is deliberate:
+
+- A missing oracle **errors, never skips.** A suite whose submodule (or Node oracle) is absent must fail loudly, so a
+  half-checked-out tree can never report a green run that silently validated nothing.
+- They run only in the dedicated ``🔬 conformance`` CI job, which checks out every submodule recursively and installs the
+  Node oracle deps before running ``tox r -e conformance``. The normal test matrix deselects ``tests/conformance``
+  (``--ignore``), so it never tries an oracle suite without its oracle.
+- It is a pass/fail correctness gate, **not** a coverage gate. The 100% line/branch coverage gate stays on the matrix;
+  the conformance job only asserts the oracle suites pass, so it does not run under coverage.
+
+.. code-block:: console
+
+    $ git submodule update --init tests/conformance/parse5   # fetch one oracle
+    $ tox r -e conformance                                    # run the suites against their oracles
+
+The vendored ``html5lib-tests`` conformance data is separate: it lives under ``tests/dom``, ``tests/tokenizer``, and
+``tests/encoding`` (not ``tests/conformance``) and runs in the ordinary matrix, so it is unaffected by the above.
+
 *********
  Fuzzing
 *********

--- a/tox.toml
+++ b/tox.toml
@@ -73,6 +73,11 @@ commands = [
     "term-missing:skip-covered",
     "--cov-report",
     "html:{env_tmp_dir}{/}htmlcov",
+    # the tests/conformance suites validate a feature against a competitor's or standards body's own suite,
+    # vendored as pinned submodules; they only run with those oracles present, in the dedicated `conformance`
+    # env (the "🔬 conformance" CI job). Deselect them here so the normal matrix never runs an oracle suite
+    # without its oracle -- a missing oracle must error there, not skip silently in the matrix.
+    "--ignore={tox_root}{/}tests{/}conformance",
     { replace = "posargs", default = [ "tests" ], extend = true },
   ],
   # enforce 100% C LINE coverage everywhere gcov runs, and 100% BRANCH coverage on
@@ -239,6 +244,45 @@ commands_pre = [
 ]
 commands = [
   [ "pytest", "{tox_root}{/}tests{/}benchmarks", "--codspeed", { replace = "posargs", extend = true } ],
+]
+
+[env.conformance]
+description = "run the vendored-oracle conformance suites in tests/conformance (the '🔬 conformance' CI job, not a per-PR gate)"
+package = "skip"  # commands_pre installs a plain release editable build; no coverage instrumentation
+deps = []  # no gcovr: this is a pass/fail correctness gate, not a coverage gate (the matrix owns the 100% gate)
+dependency_groups = [ "test" ]
+pass_env = [ "PYTEST_*" ]
+commands_pre = [
+  # a plain release build, uninstrumented -- the conformance suites only assert behavior against the oracles
+  [
+    "uv",
+    "pip",
+    "install",
+    "--reinstall",
+    "--no-deps",
+    "--no-build-isolation",
+    "--editable",
+    "{tox_root}",
+    "--config-settings=build-dir={env_dir}{/}cbuild",
+    "--config-settings=setup-args=-Dbuildtype=release",
+  ],
+]
+# Each tests/conformance/test_*.py validates one feature against a competitor's or standards body's OWN suite,
+# vendored as a pinned submodule under tests/conformance/<oracle> (libxml2, unicodetools, qt3tests, parse5,
+# DOMPurify, ...) and/or a Node oracle in tools/bench/node. Run them for real with the oracles present: a suite
+# whose oracle submodule is absent errors here (never skips) -- that is the point of this env. This is a
+# correctness gate, not a coverage gate (no --cov). An empty or absent tests/conformance (no suites on this
+# branch yet) is a clean pass, not a failure, so a branch that adds no suite still goes green.
+commands = [
+  [
+    "python",
+    "-c",
+    """\
+  import pathlib, subprocess, sys; suites = sorted(pathlib.Path('tests', 'conformance').glob('test_*.py')); print('no \
+  tests/conformance suites present; nothing to run') if not suites else None; raise SystemExit(0 if not suites else \
+  subprocess.call([sys.executable, '-m', 'pytest', 'tests/conformance', '--no-cov', '-p', 'no:cacheprovider']))\
+  """,
+  ],
 ]
 
 [env.dev]


### PR DESCRIPTION
A conformance suite under `tests/conformance/` validates one feature against a competitor's or a standards body's own test suite: libxml2, the Unicode `unicodetools`, the W3C `xml-conformance-suite` and `qt3tests`, `parse5`, DOMPurify. Each oracle is vendored as a pinned git submodule at `tests/conformance/<oracle>` and/or driven through a Node oracle in `tools/bench/node`. 🔬 A suite only means anything with its oracle present, and the normal matrix checks out just the `html5lib-tests` data, so running these there would skip every one and report green while validating nothing.

This adds a dedicated `🔬 conformance` job that checks out all submodules recursively, installs the Node oracle deps (`npm ci` in `tools/bench/node`), builds the extension the way the matrix does, and runs `tox r -e conformance`. A suite whose oracle submodule is absent errors instead of skipping, which is the point of the job. The matrix deselects `tests/conformance` with `--ignore`, so it never runs an oracle suite without its oracle. The `conformance` env is a pass/fail correctness gate, not a coverage gate: the 100% line and branch gate stays on the matrix and is kept off this job on purpose.

A suite is picked up by dropping a `tests/conformance/test_*.py` file and vendoring its oracle as a pinned submodule; the job then runs it against that oracle. An empty or absent `tests/conformance` is a clean pass, so this branch, which adds no suite yet, stays green. The convention is written up under `docs/development/`.
