### PR TITLE
✅ test: error on missing submodule instead of silent skip

### DIFF
--- a/tests/benchmarks/test_operations.py
+++ b/tests/benchmarks/test_operations.py
@@ -5,7 +5,7 @@ times over the same real corpora, so every operation the project tracks gets an 
 and adding an operation adds a benchmark. The benchmarks run only under ``--codspeed`` (see ``conftest.py``): the CI
 benchmark job passes it, and locally it is opt-in. Mutating operations rebuild their tree through the pedantic ``setup``
 hook, which runs untimed before each measured call, so the number is the mutation and not the parse. A case whose corpus
-is not checked out (or cannot be fetched) skips rather than fails.
+is not checked out fails loudly rather than skipping, so a benchmark run can never silently measure nothing.
 """
 
 from __future__ import annotations
@@ -29,8 +29,10 @@ if TYPE_CHECKING:
 def test_feature(benchmark: BenchmarkFixture, operation: object, load: Callable[[], object]) -> None:
     try:
         case = load()
-    except OSError as exc:  # corpus submodule not checked out, or the pinned upstream file could not be fetched
-        pytest.skip(f"corpus unavailable: {exc}")
+    except OSError as exc:
+        # this body runs only under --codspeed (conftest skips it otherwise), so a missing corpus is a hard error
+        msg = f"bench corpus submodule not checked out: {exc}; run: git submodule update --init tools/bench-data"
+        raise RuntimeError(msg) from exc
     if isinstance(operation, Mutating):
         benchmark.pedantic(operation.run, setup=lambda: ((operation.setup(case),), {}))
     else:

--- a/tests/dom/test_treebuilder_conformance.py
+++ b/tests/dom/test_treebuilder_conformance.py
@@ -19,6 +19,11 @@ from turbohtml import _html
 
 _TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
 
+# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
+if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
+    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
+    raise RuntimeError(msg)
+
 
 def _parse_dat(path: Path) -> list[tuple[str, str, bool, str | None]]:
     """Return (input, expected-document, script-on, fragment-context) per block."""

--- a/tests/dom/test_treebuilder_differential.py
+++ b/tests/dom/test_treebuilder_differential.py
@@ -39,6 +39,11 @@ from turbohtml import Comment, Doctype, Document, Element, Namespace, Node, Text
 
 _TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
 
+# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
+if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
+    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
+    raise RuntimeError(msg)
+
 # "adjust foreign attributes" (WHATWG 13.2.6.5): only these prefixed names on an SVG/MathML
 # element serialize with a namespace-separating space; any other xml:/xlink: name keeps its colon.
 # Bare ``xmlns`` is in the spec table but never appears on a foreign element in the pinned corpus.

--- a/tests/encoding/test_encoding_conformance.py
+++ b/tests/encoding/test_encoding_conformance.py
@@ -10,6 +10,11 @@ from turbohtml import parse
 
 _SUITE = Path(__file__).parents[1] / "html5lib-tests" / "encoding"
 
+# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
+if not _SUITE.is_dir() or not any(_SUITE.glob("*.dat")):  # pragma: no cover
+    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
+    raise RuntimeError(msg)
+
 # A few tests1.dat cases place the only <meta charset> well past byte 1024 (the
 # "N characters" boundary fixtures and the multi-script test, meta at 2026..8323)
 # and expect it honored. The WHATWG "prescan a byte stream to determine its

--- a/tests/serialize/test_minify_roundtrip.py
+++ b/tests/serialize/test_minify_roundtrip.py
@@ -23,6 +23,12 @@ from turbohtml import Html, Minify, parse
 from turbohtml.clean import CSSMinify
 
 _TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
+
+# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
+if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
+    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
+    raise RuntimeError(msg)
+
 _MINIFY = Minify()
 # the CSS pass rewrites every <style> body and style="" value the corpus carries; the
 # value-safe engine is itself idempotent, so enabling it must keep the reparse a fixpoint

--- a/tests/serialize/test_tree_markdown.py
+++ b/tests/serialize/test_tree_markdown.py
@@ -18,6 +18,13 @@ from markdown_it import MarkdownIt
 
 from turbohtml import parse
 
+_TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
+
+# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
+if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
+    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
+    raise RuntimeError(msg)
+
 
 def md(html: str) -> str:
     return parse(html).to_markdown()
@@ -483,9 +490,8 @@ def test_roundtrip_preserves_text(html: str) -> None:
 def _corpus_inputs() -> list[str]:
     """HTML fragments pulled from the vendored html5lib-tests tree-construction
     .dat files: small, deliberately malformed markup that stresses the walker."""
-    root = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
     inputs: list[str] = []
-    for dat in sorted(root.glob("*.dat")):
+    for dat in sorted(_TREE_DIR.glob("*.dat")):
         for block in dat.read_text(encoding="utf-8").split("#data\n")[1:]:
             data = block.split("\n#errors", 1)[0]
             if "�" not in data and len(data) < 200:

--- a/tests/serialize/test_tree_serialize.py
+++ b/tests/serialize/test_tree_serialize.py
@@ -270,6 +270,11 @@ def test_serialize_iter_propagates_a_raising_truthiness() -> None:
 
 _TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
 
+# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
+if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
+    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
+    raise RuntimeError(msg)
+
 
 def _corpus_sources(path: Path) -> list[str]:
     sources: list[str] = []

--- a/tests/tokenizer/test_html5lib_entities.py
+++ b/tests/tokenizer/test_html5lib_entities.py
@@ -27,6 +27,11 @@ if TYPE_CHECKING:
 _TOKENIZER = Path(__file__).parents[1] / "html5lib-tests" / "tokenizer"
 _FILES = ["entities.test", "namedEntities.test", "numericEntities.test"]
 
+# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
+if not _TOKENIZER.is_dir() or not any(_TOKENIZER.glob("*.test")):  # pragma: no cover
+    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
+    raise RuntimeError(msg)
+
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Generate one test per html5lib character-reference case."""

--- a/tests/tokenizer/test_tokenizer_conformance.py
+++ b/tests/tokenizer/test_tokenizer_conformance.py
@@ -25,6 +25,11 @@ from turbohtml import _html
 
 TOKENIZER_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tokenizer"
 
+# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
+if not TOKENIZER_DIR.is_dir() or not any(TOKENIZER_DIR.glob("*.test")):  # pragma: no cover
+    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
+    raise RuntimeError(msg)
+
 _DOUBLE_ESCAPE = re.compile(r"\\u([0-9A-Fa-f]{4})")
 
 


### PR DESCRIPTION
The conformance suites parametrize over `glob("tests/html5lib-tests/<subdir>/*.dat")`. When that submodule is not checked out the glob matches nothing, so the suites collect zero cases and pytest reports green. Conformance never ran, and nothing said so. A contributor who forgot `git submodule update --init`, or any CI path that skipped submodule checkout, would ship against a suite that silently tested nothing.

Every submodule-gated module now raises `RuntimeError` at import when its vendored data is absent, naming the exact command to fix it. The guard sits on the `if` so a missing submodule fails collection loudly instead of degrading to an empty parametrization. CI checks out submodules (`actions/checkout` with `submodules: true`), so the guard never fires there and carries `# pragma: no cover` on the `if` line to keep the whole block out of the 100% coverage gate. This covers the three named suites plus the tree-serialize, minify round-trip, markdown, entities, and treebuilder-differential modules, which read the same corpus.

The benchmark corpus under `tools/bench-data` changes the same way: its silent `pytest.skip` becomes a hard error. That raise lives inside the test body, which runs only under `--codspeed`, so a plain `pytest` run still deselects the benchmarks and is untouched. A `--codspeed` run without the corpus now fails loudly rather than measuring nothing.

No changelog fragment.
