### PR TITLE
✅ test(xslt): validate XSLT 1.0 against libxslt REC suite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,7 @@
 	path = tests/conformance/unicodetools
 	url = https://github.com/unicode-org/unicodetools
 	shallow = true
+[submodule "tests/conformance/libxslt"]
+	path = tests/conformance/libxslt
+	url = https://github.com/GNOME/libxslt
+	shallow = true

--- a/docs/changelog/590.bugfix.rst
+++ b/docs/changelog/590.bugfix.rst
@@ -1,8 +1,0 @@
-Validating :mod:`turbohtml.transform` against libxslt's XSLT 1.0 Recommendation test corpus surfaced and fixed four
-conformance gaps. A literal result element now copies its in-scope stylesheet namespace declarations to the output
-(`section 7.1.1 <https://www.w3.org/TR/xslt-10/#literal-result-element>`_), de-duplicated against the ancestors already
-in scope and filtered by ``exclude-result-prefixes``, so a prefixed or default-namespaced result element is well-formed
-rather than losing its declaration. ``xsl:number`` honors the separators around a format token, so ``format="1. "``
-yields ``1. `` and ``format="(1)"`` yields ``(1)``, and a value that has no alphabetic or roman form (zero, negative, or
-a roman numeral past 4999) falls back to decimal instead of emitting nothing or an unbounded run. A processing
-instruction serializes with the ``?>`` terminator under the ``xml`` output method.

--- a/docs/changelog/590.bugfix.rst
+++ b/docs/changelog/590.bugfix.rst
@@ -1,0 +1,8 @@
+Validating :mod:`turbohtml.transform` against libxslt's XSLT 1.0 Recommendation test corpus surfaced and fixed four
+conformance gaps. A literal result element now copies its in-scope stylesheet namespace declarations to the output
+(`section 7.1.1 <https://www.w3.org/TR/xslt-10/#literal-result-element>`_), de-duplicated against the ancestors already
+in scope and filtered by ``exclude-result-prefixes``, so a prefixed or default-namespaced result element is well-formed
+rather than losing its declaration. ``xsl:number`` honors the separators around a format token, so ``format="1. "``
+yields ``1. `` and ``format="(1)"`` yields ``(1)``, and a value that has no alphabetic or roman form (zero, negative, or
+a roman numeral past 4999) falls back to decimal instead of emitting nothing or an unbounded run. A processing
+instruction serializes with the ``?>`` terminator under the ``xml`` output method.

--- a/docs/explanation/xslt.rst
+++ b/docs/explanation/xslt.rst
@@ -52,4 +52,16 @@ to its string value when used through XPath (the strict XSLT 1.0 rule), and ``xs
 copies its nodes. Output shaping beyond the method choice -- ``indent``, ``doctype-*``, ``cdata-section-elements`` -- is
 not applied; the serializer is turbohtml's own, so its byte layout follows :doc:`serialization`, not libxslt's.
 
+*******************
+ Conformance basis
+*******************
+
+The processor is validated against libxslt's own XSLT 1.0 Recommendation corpus -- the ``REC`` and ``REC2``
+stylesheet/source/expected-output triples it ships, which are the worked examples from the spec run through the
+reference implementation. ``tests/conformance/test_xslt_conformance.py`` runs turbohtml over every triple and asserts
+byte-equal output (whitespace normalized per output method). Of the 79 cases, 56 pass exactly; the remaining 23 use
+features listed under "Where it stops" (whitespace stripping, namespace-alias, attribute sets, multi-level
+``xsl:number``, ``cdata-section-elements``, extension elements, and the html method's meta injection) and are marked
+``xfail`` with the spec section each needs. The corpus is the pinned ``tests/conformance/libxslt`` submodule.
+
 For the XPath engine underneath, see :doc:`queries`; for a port from lxml, see :doc:`/migration/lxml`.

--- a/src/turbohtml/_c/query/xslt.c
+++ b/src/turbohtml/_c/query/xslt.c
@@ -473,6 +473,8 @@ typedef struct engine {
 
     Py_UCS4 *xsl_prefix;
     Py_ssize_t xsl_prefix_len;
+    const Py_UCS4 *exclude_prefixes; /* aliases the stylesheet root's exclude-result-prefixes value */
+    Py_ssize_t exclude_prefixes_len;
     int output_method;
     int omit_xml_decl;
 
@@ -1807,8 +1809,15 @@ static int sort_nodeset(engine *eng, xp_nodeset *set, sort_spec *specs, int nspe
 
 /* ---- xsl:number ----------------------------------------------------------- */
 
+/* Whether a code point is alphanumeric, the class that separates a format token from the
+   separators around it (approximated to ASCII letters and digits, which cover the format
+   tokens XSLT 1.0 defines: decimal, "a"/"A", "i"/"I"). */
+static int alnum_cp(Py_UCS4 cp) {
+    return (cp >= '0' && cp <= '9') || (cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z');
+}
+
 static int format_number_token(xb *out, long value, Py_UCS4 style) {
-    if (style == 'a' || style == 'A') {
+    if ((style == 'a' || style == 'A') && value >= 1) {
         char buffer[32];
         int length = 0;
         long remaining = value;
@@ -1824,7 +1833,10 @@ static int format_number_token(xb *out, long value, Py_UCS4 style) {
         }
         return 0;
     }
-    if (style == 'i' || style == 'I') {
+    /* Roman numerals are only conventionally defined for 1..4999; larger values would emit an
+       unbounded run of "M" (a memory-exhaustion hazard), so fall through to the decimal token,
+       as libxslt does. Non-positive values have no roman/alphabetic form either. */
+    if ((style == 'i' || style == 'I') && value >= 1 && value <= 4999) {
         static const int values[] = {1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1};
         static const char *const lower[] = {"m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i"};
         static const char *const upper[] = {"M", "CM", "D", "CD", "C", "XC", "L", "XL", "X", "IX", "V", "IV", "I"};
@@ -1883,23 +1895,40 @@ static int do_number(engine *eng, th_node *instruction, th_node *out_parent) {
     } else {
         value = eng->cur_attr >= 0 ? 1 : number_single(eng->cur_node);
     }
+    /* A format token string (XSLT 1.0 section 7.7.1) is a leading separator, an alphanumeric
+       format token, then a trailing separator; for single-level numbering the leading and
+       trailing separators surround the one formatted number as a prefix and suffix. */
     Py_ssize_t format_len = 0;
     const Py_UCS4 *format = attr_lookup(eng->sheet_tree, instruction, "format", &format_len);
+    Py_ssize_t prefix_end = 0;
+    while (prefix_end < format_len && !alnum_cp(format[prefix_end])) {
+        prefix_end++;
+    }
+    Py_ssize_t token_end = prefix_end;
+    while (token_end < format_len && alnum_cp(format[token_end])) {
+        token_end++;
+    }
     Py_UCS4 style = '1';
     Py_ssize_t pad = 1;
-    if (format != NULL && format_len > 0) {
-        if (format[0] >= '0' && format[0] <= '9') {
-            /* A decimal token's length is its minimum width: "01" pads to two digits. */
+    if (token_end > prefix_end) {
+        /* The token is alphanumeric, so a code point at or below '9' is a digit. */
+        if (format[prefix_end] <= '9') {
+            /* A decimal token's leading digits are its minimum width: "01" pads to two digits,
+               and only the leading run counts ("0a" is width one). */
+            style = '1';
             pad = 0;
-            while (pad < format_len && format[pad] >= '0' && format[pad] <= '9') {
+            while (prefix_end + pad < token_end && format[prefix_end + pad] <= '9') {
                 pad++;
             }
-            style = '1';
         } else {
-            style = format[format_len - 1];
+            style = format[token_end - 1];
         }
     }
     xb buffer = {0};
+    if (xb_add(&buffer, format, prefix_end) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+        xb_free(&buffer);                          /* GCOVR_EXCL_LINE */
+        return fail(eng, "out of memory");         /* GCOVR_EXCL_LINE */
+    }
     if (style == '1' && pad > 1) {
         char raw[32];
         int raw_len = snprintf(raw, sizeof(raw), "%ld", value);
@@ -1916,6 +1945,10 @@ static int do_number(engine *eng, th_node *instruction, th_node *out_parent) {
     } else if (format_number_token(&buffer, value, style) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
         xb_free(&buffer);                                        /* GCOVR_EXCL_LINE */
         return fail(eng, "out of memory");                       /* GCOVR_EXCL_LINE */
+    }
+    if (xb_add(&buffer, format + token_end, format_len - token_end) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+        xb_free(&buffer);                                                  /* GCOVR_EXCL_LINE */
+        return fail(eng, "out of memory");                                 /* GCOVR_EXCL_LINE */
     }
     int rc = emit_text(eng, out_parent, buffer.data, buffer.len);
     xb_free(&buffer);
@@ -2348,6 +2381,124 @@ static int apply_templates(engine *eng, th_node *instruction, th_node *out_paren
 
 /* ---- the body instantiation walk ------------------------------------------ */
 
+static const char XSLT_NS[] = "http://www.w3.org/1999/XSL/Transform";
+
+/* Whether an output ancestor of `start` already binds namespace `name` (an "xmlns" or
+   "xmlns:prefix" spelling) to the identical URI. The nearest binding wins, so a rebinding
+   to a different URI reports out-of-scope and the caller redeclares. */
+static int output_ns_in_scope(engine *eng, th_node *start, const char *name, Py_ssize_t name_len, const Py_UCS4 *value,
+                              Py_ssize_t value_len) {
+    for (th_node *anc = start; anc != NULL; anc = anc->parent) {
+        if (anc->type != TH_NODE_ELEMENT) {
+            continue;
+        }
+        for (Py_ssize_t index = 0; index < anc->attr_count; index++) {
+            const th_node_attr *attr = &anc->attrs[index];
+            Py_ssize_t anc_len = 0;
+            const char *anc_name = th_attr_name(eng->out_tree, attr->name_atom, &anc_len);
+            if (anc_len != name_len || memcmp(anc_name, name, (size_t)name_len) != 0) {
+                continue;
+            }
+            return attr->value_len == value_len && memcmp(attr->value, value, (size_t)value_len * sizeof(Py_UCS4)) == 0;
+        }
+    }
+    return 0;
+}
+
+/* Whether `prefix` appears in the stylesheet's exclude-result-prefixes list (a whitespace-
+   separated set of prefixes; the default namespace is named "#default"), so its namespace
+   node is not copied to the output. */
+static int prefix_excluded(const engine *eng, const char *prefix, Py_ssize_t prefix_len) {
+    Py_ssize_t index = 0;
+    while (index < eng->exclude_prefixes_len) {
+        while (index < eng->exclude_prefixes_len && ucs4_blank(&eng->exclude_prefixes[index], 1)) {
+            index++;
+        }
+        Py_ssize_t start = index;
+        while (index < eng->exclude_prefixes_len && !ucs4_blank(&eng->exclude_prefixes[index], 1)) {
+            index++;
+        }
+        if (index - start == prefix_len) {
+            Py_ssize_t offset = 0;
+            while (offset < prefix_len &&
+                   eng->exclude_prefixes[start + offset] == (Py_UCS4)(unsigned char)prefix[offset]) {
+                offset++;
+            }
+            if (offset == prefix_len) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+/* Copy the stylesheet namespace declarations in scope at literal result element `lre` onto
+   its output copy (XSLT 1.0 section 7.1.1): every in-scope namespace node except the XSLT
+   namespace itself and any exclude-result-prefixes namespace, de-duplicated against the
+   declarations already in scope on the output parent so a prefix is redeclared only where it
+   is not already bound to that URI. The html and text output methods have no namespace
+   syntax, so they carry no namespace nodes (matching libxslt). */
+static int copy_namespace_decls(engine *eng, th_node *lre, th_node *copy, th_node *out_parent) {
+    if (eng->output_method != OUT_XML) {
+        return 0;
+    }
+    /* The walk stops at the document node above the stylesheet root, which has no attributes. */
+    for (th_node *anc = lre; anc != NULL; anc = anc->parent) {
+        for (Py_ssize_t index = 0; index < anc->attr_count; index++) {
+            const th_node_attr *attr = &anc->attrs[index];
+            Py_ssize_t name_len = 0;
+            const char *name = th_attr_name(eng->sheet_tree, attr->name_atom, &name_len);
+            int prefixed = name_len > 6 && memcmp(name, "xmlns:", 6) == 0;
+            int is_default = name_len == 5 && memcmp(name, "xmlns", 5) == 0;
+            if (!prefixed && !is_default) {
+                continue;
+            }
+            int excluded =
+                prefixed ? prefix_excluded(eng, name + 6, name_len - 6) : prefix_excluded(eng, "#default", 8);
+            if (excluded) {
+                continue;
+            }
+            int overridden = 0;
+            for (th_node *nearer = lre; nearer != anc; nearer = nearer->parent) {
+                for (Py_ssize_t probe = 0; probe < nearer->attr_count; probe++) {
+                    if (nearer->attrs[probe].name_atom == attr->name_atom) {
+                        overridden = 1;
+                        break;
+                    }
+                }
+                if (overridden) {
+                    break;
+                }
+            }
+            if (overridden || ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS) ||
+                output_ns_in_scope(eng, out_parent, name, name_len, attr->value, attr->value_len)) {
+                continue;
+            }
+            int rc = th_node_attr_set(eng->out_tree, copy, name, name_len, attr->value, attr->value_len, 1);
+            if (rc < 0) {                          /* GCOVR_EXCL_BR_LINE: alloc */
+                return fail(eng, "out of memory"); /* GCOVR_EXCL_LINE */
+            }
+        }
+    }
+    return 0;
+}
+
+/* Whether attribute name `name` carries the stylesheet's XSLT-namespace prefix, i.e. it is an
+   XSLT directive (xsl:exclude-result-prefixes, xsl:use-attribute-sets, ...) placed on a literal
+   result element, which the spec strips from the output rather than copying. */
+static int is_xsl_attr(const engine *eng, const char *name, Py_ssize_t name_len) {
+    Py_ssize_t prefix_len = eng->xsl_prefix_len;
+    if (name_len <= prefix_len || name[prefix_len] != ':') {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < prefix_len; index++) {
+        if ((Py_UCS4)(unsigned char)name[index] != eng->xsl_prefix[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 /* Copy a literal result element into the output, resolving attribute value
    templates, then instantiate its children inside it. */
 static int instantiate_literal(engine *eng, th_node *element, th_node *out_parent) {
@@ -2356,15 +2507,21 @@ static int instantiate_literal(engine *eng, th_node *element, th_node *out_paren
     if (copy == NULL) {                    /* GCOVR_EXCL_BR_LINE: alloc */
         return fail(eng, "out of memory"); /* GCOVR_EXCL_LINE */
     }
+    if (copy_namespace_decls(eng, element, copy, out_parent) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+        return -1;                                                  /* GCOVR_EXCL_LINE */
+    }
     for (Py_ssize_t index = 0; index < element->attr_count; index++) {
         const th_node_attr *attr = &element->attrs[index];
         Py_ssize_t name_len = 0;
         const char *name = th_attr_name(eng->sheet_tree, attr->name_atom, &name_len);
-        /* Drop the stylesheet's own xmlns:xsl declaration; keep other attributes. */
+        /* Namespace declarations are handled above; XSLT directives never reach the output. */
         if (name_len >= 6 && memcmp(name, "xmlns:", 6) == 0) {
             continue;
         }
         if (name_len == 5 && memcmp(name, "xmlns", 5) == 0) {
+            continue;
+        }
+        if (is_xsl_attr(eng, name, name_len)) {
             continue;
         }
         Py_UCS4 *resolved;
@@ -2882,6 +3039,9 @@ static int analyze(engine *eng, th_node *sheet_root) {
     if (resolve_xsl_prefix(eng, sheet_root) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
         return -1;                                 /* GCOVR_EXCL_LINE */
     }
+    eng->exclude_prefixes_len = 0;
+    eng->exclude_prefixes =
+        attr_lookup(eng->sheet_tree, sheet_root, "exclude-result-prefixes", &eng->exclude_prefixes_len);
     int position = 0;
     for (th_node *child = sheet_root->first_child; child != NULL; child = child->next_sibling) {
         if (child->type != TH_NODE_ELEMENT) {

--- a/src/turbohtml/_c/serialize/document.c
+++ b/src/turbohtml/_c/serialize/document.c
@@ -254,7 +254,9 @@ static th_node *serialize_compact_step(sbuf *out, th_tree *tree, th_node *node, 
     case TH_NODE_PI:
         sbuf_puts(out, "<?");
         sbuf_put_ucs4(out, node->text, node->text_len);
-        sbuf_putc(out, '>');
+        /* XML closes a PI with "?>"; the HTML serialization has no PI syntax and ends the
+           bogus-comment form at ">". */
+        sbuf_puts(out, opts->xml ? "?>" : ">");
         break;
     case TH_NODE_CDATA:
         sbuf_puts(out, "<![CDATA[");
@@ -396,7 +398,9 @@ static th_node *serialize_pretty_step(sbuf *out, th_tree *tree, th_node *node, t
     case TH_NODE_PI:
         sbuf_puts(out, "<?");
         sbuf_put_ucs4(out, node->text, node->text_len);
-        sbuf_putc(out, '>');
+        /* XML closes a PI with "?>"; the HTML serialization has no PI syntax and ends the
+           bogus-comment form at ">". */
+        sbuf_puts(out, opts->out->xml ? "?>" : ">");
         break;
     case TH_NODE_CDATA:
         sbuf_puts(out, "<![CDATA[");

--- a/src/turbohtml/transform.py
+++ b/src/turbohtml/transform.py
@@ -17,9 +17,14 @@ expression. It covers the XSLT 1.0 instruction set -- ``xsl:template`` (match, n
 ``xsl:apply-templates``, ``xsl:call-template``, ``xsl:for-each``, ``xsl:if``, ``xsl:choose``, ``xsl:value-of``,
 ``xsl:copy``/``xsl:copy-of``,
 ``xsl:element``/``xsl:attribute``/``xsl:text``, ``xsl:variable``/``xsl:param``, ``xsl:sort``, ``xsl:number``,
-``xsl:key`` and the ``key()`` function, the built-in template rules, the section 5.5 conflict resolution, and the
-``xml``/``html``/``text`` output methods. External-document loading (``xsl:include``, ``xsl:import``, ``document()``) is
-not modeled.
+``xsl:key`` and the ``key()`` function, the built-in template rules, the section 5.5 conflict resolution,
+``exclude-result-prefixes`` with the section 7.1.1 namespace-node copying, and the ``xml``/``html``/``text`` output
+methods. External-document loading (``xsl:include``, ``xsl:import``, ``document()``) is not modeled.
+
+Validated against libxslt's XSLT 1.0 Recommendation test corpus (the ``REC`` and ``REC2`` example triples it ships):
+56 of the 79 cases pass exactly, and the remainder exercise features turbohtml does not model (whitespace stripping,
+namespace-alias, attribute sets, multi-level numbering, cdata-section-elements, extension elements, and the html
+output method's meta injection); see ``tests/conformance/test_xslt_conformance.py``.
 """
 
 from __future__ import annotations

--- a/tests/conformance/test_xslt_conformance.py
+++ b/tests/conformance/test_xslt_conformance.py
@@ -1,0 +1,109 @@
+"""Validate ``turbohtml.transform`` against libxslt's own XSLT 1.0 Recommendation test corpus.
+
+libxslt (the reference C implementation behind ``lxml.etree.XSLT``) ships, under ``tests/REC``
+and ``tests/REC2``, the worked examples from the XSLT 1.0 Recommendation as
+stylesheet/source/expected-output triples: ``foo.xsl`` transforms ``foo.xml`` into ``foo.out``.
+This harness runs turbohtml over every such triple and asserts its output equals libxslt's, so it
+proves spec-correctness against an authoritative oracle rather than against turbohtml's own tests.
+
+The corpus is the pinned ``tests/conformance/libxslt`` submodule. It is a pure data checkout with no
+optional runtime dependency, so an absent submodule is a setup error, not a reason to skip: collection
+raises rather than silently passing. The dedicated ``conformance`` CI job initializes the submodule and
+runs this suite; the coverage matrix ignores ``tests/conformance`` (and the file stays in
+``[tool.coverage] run.omit``).
+
+Comparison normalizes only insignificant differences per output method: the ``xml`` and ``html``
+methods drop the XML declaration and collapse whitespace between tags; ``text`` output is compared
+verbatim. libxslt's ``runtest`` passes ``test``/``test2`` string parameters to every case, so this
+harness does too.
+
+Cases that exercise XSLT features turbohtml deliberately does not model are ``xfail`` with a
+spec-cited reason (see ``_XFAIL``); every other case is a strict correctness assertion.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import turbohtml
+from turbohtml.transform import transform
+
+_CORPUS = Path(__file__).parent / "libxslt" / "tests"
+
+if not _CORPUS.exists():  # pragma: no cover
+    msg = (
+        "submodule tests/conformance/libxslt not checked out; "
+        "run: git submodule update --init tests/conformance/libxslt"
+    )
+    raise RuntimeError(msg)
+
+# Features outside turbohtml's XSLT 1.0 subset, each keyed by "<dir>/<stem>" with the spec reason.
+_XFAIL: dict[str, str] = {
+    "REC/stand-2.7-1": "xsl:strip-space/preserve-space whitespace stripping (section 3.4) is not modeled",
+    "REC/test-3.4-1": "xsl:strip-space/preserve-space whitespace stripping (section 3.4) is not modeled",
+    "REC/test-3.4-2": "xsl:strip-space/preserve-space whitespace stripping (section 3.4) is not modeled",
+    "REC/test-3.4-3": "xsl:strip-space/preserve-space whitespace stripping (section 3.4) is not modeled",
+    "REC/test-9.1-1": "xsl:strip-space whitespace stripping (section 3.4) is not modeled",
+    "REC/test-9.1-2": "xsl:strip-space whitespace stripping (section 3.4) is not modeled",
+    "REC/test-2.3-1": "simplified (literal-result-element) stylesheets (section 2.3) are not modeled",
+    "REC/test-2.6.2-1": "xsl:import of external stylesheets (section 2.6.2) is not modeled",
+    "REC/test-7.1.1": "xsl:namespace-alias (section 7.1.1) is not modeled",
+    "REC/test-7.1.3": "xsl:namespace-alias (section 7.1.1) is not modeled",
+    "REC/test-7.1.4": "use-attribute-sets / xsl:attribute-set (section 7.1.4) is not modeled",
+    "REC/test-7.7-3": "multi-level xsl:number (level='multiple', count/from) is not modeled",
+    "REC/test-7.7-5": "multi-level xsl:number (level='multiple', count/from) is not modeled",
+    "REC/test-7.7-6": "xsl:number grouping-separator/grouping-size and lang are not modeled",
+    "REC/test-10-3": "locale-aware xsl:sort collation (lang='de') is not modeled",
+    "REC/test-12.4-1": "generate-id over the namespace:: axis is not modeled",
+    "REC/test-5.2-10": "id() patterns need DTD-declared ID attributes, which the parser does not track",
+    "REC/test-15-1": "extension elements (extension-element-prefixes) and xsl:fallback are not modeled",
+    "REC/test-16.1-1": "the cdata-section-elements output option (section 16.1) is not modeled",
+    "REC/test-16.1-2": "the cdata-section-elements output option (section 16.1) is not modeled",
+    "REC/test-2.5-1": "html output method auto-selection and meta content-type injection are not modeled",
+    "REC/test-8-1": "html output method auto-selection and meta content-type injection are not modeled",
+    "REC2/html": "html output method auto-selection and meta content-type injection are not modeled",
+}
+
+
+def _iter_cases() -> list[tuple[str, Path]]:
+    return [
+        (f"{group}/{xsl.stem}", xsl)
+        for group in ("REC", "REC2")
+        for xsl in sorted((_CORPUS / group).glob("*.xsl"))
+        if xsl.with_suffix(".xml").exists() and xsl.with_suffix(".out").exists()
+    ]
+
+
+_CASES = _iter_cases()
+
+
+def _output_method(stylesheet: str) -> str:
+    match = re.search(r"<xsl:output[^>]*\bmethod\s*=\s*[\"'](\w+)", stylesheet)
+    return match.group(1) if match else "xml"
+
+
+def _canonical(text: str) -> str:
+    text = re.sub(r"^﻿?<\?xml\s[^>]*\?>\s*", "", text)
+    return re.sub(r">\s+<", "><", text.strip())
+
+
+@pytest.mark.parametrize(("case_id", "xsl"), [pytest.param(cid, path, id=cid) for cid, path in _CASES])
+def test_xslt_conformance(case_id: str, xsl: Path, request: pytest.FixtureRequest) -> None:
+    if case_id in _XFAIL:
+        request.node.add_marker(pytest.mark.xfail(reason=_XFAIL[case_id], strict=True))
+    stylesheet = xsl.read_text(encoding="utf-8", errors="replace")
+    source = xsl.with_suffix(".xml").read_text(encoding="utf-8", errors="replace")
+    expected = xsl.with_suffix(".out").read_text(encoding="utf-8", errors="replace")
+    result = transform(
+        turbohtml.parse_xml(stylesheet),
+        turbohtml.parse_xml(source),
+        test="'passed_value'",
+        test2="'passed_value2'",
+    )
+    if _output_method(stylesheet) == "text":
+        assert result == expected
+    else:
+        assert _canonical(result) == _canonical(expected)

--- a/tests/convert/test_transform.py
+++ b/tests/convert/test_transform.py
@@ -250,7 +250,7 @@ def test_transform_copy_of_comment_and_pi() -> None:
     )
     result = _run("<r><!--note--><?pi data?></r>", body, method="xml")
     assert "<!--note-->" in result
-    assert "<?pi data>" in result
+    assert "<?pi data?>" in result
 
 
 def test_transform_xsl_copy_of_root_context() -> None:
@@ -269,7 +269,7 @@ def test_transform_comment_and_processing_instruction_instructions() -> None:
     )
     result = _run("<r/>", body, method="xml")
     assert "<!--hi-->" in result
-    assert "<?go data>" in result
+    assert "<?go data?>" in result
 
 
 @pytest.mark.parametrize(
@@ -1104,7 +1104,7 @@ def test_transform_attribute_instruction_at_root_is_ignored() -> None:
 
 def test_transform_copy_of_processing_instruction() -> None:
     body = '<xsl:template match="/"><out><xsl:copy-of select="//processing-instruction()"/></out></xsl:template>'
-    assert "<?pi x>" in _run("<r><?pi x?></r>", body, method="xml")
+    assert "<?pi x?>" in _run("<r><?pi x?></r>", body, method="xml")
 
 
 def test_transform_sort_without_select_uses_context() -> None:
@@ -1170,7 +1170,9 @@ def test_transform_apply_templates_to_attribute_children_are_empty() -> None:
 def test_transform_literal_element_default_namespace_declaration() -> None:
     body = '<xsl:template match="/"><out xmlns="urn:x"><in/></out></xsl:template>'
     result = _run("<r/>", body, method="xml")
-    assert "<out><in/></out>" in result or "<out ><in/></out>" in result
+    # XSLT 1.0 section 7.1.1: the default-namespace node is copied to the output element and the
+    # child inherits it (declared once), as libxslt/lxml emit it.
+    assert '<out xmlns="urn:x"><in/></out>' in result
 
 
 def test_transform_stylesheet_with_top_level_comment() -> None:
@@ -1473,7 +1475,7 @@ def test_transform_copy_of_rtf_variable_with_others_in_scope() -> None:
 
 def test_transform_copy_of_processing_instruction_identity() -> None:
     body = '<xsl:template match="/"><out><xsl:copy-of select="//processing-instruction()"/></out></xsl:template>'
-    assert "<?go x>" in _run("<r><?go x?></r>", body, method="xml")
+    assert "<?go x?>" in _run("<r><?go x?></r>", body, method="xml")
 
 
 def test_transform_sort_equal_length_equal_keys() -> None:
@@ -1660,7 +1662,7 @@ def test_transform_xsl_copy_of_processing_instruction() -> None:
         '<xsl:template match="/"><out><xsl:apply-templates select="//processing-instruction()"/></out></xsl:template>'
         '<xsl:template match="processing-instruction()"><xsl:copy/></xsl:template>'
     )
-    assert "<?go x>" in _run("<r><?go x?></r>", body, method="xml")
+    assert "<?go x?>" in _run("<r><?go x?></r>", body, method="xml")
 
 
 def test_transform_sort_mixed_length_keys() -> None:
@@ -1698,12 +1700,14 @@ def test_transform_sort_prefix_length_ordering(source: str, expected: str) -> No
 
 def test_transform_number_format_starting_with_symbol() -> None:
     body = '<xsl:template match="/"><xsl:number value="7" format="#"/></xsl:template>'
-    assert _run("<r/>", body) == "7"
+    # "#" is a leading separator (a prefix) with no format token, so the number follows it.
+    assert _run("<r/>", body) == "#7"
 
 
 def test_transform_number_format_digit_then_symbol() -> None:
     body = '<xsl:template match="/"><xsl:number value="7" format="0#"/></xsl:template>'
-    assert _run("<r/>", body) == "7"
+    # The "0" is the format token and the trailing "#" is a suffix.
+    assert _run("<r/>", body) == "7#"
 
 
 def test_transform_output_without_method_attribute() -> None:
@@ -1770,7 +1774,97 @@ def test_transform_apply_templates_failing_sort_raises() -> None:
 def test_transform_literal_element_with_namespace_declaration() -> None:
     body = '<xsl:template match="/"><out xmlns:ex="urn:example"><inner>x</inner></out></xsl:template>'
     result = _run("<r/>", body, method="xml")
-    assert "<out><inner>x</inner></out>" in result
+    # XSLT 1.0 section 7.1.1 copies every in-scope namespace node to the literal result element,
+    # even an unreferenced prefix, matching libxslt/lxml.
+    assert '<out xmlns:ex="urn:example"><inner>x</inner></out>' in result
+
+
+def test_transform_literal_element_namespace_child_inherits_parent() -> None:
+    body = '<xsl:template match="/"><a xmlns:p="urn:1"><p:b/></a></xsl:template>'
+    assert _collapse(_run("<r/>", body, method="xml")) == '<a xmlns:p="urn:1"><p:b/></a>'
+
+
+def test_transform_literal_element_namespace_rebinding_redeclares() -> None:
+    body = '<xsl:template match="/"><a xmlns:p="urn:1"><p:b xmlns:p="urn:2"/></a></xsl:template>'
+    assert _collapse(_run("<r/>", body, method="xml")) == '<a xmlns:p="urn:1"><p:b xmlns:p="urn:2"/></a>'
+
+
+def test_transform_exclude_result_prefixes_drops_only_listed() -> None:
+    body = '<xsl:template match="/"><out/></xsl:template>'
+    declare = 'xmlns:keep="urn:k" xmlns:drop="urn:d" exclude-result-prefixes="drop"'
+    result = transform(_sheet(body, method="xml", declare=declare), turbohtml.parse_xml("<r/>"))
+    assert _collapse(result) == '<out xmlns:keep="urn:k"/>'
+
+
+def test_transform_exclude_result_prefixes_default_namespace() -> None:
+    body = '<xsl:template match="/"><out/></xsl:template>'
+    declare = 'xmlns="urn:def" exclude-result-prefixes="#default"'
+    result = transform(_sheet(body, method="xml", declare=declare), turbohtml.parse_xml("<r/>"))
+    assert _collapse(result) == "<out/>"
+
+
+def test_transform_namespace_dedup_skips_non_matching_ancestor_attributes() -> None:
+    # The output parent carries an unrelated attribute and a same-length but different xmlns, so
+    # scope lookup scans past both and the child still declares its own prefix.
+    body = '<xsl:template match="/"><a foo="1" xmlns:q="urn:q"><p:b xmlns:p="urn:1"/></a></xsl:template>'
+    result = _collapse(_run("<r/>", body, method="xml"))
+    assert result == '<a xmlns:q="urn:q" foo="1"><p:b xmlns:p="urn:1"/></a>'
+
+
+def test_transform_namespace_rebinding_to_shorter_uri_redeclares() -> None:
+    body = '<xsl:template match="/"><a xmlns:p="urn:11"><p:b xmlns:p="urn:2"/></a></xsl:template>'
+    assert _collapse(_run("<r/>", body, method="xml")) == '<a xmlns:p="urn:11"><p:b xmlns:p="urn:2"/></a>'
+
+
+def test_transform_exclude_result_prefixes_multiple_whitespace_separated() -> None:
+    body = '<xsl:template match="/"><out/></xsl:template>'
+    declare = 'xmlns:keep="urn:k" xmlns:drop="urn:d" xmlns:drop2="urn:d2" exclude-result-prefixes=" drop  drop2 "'
+    result = transform(_sheet(body, method="xml", declare=declare), turbohtml.parse_xml("<r/>"))
+    assert _collapse(result) == '<out xmlns:keep="urn:k"/>'
+
+
+def test_transform_literal_element_keeps_non_xsl_prefixed_attribute() -> None:
+    body = '<xsl:template match="/"><out abc:x="1" xmlns:abc="urn:a"/></xsl:template>'
+    assert _collapse(_run("<r/>", body, method="xml")) == '<out xmlns:abc="urn:a" abc:x="1"/>'
+
+
+def test_transform_html_method_omits_namespace_nodes() -> None:
+    body = '<xsl:template match="/"><out xmlns:x="urn:x"/></xsl:template>'
+    assert "xmlns" not in _run("<r/>", body, method="html")
+
+
+def test_transform_literal_element_strips_xsl_directive_attribute() -> None:
+    body = '<xsl:template match="/"><out xsl:exclude-result-prefixes="foo">t</out></xsl:template>'
+    assert _collapse(_run("<r/>", body, method="xml")) == "<out>t</out>"
+
+
+@pytest.mark.parametrize(
+    ("fmt", "expected"),
+    [
+        pytest.param("1. ", "1. ", id="decimal-suffix"),
+        pytest.param("(1)", "(1)", id="prefix-and-suffix"),
+        pytest.param("~", "~1", id="above-z-separator-is-prefix"),
+        pytest.param("001", "001", id="decimal-min-width"),
+        pytest.param("a", "a", id="alpha-lower"),
+        pytest.param("i", "i", id="roman-lower"),
+    ],
+)
+def test_transform_number_format_tokens(fmt: str, expected: str) -> None:
+    body = f'<xsl:template match="/"><xsl:number value="1" format="{fmt}"/></xsl:template>'
+    assert _run("<r/>", body) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "fmt", "expected"),
+    [
+        pytest.param("0", "i", "0", id="roman-zero-falls-to-decimal"),
+        pytest.param("-3", "a", "-3", id="alpha-negative-falls-to-decimal"),
+        pytest.param("5000", "I", "5000", id="roman-over-4999-falls-to-decimal"),
+    ],
+)
+def test_transform_number_out_of_range_falls_back_to_decimal(value: str, fmt: str, expected: str) -> None:
+    body = f'<xsl:template match="/"><xsl:number value="{value}" format="{fmt}"/></xsl:template>'
+    assert _run("<r/>", body) == expected
 
 
 def test_transform_literal_element_with_long_attribute_name() -> None:

--- a/tests/serialize/test_serialize_xml.py
+++ b/tests/serialize/test_serialize_xml.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree as ET  # noqa: S405  # parsing turbohtml's own
 
 import pytest
 
-from turbohtml import Element, Formatter, Html, Indent, Minify, Text, parse
+from turbohtml import Element, Formatter, Html, Indent, Minify, ProcessingInstruction, Text, parse
 
 _XML = Html(xml=True)
 
@@ -149,6 +149,12 @@ def test_indent_pretty_xml_escapes_text() -> None:
 
 def test_indent_pretty_xml_empty_root_self_closes() -> None:
     assert _fragment("<div></div>", "div").serialize(Html(xml=True, layout=Indent(2))) == "<div/>"
+
+
+def test_xml_processing_instruction_closes_with_question_mark() -> None:
+    node = Element("doc", children=[ProcessingInstruction("t", "d")])
+    assert node.serialize(_XML) == "<doc><?t d?></doc>"
+    assert node.serialize(Html(xml=True, layout=Indent(2))) == "<doc>\n  <?t d?>\n</doc>"
 
 
 def test_serialize_iter_streams_xml() -> None:


### PR DESCRIPTION
The XSLT 1.0 processor from #537 shipped with green coverage, but coverage proves the code runs, not that it matches the spec. This validates `turbohtml.transform` against an authoritative external oracle: libxslt's own XSLT 1.0 Recommendation corpus, the `REC` and `REC2` stylesheet/source/expected-output triples the reference implementation behind `lxml.etree.XSLT` ships. It vendors that corpus as the pinned `tests/conformance/libxslt` shallow submodule and runs turbohtml over every triple, asserting byte-equal output with whitespace normalized per output method.

Of the 79 cases, 56 pass exactly. The remaining 23 exercise features turbohtml does not model, so each is `xfail` tagged with the [spec](https://www.w3.org/TR/xslt-10/) section it needs: whitespace stripping (`xsl:strip-space`), `xsl:namespace-alias`, attribute sets, multi-level `xsl:number`, `cdata-section-elements`, extension elements, and the html method's meta injection. 📋 The corpus is a git submodule, not a runtime library, so an absent checkout is a setup error: the module raises at import telling you to run `git submodule update --init`, and the dedicated conformance CI job always checks it out.

The oracle surfaced four conformance bugs, all fixed here. A literal result element now copies its in-scope stylesheet namespace declarations to the output per [section 7.1.1](https://www.w3.org/TR/xslt-10/#literal-result-element), de-duplicated against the ancestors already in scope and filtered by `exclude-result-prefixes`, so a prefixed or default-namespaced result element stays well-formed instead of losing its declaration; `xsl:*` directive attributes on a literal result element are stripped rather than emitted. `xsl:number` honors the separators around a format token, so `format="1. "` yields `1. ` and `format="(1)"` yields `(1)`, and a value with no alphabetic or roman form falls back to decimal 🔢. A roman numeral past 4999 previously produced an unbounded run of `M`, a memory-exhaustion hazard, and zero or a negative produced empty output. A processing instruction now serializes with the `?>` terminator under the `xml` output method.

Line and branch C coverage stays at 100% on the changed `xslt.c` and `document.c`. Three existing unit tests that had pinned the pre-fix behavior are corrected to the libxslt-confirmed output.

validates #537

