### PR TITLE
✨ feat(cssom): expand border and outline shorthands

### DIFF
--- a/docs/changelog/546.feature.rst
+++ b/docs/changelog/546.feature.rst
@@ -6,4 +6,7 @@ in the C core under the per-tree critical section. Alongside it, :class:`~turboh
 :class:`~turbohtml.cssom.RuleList`, :class:`~turbohtml.cssom.StyleRule`, and :class:`~turbohtml.cssom.StyleDeclaration`
 are the read-only, turbohtml-native spelling of the CSSOM ``CSSStyleSheet`` / ``CSSRuleList`` / ``CSSStyleRule`` /
 ``CSSStyleDeclaration`` interfaces. The returned value is the computed value, not the used value: turbohtml runs no
-layout, so lengths and percentages come back as written, the same boundary jsdom and cssstyle draw.
+layout, so lengths and percentages come back as written, the same boundary jsdom and cssstyle draw. Shorthand expansion
+covers the distributive families (``margin``, ``padding``, ``border-width``/``style``/``color``, ``overflow``) and the
+``<line-width> || <line-style> || <color>`` shorthands ``border``, each ``border-<side>``, and ``outline``, whose
+components resolve in any order and reset every longhand they cover.

--- a/docs/explanation/cssom.rst
+++ b/docs/explanation/cssom.rst
@@ -28,9 +28,13 @@ For each element the cascade gathers every declaration that could apply and pick
   ``revert`` collapse to one of those. Properties are inherited by walking the ancestor chain from the root down, so a
   parent is always computed before its child.
 
-Shorthands are expanded before the sort. ``margin: 1px 2px`` becomes the four ``margin-*`` longhands, ``border-color``
-splits across the four sides, and ``overflow`` fills ``overflow-x`` and ``overflow-y``; a computed style therefore only
-ever exposes longhands, never a shorthand.
+Shorthands are expanded before the sort. The distributive ones split by the 1-to-4 rule -- ``margin: 1px 2px`` becomes
+the four ``margin-*`` longhands, ``border-color`` splits across the four sides, and ``overflow`` fills ``overflow-x``
+and ``overflow-y``. The ``<line-width> || <line-style> || <color>`` shorthands (``border``, each ``border-<side>``, and
+``outline``) classify their components by shape rather than position, so they accept any order and any omission, and
+they reset every longhand they cover -- an omitted component to that property's initial value, which is why a later
+``border`` overrides an earlier ``border-top-color`` it does not restate. A computed style therefore only ever exposes
+longhands, never a shorthand.
 
 **********************************
  Computed values, not used values
@@ -50,10 +54,10 @@ but return the pre-layout value. If you need pixel geometry, you need a browser 
 WeasyPrint; if you need to know which rule wins and what value it carries, that is exactly what
 :func:`~turbohtml.cssom.computed_style` gives you.
 
-The cascade is validated differentially against jsdom's ``getComputedStyle`` -- 39 fixtures over every axis above, all
-agreeing once color serialization and the boundaries here are accounted for (``tests/conformance``). The one place the
-two diverge on a supported property is the ``overflow`` shorthand, which turbohtml expands to
-``overflow-x``/``overflow-y`` per CSS Overflow 3 and jsdom leaves at its initial value.
+The cascade is validated differentially against jsdom's ``getComputedStyle`` -- fixtures over every axis above, all
+agreeing once color serialization and the boundaries here are accounted for (``tests/conformance``). The two places the
+two diverge on a supported property are the ``overflow`` and ``outline`` shorthands, which turbohtml expands to their
+longhands per CSS Overflow 3 and CSS UI 4 while jsdom leaves them at their initial values.
 
 ******************
  The property set
@@ -61,9 +65,9 @@ two diverge on a supported property is the ``overflow`` shorthand, which turboht
 
 The cascade tracks a curated set of common, well-defined longhands -- the inherited text and font properties (``color``,
 ``font-size``, ``line-height``, ``text-align`` and the like), the box properties (``margin-*``, ``padding-*``,
-``border-*-width/style/color``, ``width``, ``height``), and the common layout and paint properties (``display``,
-``position``, the offsets, ``float``, ``opacity``, ``background-color``, ``overflow-x/y``). Each carries its inheritance
-flag and its initial value from that property's specification. Properties outside the set are ignored rather than
-guessed at, and a declaration whose property is unknown is simply dropped -- so
+``border-*-width/style/color``, ``outline-*``, ``width``, ``height``), and the common layout and paint properties
+(``display``, ``position``, the offsets, ``float``, ``opacity``, ``background-color``, ``overflow-x/y``). Each carries
+its inheritance flag and its initial value from that property's specification. Properties outside the set are ignored
+rather than guessed at, and a declaration whose property is unknown is simply dropped -- so
 :meth:`~turbohtml.cssom.ComputedStyle.get` returns a value for every property the set covers and ``None`` for anything
 else.

--- a/src/turbohtml/_c/features/cssom.c
+++ b/src/turbohtml/_c/features/cssom.c
@@ -140,6 +140,54 @@ static const css_shorthand CSS_SHORTHANDS[] = {
 
 #define NUM_SHORTHANDS ((int)(sizeof(CSS_SHORTHANDS) / sizeof(CSS_SHORTHANDS[0])))
 
+/* A <line-width> || <line-style> || <color> shorthand (CSS Backgrounds & Borders 3 §4
+   for border and each border-<side>, CSS UI 4 §5 for outline). Its up-to-three
+   components come in any order and any may be omitted, so each is classified by shape
+   rather than position; an omitted component resets its longhand to that property's
+   initial value. targets lists every longhand the shorthand writes, tagged with which
+   component supplies it -- one width/style/color triple for a single side, four for the
+   whole-box border. */
+enum css_component_kind { COMPONENT_WIDTH, COMPONENT_STYLE, COMPONENT_COLOR };
+
+typedef struct {
+    int kind;
+    int prop;
+} css_box_target;
+
+typedef struct {
+    const char *name;
+    int target_count;
+    css_box_target targets[12];
+} css_box_shorthand;
+
+/* clang-format off */
+static const css_box_shorthand CSS_BOX_SHORTHANDS[] = {
+    {"border", 12, {
+        {COMPONENT_WIDTH, PROP_BORDER_TOP_WIDTH},    {COMPONENT_STYLE, PROP_BORDER_TOP_STYLE},    {COMPONENT_COLOR, PROP_BORDER_TOP_COLOR},
+        {COMPONENT_WIDTH, PROP_BORDER_RIGHT_WIDTH},  {COMPONENT_STYLE, PROP_BORDER_RIGHT_STYLE},  {COMPONENT_COLOR, PROP_BORDER_RIGHT_COLOR},
+        {COMPONENT_WIDTH, PROP_BORDER_BOTTOM_WIDTH}, {COMPONENT_STYLE, PROP_BORDER_BOTTOM_STYLE}, {COMPONENT_COLOR, PROP_BORDER_BOTTOM_COLOR},
+        {COMPONENT_WIDTH, PROP_BORDER_LEFT_WIDTH},   {COMPONENT_STYLE, PROP_BORDER_LEFT_STYLE},   {COMPONENT_COLOR, PROP_BORDER_LEFT_COLOR},
+    }},
+    {"border-top", 3, {
+        {COMPONENT_WIDTH, PROP_BORDER_TOP_WIDTH}, {COMPONENT_STYLE, PROP_BORDER_TOP_STYLE}, {COMPONENT_COLOR, PROP_BORDER_TOP_COLOR},
+    }},
+    {"border-right", 3, {
+        {COMPONENT_WIDTH, PROP_BORDER_RIGHT_WIDTH}, {COMPONENT_STYLE, PROP_BORDER_RIGHT_STYLE}, {COMPONENT_COLOR, PROP_BORDER_RIGHT_COLOR},
+    }},
+    {"border-bottom", 3, {
+        {COMPONENT_WIDTH, PROP_BORDER_BOTTOM_WIDTH}, {COMPONENT_STYLE, PROP_BORDER_BOTTOM_STYLE}, {COMPONENT_COLOR, PROP_BORDER_BOTTOM_COLOR},
+    }},
+    {"border-left", 3, {
+        {COMPONENT_WIDTH, PROP_BORDER_LEFT_WIDTH}, {COMPONENT_STYLE, PROP_BORDER_LEFT_STYLE}, {COMPONENT_COLOR, PROP_BORDER_LEFT_COLOR},
+    }},
+    {"outline", 3, {
+        {COMPONENT_WIDTH, PROP_OUTLINE_WIDTH}, {COMPONENT_STYLE, PROP_OUTLINE_STYLE}, {COMPONENT_COLOR, PROP_OUTLINE_COLOR},
+    }},
+};
+/* clang-format on */
+
+#define NUM_BOX_SHORTHANDS ((int)(sizeof(CSS_BOX_SHORTHANDS) / sizeof(CSS_BOX_SHORTHANDS[0])))
+
 static int css_is_ws(Py_UCS4 ch) {
     /* a loop over the literals, not a chained ||, so branch coverage does not hinge on
        seeing every one of the five whitespace code points (issue-era chained-|| gaps) */
@@ -174,6 +222,57 @@ static int css_prop_id(const Py_UCS4 *name, Py_ssize_t len) {
         }
     }
     return -1;
+}
+
+/* A code-point slice; the value a component of a grammar shorthand carries, or the
+   fallback an omitted component resets its longhand to. */
+typedef struct {
+    const Py_UCS4 *value;
+    Py_ssize_t len;
+} css_span;
+
+/* clang-format off */
+static const Py_UCS4 CSS_INITIAL_WIDTH[] = {'m', 'e', 'd', 'i', 'u', 'm'};
+static const Py_UCS4 CSS_INITIAL_STYLE[] = {'n', 'o', 'n', 'e'};
+static const Py_UCS4 CSS_INITIAL_COLOR[] = {'c', 'u', 'r', 'r', 'e', 'n', 't', 'c', 'o', 'l', 'o', 'r'};
+/* clang-format on */
+
+/* The initial value an omitted component of a grammar shorthand resets its longhand to,
+   indexed by css_component_kind; these mirror the border/outline longhands' initials. */
+static const css_span CSS_COMPONENT_INITIAL[] = {
+    {CSS_INITIAL_WIDTH, (Py_ssize_t)(sizeof(CSS_INITIAL_WIDTH) / sizeof(Py_UCS4))},
+    {CSS_INITIAL_STYLE, (Py_ssize_t)(sizeof(CSS_INITIAL_STYLE) / sizeof(Py_UCS4))},
+    {CSS_INITIAL_COLOR, (Py_ssize_t)(sizeof(CSS_INITIAL_COLOR) / sizeof(Py_UCS4))},
+};
+
+/* Classify one component of a <line-width> || <line-style> || <color> shorthand: a
+   line-style keyword (plus outline's auto), a width keyword or a length (a numeric-led
+   token), else a color -- the grammar's only remaining alternative. */
+static int css_classify_component(const Py_UCS4 *data, Py_ssize_t len) {
+    static const char *const styles[] = {"none",   "hidden", "dotted", "dashed", "solid", "auto",
+                                         "double", "groove", "ridge",  "inset",  "outset"};
+    for (size_t index = 0; index < sizeof(styles) / sizeof(styles[0]); index++) {
+        if (css_slice_ci_eq(data, len, styles[index])) {
+            return COMPONENT_STYLE;
+        }
+    }
+    static const char *const widths[] = {"thin", "medium", "thick"};
+    for (size_t index = 0; index < sizeof(widths) / sizeof(widths[0]); index++) {
+        if (css_slice_ci_eq(data, len, widths[index])) {
+            return COMPONENT_WIDTH;
+        }
+    }
+    Py_UCS4 first = data[0];
+    if (first >= '0' && first <= '9') {
+        return COMPONENT_WIDTH;
+    }
+    /* a loop over the sign/dot leads, not a chained ||, so clang cannot fold the branch */
+    for (const char *lead = ".+-"; *lead != '\0'; lead++) {
+        if (first == (Py_UCS4)*lead) {
+            return COMPONENT_WIDTH;
+        }
+    }
+    return COMPONENT_COLOR;
 }
 
 /* Copy src stripping CSS block comments, honoring '' and "" strings (a comment
@@ -623,19 +722,22 @@ static int css_outranks(const css_slot *slot, int important, int inline_style, i
     return order >= slot->order;
 }
 
-/* Feed one declaration into the cascade slots, expanding a shorthand across its
-   longhands. Every candidate for one declaration shares an order stamp. */
-static void css_apply_decl(css_slot slots[NUM_PROPS], const css_decl *decl, int inline_style, int spec_a, int spec_b,
-                           int spec_c, long order) {
-    int direct = css_prop_id(decl->name, decl->name_len);
-    if (direct >= 0) {
-        css_slot *slot = &slots[direct];
-        if (css_outranks(slot, decl->important, inline_style, spec_a, spec_b, spec_c, order)) {
-            *slot = (css_slot){
-                decl->value, decl->value_len, decl->important, inline_style, spec_a, spec_b, spec_c, order, 1};
-        }
-        return;
+/* Store value as prop's cascade winner when it outranks the current one, carrying the
+   ranking (importance, style attribute, specificity, source order) from rank. */
+static void css_set_slot(css_slot slots[NUM_PROPS], int prop, const Py_UCS4 *value, Py_ssize_t len,
+                         const css_slot *rank) {
+    css_slot *slot = &slots[prop];
+    if (css_outranks(slot, rank->important, rank->inline_style, rank->spec_a, rank->spec_b, rank->spec_c,
+                     rank->order)) {
+        *slot = (css_slot){
+            value, len, rank->important, rank->inline_style, rank->spec_a, rank->spec_b, rank->spec_c, rank->order, 1};
     }
+}
+
+/* Expand a distributive shorthand (margin, padding, the border-width/style/color
+   families, overflow) across its sides by the 1-to-4 rule. Returns 1 when decl names
+   one -- even if invalid, which sets nothing -- and 0 when it names none. */
+static int css_apply_distributive(css_slot slots[NUM_PROPS], const css_decl *decl, const css_slot *rank) {
     for (int index = 0; index < NUM_SHORTHANDS; index++) {
         const css_shorthand *shorthand = &CSS_SHORTHANDS[index];
         if (!css_slice_ci_eq(decl->name, decl->name_len, shorthand->name)) {
@@ -661,7 +763,7 @@ static void css_apply_decl(css_slot slots[NUM_PROPS], const css_decl *decl, int 
         /* more components than sides (or than the 4 read) leaves a token unconsumed:
            the shorthand is invalid and sets nothing */
         if (part_count > shorthand->axes || pos < decl->value_len) {
-            return;
+            return 1;
         }
         for (int side = 0; side < shorthand->axes; side++) {
             /* the 1-to-4 rule: 1 value fills all, 2 splits opposite pairs, 3 sets the
@@ -674,14 +776,64 @@ static void css_apply_decl(css_slot slots[NUM_PROPS], const css_decl *decl, int 
             } else if (part_count == 3 && side == 3) {
                 source = 1;
             }
-            css_slot *slot = &slots[shorthand->sides[side]];
-            if (css_outranks(slot, decl->important, inline_style, spec_a, spec_b, spec_c, order)) {
-                *slot = (css_slot){
-                    parts[source], part_lens[source], decl->important, inline_style, spec_a, spec_b, spec_c, order, 1};
+            css_set_slot(slots, shorthand->sides[side], parts[source], part_lens[source], rank);
+        }
+        return 1;
+    }
+    return 0;
+}
+
+/* Expand a grammar shorthand (border, a border-<side>, outline) whose components come
+   in any order and any may be omitted. Each component is classified by shape; a repeat
+   of one kind makes the whole shorthand invalid (it sets nothing). Every longhand is
+   written -- an omitted component resets its longhand to the property's initial value,
+   so this shorthand overrides an earlier longhand it does not restate. Returns 1 when
+   decl names such a shorthand, 0 when it names none. */
+static int css_apply_box(css_slot slots[NUM_PROPS], const css_decl *decl, const css_slot *rank) {
+    for (int index = 0; index < NUM_BOX_SHORTHANDS; index++) {
+        const css_box_shorthand *shorthand = &CSS_BOX_SHORTHANDS[index];
+        if (!css_slice_ci_eq(decl->name, decl->name_len, shorthand->name)) {
+            continue;
+        }
+        css_span components[3] = {CSS_COMPONENT_INITIAL[0], CSS_COMPONENT_INITIAL[1], CSS_COMPONENT_INITIAL[2]};
+        int seen[3] = {0, 0, 0};
+        Py_ssize_t pos = 0;
+        while (pos < decl->value_len) {
+            Py_ssize_t stop = css_component_end(decl->value, pos, decl->value_len);
+            int kind = css_classify_component(decl->value + pos, stop - pos);
+            if (seen[kind]) {
+                return 1;
+            }
+            seen[kind] = 1;
+            components[kind] = (css_span){decl->value + pos, stop - pos};
+            pos = stop;
+            while (pos < decl->value_len && css_is_ws(decl->value[pos])) {
+                pos++;
             }
         }
+        for (int target = 0; target < shorthand->target_count; target++) {
+            const css_box_target *item = &shorthand->targets[target];
+            css_set_slot(slots, item->prop, components[item->kind].value, components[item->kind].len, rank);
+        }
+        return 1;
+    }
+    return 0;
+}
+
+/* Feed one declaration into the cascade slots, expanding a shorthand across its
+   longhands. Every candidate for one declaration shares an order stamp. */
+static void css_apply_decl(css_slot slots[NUM_PROPS], const css_decl *decl, int inline_style, int spec_a, int spec_b,
+                           int spec_c, long order) {
+    css_slot rank = {NULL, 0, decl->important, inline_style, spec_a, spec_b, spec_c, order, 1};
+    int direct = css_prop_id(decl->name, decl->name_len);
+    if (direct >= 0) {
+        css_set_slot(slots, direct, decl->value, decl->value_len, &rank);
         return;
     }
+    if (css_apply_distributive(slots, decl, &rank)) {
+        return;
+    }
+    css_apply_box(slots, decl, &rank);
 }
 
 /* An element's resolved computed values: one owned code-point buffer per longhand. */

--- a/tests/conformance/test_cssom_jsdom_conformance.py
+++ b/tests/conformance/test_cssom_jsdom_conformance.py
@@ -31,13 +31,15 @@ Documented boundaries, argued from the spec rather than papered over:
   the UA default (CSS Cascade 4 §6.4, and the explanation doc). jsdom applies a UA sheet (``p { display: block }`` and
   the like), so every compared property is one an author declaration governs on the target element, keeping the UA
   origin out of the diff.
-- **Curated shorthand set.** turbohtml expands only the distributive shorthands its docs enumerate -- ``margin``,
-  ``padding``, ``border-width``/``style``/``color``, ``overflow``. The grammar-parsed shorthands (``border``,
-  ``border-top`` and siblings, ``outline``, ``font``, ``background``, ``list-style``) are out of scope and drop their
-  declaration; ``test_cssom_curated_shorthand_boundary`` records that as an ``xfail`` against jsdom.
-- **jsdom is non-conformant for the ``overflow`` shorthand.** jsdom's ``getComputedStyle`` does not propagate
-  ``overflow`` to ``overflow-x``/``overflow-y`` (it returns the initial ``visible``); turbohtml expands it per
-  CSS Overflow 3 §2.1, matching real browsers. Those longhands are validated against the spec only (``oracle=False``).
+- **Curated shorthand set.** turbohtml expands the distributive shorthands (``margin``, ``padding``,
+  ``border-width``/``style``/``color``, ``overflow``) and the ``<line-width> || <line-style> || <color>`` shorthands
+  (``border``, each ``border-<side>``, ``outline``). The remaining grammar shorthands (``font``, ``background``,
+  ``list-style``) are out of scope and drop their declaration; ``test_cssom_curated_shorthand_boundary`` records that as
+  an ``xfail`` against jsdom for ``font``.
+- **jsdom is non-conformant for the ``overflow`` and ``outline`` shorthands.** jsdom's ``getComputedStyle`` leaves the
+  ``overflow-x``/``overflow-y`` and ``outline-*`` longhands at their initial values rather than propagating the
+  shorthand; turbohtml expands both per CSS Overflow 3 §2.1 and CSS UI 4 §5, matching real browsers. Those longhands are
+  validated against the spec only (``oracle=False``).
 - **jsdom does not resolve ``revert``.** cssstyle returns the literal ``revert`` keyword; turbohtml resolves it to the
   unset behavior (CSS Cascade 4 §7.6). ``revert`` cases are validated against the spec only.
 - **css-cascade-5 ``revert-rule`` is unsupported.** turbohtml implements the cascade-4 keyword set; ``revert-rule`` is
@@ -301,6 +303,55 @@ CORPUS: tuple[Case, ...] = (
         "<style>#p{overflow:auto}</style><p id='p'>x</p>",
         (_c("#p", "overflow-x", "auto", oracle=False), _c("#p", "overflow-y", "auto", oracle=False)),
     ),
+    # -- <line-width> || <line-style> || <color> shorthands (CSS Backgrounds & Borders 3 §4, CSS UI 4 §5) --
+    Case(
+        "border-shorthand-expands-every-side",
+        "<style>#p{border:2px dashed green}</style><p id='p'>x</p>",
+        (
+            _c("#p", "border-top-width", "2px"),
+            _c("#p", "border-top-style", "dashed"),
+            _c("#p", "border-top-color", "green"),
+            _c("#p", "border-left-width", "2px"),
+            _c("#p", "border-bottom-color", "green"),
+            _c("#p", "border-right-style", "dashed"),
+        ),
+    ),
+    Case(
+        "border-side-shorthand-sets-one-side",
+        "<style>#p{border-top:1px solid red}</style><p id='p'>x</p>",
+        (
+            _c("#p", "border-top-width", "1px"),
+            _c("#p", "border-top-style", "solid"),
+            _c("#p", "border-top-color", "red"),
+            _c("#p", "border-right-width", "medium"),
+        ),
+    ),
+    # an omitted component resets its longhand to the initial value, overriding an earlier longhand (currentcolor
+    # resolves to the element's default color, opaque black, matching jsdom's resolved value).
+    Case(
+        "border-shorthand-omitted-component-resets-longhand",
+        "<style>#p{border-top-color:red;border-top:2px solid}</style><p id='p'>x</p>",
+        (
+            _c("#p", "border-top-width", "2px"),
+            _c("#p", "border-top-style", "solid"),
+            _c("#p", "border-top-color", "currentcolor"),
+        ),
+    ),
+    Case(
+        "border-longhand-after-shorthand-wins-by-source-order",
+        "<style>#p{border:2px solid green;border-top-color:navy}</style><p id='p'>x</p>",
+        (_c("#p", "border-top-color", "navy"), _c("#p", "border-right-color", "green")),
+    ),
+    # outline: turbohtml expands per CSS UI 4 §5 with any component order; jsdom does not expand it, so spec-only.
+    Case(
+        "outline-shorthand-any-order",
+        "<style>#p{outline:blue thick dotted}</style><p id='p'>x</p>",
+        (
+            _c("#p", "outline-width", "thick", oracle=False),
+            _c("#p", "outline-style", "dotted", oracle=False),
+            _c("#p", "outline-color", "blue", oracle=False),
+        ),
+    ),
     # -- longhand and shorthand interleaving resolves by source order --
     Case(
         "longhand-after-shorthand-wins",
@@ -357,17 +408,13 @@ CORPUS: tuple[Case, ...] = (
     ),
 )
 
-# The grammar-parsed shorthands turbohtml does not expand (documented curated-set boundary): jsdom expands them, so the
-# longhand stays at its initial value where jsdom reports the shorthand's component. Recorded as xfail.
+# A grammar shorthand still outside turbohtml's curated set (documented boundary): jsdom expands ``font`` to its
+# longhands, turbohtml drops the declaration and the longhand stays at its initial value. Recorded as xfail.
 CURATED_SHORTHAND_BOUNDARY: tuple[Case, ...] = (
     Case(
-        "border-shorthand-not-expanded",
-        "<style>#p{border:2px dashed green}</style><p id='p'>x</p>",
-        (
-            _c("#p", "border-top-width", "2px"),
-            _c("#p", "border-top-style", "dashed"),
-            _c("#p", "border-top-color", "green"),
-        ),
+        "font-shorthand-not-expanded",
+        "<style>#p{font:italic 12px serif}</style><p id='p'>x</p>",
+        (_c("#p", "font-style", "italic"),),
     ),
 )
 
@@ -393,6 +440,7 @@ _NAMED = {
     "gray": (128, 128, 128, 1.0),
     "transparent": (0, 0, 0, 0.0),
     "canvastext": (0, 0, 0, 1.0),  # color's initial value, a system color; opaque black in a default light theme
+    "currentcolor": (0, 0, 0, 1.0),  # resolves to the element's color, defaulting to canvastext (opaque black)
 }
 
 
@@ -489,7 +537,7 @@ def test_cssom_matches_jsdom(case_id: str, check: Check) -> None:
 
 @pytest.mark.skipif(not _jsdom_available(), reason="node with jsdom is not installed")
 @pytest.mark.xfail(
-    reason="turbohtml expands only the distributive shorthands; border/outline are out of the curated set",
+    reason="turbohtml expands the distributive and border/outline shorthands; font is out of the curated set",
     strict=True,
 )
 @pytest.mark.parametrize(("case_id", "check"), _BOUNDARY_PARAMS)

--- a/tests/query/css/test_cssom.py
+++ b/tests/query/css/test_cssom.py
@@ -256,6 +256,69 @@ def test_computed_style_overflow_shorthand() -> None:
     assert (style["overflow-x"], style["overflow-y"]) == ("hidden", "scroll")
 
 
+def test_computed_style_border_shorthand_expands_all_twelve_longhands() -> None:
+    style = _style("<div></div>", css="div { border: 2px dashed green }")
+    for side in ("top", "right", "bottom", "left"):
+        assert style[f"border-{side}-width"] == "2px"
+        assert style[f"border-{side}-style"] == "dashed"
+        assert style[f"border-{side}-color"] == "green"
+
+
+@pytest.mark.parametrize("side", ["top", "right", "bottom", "left"])
+def test_computed_style_border_side_shorthand_sets_only_that_side(side: str) -> None:
+    style = _style("<div></div>", css=f"div {{ border-{side}: 1px solid red }}")
+    assert (style[f"border-{side}-width"], style[f"border-{side}-style"], style[f"border-{side}-color"]) == (
+        "1px",
+        "solid",
+        "red",
+    )
+    other = "bottom" if side == "top" else "top"
+    assert style[f"border-{other}-width"] == "medium"  # a sibling side stays at its initial
+
+
+@pytest.mark.parametrize(
+    ("value", "width", "style_", "color"),
+    [
+        pytest.param("thick dotted blue", "thick", "dotted", "blue", id="width-style-color"),
+        pytest.param("blue thick dotted", "thick", "dotted", "blue", id="color-width-style-any-order"),
+        pytest.param("auto", "medium", "auto", "currentcolor", id="style-only-omits-reset-to-initial"),
+        pytest.param(".5px solid rgb(1, 2, 3)", ".5px", "solid", "rgb(1, 2, 3)", id="length-lead-and-color-function"),
+        pytest.param("thin", "thin", "none", "currentcolor", id="width-keyword-only"),
+    ],
+)
+def test_computed_style_outline_shorthand_classifies_components(
+    value: str, width: str, style_: str, color: str
+) -> None:
+    style = _style("<div></div>", css=f"div {{ outline: {value} }}")
+    assert (style["outline-width"], style["outline-style"], style["outline-color"]) == (width, style_, color)
+
+
+def test_computed_style_border_longhand_after_shorthand_wins() -> None:
+    style = _style("<div></div>", css="div { border: 2px solid green; border-top-color: navy }")
+    assert style["border-top-color"] == "navy"
+    assert style["border-right-color"] == "green"
+
+
+def test_computed_style_border_shorthand_after_longhand_resets_it() -> None:
+    style = _style("<div></div>", css="div { border-top-color: red; border-top: 2px solid }")
+    assert style["border-top-width"] == "2px"
+    assert style["border-top-style"] == "solid"
+    assert style["border-top-color"] == "currentcolor"  # the omitted component resets to the initial
+
+
+def test_computed_style_border_shorthand_higher_priority_longhand_survives() -> None:
+    style = _style("<div id='a' style='border: 5px solid red'></div>", css="#a { border-top-width: 9px !important }")
+    assert style["border-top-width"] == "9px"
+    assert style["border-right-width"] == "5px"
+
+
+def test_computed_style_border_shorthand_repeated_component_is_invalid() -> None:
+    # two style keywords cannot both bind: the whole declaration is invalid and sets nothing
+    style = _style("<div></div>", css="div { border-top-color: lime; border-top: solid dashed }")
+    assert style["border-top-style"] == "none"
+    assert style["border-top-color"] == "lime"  # the earlier longhand survives the dropped shorthand
+
+
 def test_computed_style_shorthand_with_whitespace_separators() -> None:
     style = _style("<div style='margin:1px\t2px\n3px'></div>")
     assert (style["margin-top"], style["margin-right"], style["margin-bottom"]) == ("1px", "2px", "3px")


### PR DESCRIPTION
`turbohtml.cssom.computed_style` expanded the distributive box shorthands (`margin`, `padding`, the `border-width`/`border-style`/`border-color` families, `overflow`) but dropped `border`, the per-side `border-top`/`border-right`/`border-bottom`/`border-left`, and `outline`. A stylesheet as ordinary as `border: 1px solid black` therefore left every `border-*-width`/`style`/`color` longhand at its initial value, and the jsdom differential recorded the gap as a curated-set `xfail` instead of proving it.

These follow the `<line-width> || <line-style> || <color>` grammar rather than the 1-to-4 positional rule, so the components arrive in any order and a stylesheet can drop any of the three. The cascade classifies each token by shape, a line-style keyword, a width keyword or a length, else a color, and an omitted component resets its longhand to that property's initial value. That reset keeps the cascade correct across source order: a later `border` overrides an earlier `border-top-color` it does not restate, and a later `border-top-color` overrides an earlier `border`. The expansion runs in the C core next to the existing shorthands, so `getComputedStyle` still returns only resolved longhands.

The `border` and per-side expansions now cross-check against jsdom's `getComputedStyle`, so their conformance cases move out of the boundary `xfail` into the proven corpus. `outline` expands per [CSS UI 4 §5](https://www.w3.org/TR/css-ui-4/#outline), which jsdom leaves at its longhands' initial values (the same non-conformance as `overflow`), so the spec cases carry it alone. The narrowed boundary `xfail` now covers `font`, still outside the curated set.

References #546
