### PR TITLE
✨ feat(xml): enforce Namespaces 1.0 well-formedness

### DIFF
--- a/docs/changelog/540.feature.rst
+++ b/docs/changelog/540.feature.rst
@@ -2,7 +2,10 @@
 returning the same navigable :class:`~turbohtml.Document`. Names stay case-sensitive, ``<x/>`` self-closes any element,
 CDATA sections and processing instructions become :class:`~turbohtml.CData` and
 :class:`~turbohtml.ProcessingInstruction` nodes, only the five predefined entities and numeric references resolve, and a
-namespace prefix must be declared with ``xmlns``. There is no HTML recovery: the first well-formedness violation -- a
-mismatched or unclosed tag, an undeclared prefix, an undefined entity, a duplicate attribute -- raises
-:exc:`~turbohtml.HTMLParseError`. This is the equivalent of ``lxml.etree.fromstring`` / ``etree.XMLParser`` over
-turbohtml's dependency-free, fully typed node API.
+namespace prefix must be declared with ``xmlns``. Names follow the exact XML 1.0 ``NameStartChar`` /``NameChar``
+productions, and the Namespaces in XML 1.0 well-formedness constraints hold in full: the reserved ``xml`` and ``xmlns``
+prefixes and their namespace names cannot be rebound, a prefix declaration cannot be empty, a processing-instruction
+target carries no colon, and no two attributes share an expanded name. There is no HTML recovery: the first
+well-formedness violation -- a mismatched or unclosed tag, an undeclared prefix, an undefined entity, a duplicate
+attribute -- raises :exc:`~turbohtml.HTMLParseError`. This is the equivalent of ``lxml.etree.fromstring`` /
+``etree.XMLParser`` over turbohtml's dependency-free, fully typed node API.

--- a/docs/explanation/xml.rst
+++ b/docs/explanation/xml.rst
@@ -36,10 +36,13 @@ The two modes differ wherever the HTML tree builder makes an assumption XML does
 
 XML namespaces are a well-formedness concern here, not a rewrite. The parser tracks the ``xmlns:prefix`` declarations in
 scope on the open-element stack, pushes each element's declarations before validating it, and reports an undeclared
-prefix as an error; the reserved ``xml`` prefix is always in scope. What it does **not** do is resolve a prefix to a
-URI. ``lxml`` stores a namespaced tag in Clark notation (``{urn:h}a``) and exposes an ``nsmap``; turbohtml keeps the
-qualified name exactly as written (``h:a``) and leaves every ``xmlns``/``xmlns:prefix`` declaration as an ordinary
-attribute on the element.
+prefix as an error; the reserved ``xml`` prefix is always in scope. It enforces the Namespaces in XML 1.0 constraints in
+full: the ``xml`` prefix binds only to its own namespace and no other prefix may take that URI, the ``xmlns`` prefix is
+never declarable, a prefix declaration is never empty (``xmlns:=``), a processing-instruction target is an NCName and
+carries no colon, and two attributes may not resolve to one expanded name -- the same local name reached through two
+prefixes bound to a single URI is a duplicate. What it does **not** do is resolve a prefix to a URI. ``lxml`` stores a
+namespaced tag in Clark notation (``{urn:h}a``) and exposes an ``nsmap``; turbohtml keeps the qualified name exactly as
+written (``h:a``) and leaves every ``xmlns``/``xmlns:prefix`` declaration as an ordinary attribute on the element.
 
 This is a deliberate fit to turbohtml's node model, whose element namespace is the fixed HTML/SVG/MathML enumeration the
 HTML parser needs, not an open set of URIs. Keeping qualified names verbatim means an XML document round-trips through

--- a/docs/how-to/xml.rst
+++ b/docs/how-to/xml.rst
@@ -86,4 +86,5 @@ pipeline can report exactly what and where:
     xml-mismatched-tag 1 8
 
 The same exception surfaces an unclosed tag, an undeclared namespace prefix, an undefined entity, a duplicate attribute,
-or content outside the root element.
+content outside the root element, or a Namespaces in XML 1.0 violation -- rebinding the reserved ``xml`` or ``xmlns``
+prefix, a colon in a processing-instruction target, or two attributes that resolve to the same expanded name.

--- a/src/turbohtml/_c/tokenizer/xml.c
+++ b/src/turbohtml/_c/tokenizer/xml.c
@@ -52,11 +52,29 @@ static int in_ranges(Py_UCS4 ch, const cp_range *ranges, Py_ssize_t count) {
     return 0;
 }
 
+/* ASCII (U+0000..U+007F) fast path: real XML names are almost all ASCII, so a table lookup skips the
+   range scan on the hot per-character path. Bit 0 marks a NameStartChar, bit 1 a NameChar (every
+   NameStartChar is also a NameChar); the values are the ASCII subset of the ranges above. */
+#define XML_NAME_START_FLAG 0x1
+#define XML_NAME_CHAR_FLAG 0x2
+static const unsigned char ASCII_NAME_FLAGS[128] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 0, 0, 0, 0, 0,
+    0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 3,
+    0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,
+};
+
 static int is_name_start(Py_UCS4 ch) {
+    if (ch < 0x80) {
+        return (ASCII_NAME_FLAGS[ch] & XML_NAME_START_FLAG) != 0;
+    }
     return in_ranges(ch, NAME_START_RANGES, (Py_ssize_t)(sizeof(NAME_START_RANGES) / sizeof(cp_range)));
 }
 
 static int is_name_char(Py_UCS4 ch) {
+    if (ch < 0x80) {
+        return (ASCII_NAME_FLAGS[ch] & XML_NAME_CHAR_FLAG) != 0;
+    }
     return in_ranges(ch, NAME_CHAR_RANGES, (Py_ssize_t)(sizeof(NAME_CHAR_RANGES) / sizeof(cp_range)));
 }
 

--- a/src/turbohtml/_c/tokenizer/xml.c
+++ b/src/turbohtml/_c/tokenizer/xml.c
@@ -20,16 +20,44 @@ static int xml_is_space(Py_UCS4 ch) {
     return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
 }
 
-/* XML NameStartChar, approximated: a letter, '_' or ':' (the qualified-name
-   separator), or any code point past ASCII. The exact spec ranges exclude a few
-   punctuation blocks; a name that starts with a digit, '-' or '.' -- the cases
-   real input mistakes -- is still rejected. */
+typedef struct {
+    Py_UCS4 lo;
+    Py_UCS4 hi;
+} cp_range;
+
+/* NameStartChar (XML 1.0 [4]) as inclusive code-point ranges, common ASCII first for the
+   early exit; the exact list -- not the "any code point >= U+0080" approximation -- so a
+   combining mark, a middle dot or the other punctuation the spec omits is rejected. */
+static const cp_range NAME_START_RANGES[] = {
+    {'a', 'z'},       {'A', 'Z'},       {'_', '_'},       {':', ':'},         {0xC0, 0xD6},     {0xD8, 0xF6},
+    {0xF8, 0x2FF},    {0x370, 0x37D},   {0x37F, 0x1FFF},  {0x200C, 0x200D},   {0x2070, 0x218F}, {0x2C00, 0x2FEF},
+    {0x3001, 0xD7FF}, {0xF900, 0xFDCF}, {0xFDF0, 0xFFFD}, {0x10000, 0xEFFFF},
+};
+
+/* NameChar (XML 1.0 [4a]): every NameStartChar plus the digits, '-', '.' and the
+   combining/extender ranges the production adds. */
+static const cp_range NAME_CHAR_RANGES[] = {
+    {'a', 'z'},       {'A', 'Z'},       {'0', '9'},         {'_', '_'},       {':', ':'},       {'-', '-'},
+    {'.', '.'},       {0xB7, 0xB7},     {0xC0, 0xD6},       {0xD8, 0xF6},     {0xF8, 0x2FF},    {0x300, 0x37D},
+    {0x37F, 0x1FFF},  {0x200C, 0x200D}, {0x203F, 0x2040},   {0x2070, 0x218F}, {0x2C00, 0x2FEF}, {0x3001, 0xD7FF},
+    {0xF900, 0xFDCF}, {0xFDF0, 0xFFFD}, {0x10000, 0xEFFFF},
+};
+
+static int in_ranges(Py_UCS4 ch, const cp_range *ranges, Py_ssize_t count) {
+    for (Py_ssize_t index = 0; index < count; index++) {
+        if (ch >= ranges[index].lo && ch <= ranges[index].hi) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 static int is_name_start(Py_UCS4 ch) {
-    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_' || ch == ':' || ch >= 0x80;
+    return in_ranges(ch, NAME_START_RANGES, (Py_ssize_t)(sizeof(NAME_START_RANGES) / sizeof(cp_range)));
 }
 
 static int is_name_char(Py_UCS4 ch) {
-    return is_name_start(ch) || (ch >= '0' && ch <= '9') || ch == '-' || ch == '.';
+    return in_ranges(ch, NAME_CHAR_RANGES, (Py_ssize_t)(sizeof(NAME_CHAR_RANGES) / sizeof(cp_range)));
 }
 
 /* The Char production [2]: TAB/LF/CR or a scalar value outside the surrogate range
@@ -45,6 +73,8 @@ static int is_xml_char(long ch) {
 typedef struct {
     Py_UCS4 *prefix;
     Py_ssize_t prefix_len;
+    Py_UCS4 *uri; /* the namespace name the prefix binds, for expanded-name comparison */
+    Py_ssize_t uri_len;
     Py_ssize_t depth;
 } xml_nsdecl;
 
@@ -201,6 +231,24 @@ static int name_equals(const xml_parser *parser, Py_ssize_t start, Py_ssize_t en
     return 1;
 }
 
+/* The reserved namespace names Namespaces in XML 1.0 binds by definition to the xml and
+   xmlns prefixes; neither may be re-bound and the xmlns name may not be bound at all. */
+static const char XML_NS_URI[] = "http://www.w3.org/XML/1998/namespace";
+static const char XMLNS_NS_URI[] = "http://www.w3.org/2000/xmlns/";
+
+/* Whether the scratch buffer (a parsed, entity-normalized attribute value) equals `text`. */
+static int scratch_equals(const xml_parser *parser, const char *text, Py_ssize_t text_len) {
+    if (parser->scratch_len != text_len) {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < text_len; index++) {
+        if (parser->scratch[index] != (Py_UCS4)text[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 /* Read a Name starting at `pos`, leaving `pos` just past it and returning its end
    offset; records xml-invalid-name and returns -1 on a bad start character. */
 static Py_ssize_t read_name(xml_parser *parser) {
@@ -309,7 +357,19 @@ static int push_open(xml_parser *parser, th_node *element) {
 }
 
 /* Declare a namespace prefix (arena-owned copy) in scope at `depth`. */
-static int declare_prefix(xml_parser *parser, Py_ssize_t start, Py_ssize_t len, Py_ssize_t depth) {
+/* Copy a code-point run (an entity-normalized attribute value) into the arena. */
+static Py_UCS4 *arena_copy(th_tree *tree, const Py_UCS4 *src, Py_ssize_t len) {
+    Py_UCS4 *out = arena_alloc(tree, len * (Py_ssize_t)sizeof(Py_UCS4));
+    if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    memcpy(out, src, (size_t)len * sizeof(Py_UCS4));
+    return out;
+}
+
+/* Declare a namespace prefix bound to `uri` (arena-owned copies) in scope at `depth`. */
+static int declare_prefix(xml_parser *parser, Py_ssize_t start, Py_ssize_t len, const Py_UCS4 *uri, Py_ssize_t uri_len,
+                          Py_ssize_t depth) {
     if (parser->ns_len == parser->ns_cap) {
         Py_ssize_t cap = parser->ns_cap ? parser->ns_cap * 2 : 8;
         xml_nsdecl *grown = PyMem_Realloc(parser->ns, (size_t)cap * sizeof(xml_nsdecl));
@@ -324,8 +384,14 @@ static int declare_prefix(xml_parser *parser, Py_ssize_t start, Py_ssize_t len, 
     if (owned == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;       /* GCOVR_EXCL_LINE: allocation-failure path */
     }
+    Py_UCS4 *owned_uri = arena_copy(parser->tree, uri, uri_len);
+    if (owned_uri == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;           /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
     parser->ns[parser->ns_len].prefix = owned;
     parser->ns[parser->ns_len].prefix_len = len;
+    parser->ns[parser->ns_len].uri = owned_uri;
+    parser->ns[parser->ns_len].uri_len = uri_len;
     parser->ns[parser->ns_len].depth = depth;
     parser->ns_len++;
     return 0;
@@ -337,13 +403,8 @@ static void pop_prefixes(xml_parser *parser, Py_ssize_t depth) {
     }
 }
 
-/* Whether the prefix range [start, end) is the reserved "xml" or an in-scope
-   declaration; the source position `at` locates an undeclared-prefix error. */
-static int prefix_in_scope(xml_parser *parser, Py_ssize_t start, Py_ssize_t end, Py_ssize_t at) {
-    if (name_equals(parser, start, end, "xml")) {
-        return 1;
-    }
-    Py_ssize_t len = end - start;
+/* The index of the innermost in-scope declaration of prefix [start, start+len), or -1. */
+static Py_ssize_t find_prefix(const xml_parser *parser, Py_ssize_t start, Py_ssize_t len) {
     for (Py_ssize_t index = parser->ns_len - 1; index >= 0; index--) {
         if (parser->ns[index].prefix_len != len) {
             continue;
@@ -356,8 +417,17 @@ static int prefix_in_scope(xml_parser *parser, Py_ssize_t start, Py_ssize_t end,
             }
         }
         if (same) {
-            return 1;
+            return index;
         }
+    }
+    return -1;
+}
+
+/* Whether the prefix range [start, end) is the reserved "xml" or an in-scope
+   declaration; the source position `at` locates an undeclared-prefix error. */
+static int prefix_in_scope(xml_parser *parser, Py_ssize_t start, Py_ssize_t end, Py_ssize_t at) {
+    if (name_equals(parser, start, end, "xml") || find_prefix(parser, start, end - start) >= 0) {
+        return 1;
     }
     record(parser, "xml-undeclared-namespace", at);
     return 0;
@@ -669,6 +739,12 @@ static int consume_pi(xml_parser *parser) {
         record(parser, "xml-reserved-pi-target", target_start);
         return -1;
     }
+    for (Py_ssize_t index = target_start; index < target_end; index++) { /* a PI target is an NCName: no ':' */
+        if (cp(parser, index) == ':') {
+            record(parser, "xml-invalid-pi-target", target_start);
+            return -1;
+        }
+    }
     if (parser->pos < parser->length && !starts_with(parser, parser->pos, "?>") &&
         !xml_is_space(cp(parser, parser->pos))) { /* [16]: target and data are S-separated */
         record(parser, "xml-malformed-pi", parser->pos);
@@ -797,6 +873,53 @@ static int consume_end_tag(xml_parser *parser) {
     return 0;
 }
 
+/* Enforce Namespaces in XML 1.0 on an xmlns / xmlns:prefix attribute whose value is in the
+   scratch buffer, declaring a well-formed prefix binding. Returns 0 for an ordinary attribute
+   or a valid declaration, -1 with an error recorded for a reserved-binding violation. */
+static int consume_namespace_decl(xml_parser *parser, Py_ssize_t name_start, Py_ssize_t name_end, Py_ssize_t depth) {
+    int is_default = name_equals(parser, name_start, name_end, "xmlns");
+    if (!is_default && !starts_with(parser, name_start, "xmlns:")) {
+        return 0;
+    }
+    int binds_xml_uri = scratch_equals(parser, XML_NS_URI, (Py_ssize_t)(sizeof(XML_NS_URI) - 1));
+    int binds_xmlns_uri = scratch_equals(parser, XMLNS_NS_URI, (Py_ssize_t)(sizeof(XMLNS_NS_URI) - 1));
+    if (is_default) { /* a reserved name may not be bound as the default namespace */
+        if (binds_xml_uri || binds_xmlns_uri) {
+            record(parser, "xml-reserved-namespace", name_start);
+            return -1;
+        }
+        return 0;
+    }
+    Py_ssize_t prefix_start = name_start + 6;
+    Py_ssize_t prefix_len = name_end - prefix_start;
+    if (prefix_len == 0) { /* xmlns:="..." -- an empty prefix is not an NCName */
+        record(parser, "xml-invalid-namespace-decl", name_start);
+        return -1;
+    }
+    if (name_equals(parser, prefix_start, name_end, "xmlns")) { /* the xmlns prefix is never declarable */
+        record(parser, "xml-reserved-prefix", prefix_start);
+        return -1;
+    }
+    if (name_equals(parser, prefix_start, name_end, "xml")) { /* xml binds only to the xml namespace */
+        if (!binds_xml_uri) {
+            record(parser, "xml-reserved-prefix", prefix_start);
+            return -1;
+        }
+    } else if (binds_xml_uri) { /* no other prefix may bind the xml namespace */
+        record(parser, "xml-reserved-namespace", prefix_start);
+        return -1;
+    }
+    if (binds_xmlns_uri) { /* the xmlns namespace may not be bound to any prefix */
+        record(parser, "xml-reserved-namespace", prefix_start);
+        return -1;
+    }
+    int declared = declare_prefix(parser, prefix_start, prefix_len, parser->scratch, parser->scratch_len, depth);
+    if (declared < 0) { /* GCOVR_EXCL_BR_LINE: declare_prefix only fails on allocation */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    return 0;
+}
+
 /* Parse one attribute onto `element`, tracking any xmlns declaration at `depth`.
    Advances past the attribute; returns 0, or -1 with an error recorded. */
 static int consume_attribute(xml_parser *parser, th_node *element, Py_ssize_t depth) {
@@ -877,13 +1000,33 @@ static int consume_attribute(xml_parser *parser, th_node *element, Py_ssize_t de
     }
     parser->attr_spans[parser->attr_spans_len++] = name_start;
     parser->attr_spans[parser->attr_spans_len++] = name_end;
-    if (starts_with(parser, name_start, "xmlns:") && name_end - name_start > 6) {
-        /* declare_prefix only fails on allocation */
-        if (declare_prefix(parser, name_start + 6, name_end - (name_start + 6), depth) < 0) { /* GCOVR_EXCL_BR_LINE */
-            return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+    return consume_namespace_decl(parser, name_start, name_end, depth);
+}
+
+/* The in-scope declaration index for the prefix of attribute [start, end), with *colon set to
+   the ':' offset; -1 when no namespace applies (unprefixed, the xml prefix, or an xmlns decl).
+   A declared prefix is guaranteed in scope: check_qname_prefix has already validated it. */
+static Py_ssize_t attr_ns_index(const xml_parser *parser, Py_ssize_t start, Py_ssize_t end, Py_ssize_t *colon) {
+    for (Py_ssize_t index = start; index < end; index++) {
+        if (cp(parser, index) == ':') {
+            *colon = index;
+            if (name_equals(parser, start, index, "xml") || name_equals(parser, start, index, "xmlns")) {
+                return -1;
+            }
+            return find_prefix(parser, start, index - start);
         }
     }
-    return 0;
+    return -1;
+}
+
+/* Whether the local names [a, a+len) and [b, b+len) are equal code point for code point. */
+static int local_names_equal(const xml_parser *parser, Py_ssize_t a, Py_ssize_t b, Py_ssize_t len) {
+    for (Py_ssize_t offset = 0; offset < len; offset++) {
+        if (cp(parser, a + offset) != cp(parser, b + offset)) {
+            return 0;
+        }
+    }
+    return 1;
 }
 
 static int consume_start_tag(xml_parser *parser) {
@@ -954,6 +1097,35 @@ static int consume_start_tag(xml_parser *parser) {
         }
         if (check_qname_prefix(parser, attr_start, attr_end) < 0) {
             return -1;
+        }
+    }
+    /* expanded-name uniqueness: no two attributes may share a local name and namespace URI,
+       even through different prefixes bound to the same URI (Namespaces in XML 1.0 5.3) */
+    for (Py_ssize_t index = 0; index < parser->attr_spans_len; index += 2) {
+        Py_ssize_t colon = 0;
+        Py_ssize_t decl = attr_ns_index(parser, parser->attr_spans[index], parser->attr_spans[index + 1], &colon);
+        if (decl < 0) {
+            continue;
+        }
+        Py_ssize_t local_start = colon + 1;
+        Py_ssize_t local_len = parser->attr_spans[index + 1] - local_start;
+        const xml_nsdecl *decl_ns = &parser->ns[decl];
+        for (Py_ssize_t other = 0; other < index; other += 2) {
+            Py_ssize_t other_colon = 0;
+            Py_ssize_t other_decl =
+                attr_ns_index(parser, parser->attr_spans[other], parser->attr_spans[other + 1], &other_colon);
+            if (other_decl < 0) {
+                continue;
+            }
+            Py_ssize_t other_local_len = parser->attr_spans[other + 1] - (other_colon + 1);
+            const xml_nsdecl *other_ns = &parser->ns[other_decl];
+            int same_uri = decl_ns->uri_len == other_ns->uri_len &&
+                           memcmp(decl_ns->uri, other_ns->uri, (size_t)decl_ns->uri_len * sizeof(Py_UCS4)) == 0;
+            if (same_uri && local_len == other_local_len &&
+                local_names_equal(parser, local_start, other_colon + 1, local_len)) {
+                record(parser, "xml-duplicate-attribute", parser->attr_spans[index]);
+                return -1;
+            }
         }
     }
     node_append(current(parser), element);

--- a/tests/conformance/test_xml_conformance.py
+++ b/tests/conformance/test_xml_conformance.py
@@ -68,22 +68,10 @@ _ENCODING = (
     "parse_xml takes already-decoded text; byte-level encoding errors and declared-versus-actual encoding "
     "mismatches belong to the decoding layer, not to well-formedness"
 )
-_NAME_CHAR = (
-    "parse_xml approximates the Name productions as ':', '_', a letter or any code point >= U+0080; a few "
-    "combining/punctuation code points the spec excludes from a name start are accepted"
-)
 _NS_COLON = (
-    "parse_xml is namespace-aware, so a ':' is the prefix separator; a colon used as an ordinary XML 1.0 Name "
-    "character reads as an undeclared prefix"
-)
-_NS_XMLNS_EMPTY = "parse_xml leniently accepts an empty namespace-prefix declaration (xmlns:=...)"
-_NS_CONSTRAINTS = (
-    "parse_xml checks that a prefix is declared but does not enforce the reserved-prefix / reserved-namespace "
-    "binding rules or expanded-name attribute uniqueness from Namespaces in XML"
-)
-_NS_PI = (
-    "parse_xml allows a ':' in a processing-instruction target; the Namespaces NCName constraint on PI targets "
-    "is not enforced"
+    "parse_xml is namespace-aware, so a ':' is the prefix separator, not an ordinary XML 1.0 Name character; a "
+    "name that uses it as one reads as an undeclared prefix, and a processing-instruction target that does reads "
+    "as a non-NCName -- both rejected where plain XML 1.0 accepts them"
 )
 _NS_11 = "namespace prefix undeclaration is a Namespaces 1.1 feature; parse_xml targets XML 1.0"
 
@@ -94,23 +82,14 @@ _DEVIATIONS = {
     "rmt-e2e-61": _ENCODING,
     "hst-lhs-007": _ENCODING,
     "hst-lhs-008": _ENCODING,
-    "o-p05fail4": _NAME_CHAR,
-    "o-p05fail5": _NAME_CHAR,
     "o-p04pass1": _NS_COLON,
     "o-p05pass1": _NS_COLON,
     "x-ibm-1-0.5-valid-P04-ibm04v01.xml": _NS_COLON,
     "x-ibm-1-0.5-valid-P05-ibm05v01.xml": _NS_COLON,
+    "x-ibm-1-0.5-valid-P05-ibm05v02.xml": _NS_COLON,
     "x-ibm-1-0.5-valid-P05-ibm05v03.xml": _NS_COLON,
     "valid-sa-012": "the namespace declaration is supplied by a DTD ATTLIST default, which parse_xml does not apply",
-    "rmt-ns10-016": _NS_XMLNS_EMPTY,
     "rmt-ns10-023": _NS_11,
-    "rmt-ns10-029": _NS_CONSTRAINTS,
-    "rmt-ns10-030": _NS_CONSTRAINTS,
-    "rmt-ns10-031": _NS_CONSTRAINTS,
-    "rmt-ns10-032": _NS_CONSTRAINTS,
-    "rmt-ns10-033": _NS_CONSTRAINTS,
-    "rmt-ns10-036": _NS_CONSTRAINTS,
-    "rmt-ns10-042": _NS_PI,
 }
 
 

--- a/tests/dom/test_parse_xml.py
+++ b/tests/dom/test_parse_xml.py
@@ -382,6 +382,27 @@ def test_long_reference_run_grows_scratch() -> None:
         pytest.param("<a:r/>", "xml-undeclared-namespace", id="undeclared-element-prefix"),
         pytest.param('<r xmlns:pp="u" p:x="1"/>', "xml-undeclared-namespace", id="undeclared-attr-prefix-len"),
         pytest.param('<r xmlns:px="u" py:x="1"/>', "xml-undeclared-namespace", id="undeclared-attr-prefix-char"),
+        pytest.param("<̀a/>", "xml-invalid-name", id="combining-mark-name-start"),
+        pytest.param("<·a/>", "xml-invalid-name", id="middle-dot-name-start"),
+        pytest.param('<r xmlns:="u"/>', "xml-invalid-namespace-decl", id="empty-prefix-declaration"),
+        pytest.param('<r xmlns:xml="urn:x"/>', "xml-reserved-prefix", id="xml-prefix-rebound"),
+        pytest.param(
+            '<r xmlns:xmlns="http://www.w3.org/2000/xmlns/"/>', "xml-reserved-prefix", id="xmlns-prefix-declared"
+        ),
+        pytest.param(
+            '<r xmlns:p="http://www.w3.org/XML/1998/namespace"/>', "xml-reserved-namespace", id="xml-uri-other-prefix"
+        ),
+        pytest.param('<r xmlns:p="http://www.w3.org/2000/xmlns/"/>', "xml-reserved-namespace", id="xmlns-uri-bound"),
+        pytest.param(
+            '<r xmlns="http://www.w3.org/XML/1998/namespace"/>', "xml-reserved-namespace", id="xml-uri-as-default"
+        ),
+        pytest.param('<r xmlns="http://www.w3.org/2000/xmlns/"/>', "xml-reserved-namespace", id="xmlns-uri-as-default"),
+        pytest.param(
+            '<r xmlns:a="u" xmlns:b="u"><q a:k="1" b:k="2"/></r>',
+            "xml-duplicate-attribute",
+            id="expanded-name-collision",
+        ),
+        pytest.param("<?a:b d?><r/>", "xml-invalid-pi-target", id="colon-in-pi-target"),
     ],
 )
 def test_well_formedness_error(markup: str, code: str) -> None:
@@ -399,8 +420,32 @@ def test_error_carries_line_and_column() -> None:
     assert error.col == 2
 
 
-def test_lenient_empty_namespace_prefix_declaration() -> None:
-    assert dict(root_of(parse_xml('<r xmlns:="u"/>')).attrs) == {"xmlns:": "u"}
+def test_combining_mark_is_a_name_char_but_not_a_name_start() -> None:
+    tag = "a\u00e9\u0300"  # a start letter, a non-ASCII NameStartChar, then a combining grave (NameChar only)
+    assert root_of(parse_xml(f"<{tag}/>")).tag == tag
+
+
+def test_xml_prefix_may_bind_its_own_namespace() -> None:
+    doc = parse_xml('<r xmlns:xml="http://www.w3.org/XML/1998/namespace" xml:lang="en"/>')
+    assert dict(root_of(doc).attrs)["xml:lang"] == "en"
+
+
+def test_default_declaration_of_a_plain_2000_length_uri_parses() -> None:
+    doc = parse_xml('<r xmlns="http://www.w3.org/2000/abcde/"/>')  # same length as the reserved xmlns name, not it
+    assert dict(root_of(doc).attrs) == {"xmlns": "http://www.w3.org/2000/abcde/"}
+
+
+@pytest.mark.parametrize(
+    "markup",
+    [
+        pytest.param('<r xmlns:a="urn:a" xmlns:b="urn:b" a:k="1" b:k="2"/>', id="same-local-different-uri"),
+        pytest.param('<r xmlns:a="u" xmlns:b="vv" a:k="1" b:k="2"/>', id="same-local-different-uri-length"),
+        pytest.param('<r xmlns:a="urn:a" a:k="1" a:m="2"/>', id="same-uri-different-local"),
+        pytest.param('<r xmlns:a="urn:a" a:k="1" a:kk="2"/>', id="same-uri-different-local-length"),
+    ],
+)
+def test_attributes_with_distinct_expanded_names_are_allowed(markup: str) -> None:
+    parse_xml(markup)  # a shared prefix, URI, or local name alone is not a collision
 
 
 def test_non_str_raises_type_error() -> None:


### PR DESCRIPTION
`parse_xml` was namespace-aware but only checked that a prefix was declared, and it matched the XML Name productions with a `>= U+0080` approximation. That let it accept documents the Namespaces in XML 1.0 well-formedness constraints forbid, which is why the W3C `xmlconf` conformance suite (#588) marked roughly twenty namespace and name cases as expected deviations rather than proving them.

This closes that gap. Names now follow the exact `NameStartChar` and `NameChar` code-point ranges from [XML 1.0 §2.3](https://www.w3.org/TR/xml/#sec-common-syn), so a leading combining mark or middle dot is rejected. The parser holds the [Namespaces in XML 1.0](https://www.w3.org/TR/REC-xml-names/) binding rules: the `xml` prefix binds only to its own namespace and no other prefix may take that URI, the `xmlns` prefix is never declarable and its namespace name is never bindable, `xmlns:=` is rejected, a processing-instruction target carries no colon, and two attributes may not resolve to one expanded name through different prefixes bound to the same URI. Prefix declarations now carry their resolved URI so the expanded-name comparison can see through the prefix. 🔍

Dropping the matching `_DEVIATIONS` entries from the `xmlconf` suite turns ten namespace and name cases from `xfail` into passing hard assertions, taking the suite from 914 to 923 hard-asserted verdicts with none failing. One plain XML 1.0 valid case (`ibm05v02`) puts a colon in a PI target, which a namespace-aware processor must reject, so it joins the existing colon-as-name-character deviations alongside `ibm05v01` and `ibm05v03`. The genuine boundaries stay `xfail`ed with honest reasons: XML 1.1 prefix undeclaration, DTD-supplied declarations, and the byte-level encoding layer.

This PR is stacked on the conformance-suite branch (#588); rebase onto or merge after it so the deviation-map edit lands on the file that PR introduces. Refs #540.
