### PR TITLE
👷 fix(tools): route HTTP through httpx2 with tenacity retry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
 test = [
   "covdefaults>=2.3",
   "elementpath>=5",             # the XPath 2.0 oracle the string-function differential test cross-checks against
+  "httpx2>=2.5",                # the benchmark corpora and the tools/generate_* scripts fetch pinned data over it
   "jinja2>=3.1.6",              # the markup migration test renders templates with markupsafe swapped for turbohtml.markup
   "markdown-it-py>=4.2",        # a pure-Python GFM reference to round-trip to_markdown() output back to HTML and check it
   "meson>=1.11.1",
@@ -75,6 +76,7 @@ test = [
   "pytest-cov>=7.1",
   "pytest-mock>=3.15.1",
   "pytest-run-parallel>=0.9.1", # runs each test in many threads to surface free-threaded data races
+  "tenacity>=9",                # the retry policy wrapping every tools/ HTTP fetch (httpfetch.py)
 ]
 type = [
   "ty>=0.0.52",
@@ -183,8 +185,9 @@ test-command = "python -c \"import turbohtml; assert turbohtml.unescape(turbohtm
 # hot paths. Scoped to Linux on purpose: the measured win is gcc's, and clang/MSVC add a profile-merge step the
 # release does not need. See tools/pgo_build.py.
 linux.before-build = """\
-  rm -rf /tmp/turbohtml-pgo && pip install uv meson-python meson ninja && python {project}/tools/pgo_build.py --python \
-  python --system --project {project} --build-dir /tmp/turbohtml-pgo --phase profile\
+  rm -rf /tmp/turbohtml-pgo && pip install uv meson-python meson ninja httpx2 tenacity && python \
+  {project}/tools/pgo_build.py --python python --system --project {project} --build-dir /tmp/turbohtml-pgo --phase \
+  profile\
   """
 linux.config-settings.build-dir = "/tmp/turbohtml-pgo"
 # -Db_lto lands cross-TU inlining across the header splits the 1.0 rearchitecture introduced (spike #478): the hot

--- a/tools/bench/corpus.py
+++ b/tools/bench/corpus.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import html
 import random
-import urllib.request
 from pathlib import Path
+
+from httpfetch import fetch_bytes
 
 _TOOLS = Path(__file__).resolve().parent.parent
 
@@ -96,8 +97,7 @@ def large_text(filename: str, url: str) -> str:
     target = _LARGE_DIR / filename
     if not target.exists():
         target.parent.mkdir(parents=True, exist_ok=True)
-        with urllib.request.urlopen(url) as response:  # noqa: S310  # pinned https URL
-            target.write_bytes(response.read())
+        target.write_bytes(fetch_bytes(url))
     return target.read_text(encoding="utf-8")
 
 

--- a/tools/generate_idna.py
+++ b/tools/generate_idna.py
@@ -30,9 +30,10 @@ from __future__ import annotations
 import hashlib
 import sys
 import unicodedata
-import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from httpfetch import fetch_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -66,8 +67,7 @@ _HANGUL_SCOUNT = _HANGUL_LCOUNT * _HANGUL_VCOUNT * _HANGUL_TCOUNT
 
 def _fetch(url: str, expected_sha256: str) -> str:
     """Return the decoded body of a pinned Unicode data file, aborting if its SHA-256 is not *expected_sha256*."""
-    with urllib.request.urlopen(url) as response:  # noqa: S310 -- url is always a pinned https unicode.org constant
-        raw = response.read()
+    raw = fetch_bytes(url)
     if (digest := hashlib.sha256(raw).hexdigest()) != expected_sha256:
         msg = f"Unicode source {url} has sha256 {digest}, not the pinned {expected_sha256}; review, then bump the pin"
         raise SystemExit(msg)

--- a/tools/generate_normalize.py
+++ b/tools/generate_normalize.py
@@ -26,9 +26,10 @@ from __future__ import annotations
 import hashlib
 import sys
 import unicodedata
-import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
+
+from httpfetch import fetch_bytes
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -56,8 +57,7 @@ _QC_MAYBE = 2
 
 def _fetch(url: str, expected_sha256: str) -> str:
     """Return the decoded body of a pinned Unicode data file, aborting if its SHA-256 is not *expected_sha256*."""
-    with urllib.request.urlopen(url) as response:  # noqa: S310 -- url is always a pinned https unicode.org constant
-        raw = response.read()
+    raw = fetch_bytes(url)
     if (digest := hashlib.sha256(raw).hexdigest()) != expected_sha256:
         msg = f"Unicode source {url} has sha256 {digest}, not the pinned {expected_sha256}; review, then bump the pin"
         raise SystemExit(msg)

--- a/tools/generate_psl.py
+++ b/tools/generate_psl.py
@@ -22,8 +22,9 @@ from __future__ import annotations
 
 import hashlib
 import sys
-import urllib.request
 from pathlib import Path
+
+from httpfetch import fetch_bytes
 
 # The Public Suffix List ships no releases, so a rebuild off @main would silently drift with whatever the branch
 # points at that day -- a reproducibility and supply-chain gap. Pin a specific commit instead, and pin the SHA-256 of
@@ -48,8 +49,7 @@ def _punycode(rule: str) -> str:
 
 def fetch_rules() -> tuple[str, list[tuple[str, int]]]:
     """Return the fetched-commit marker and the ``(rule_text, kind)`` pairs for every multi-label PSL rule."""
-    with urllib.request.urlopen(PSL_URL) as response:
-        raw = response.read()
+    raw = fetch_bytes(PSL_URL)
     if (digest := hashlib.sha256(raw).hexdigest()) != PSL_SHA256:
         msg = f"PSL source at {PSL_COMMIT} has sha256 {digest}, not the pinned {PSL_SHA256}; review, then bump the pin"
         raise SystemExit(msg)

--- a/tools/generate_tlds.py
+++ b/tools/generate_tlds.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import hashlib
 import sys
-import urllib.request
 from pathlib import Path
+
+from httpfetch import fetch_bytes
 
 IANA_TLDS_URL = "https://data.iana.org/TLD/tlds-alpha-by-domain.txt"
 
@@ -31,8 +32,7 @@ IANA_SHA256 = "01dd82fed6299013f2e4bc4c5af2469b95497a4e9825801741ffff95b6e55d8f"
 
 def fetch_tlds() -> tuple[str, list[str]]:
     """Return the pinned IANA version and the lowercased ASCII TLDs, punycode entries included."""
-    with urllib.request.urlopen(IANA_TLDS_URL) as response:
-        raw = response.read()
+    raw = fetch_bytes(IANA_TLDS_URL)
     version = ""
     names: list[str] = []
     for line in raw.decode("ascii").splitlines():

--- a/tools/httpfetch.py
+++ b/tools/httpfetch.py
@@ -1,0 +1,53 @@
+"""
+Shared HTTP access for the tooling: httpx2 with a tenacity retry over the transient failure modes.
+
+Every network fetch in ``tools/`` (the benchmark corpora and the code generators that pull pinned Unicode,
+PSL, and IANA data) goes through here, so a rate limit or a dropped connection retries with capped backoff
+instead of failing the run. A benchmark job or a regenerate script draws a ``429`` from GitHub and the CDNs
+often enough that a single unretried GET turns the whole run red.
+"""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import Final
+
+import httpx2
+from tenacity import before_sleep_log, retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+__all__ = ["fetch_bytes"]
+
+_LOGGER: Final = logging.getLogger("turbohtml.tools.httpfetch")
+
+# The transient statuses a later attempt can clear; a 4xx like 404 or 403 is not among them, so it raises at once.
+_RETRYABLE_STATUS: Final = frozenset({
+    HTTPStatus.REQUEST_TIMEOUT,
+    HTTPStatus.TOO_EARLY,
+    HTTPStatus.TOO_MANY_REQUESTS,
+    HTTPStatus.INTERNAL_SERVER_ERROR,
+    HTTPStatus.BAD_GATEWAY,
+    HTTPStatus.SERVICE_UNAVAILABLE,
+    HTTPStatus.GATEWAY_TIMEOUT,
+})
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Retry a dropped connection or a transient server status, never a 4xx a retry cannot fix."""
+    if isinstance(exc, httpx2.TransportError):
+        return True
+    return isinstance(exc, httpx2.HTTPStatusError) and exc.response.status_code in _RETRYABLE_STATUS
+
+
+@retry(
+    retry=retry_if_exception(_is_retryable),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential(exp_base=3, max=30),
+    before_sleep=before_sleep_log(_LOGGER, logging.WARNING),
+    reraise=True,
+)
+def fetch_bytes(url: str) -> bytes:
+    """Download ``url`` and return its body, retrying the transient failures with capped backoff."""
+    response = httpx2.get(url, follow_redirects=True, timeout=30.0)
+    response.raise_for_status()
+    return response.content


### PR DESCRIPTION
The `🚀 CodSpeed` job fetches the CSS and JS minify corpora over HTTP the first time each benchmark runs, and the `tools/generate_*` scripts pull pinned Unicode, PSL, and IANA data the same way. When several CI runs start close together, GitHub and the npm CDNs answer one of those GETs with `429 Too Many Requests`, and because the stdlib `urllib` calls had no retry a single rate-limited response raised straight out of the run and turned it red. 🚦

Every network fetch in `tools/` now goes through one `httpfetch.fetch_bytes` helper built on `httpx2` and wrapped in a `tenacity` retry. The retry stays narrow: it backs off with capped exponential wait on a dropped connection (`TransportError`) and the transient server statuses (`429`, `408`, `425`, the `5xx` family), then re-raises at once anything a retry cannot fix, such as a `404` or `403`. The corpus bytes are unchanged, so no benchmark baseline shifts; the fetch just survives a transient rate limit instead of failing the job.

`httpx2` and `tenacity` join the `test` dependency group because the benchmark registry imports the corpus module during collection; both ship pure-Python `py3-none-any` wheels for every supported interpreter, the free-threaded builds included.
