### PR TITLE
📝 docs(migration): order guides by downloads, add npm/crates shields

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,12 +10,14 @@ import sys
 from html import escape as _html_escape
 from importlib.metadata import version as _version
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sphinx.application import Sphinx
 
 sys.path.insert(0, str(Path(__file__).parent / "_ext"))
@@ -246,35 +248,22 @@ def _stub_signature_for_alias(  # noqa: PLR0913, PLR0917 -- the signature is fix
 
 class _PackageMeta(Directive):
     """
-    Render one badge row of package metadata: ``.. package-meta:: <pypi-name> [github-slug]``.
+    Render one badge row of package metadata: ``.. package-meta:: [ecosystem] <name> [github-slug]``.
 
     Every migration guide opens with the same at-a-glance facts about the library it replaces (latest release,
     supported Pythons, license, downloads, and -- when the project lives on GitHub -- stars and recency), so a single
-    directive keeps the set and its order identical across the guides instead of hand-maintaining badge stacks.
+    directive keeps the set and its order identical across the guides instead of hand-maintaining badge stacks. The
+    first argument may name the ecosystem -- ``npm`` or ``crates`` for the JavaScript and Rust libraries -- and defaults
+    to PyPI when it is a bare package name, so every existing ``.. package-meta:: <pypi-name>`` call is unchanged.
     """
 
     required_arguments = 1
-    optional_arguments = 1
+    optional_arguments = 2
 
     def run(self) -> list[nodes.Node]:
-        pypi = self.arguments[0]
-        badges = [
-            (
-                "latest release",
-                f"https://img.shields.io/pypi/v/{pypi}?label=release",
-                f"https://pypi.org/project/{pypi}/",
-            ),
-            (
-                "supported Pythons",
-                f"https://img.shields.io/pypi/pyversions/{pypi}",
-                f"https://pypi.org/project/{pypi}/",
-            ),
-            ("license", f"https://img.shields.io/pypi/l/{pypi}", f"https://pypi.org/project/{pypi}/"),
-            ("monthly downloads", f"https://static.pepy.tech/badge/{pypi}/month", f"https://pepy.tech/project/{pypi}"),
-            ("total downloads", f"https://static.pepy.tech/badge/{pypi}", f"https://pepy.tech/project/{pypi}"),
-        ]
-        if len(self.arguments) > 1:
-            slug = self.arguments[1]
+        ecosystem, name, slug = self._parse_arguments()
+        badges = self._ECOSYSTEMS[ecosystem](name)
+        if slug is not None:
             badges += [
                 ("GitHub stars", f"https://img.shields.io/github/stars/{slug}", f"https://github.com/{slug}"),
                 ("last commit", f"https://img.shields.io/github/last-commit/{slug}", f"https://github.com/{slug}"),
@@ -282,9 +271,53 @@ class _PackageMeta(Directive):
         row = nodes.paragraph(classes=["package-meta"])
         for alt, image, target in badges:
             link = nodes.reference(refuri=target)
-            link += nodes.image(uri=image, alt=f"{pypi} {alt}")
+            link += nodes.image(uri=image, alt=f"{name} {alt}")
             row += link
         return [row]
+
+    def _parse_arguments(self) -> tuple[str, str, str | None]:
+        head, *rest = self.arguments
+        if head in self._ECOSYSTEMS:
+            name, *tail = rest
+        else:
+            name, tail = head, rest
+            head = "pypi"
+        return head, name, tail[0] if tail else None
+
+    @staticmethod
+    def _pypi_badges(name: str) -> list[tuple[str, str, str]]:
+        page = f"https://pypi.org/project/{name}/"
+        return [
+            ("latest release", f"https://img.shields.io/pypi/v/{name}?label=release", page),
+            ("supported Pythons", f"https://img.shields.io/pypi/pyversions/{name}", page),
+            ("license", f"https://img.shields.io/pypi/l/{name}", page),
+            ("monthly downloads", f"https://static.pepy.tech/badge/{name}/month", f"https://pepy.tech/project/{name}"),
+            ("total downloads", f"https://static.pepy.tech/badge/{name}", f"https://pepy.tech/project/{name}"),
+        ]
+
+    @staticmethod
+    def _npm_badges(name: str) -> list[tuple[str, str, str]]:
+        page = f"https://www.npmjs.com/package/{name}"
+        return [
+            ("latest release", f"https://img.shields.io/npm/v/{name}", page),
+            ("license", f"https://img.shields.io/npm/l/{name}", page),
+            ("monthly downloads", f"https://img.shields.io/npm/dm/{name}", page),
+        ]
+
+    @staticmethod
+    def _crates_badges(name: str) -> list[tuple[str, str, str]]:
+        page = f"https://crates.io/crates/{name}"
+        return [
+            ("latest release", f"https://img.shields.io/crates/v/{name}", page),
+            ("license", f"https://img.shields.io/crates/l/{name}", page),
+            ("downloads", f"https://img.shields.io/crates/d/{name}", page),
+        ]
+
+    _ECOSYSTEMS: ClassVar[dict[str, Callable[[str], list[tuple[str, str, str]]]]] = {
+        "pypi": _pypi_badges,
+        "npm": _npm_badges,
+        "crates": _crates_badges,
+    }
 
 
 _DESCRIPTION_LIMIT = 160

--- a/docs/migration/dompurify.rst
+++ b/docs/migration/dompurify.rst
@@ -2,6 +2,8 @@
  From DOMPurify
 ################
 
+.. package-meta:: npm dompurify cure53/DOMPurify
+
 `DOMPurify <https://github.com/cure53/DOMPurify>`_ is the reference client-side HTML sanitizer: it parses untrusted
 markup, walks it against a hardened allowlist, and hands back a string safe to assign to ``innerHTML``. It runs in a
 browser or, server-side, on ``jsdom`` through ``isomorphic-dompurify``. Several of its options harden against attacks

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -727,67 +727,67 @@ GitHub-Flavored Markdown, and :meth:`turbohtml.Node.to_text` extracts rendered t
     :hidden:
     :maxdepth: 1
 
-    beautifulsoup
-    lxml
-    html5lib
-    selectolax
-    resiliparse
-    mechanicalsoup
-    html5-parser
-    stdlib
-    parse5
-    jsdom
-    lol-html
     charset-normalizer
-    chardet
+    pandas
+    markupsafe
+    parse5
+    beautifulsoup
     soupsieve
-    parsel
-    pyquery
-    cssutils
+    lxml
+    jsdom
+    dompurify
+    chardet
     linkify-it-py
     bleach
+    markdownify
     nh3
     sanitize-html
-    dompurify
-    lxml-html-clean
-    rcssmin
-    rjsmin
-    jsmin
-    minify-html
-    htmlmin
-    csscompressor
-    html-sanitizer
-    calmjs-parse
-    lightningcss
+    html5lib
     cssselect
-    pandas
+    html2text
+    lxml-html-clean
+    feedparser
+    htmldate
     w3lib
     trafilatura
     courlan
-    extruct
+    cssutils
     justext
-    readability-lxml
-    readabilipy
-    metadata_parser
-    newspaper3k
-    boilerpy3
-    goose3
-    microdata
-    news-please
-    opengraph
-    htmldate
-    feedparser
+    selectolax
+    parsel
+    rjsmin
+    rcssmin
     dominate
+    pyquery
+    readability-lxml
+    html-text
+    minify-html
+    readabilipy
+    inscriptis
+    jsmin
+    htmlmin
+    resiliparse
+    csscompressor
+    newspaper3k
+    html-sanitizer
     yattag
+    extruct
+    lol-html
     htbuilder
+    boilerpy3
     htpy
+    mechanicalsoup
     airium
+    goose3
+    calmjs-parse
+    html5-parser
+    news-please
     markyp
+    lightningcss
+    metadata_parser
+    microdata
     fast-html
     simple-html
+    opengraph
     hyperpython
-    markupsafe
-    markdownify
-    html2text
-    inscriptis
-    html-text
+    stdlib

--- a/docs/migration/jsdom.rst
+++ b/docs/migration/jsdom.rst
@@ -2,6 +2,8 @@
  From jsdom
 ############
 
+.. package-meta:: npm jsdom jsdom/jsdom
+
 `jsdom <https://github.com/jsdom/jsdom>`_ is a JavaScript implementation of the WHATWG DOM and HTML standards, used to
 run browser-shaped code under Node. Its ``document.createTreeWalker`` and ``document.createNodeIterator`` are the DOM
 Living Standard traversal objects: a movable cursor and a flat filtered view over a subtree, each driven by a

--- a/docs/migration/lol-html.rst
+++ b/docs/migration/lol-html.rst
@@ -2,6 +2,8 @@
  From lol-html
 ###############
 
+.. package-meta:: crates lol-html cloudflare/lol-html
+
 `lol-html <https://github.com/cloudflare/lol-html>`_ is Cloudflare's streaming HTML rewriter -- the engine behind
 Workers' ``HTMLRewriter`` that transforms responses at the edge. It is written in Rust (with a WebAssembly/JavaScript
 binding) and, like turbohtml's rewriter, never builds a DOM: it runs the tokenizer over the input, matches CSS selectors

--- a/docs/migration/parse5.rst
+++ b/docs/migration/parse5.rst
@@ -2,6 +2,8 @@
  From parse5
 #############
 
+.. package-meta:: npm parse5 inikulin/parse5
+
 `parse5 <https://github.com/inikulin/parse5>`_ is the reference JavaScript WHATWG parser -- the tree builder behind
 jsdom, Angular, and much of the Node HTML ecosystem. It is unusual among the libraries here in being JavaScript rather
 than Python, so this guide is a cross-language reference: it maps the parse5 API, and its ``sourceCodeLocationInfo``

--- a/docs/migration/sanitize-html.rst
+++ b/docs/migration/sanitize-html.rst
@@ -2,6 +2,8 @@
  From sanitize-html
 ####################
 
+.. package-meta:: npm sanitize-html apostrophecms/sanitize-html
+
 `sanitize-html <https://github.com/apostrophecms/sanitize-html>`_ is the standard Node HTML sanitizer: you declare the
 tags, attributes, URL schemes, and CSS properties you trust, and everything else is stripped. Its distinguishing feature
 is ``transformTags`` -- a map that renames an element (and optionally rewrites its attributes) during the sanitize pass,


### PR DESCRIPTION
The migration-guide index ordered its toctree by per-namespace adoption, so a reader scanning the sidebar saw parse-and-DOM libraries first regardless of how widely each library is used. This orders the whole toctree by last-month download count, descending, across PyPI, npm, and crates, so the guides a reader is most likely to want sit at the top. 📊 The stdlib parser has no download metric, so it sorts last.

The `package-meta` directive rendered PyPI shields only, which left the five non-Python guides with no metadata row at all. The directive now takes an optional leading ecosystem argument: `npm` and `crates` render the shields.io badges for those registries, and a bare package name still means PyPI, so every existing `.. package-meta:: <pypi-name>` call is unchanged. npm carries version, license, and monthly downloads (there is no supported-Pythons badge); crates carries version, license, and downloads. The optional GitHub slug still adds the stars and last-commit badges for any ecosystem.

With that in place, the parse5, jsdom, DOMPurify, sanitize-html, and lol-html guides now open with their npm or crates shields, matching the PyPI guides. This also gives the lol-html guide the metadata row it never had.
