### PR TITLE
⚡ perf(c14n): drop redundant xlink ancestor walk

### DIFF
--- a/src/turbohtml/_c/serialize/c14n.c
+++ b/src/turbohtml/_c/serialize/c14n.c
@@ -255,7 +255,7 @@ static void c14n_open_tag(sbuf *out, th_tree *tree, th_node *node, const th_node
     } else if (opts->exclusive) {
         render_xlink = c14n_has_xlink(tree, node) && !c14n_ancestor_binds_xlink(tree, node, apex);
     } else {
-        render_xlink = c14n_xlink_in_scope(tree, node) && !c14n_xlink_in_scope(tree, node->parent);
+        render_xlink = c14n_has_xlink(tree, node) && !c14n_xlink_in_scope(tree, node->parent);
     }
     if (render_xlink) {
         sbuf_puts(out, " xmlns:xlink=\"");


### PR DESCRIPTION
## Summary

The inclusive, non-apex `xmlns:xlink` decision in `c14n_open_tag` walked the ancestor chain twice per element:

```c
render_xlink = c14n_xlink_in_scope(node) && !c14n_xlink_in_scope(node->parent);
```

Since `in_scope(node) == has_xlink(node) || in_scope(parent)`, the expression reduces algebraically to

```c
render_xlink = c14n_has_xlink(node) && !c14n_xlink_in_scope(node->parent);
```

A single local attribute scan (`c14n_has_xlink`) now short-circuits the whole ancestor walk in the common xlink-free case. The exclusive path already tests this way, so this also brings the two branches into line.

Part of the pre-1.0 perf audit. Exact simplification, no behavior change.

## Correctness

- `tests/serialize/test_c14n_differential.py`: 14 passed
- `tests/conformance/test_c14n_conformance.py` (libxml2 oracle): 9 passed, 64 xfailed (unchanged) — output stays byte-identical

## Coverage

- llvm (`tox -e 3.14`): Python 100%, C 100% line + branch; `c14n.c` 289/289
- gcc-16: `c14n.c` 100% line + branch (only the pre-existing documented `unescape.c:299` gap remains, unrelated)

The change swaps one already-covered call for another and adds no new branch, so branch topology is unchanged.