### PR TITLE
📝 docs: re-taxonomize reference by task

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -5,18 +5,21 @@
 The complete public API, grouped by task. Types and signatures come from the ``turbohtml._html`` extension's stub; the
 prose is the C docstrings, so the reference cannot drift from the compiled core.
 
-The pages are grouped by task, in the order the :doc:`how-to guides </how-to/index>` and :doc:`migration guides
-</migration/index>` use. :doc:`reference/parsing` turns markup into a tree, :doc:`reference/nodes` is the node model and
-the navigation, query, and mutation methods shared by every node, and :doc:`reference/tokenizer` is the low-level token
-surface. :doc:`reference/detect` sniffs the character encoding of raw bytes. :doc:`reference/query` is the CSS, XPath,
-and soupsieve-shaped search surface, and :doc:`reference/cssom` resolves the CSS cascade to a computed style.
-:doc:`reference/clean` covers allowlist sanitizing, link rewriting, and minification, :doc:`reference/convert`
-translates CSS selectors to XPath 1.0, and :doc:`reference/transform` applies an XSLT 1.0 stylesheet.
-:doc:`reference/extract` and :doc:`reference/structured-data` pull the article, its metadata, and the JSON-LD /
-Microdata / OpenGraph records out of a page. :doc:`reference/build` constructs a tree in code, and
-:doc:`reference/serialize` renders one back to HTML, Markdown, or plain text. :doc:`reference/validate` checks a
-document against an XSD 1.0 or RELAX NG schema, and :doc:`reference/conformance` runs the HTML5 authoring-conformance
-rules.
+The pages group the same way the :doc:`how-to guides </how-to/index>` and :doc:`migration guides </migration/index>` do,
+by the turbohtml namespace that owns each task:
+
+**Parse & DOM** turns markup into a tree (:doc:`reference/parsing`), documents the node model with the navigation,
+query, and mutation methods every node shares (:doc:`reference/nodes`), and exposes the low-level token surface beneath
+it (:doc:`reference/tokenizer`). **Detect** sniffs the character encoding and language of raw bytes
+(:doc:`reference/detect`). **Query** searches a tree with CSS, XPath, and the soupsieve-shaped API
+(:doc:`reference/query`) and resolves the CSS cascade to a computed style (:doc:`reference/cssom`). **Clean** sanitizes
+against an allowlist, rewrites bare URLs into links, and minifies (:doc:`reference/clean`). **Convert & transform**
+translates CSS selectors to XPath 1.0 (:doc:`reference/convert`) and applies an XSLT 1.0 stylesheet
+(:doc:`reference/transform`). **Extract** pulls the article and its metadata (:doc:`reference/extract`) and the JSON-LD,
+Microdata, and OpenGraph records (:doc:`reference/structured-data`) out of a page. **Build** constructs a tree in code
+(:doc:`reference/build`), and **Serialize** renders one back to HTML, Markdown, or plain text
+(:doc:`reference/serialize`). **Validate** checks a document against an XSD 1.0 or RELAX NG schema
+(:doc:`reference/validate`) and runs the HTML5 authoring-conformance rules (:doc:`reference/conformance`).
 
 .. currentmodule:: turbohtml
 
@@ -24,19 +27,60 @@ rules.
 
 .. toctree::
     :maxdepth: 2
+    :caption: Parse & DOM
 
     reference/parsing
     reference/nodes
     reference/tokenizer
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Detect
+
     reference/detect
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Query
+
     reference/query
     reference/cssom
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Clean
+
     reference/clean
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Convert & transform
+
     reference/convert
     reference/transform
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Extract
+
     reference/extract
     reference/structured-data
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Build
+
     reference/build
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Serialize
+
     reference/serialize
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Validate
+
     reference/validate
     reference/conformance


### PR DESCRIPTION
The reference section listed all fifteen API pages in one flat toctree, so the sidebar was a single undifferentiated run and a reader could not see which pages belong to the same task. 📚 The how-to and migration guides already group their pages by the `Parse & DOM` / `Detect` / `Query` / `Clean` / `Convert` / `Extract` / `Build` / `Serialize` namespace taxonomy, but the reference did not follow suit, so the three sections navigated differently.

This splits the flat toctree into captioned groups along that same taxonomy, adding a `Validate` group for the schema and conformance checkers that have no migration section. The page files stay where they are, so every `:doc:` and `:ref:` target that points into `reference/` keeps resolving; only the navigation grouping and the landing prose change. The grouping mirrors the C subsystem cleanup in #606, #608, #609, and #610 while keeping the two audiences distinct: the reference documents the public Python API by task, and the development docs describe the C internals.

There is no behavior change and no new page, so external links and intra-doc cross-references stay intact. The `docs` build passes with `-W` and all nine captions render in the furo sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
