### PR TITLE
📝 docs: generate CLI reference from the argparse parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",  # run the testcode/testoutput examples so the docs cannot drift from the code
     "sphinx.ext.intersphinx",
+    "sphinx_argparse_cli",  # generate the CLI reference from turbohtml.__main__._parser so it cannot drift
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "sphinx_issues",  # the :issue: role used by the changelog

--- a/docs/how-to/cli.rst
+++ b/docs/how-to/cli.rst
@@ -50,3 +50,6 @@ is omitted or ``-``) and writes to stdout, or to the ``-o FILE`` given:
 A subcommand exits ``0`` on success and ``1`` with a message on stderr when the library rejects the input (an unparsable
 script, an empty byte stream to ``detect``) or the input file cannot be read; argument errors exit ``2``. For policies,
 renderer options, or streaming, call the API from Python.
+
+The :doc:`/reference/cli` lists every subcommand and flag, generated from the parser so it cannot drift from the
+command.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -19,7 +19,8 @@ translates CSS selectors to XPath 1.0 (:doc:`reference/convert`) and applies an 
 Microdata, and OpenGraph records (:doc:`reference/structured-data`) out of a page. **Build** constructs a tree in code
 (:doc:`reference/build`), and **Serialize** renders one back to HTML, Markdown, or plain text
 (:doc:`reference/serialize`). **Validate** checks a document against an XSD 1.0 or RELAX NG schema
-(:doc:`reference/validate`) and runs the HTML5 authoring-conformance rules (:doc:`reference/conformance`).
+(:doc:`reference/validate`) and runs the HTML5 authoring-conformance rules (:doc:`reference/conformance`). **Command
+line** wraps that surface for the shell, one subcommand per entry point (:doc:`reference/cli`).
 
 .. currentmodule:: turbohtml
 
@@ -84,3 +85,9 @@ Microdata, and OpenGraph records (:doc:`reference/structured-data`) out of a pag
 
     reference/validate
     reference/conformance
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Command line
+
+    reference/cli

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -1,0 +1,14 @@
+##############
+ Command line
+##############
+
+The ``turbohtml`` console script (also ``python -m turbohtml``) is a thin front end over the public API: every
+subcommand reads one input and writes one output, delegating to the matching function. The reference below is generated
+from the argparse parser, so it lists every subcommand and flag exactly as the command exposes them and cannot drift
+from the code. For the subcommand-to-API mapping and pipeline examples, see :doc:`/how-to/cli`.
+
+.. sphinx_argparse_cli::
+    :module: turbohtml.__main__
+    :func: _parser
+    :prog: turbohtml
+    :title: turbohtml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ type = [
 docs = [
   "furo>=2025.12.19",
   "sphinx>=9.1",
+  "sphinx-argparse-cli>=1.19",        # generate the CLI reference from the argparse parser so it cannot drift
   "sphinx-autodoc-typehints>=3.11",   # 3.11 types C getset descriptors from the stub
   "sphinx-copybutton>=0.5.2",
   "sphinx-issues>=6",


### PR DESCRIPTION
The command line was documented only by a hand-written how-to whose per-flag details drifted from the argparse parser in `turbohtml.__main__`. 📝 This PR generates an exhaustive CLI reference straight from `_parser()` with `sphinx-argparse-cli`, so the documented subcommands and flags track the code the same way the doctest-run examples keep the rest of the docs honest.

The new `docs/reference/cli.rst` renders the parser under a `Command line` toctree group; `sphinx-argparse-cli` walks every subcommand (`minify`, `minify-css`, `minify-js`, `detect`, `to-markdown`, `to-text`, `sanitize`) and their options. `docs/how-to/cli.rst` stays the task-oriented guide with the subcommand-to-API mapping and pipeline examples, and now points at the generated reference for the full flag surface, so the flags are described in one place.

This is internal docs tooling, so there is no changelog fragment. The docs build passes under `-W`, with the directive rendering every subcommand.
