### PR TITLE
🔧 chore: correct package metadata and widen discoverability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,19 @@ name = "turbohtml"
 description = "A fast, fully typed HTML toolkit for Python, powered by a C-accelerated core."
 readme = "README.md"
 keywords = [
+  "css-selector",
+  "encoding-detection",
   "escape",
   "html",
   "html5",
+  "markdown",
+  "minify",
   "parser",
+  "sanitize",
+  "scraping",
   "unescape",
+  "xml",
+  "xpath",
 ]
 license = "MIT"
 license-files = [
@@ -26,7 +34,7 @@ maintainers = [
 ]
 requires-python = ">=3.10"
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
@@ -41,6 +49,9 @@ classifiers = [
   "Topic :: Internet",
   "Topic :: Software Development :: Libraries",
   "Topic :: Text Processing :: Markup :: HTML",
+  "Topic :: Text Processing :: Markup :: Markdown",
+  "Topic :: Text Processing :: Markup :: XML",
+  "Typing :: Typed",
 ]
 dynamic = [
   "version",


### PR DESCRIPTION
The published package metadata lagged the project. The Trove classifiers still declared `Development Status :: 3 - Alpha` even though 1.0.0 shipped, so PyPI presented the library as pre-release. This corrects it to `5 - Production/Stable`.

It also widens discoverability: the classifiers gain the `Markdown` and `XML` markup topics and `Typing :: Typed` (the package ships type information), and the keyword list grows from the five escaping/parsing terms to cover the rest of the surface — sanitize, markdown, minify, scraping, encoding-detection, css-selector, xpath, and xml — so a search for those tasks finds turbohtml.

No code or behavior changes; metadata only.
