### PR TITLE
🐛 fix(dom): lock threaded tree reads

### DIFF
--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -57,7 +57,11 @@ static void attrs_dealloc(PyObject *self) {
 }
 
 static Py_ssize_t attrs_length(PyObject *self) {
-    return ((AttrsObject *)self)->node->attr_count;
+    Py_ssize_t count;
+    Py_BEGIN_CRITICAL_SECTION(((AttrsObject *)self)->handle);
+    count = ((AttrsObject *)self)->node->attr_count;
+    Py_END_CRITICAL_SECTION();
+    return count;
 }
 
 static PyObject *attrs_subscript(PyObject *self, PyObject *key) {
@@ -154,17 +158,23 @@ static int attrs_contains(PyObject *self, PyObject *key) {
 static PyObject *attrs_iter(PyObject *self) {
     th_node *node = ((AttrsObject *)self)->node;
     th_tree *tree = tree_of(self);
-    PyObject *names = PyList_New(node->attr_count);
-    if (names == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
-    for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-        PyObject *name = attr_name_obj(tree, &node->attrs[index]);
-        if (name == NULL) {   /* GCOVR_EXCL_BR_LINE: a stored name always decodes */
-            Py_DECREF(names); /* GCOVR_EXCL_LINE: decode-failure path */
-            return NULL;      /* GCOVR_EXCL_LINE: decode-failure path */
+    PyObject *names;
+    Py_BEGIN_CRITICAL_SECTION(((AttrsObject *)self)->handle);
+    names = PyList_New(node->attr_count);
+    if (names != NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
+            PyObject *name = attr_name_obj(tree, &node->attrs[index]);
+            if (name == NULL) {   /* GCOVR_EXCL_BR_LINE: a stored name always decodes */
+                Py_DECREF(names); /* GCOVR_EXCL_LINE: decode-failure path */
+                names = NULL;     /* GCOVR_EXCL_LINE: decode-failure path */
+                break;            /* GCOVR_EXCL_LINE: decode-failure path */
+            }
+            PyList_SET_ITEM(names, index, name);
         }
-        PyList_SET_ITEM(names, index, name);
+    }
+    Py_END_CRITICAL_SECTION();
+    if (names == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure and stored-name decode failure cannot be forced */
+        return NULL;     /* GCOVR_EXCL_LINE: allocation/decode-failure path */
     }
     PyObject *iterator = PyObject_GetIter(names);
     Py_DECREF(names);
@@ -177,41 +187,46 @@ enum attrs_view { ATTRS_KEYS, ATTRS_VALUES, ATTRS_ITEMS };
 static PyObject *attrs_collect(PyObject *self, enum attrs_view kind) {
     th_node *node = ((AttrsObject *)self)->node;
     th_tree *tree = tree_of(self);
-    PyObject *out = PyList_New(node->attr_count);
-    if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
-    for (Py_ssize_t index = 0; index < node->attr_count; index++) {
-        const th_node_attr *attr = &node->attrs[index];
-        PyObject *item;
-        if (kind == ATTRS_VALUES) {
-            item = attr_value_obj(attr);
-        } else {
-            PyObject *name = attr_name_obj(tree, attr);
-            if (name == NULL) { /* GCOVR_EXCL_BR_LINE: a stored name always decodes */
-                Py_DECREF(out); /* GCOVR_EXCL_LINE: decode-failure path */
-                return NULL;    /* GCOVR_EXCL_LINE: decode-failure path */
-            }
-            if (kind == ATTRS_KEYS) {
-                item = name;
+    PyObject *out;
+    Py_BEGIN_CRITICAL_SECTION(((AttrsObject *)self)->handle);
+    out = PyList_New(node->attr_count);
+    if (out != NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
+            const th_node_attr *attr = &node->attrs[index];
+            PyObject *item;
+            if (kind == ATTRS_VALUES) {
+                item = attr_value_obj(attr);
             } else {
-                PyObject *value = attr_value_obj(attr);
-                if (value == NULL) { /* GCOVR_EXCL_BR_LINE: value object build cannot be forced to fail */
-                    Py_DECREF(name); /* GCOVR_EXCL_LINE: alloc-failure path */
-                    Py_DECREF(out);  /* GCOVR_EXCL_LINE: alloc-failure path */
-                    return NULL;     /* GCOVR_EXCL_LINE: alloc-failure path */
+                PyObject *name = attr_name_obj(tree, attr);
+                if (name == NULL) { /* GCOVR_EXCL_BR_LINE: a stored name always decodes */
+                    Py_DECREF(out); /* GCOVR_EXCL_LINE: decode-failure path */
+                    out = NULL;     /* GCOVR_EXCL_LINE: decode-failure path */
+                    break;          /* GCOVR_EXCL_LINE: decode-failure path */
                 }
-                item = PyTuple_Pack(2, name, value);
-                Py_DECREF(name);
-                Py_DECREF(value);
+                if (kind == ATTRS_KEYS) {
+                    item = name;
+                } else {
+                    PyObject *value = attr_value_obj(attr);
+                    if (value == NULL) { /* GCOVR_EXCL_BR_LINE: value object build cannot be forced to fail */
+                        Py_DECREF(name); /* GCOVR_EXCL_LINE: alloc-failure path */
+                        Py_DECREF(out);  /* GCOVR_EXCL_LINE: alloc-failure path */
+                        out = NULL;      /* GCOVR_EXCL_LINE: alloc-failure path */
+                        break;           /* GCOVR_EXCL_LINE: alloc-failure path */
+                    }
+                    item = PyTuple_Pack(2, name, value);
+                    Py_DECREF(name);
+                    Py_DECREF(value);
+                }
             }
+            if (item == NULL) { /* GCOVR_EXCL_BR_LINE: item build cannot be forced to fail */
+                Py_DECREF(out); /* GCOVR_EXCL_LINE: alloc-failure path */
+                out = NULL;     /* GCOVR_EXCL_LINE: alloc-failure path */
+                break;          /* GCOVR_EXCL_LINE: alloc-failure path */
+            }
+            PyList_SET_ITEM(out, index, item);
         }
-        if (item == NULL) { /* GCOVR_EXCL_BR_LINE: item build cannot be forced to fail */
-            Py_DECREF(out); /* GCOVR_EXCL_LINE: alloc-failure path */
-            return NULL;    /* GCOVR_EXCL_LINE: alloc-failure path */
-        }
-        PyList_SET_ITEM(out, index, item);
     }
+    Py_END_CRITICAL_SECTION();
     return out;
 }
 

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -154,26 +154,31 @@ static void walker_dealloc(PyObject *self) {
 
 static PyObject *walker_next(PyObject *self) {
     WalkerObject *walker = (WalkerObject *)self;
-    if (walker->current == NULL) {
-        return NULL;
+    th_node *node;
+    Py_BEGIN_CRITICAL_SECTION(walker->handle);
+    node = walker->current;
+    if (node != NULL) {
+        switch (walker->mode) {
+        case WALK_ANCESTORS:
+            walker->current = node->parent;
+            break;
+        case WALK_NEXT_SIBLINGS:
+            walker->current = node->next_sibling;
+            break;
+        case WALK_PREVIOUS_SIBLINGS:
+            walker->current = node->prev_sibling;
+            break;
+        case WALK_PRECEDING:
+            walker->current = preceding_skip(previous_element(node), walker->root);
+            break;
+        default: /* WALK_DESCENDANTS, and the following axis bounded by a NULL root */
+            walker->current = preorder_next(node, walker->root);
+            break;
+        }
     }
-    th_node *node = walker->current;
-    switch (walker->mode) {
-    case WALK_ANCESTORS:
-        walker->current = node->parent;
-        break;
-    case WALK_NEXT_SIBLINGS:
-        walker->current = node->next_sibling;
-        break;
-    case WALK_PREVIOUS_SIBLINGS:
-        walker->current = node->prev_sibling;
-        break;
-    case WALK_PRECEDING:
-        walker->current = preceding_skip(previous_element(node), walker->root);
-        break;
-    default: /* WALK_DESCENDANTS, and the following axis bounded by a NULL root */
-        walker->current = preorder_next(node, walker->root);
-        break;
+    Py_END_CRITICAL_SECTION();
+    if (node == NULL) {
+        return NULL;
     }
     return node_wrap(state_of(self), walker->handle, node);
 }
@@ -448,32 +453,55 @@ static PyObject *node_get_children(PyObject *self, void *Py_UNUSED(closure)) {
 
 static PyObject *node_get_descendants(PyObject *self, void *Py_UNUSED(closure)) {
     NodeObject *node = (NodeObject *)self;
-    return walker_new(state_of(self), node->handle, node->node->first_child, node->node, WALK_DESCENDANTS);
+    th_node *first_child;
+    Py_BEGIN_CRITICAL_SECTION(node->handle);
+    first_child = node->node->first_child;
+    Py_END_CRITICAL_SECTION();
+    return walker_new(state_of(self), node->handle, first_child, node->node, WALK_DESCENDANTS);
 }
 
 static PyObject *node_get_ancestors(PyObject *self, void *Py_UNUSED(closure)) {
     NodeObject *node = (NodeObject *)self;
-    return walker_new(state_of(self), node->handle, node->node->parent, NULL, WALK_ANCESTORS);
+    th_node *parent;
+    Py_BEGIN_CRITICAL_SECTION(node->handle);
+    parent = node->node->parent;
+    Py_END_CRITICAL_SECTION();
+    return walker_new(state_of(self), node->handle, parent, NULL, WALK_ANCESTORS);
 }
 
 static PyObject *node_get_next_siblings(PyObject *self, void *Py_UNUSED(closure)) {
     NodeObject *node = (NodeObject *)self;
-    return walker_new(state_of(self), node->handle, node->node->next_sibling, NULL, WALK_NEXT_SIBLINGS);
+    th_node *sibling;
+    Py_BEGIN_CRITICAL_SECTION(node->handle);
+    sibling = node->node->next_sibling;
+    Py_END_CRITICAL_SECTION();
+    return walker_new(state_of(self), node->handle, sibling, NULL, WALK_NEXT_SIBLINGS);
 }
 
 static PyObject *node_get_previous_siblings(PyObject *self, void *Py_UNUSED(closure)) {
     NodeObject *node = (NodeObject *)self;
-    return walker_new(state_of(self), node->handle, node->node->prev_sibling, NULL, WALK_PREVIOUS_SIBLINGS);
+    th_node *sibling;
+    Py_BEGIN_CRITICAL_SECTION(node->handle);
+    sibling = node->node->prev_sibling;
+    Py_END_CRITICAL_SECTION();
+    return walker_new(state_of(self), node->handle, sibling, NULL, WALK_PREVIOUS_SIBLINGS);
 }
 
 static PyObject *node_get_following(PyObject *self, void *Py_UNUSED(closure)) {
     NodeObject *node = (NodeObject *)self;
-    return walker_new(state_of(self), node->handle, subtree_next(node->node), NULL, WALK_DESCENDANTS);
+    th_node *start;
+    Py_BEGIN_CRITICAL_SECTION(node->handle);
+    start = subtree_next(node->node);
+    Py_END_CRITICAL_SECTION();
+    return walker_new(state_of(self), node->handle, start, NULL, WALK_DESCENDANTS);
 }
 
 static PyObject *node_get_preceding(PyObject *self, void *Py_UNUSED(closure)) {
     NodeObject *node = (NodeObject *)self;
-    th_node *start = preceding_skip(previous_element(node->node), node->node);
+    th_node *start;
+    Py_BEGIN_CRITICAL_SECTION(node->handle);
+    start = preceding_skip(previous_element(node->node), node->node);
+    Py_END_CRITICAL_SECTION();
     return walker_new(state_of(self), node->handle, start, node->node, WALK_PRECEDING);
 }
 
@@ -1296,18 +1324,23 @@ static PyGetSetDef node_getset[] = {
 
 static Py_ssize_t node_length(PyObject *self) {
     Py_ssize_t count = 0;
+    Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
     for (th_node *child = ((NodeObject *)self)->node->first_child; child != NULL; child = child->next_sibling) {
         count++;
     }
+    Py_END_CRITICAL_SECTION();
     return count;
 }
 
 static PyObject *node_item(PyObject *self, Py_ssize_t index) {
     NodeObject *node = (NodeObject *)self;
-    th_node *child = node->node->first_child;
+    th_node *child;
+    Py_BEGIN_CRITICAL_SECTION(node->handle);
+    child = node->node->first_child;
     for (Py_ssize_t step = 0; step < index && child != NULL; step++) {
         child = child->next_sibling;
     }
+    Py_END_CRITICAL_SECTION();
     if (child == NULL) {
         PyErr_SetString(PyExc_IndexError, "node child index out of range");
         return NULL;
@@ -1316,7 +1349,7 @@ static PyObject *node_item(PyObject *self, Py_ssize_t index) {
 }
 
 static PyObject *node_iter(PyObject *self) {
-    PyObject *children = node_children_tuple(self);
+    PyObject *children = node_get_children(self, NULL);
     if (children == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;        /* GCOVR_EXCL_LINE: allocation-failure path */
     }

--- a/tests/dom/test_tree_freethread.py
+++ b/tests/dom/test_tree_freethread.py
@@ -102,6 +102,63 @@ def test_concurrent_reads_and_mixed_mutations_are_memory_safe() -> None:
     assert body.serialize().startswith("<body>")  # still well-formed after the concurrent churn
 
 
+def test_concurrent_lazy_node_iterators_and_extract_is_memory_safe() -> None:
+    doc = _doc(400)
+    body = doc.find("body")
+    assert body is not None
+    children = list(body.children)
+    start = threading.Barrier(3)
+
+    def descendant_reader() -> None:
+        start.wait()
+        for _ in range(300):
+            list(body.descendants)
+            list(body.following)
+
+    def sequence_reader() -> None:
+        start.wait()
+        for _ in range(300):
+            len(body)
+            list(body)
+
+    def mutator() -> None:
+        start.wait()
+        for child in children:
+            child.extract()
+
+    _run(descendant_reader, sequence_reader, mutator)
+    assert list(body.children) == []
+
+
+def test_concurrent_attrs_views_and_mutation_are_memory_safe() -> None:
+    doc = _doc(300)
+    body = doc.find("body")
+    assert body is not None
+    divs = body.find_all("div")
+    start = threading.Barrier(2)
+
+    def reader() -> None:
+        start.wait()
+        for _ in range(200):
+            for div in divs:
+                len(div.attrs)
+                list(div.attrs)
+                div.attrs.keys()
+                div.attrs.values()
+                div.attrs.items()
+                repr(div.attrs)
+
+    def mutator() -> None:
+        start.wait()
+        for index in range(200):
+            for div in divs:
+                div.attrs["data-x"] = str(index)
+                del div.attrs["data-x"]
+
+    _run(reader, mutator)
+    assert all("data-x" not in div.attrs for div in divs)
+
+
 def test_concurrent_reads_and_bulk_wrap_is_memory_safe() -> None:
     doc = _doc(300)
     body = doc.find("body")


### PR DESCRIPTION
Free-threaded readers crashed while one thread walked child, sibling, or attribute arrays and another rewired the same tree.

The fix takes the existing tree lock around lazy node-axis cursor movement, sequence snapshots, and attrs view materialization.
