### PR TITLE
🐛 fix(xslt): resolve file URL imports

### DIFF
--- a/docs/reference/transform.rst
+++ b/docs/reference/transform.rst
@@ -25,6 +25,6 @@ conflict resolution by priority then document order. It emits the ``xml``, ``htm
 adds the XSLT functions ``current()``, ``key()``, ``generate-id()``, ``format-number()``, ``system-property()``,
 ``function-available()``, and ``element-available()``.
 
-External-document loading is out of scope: ``xsl:include``, ``xsl:import``, and ``document()`` do not resolve, so import
-precedence collapses to a single stylesheet's priority-and-order resolution, and ``document()`` returns an empty
-node-set.
+External-document loading is limited. ``xsl:import`` resolves local paths and file URLs against ``base_url``; the
+imported declarations join conflict resolution at lower import precedence. ``xsl:include`` and ``document()`` do not
+resolve, and ``document()`` returns an empty node-set.

--- a/src/turbohtml/transform.py
+++ b/src/turbohtml/transform.py
@@ -22,8 +22,8 @@ stylesheets, ``cdata-section-elements`` and the ``xml``/``html``/``text`` output
 null-namespace ``html`` document element). The documented boundaries are locale-aware ``xsl:sort`` collation (a locale
 layer turbohtml does not carry) and ``id()`` over DTD-declared IDs (no DTD layer).
 
-An ``xsl:import`` is resolved relative to ``base_url`` (the stylesheet's own path or URL, as lxml uses ``etree.parse``'s
-base): pass it when the stylesheet imports. Validated against libxslt's XSLT 1.0 Recommendation test corpus (see
+An ``xsl:import`` is resolved relative to ``base_url`` (the stylesheet's own path or file URL): pass it when the
+stylesheet imports. Validated against libxslt's XSLT 1.0 Recommendation test corpus (see
 ``tests/conformance/test_xslt_conformance.py``).
 """
 
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from ._html import Element, _xslt_transform, parse_xml
 
@@ -66,7 +68,7 @@ def _load_imports(root: Element, base: Path) -> list[Node]:
         if href is None:
             msg = "xsl:import requires an href attribute"
             raise ValueError(msg)
-        path = base / str(href)
+        path = _import_path(base, str(href))
         imported = parse_xml(path.read_text(encoding="utf-8"))
         # parse_xml raises HTMLParseError on a document with no root element, so imported.root is set here.
         imports.extend(_load_imports(cast("Element", imported.root), path.parent))
@@ -85,7 +87,38 @@ def _resolve(stylesheet: Node, base_url: str | None) -> list[Node] | None:
     if base_url is None:
         msg = "xsl:import needs a base_url to resolve the imported stylesheet's href against"
         raise ValueError(msg)
-    return _load_imports(root, Path(base_url).parent)
+    return _load_imports(root, _base_path(base_url).parent)
+
+
+def _base_path(base_url: str) -> Path:
+    parsed = urlparse(base_url)
+    if parsed.scheme == "file":
+        return _file_url_path(parsed.netloc, parsed.path, "base_url")
+    if parsed.scheme and not _is_windows_drive_path(base_url):
+        msg = "xsl:import base_url must be a local path or file URL"
+        raise ValueError(msg)
+    return Path(base_url)
+
+
+def _import_path(base: Path, href: str) -> Path:
+    parsed = urlparse(href)
+    if parsed.scheme == "file":
+        return _file_url_path(parsed.netloc, parsed.path, "href")
+    if parsed.scheme or parsed.netloc:
+        msg = "xsl:import href must be a local path or file URL"
+        raise ValueError(msg)
+    return base / url2pathname(href)
+
+
+def _file_url_path(netloc: str, path: str, name: str) -> Path:
+    if netloc not in {"", "localhost"}:
+        msg = f"xsl:import {name} file URL must point to a local path"
+        raise ValueError(msg)
+    return Path(url2pathname(path))
+
+
+def _is_windows_drive_path(value: str) -> bool:
+    return len(value) > 2 and value[1] == ":" and value[2] in "\\/"
 
 
 class Transform:
@@ -93,8 +126,8 @@ class Transform:
     A compiled XSLT 1.0 stylesheet, callable over source documents (lxml's ``etree.XSLT``).
 
     :param stylesheet: the stylesheet, a tree parsed with :func:`turbohtml.parse_xml`.
-    :param base_url: the stylesheet's path or URL, against which ``xsl:import`` hrefs resolve; required only when the
-        stylesheet imports.
+    :param base_url: the stylesheet's path or file URL, against which ``xsl:import`` hrefs resolve; required only when
+        the stylesheet imports.
     """
 
     __slots__ = ("_imports", "_stylesheet")
@@ -128,8 +161,8 @@ def transform(stylesheet: Node, source: Node, /, *, base_url: str | None = None,
 
     :param stylesheet: the stylesheet, a tree parsed with :func:`turbohtml.parse_xml`.
     :param source: the document to transform, a parsed tree.
-    :param base_url: the stylesheet's path or URL, against which ``xsl:import`` hrefs resolve; required only when the
-        stylesheet imports.
+    :param base_url: the stylesheet's path or file URL, against which ``xsl:import`` hrefs resolve; required only when
+        the stylesheet imports.
     :param params: top-level ``xsl:param`` values, each an XPath expression string.
     :returns: the transformed document serialized under the stylesheet's ``xsl:output`` method.
     """

--- a/tests/convert/test_transform.py
+++ b/tests/convert/test_transform.py
@@ -2184,6 +2184,73 @@ def test_transform_import_loads_external_templates(tmp_path: Path) -> None:
     assert _canon(result) == "[x]"
 
 
+def test_transform_import_resolves_file_url_base(tmp_path: Path) -> None:
+    (tmp_path / "base.xsl").write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:template match="a">[<xsl:value-of select="."/>]</xsl:template></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    main = tmp_path / "main.xsl"
+    main.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:import href="base.xsl"/>'
+        '<xsl:template match="/"><xsl:apply-templates select="r/a"/></xsl:template></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    sheet = turbohtml.parse_xml(main.read_text(encoding="utf-8"))
+    result = transform(sheet, turbohtml.parse_xml("<r><a>x</a></r>"), base_url=main.as_uri())
+    assert _canon(result) == "[x]"
+
+
+def test_transform_import_resolves_file_url_href(tmp_path: Path) -> None:
+    base = tmp_path / "base.xsl"
+    base.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:template match="a">[<xsl:value-of select="."/>]</xsl:template></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    main = tmp_path / "main.xsl"
+    main.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        f'<xsl:import href="{base.as_uri()}"/>'
+        '<xsl:template match="/"><xsl:apply-templates select="r/a"/></xsl:template></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    sheet = turbohtml.parse_xml(main.read_text(encoding="utf-8"))
+    result = transform(sheet, turbohtml.parse_xml("<r><a>x</a></r>"), base_url=str(main))
+    assert _canon(result) == "[x]"
+
+
+def test_transform_import_rejects_remote_base_url() -> None:
+    sheet = turbohtml.parse_xml(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:import href="base.xsl"/></xsl:stylesheet>'
+    )
+    with pytest.raises(ValueError, match="base_url must be a local path or file URL"):
+        transform(sheet, turbohtml.parse_xml("<r/>"), base_url="https://example.com/main.xsl")
+
+
+def test_transform_import_rejects_remote_href(tmp_path: Path) -> None:
+    main = tmp_path / "main.xsl"
+    main.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:import href="https://example.com/base.xsl"/></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    sheet = turbohtml.parse_xml(main.read_text(encoding="utf-8"))
+    with pytest.raises(ValueError, match="href must be a local path or file URL"):
+        transform(sheet, turbohtml.parse_xml("<r/>"), base_url=str(main))
+
+
+def test_transform_import_rejects_remote_file_url() -> None:
+    sheet = turbohtml.parse_xml(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:import href="base.xsl"/></xsl:stylesheet>'
+    )
+    with pytest.raises(ValueError, match="base_url file URL must point to a local path"):
+        transform(sheet, turbohtml.parse_xml("<r/>"), base_url="file://example.com/main.xsl")
+
+
 def test_transform_import_precedence_importer_wins(tmp_path: Path) -> None:
     (tmp_path / "base.xsl").write_text(
         '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'


### PR DESCRIPTION
`xsl:import` failed when `base_url` was a local `file://` stylesheet URL. The resolver looked for `file:/.../base.xsl`.

Convert local file URLs before resolving imports, keep remote URLs rejected, and update the docs.
