### PR TITLE
🐛 fix(linkify): normalize skip tags

### DIFF
--- a/docs/changelog/619.bugfix.rst
+++ b/docs/changelog/619.bugfix.rst
@@ -1,0 +1,1 @@
+Normalize configured ``Linkify.skip_tags`` names before matching parsed HTML tags; ``CODE`` now skips ``<code>`` text.

--- a/src/turbohtml/clean/_linkify.py
+++ b/src/turbohtml/clean/_linkify.py
@@ -159,7 +159,9 @@ class Linker:
         """Compile a configuration into the form the walk consumes."""
         config = options if options is not None else Linkify()
         self.callbacks = list(config.callbacks)
-        self.skip_tags = frozenset(config.skip_tags or ())
+        self.skip_tags = (
+            frozenset(tag.lower() for tag in config.skip_tags) if config.skip_tags is not None else frozenset()
+        )
         self.parse_email = config.parse_email
         self.process_existing = config.process_existing
         self.extra_tlds = tuple(sorted({tld.lower() for tld in config.extra_tlds})) if config.extra_tlds else ()

--- a/tests/clean/test_linkify.py
+++ b/tests/clean/test_linkify.py
@@ -148,9 +148,10 @@ def test_linkify_skips_raw_text_elements(tag: str) -> None:
     assert '<a href="http://y.com">' in out
 
 
-def test_linkify_skip_tags() -> None:
+@pytest.mark.parametrize("skip_tag", ["code", "CODE"], ids=["lowercase", "uppercase"])
+def test_linkify_skip_tags(skip_tag: str) -> None:
     html = "<code>http://x.com</code> http://y.com"
-    out = linkify(html, Linkify(skip_tags=["code"], callbacks=_no_callbacks()))
+    out = linkify(html, Linkify(skip_tags=[skip_tag], callbacks=_no_callbacks()))
     assert out == '<code>http://x.com</code> <a href="http://y.com">http://y.com</a>'
 
 


### PR DESCRIPTION
`Linkify(skip_tags=["CODE"])` did not skip `<code>` because the config kept caller casing while parsed HTML tags are lowercase.

Normalize configured skip tags during linker setup, matching existing scheme and TLD handling.
