### PR TITLE
📝 docs(changelog): backfill entries

### DIFF
--- a/docs/changelog/617.bugfix.rst
+++ b/docs/changelog/617.bugfix.rst
@@ -1,0 +1,1 @@
+Lock free-threaded DOM tree reads and attribute views; concurrent mutation no longer crashes those readers.

--- a/docs/changelog/618.bugfix.rst
+++ b/docs/changelog/618.bugfix.rst
@@ -1,0 +1,1 @@
+Resolve local ``file://`` stylesheet URLs for ``xsl:import``; ``Path.as_uri()`` bases now load sibling imports.


### PR DESCRIPTION
Backfill missing changelog fragments for #617 and #618.

#619 carries its fragment on its own branch.
