### PR TITLE
✨ feat(pypy): run the C core on PyPy, publish 3.10 + 3.11 wheels

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,6 +42,29 @@ jobs:
         env:
           UV_PYTHON_PREFERENCE: only-managed
           COV_GCOV: ${{ matrix.cov }}
+  pypy:
+    # PyPy is a separate job, not a matrix row: it needs an interpreter uv does not manage yet (uv's newest PyPy 3.11
+    # is 7.3.21, and turbohtml requires 7.3.22 -- see core/pycompat.h), and it runs no coverage gate.
+    name: 🧪 PyPy 3.11 - Linux
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          submodules: true # html5lib-tests data for the conformance test
+          persist-credentials: false
+      - name: 🐍 Install PyPy
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "pypy-3.11"
+      - name: 🔄 Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: ✅ Run pypy3.11
+        run: uvx --with tox-uv tox run --skip-missing-interpreters false -e pypy3.11
+        env:
+          UV_PYTHON_PREFERENCE: only-system
   check:
     name: 🔎 ${{ matrix.tox_env }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -43,28 +43,28 @@ jobs:
           UV_PYTHON_PREFERENCE: only-managed
           COV_GCOV: ${{ matrix.cov }}
   pypy:
-    # PyPy is a separate job, not a matrix row: it needs an interpreter uv does not manage yet (uv's newest PyPy 3.11
-    # is 7.3.21, and turbohtml requires 7.3.22 -- see core/pycompat.h), and it runs no coverage gate.
-    name: 🧪 PyPy 3.11 - Linux
+    # PyPy stands outside the test matrix because it runs no coverage gate: gcovr reaches cpyext only through lxml,
+    # which publishes no PyPy wheels, and a cpyext build has no gcov to feed it. Both gates run on the matrix above.
+    name: 🧪 ${{ matrix.py }} - Linux
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        py: ["pypy3.11", "pypy3.10"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           submodules: true # html5lib-tests data for the conformance test
           persist-credentials: false
-      - name: 🐍 Install PyPy
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "pypy-3.11"
       - name: 🔄 Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
-      - name: ✅ Run pypy3.11
-        run: uvx --with tox-uv tox run --skip-missing-interpreters false -e pypy3.11
+      - name: ✅ Run ${{ matrix.py }}
+        run: uvx --with tox-uv tox run --skip-missing-interpreters false -e ${{ matrix.py }}
         env:
-          UV_PYTHON_PREFERENCE: only-system
+          UV_PYTHON_PREFERENCE: only-managed
   check:
     name: 🔎 ${{ matrix.tox_env }}
     runs-on: ubuntu-24.04

--- a/docs/_ext/bench_table.py
+++ b/docs/_ext/bench_table.py
@@ -3,8 +3,8 @@ The ``bench-table`` directive: benchmark tables rendered from committed JSON fee
 
 Every benchmark table pairs turbohtml against competitors. A feed carries only data -- a row label and one raw number
 per party and metric (seconds for a time, bytes for a size), the shape ``tools/bench --table-json`` writes -- and this
-directive derives everything shown: the readable unit for each figure, the ``(Nx)`` ratio against turbohtml, the
-spanned party headers with metric subcolumns, and a tint on each cell from best-in-row green to worst-in-row red.
+directive derives everything shown: the readable unit for each figure, the ``(Nx)`` ratio against the leftmost party,
+the spanned party headers with metric subcolumns, and a tint on each cell from best-in-row green to worst-in-row red.
 
 ::
 
@@ -18,7 +18,8 @@ superscript, the empty cells show ``--`` with that superscript, and a legend cen
 out, so one marker never conflates two reasons. Column order is derived too: turbohtml first, then each competitor by
 its combined score with every metric weighing equally, so the best speed/size combination sits leftmost whatever order
 the feed carries. The tint scale is row-relative per metric -- a row's cells ran the same input, so they compare; a
-column mixes inputs, so it does not -- with turbohtml competing at its defining 1.0x.
+column mixes inputs, so it does not -- with the leftmost party competing at its defining 1.0x. Every column but the
+first carries its ratio, so a feed comparing turbohtml against itself (the interpreter table) reads like any other.
 """
 
 from __future__ import annotations
@@ -297,14 +298,12 @@ class BenchTable(Directive):
         rendered: dict[int, tuple[str, str | None]] = {}
         marks: dict[int, int] = {}
         for metric_index, metric in enumerate(metrics):
-            turbo = next(
-                cells[1 + party_index * len(metrics) + metric_index]
-                for party_index, party in enumerate(parties)
-                if "turbohtml" in party
-            )
+            # _order_columns has already put the baseline first, so column 0 is what every ratio is read against; a
+            # feed whose columns are all turbohtml (the interpreter comparison) still gets a ratio on every other one
+            turbo = cells[1 + metric_index]
             positions: list[int] = []
             ratios: list[float] = []
-            for party_index, party in enumerate(parties):
+            for party_index in range(len(parties)):
                 index = 1 + party_index * len(metrics) + metric_index
                 value = cells[index]
                 if isinstance(value, (int, float)):
@@ -315,7 +314,7 @@ class BenchTable(Directive):
                     else:
                         figure = _format_time(value)
                     ratio = value / turbo
-                    if "turbohtml" not in party:
+                    if party_index:
                         figure += f" {_format_ratio(ratio, metric)}"
                     positions.append(index)
                     ratios.append(ratio)

--- a/docs/changelog/623.bugfix.rst
+++ b/docs/changelog/623.bugfix.rst
@@ -1,0 +1,2 @@
+Raise :exc:`IndexError` for a negative subscript further back than a node's child count; ``node[-len - 1]`` answered the
+first child, where :class:`list` raises.

--- a/docs/changelog/623.doc.rst
+++ b/docs/changelog/623.doc.rst
@@ -1,0 +1,3 @@
+Explain what running the C core on PyPy costs, in :doc:`/explanation/interpreters`, from a table the benchmark harness
+generates (``tox -e bench -- interpreters``) rather than from figures typed into prose. How the core adapts to
+``cpyext`` moved to :doc:`/development/cpyext`, alongside the invariant that keeps CPython's machine code unchanged.

--- a/docs/changelog/623.feature.rst
+++ b/docs/changelog/623.feature.rst
@@ -1,4 +1,2 @@
-Run the C core on PyPy 3.11 (7.3.22 and newer) through ``cpyext``, with the same conformance and byte-identical output
-as CPython; see :doc:`/explanation/interpreters` for what ``cpyext`` costs and for the three behaviors that do not carry
-over. turbohtml refuses to import on older PyPy, where ``cpyext`` ignores ``Py_TPFLAGS_DISALLOW_INSTANTIATION`` and the
-C types construct without a tree and segfault on first use.
+Run the C core on PyPy 3.10 and 3.11 through ``cpyext``, with the same conformance and byte-identical output as CPython;
+see :doc:`/explanation/interpreters` for what ``cpyext`` costs and for the three behaviors that do not carry over.

--- a/docs/changelog/623.feature.rst
+++ b/docs/changelog/623.feature.rst
@@ -1,0 +1,4 @@
+Run the C core on PyPy 3.11 (7.3.22 and newer) through ``cpyext``, with the same conformance and byte-identical output
+as CPython; see :doc:`/explanation/interpreters` for what ``cpyext`` costs and for the three behaviors that do not carry
+over. turbohtml refuses to import on older PyPy, where ``cpyext`` ignores ``Py_TPFLAGS_DISALLOW_INSTANTIATION`` and the
+C types construct without a tree and segfault on first use.

--- a/docs/changelog/623.packaging.rst
+++ b/docs/changelog/623.packaging.rst
@@ -1,0 +1,3 @@
+Publish PyPy 3.11 wheels (``pp311``) for Linux, macOS, and Windows. They carry LTO but skip the profile-guided
+optimization the CPython Linux wheels use, since a profile trained under PyPy measures ``cpyext`` rather than the C hot
+paths.

--- a/docs/changelog/623.packaging.rst
+++ b/docs/changelog/623.packaging.rst
@@ -1,3 +1,3 @@
-Publish PyPy 3.11 wheels (``pp311``) for Linux, macOS, and Windows. They carry LTO but skip the profile-guided
-optimization the CPython Linux wheels use, since a profile trained under PyPy measures ``cpyext`` rather than the C hot
-paths.
+Publish PyPy 3.10 and 3.11 wheels (``pp310``, ``pp311``) for Linux, macOS, and Windows. They carry LTO but skip the
+profile-guided optimization the CPython Linux wheels use, since a profile trained under PyPy measures ``cpyext`` rather
+than the C hot paths.

--- a/docs/development/cpyext.rst
+++ b/docs/development/cpyext.rst
@@ -1,0 +1,75 @@
+####################
+ Building on cpyext
+####################
+
+The same C core runs on CPython and on PyPy, with no pure-Python fallback and no second backend. This page covers what
+had to change to make that true, and the invariant that keeps it from costing CPython anything. What cpyext costs a
+*user* is on :doc:`/explanation/interpreters`.
+
+Most of the C API surface needs no adaptation. cpyext emulates the PEP 393 layout, so ``PyUnicode_KIND``,
+``PyUnicode_DATA``, ``PyUnicode_READ`` and ``PyUnicode_WRITE`` all work, and the heap types, module state, multi-phase
+init, and GC slots the module is built on are supported. ``Py_BEGIN_CRITICAL_SECTION`` collapses to a brace no-op there
+through the same ``#ifndef`` that CPython 3.10 through 3.12 take, and for the same reason: cpyext holds the GIL across
+every call into the extension.
+
+**********************************
+ The CPython codegen is untouched
+**********************************
+
+``src/turbohtml/_c/core/pycompat.h`` holds every adaptation, and each name in it expands to the CPython spelling on
+CPython. ``TH_SEALED`` becomes ``Py_TPFLAGS_DISALLOW_INSTANTIATION``, ``TH_SEALED_END`` becomes ``{0, NULL}``, and
+``th_str_format(...)`` becomes ``PyUnicode_FromFormat(__VA_ARGS__)``. A CPython translation unit's preprocessed token
+stream is therefore unchanged, so the profile-guided and link-time-optimized layouts the release wheels depend on cannot
+shift. Every PyPy-only code path sits behind ``#ifdef PYPY_VERSION`` and never reaches the CPython compiler.
+
+The invariant is checkable rather than aspirational: compile every translation unit from ``main`` and from a branch at
+``-O3 -g0 -DNDEBUG`` and compare the normalized ``objdump -d`` output. Anything that differs and is not a deliberate
+behavior change is a regression.
+
+``tests/core/test_c_api_portability.py`` pins the other half. Each guarded spelling may be named only inside
+``pycompat.h``; everywhere else the C sources must reach it through the wrapper. Reaching for the raw spelling compiles,
+passes on CPython, and is silently wrong on PyPy, which no compiler catches.
+
+*******************
+ Sealing the types
+*******************
+
+``Document()``, ``Node()``, ``Token()`` and eleven siblings raise :exc:`TypeError`, because only a parse builds them and
+one constructed by hand carries no tree. CPython enforces that with ``Py_TPFLAGS_DISALLOW_INSTANTIATION``. cpyext
+ignored that flag until PyPy 7.3.21 (`pypy#5318 <https://github.com/pypy/pypy/issues/5318>`_), so those types would
+construct with no tree attached and segfault on first use, letting pure Python code take the interpreter down. 7.3.21
+honors the flag and prints a debug line to stdout for every type that sets it (`pypy#5388
+<https://github.com/pypy/pypy/issues/5388>`_), which corrupts anything reading the CLI's output.
+
+Neither costs anything to avoid. cpyext also seals a type through an explicit ``tp_new``, the branch the flag would
+otherwise shadow, so on PyPy the flag comes off and a ``tp_new`` that raises goes on. Every supported PyPy then refuses
+the same constructions with the same message, and 7.3.21 stays quiet because nothing sets the flag it prints for. A
+subtype declaring its own ``tp_new`` overrides the inherited one, so ``Element("div")`` and ``Text("hi")`` build as they
+do on CPython.
+
+**********************
+ The three other gaps
+**********************
+
+``PyUnicode_CopyCharacters`` does not exist in cpyext, so it gets a ``PyUnicode_READ``/``PyUnicode_WRITE`` loop.
+
+``PyUnicode_FromFormat`` returns a string cpyext has not put in canonical form, so ``PyUnicode_KIND``,
+``PyUnicode_DATA``, and ``PyUnicode_GET_LENGTH`` are all undefined on it, and with ``NDEBUG`` their assertions are
+compiled out, so ``GET_LENGTH`` answers one past the code point count (`pypy#5524
+<https://github.com/pypy/pypy/issues/5524>`_). The core readies every result before touching it.
+
+cpyext cannot take a 2-byte buffer at all (`pypy#5525 <https://github.com/pypy/pypy/issues/5525>`_). It materializes one
+by decoding it as UTF-16, so it eats a leading U+FEFF as a byte-order mark, byte-swaps the rest of the string after a
+leading U+FFFE, collapses a surrogate pair into the one code point it encodes, and aborts the interpreter on a lone
+surrogate through the strict error handler. A CPython ``str`` carries a lone surrogate fine, and both HTML input and the
+WHATWG tokenizer have to preserve one. cpyext's 1-byte and 4-byte paths are exact, so on PyPy any result too wide for
+Latin-1 is built at 4-byte kind. CPython keeps the narrowest kind, because its ``str`` equality compares kind before
+content and would report a too-wide string as unequal to its own value.
+
+``encoding/decode.h`` calls ``PyUnicode_New`` directly and deliberately: every WHATWG decoder replaces an ill-formed
+sequence with U+FFFD and no legacy encoding maps a byte to a surrogate, so its 2-byte results hold none, and
+``PyUnicode_New`` pins the byte order where ``PyUnicode_FromKindAndData`` does not.
+
+A fourth difference lives outside that header. A negative subscript reaches ``sq_item`` unadjusted (`pypy#5526
+<https://github.com/pypy/pypy/issues/5526>`_) where CPython adds the sequence length first, so ``dom/node.c`` does that
+adjustment itself.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -7,12 +7,13 @@ Claude Opus 4.8, with some help from Fable, across close to 300 pull requests an
 See :doc:`/how-this-was-built` for the full acknowledgment and the libraries and specifications turbohtml stands on.
 
 This page covers how we build, test, and maintain turbohtml; the :doc:`performance` page collects the benchmark tables
-the rest of the docs link into.
+the rest of the docs link into, and :doc:`cpyext` covers what running the C core on PyPy costs the codebase.
 
 .. toctree::
     :hidden:
 
     performance
+    cpyext
 
 ***************************
  AI-assisted contributions

--- a/docs/explanation/bench/interpreters.json
+++ b/docs/explanation/bench/interpreters.json
@@ -1,0 +1,205 @@
+{
+  "label": "operation",
+  "parties": [
+    "turbohtml on CPython 3.14",
+    "turbohtml on PyPy 3.11"
+  ],
+  "metrics": [],
+  "rows": [
+    [
+      "parse to a tree — wpt tiny (0.6 kB)",
+      1.8160549264104968e-06,
+      3.299525069344611e-06
+    ],
+    [
+      "parse to a tree — wpt small (4 kB)",
+      1.2964961409996553e-05,
+      1.7237267726481302e-05
+    ],
+    [
+      "parse to a tree — wpt medium (9.6 kB)",
+      3.150469190416061e-05,
+      4.321205815263814e-05
+    ],
+    [
+      "parse to a tree — wpt large (92 kB)",
+      0.0002844415175256169,
+      0.000327108204525454
+    ],
+    [
+      "parse to a tree — wpt CJK (124 kB)",
+      0.0005775339786850964,
+      0.0006576096545359178
+    ],
+    [
+      "parse to a tree — whatwg spec (235 kB)",
+      0.0005403873942820307,
+      0.0007296421273925564
+    ],
+    [
+      "escape — tiny plain (64 B)",
+      6.828457183027936e-08,
+      2.505380431117032e-07
+    ],
+    [
+      "escape — medium markup (4 KiB)",
+      2.5415868869060885e-06,
+      8.165669123864442e-06
+    ],
+    [
+      "escape — no-op prose (4 MiB)",
+      0.00012950227452392937,
+      0.002200463529576761
+    ],
+    [
+      "escape — book text (3 MiB)",
+      0.000660945567157493,
+      0.00377932109562001
+    ],
+    [
+      "escape — book HTML (4 MiB)",
+      0.0014308940701691123,
+      0.011259946398665004
+    ],
+    [
+      "escape — spec HTML, dense (4 MiB)",
+      0.00540990151882094,
+      0.025796923695209747
+    ],
+    [
+      "escape — UCS-2 plain (4 MiB)",
+      0.0009356884002803175,
+      0.002672294358126237
+    ],
+    [
+      "escape — UCS-2 markup (4 MiB)",
+      0.004059570638249473,
+      0.02836048872268293
+    ],
+    [
+      "escape — UCS-4 plain (4 MiB)",
+      0.0012262545852839443,
+      0.001440745621403039
+    ],
+    [
+      "escape — UCS-4 markup (4 MiB)",
+      0.004294444162345219,
+      0.021261597656121012
+    ],
+    [
+      "unescape — tiny plain (64 B)",
+      4.0059680089798985e-08,
+      2.1800457753832583e-07
+    ],
+    [
+      "unescape — medium dense refs (4 KiB)",
+      8.75087377612734e-06,
+      1.8585289009346676e-05
+    ],
+    [
+      "unescape — numeric refs (4 KiB)",
+      6.03913514728068e-06,
+      1.5051512650643418e-05
+    ],
+    [
+      "unescape — book HTML, real refs (4 MiB)",
+      0.0028521083023103225,
+      0.013763589703012257
+    ],
+    [
+      "unescape — escaped book HTML (5 MiB)",
+      0.0020155035495918127,
+      0.004436386042652884
+    ],
+    [
+      "unescape — dense refs (4 MiB)",
+      0.010659917927114293,
+      0.020425393924233502
+    ],
+    [
+      "unescape — UCS-2 refs (4 MiB)",
+      0.0030242201610841827,
+      0.014407056073347727
+    ],
+    [
+      "serialize a parsed tree — daring fireball (10 kB)",
+      9.057465272140537e-06,
+      0.00011277061425592667
+    ],
+    [
+      "serialize a parsed tree — ars technica (56 kB)",
+      4.947485389455627e-05,
+      0.0006424718914028442
+    ],
+    [
+      "serialize a parsed tree — mozilla blog (95 kB)",
+      0.00010802062375129633,
+      0.0010965116365393138
+    ],
+    [
+      "serialize a parsed tree — whatwg spec (235 kB)",
+      0.0002711944919534896,
+      0.002778453459419931
+    ],
+    [
+      "collect visible text — daring fireball (10 kB)",
+      2.9388095856101395e-06,
+      6.299138046680733e-05
+    ],
+    [
+      "collect visible text — ars technica (56 kB)",
+      1.458136876427337e-05,
+      0.0003442731296445345
+    ],
+    [
+      "collect visible text — mozilla blog (95 kB)",
+      2.583849519908199e-05,
+      0.00047889207086579215
+    ],
+    [
+      "collect visible text — whatwg spec (235 kB)",
+      8.96547522908501e-05,
+      0.0018867518128293645
+    ],
+    [
+      "select div a[href] — daring fireball (10 kB)",
+      7.598523832067865e-07,
+      3.74988218752037e-06
+    ],
+    [
+      "select div a[href] — ars technica (56 kB)",
+      1.8189967352810754e-06,
+      8.873802227545488e-06
+    ],
+    [
+      "select div a[href] — mozilla blog (95 kB)",
+      2.552165687674801e-06,
+      1.254958708519401e-05
+    ],
+    [
+      "select div a[href] — whatwg spec (235 kB)",
+      2.2247194618666793e-06,
+      9.12357652917232e-06
+    ],
+    [
+      "walk every descendant — daring fireball (10 kB)",
+      3.488743846228696e-06,
+      3.240355039129857e-05
+    ],
+    [
+      "walk every descendant — ars technica (56 kB)",
+      1.3942484199939524e-05,
+      0.0001488851411863834
+    ],
+    [
+      "walk every descendant — mozilla blog (95 kB)",
+      2.9589536180196773e-05,
+      0.000320730476899674
+    ],
+    [
+      "walk every descendant — whatwg spec (235 kB)",
+      0.00010236824077007138,
+      0.0010926485834716003
+    ]
+  ]
+}

--- a/docs/explanation/foundations.rst
+++ b/docs/explanation/foundations.rst
@@ -2,7 +2,7 @@
  Foundations
 #############
 
-Why the C core, how it matches the standard library, and the free-threaded build.
+Why the C core, how it matches the standard library, the free-threaded build, and what changes on PyPy.
 
 .. toctree::
     :maxdepth: 1
@@ -10,3 +10,4 @@ Why the C core, how it matches the standard library, and the free-threaded build
     c-core
     stdlib-parity
     free-threading
+    interpreters

--- a/docs/explanation/interpreters.rst
+++ b/docs/explanation/interpreters.rst
@@ -1,0 +1,119 @@
+##############
+ Interpreters
+##############
+
+turbohtml runs on CPython 3.10 and newer, on the free-threaded build, and on PyPy 3.11 (7.3.22 and newer). The same C
+core serves all of them: there is no pure-Python fallback, and no separate PyPy backend. What differs is the layer
+underneath, and it differs enough to be worth understanding before you choose PyPy for an HTML workload.
+
+***********************
+ What cpyext costs you
+***********************
+
+PyPy runs C extensions through ``cpyext``, an emulation of CPython's C API. PyPy's own objects are moved by a compacting
+garbage collector and its strings are stored as UTF-8; a C extension expects neither. So the first time a Python object
+crosses into C, cpyext allocates a non-moving ``PyObject`` shell for it and keeps the two views in sync, and the first
+time a ``str`` is read through the PEP 393 buffer macros, cpyext transcodes its UTF-8 storage into the UCS1/2/4 buffer
+those macros hand out and caches it on the shell.
+
+Both costs are per-object and paid once. That shape decides where PyPy is cheap and where it is not: an operation that
+crosses the boundary once and then spends its time in C amortizes the cost over the whole document, while one that
+crosses per node pays it per node. Measured on a 142 KB document against CPython 3.13, both on the same machine:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 34 22 22 22
+
+    - - Operation
+      - CPython 3.13
+      - PyPy 7.3.23
+      - PyPy is
+    - - ``parse()`` (one 142 KB ``str``)
+      - 848 µs
+      - 933 µs
+      - 1.1x slower
+    - - ``unescape()``
+      - 45.6 µs
+      - 75.7 µs
+      - 1.7x slower
+    - - ``escape()``
+      - 18.2 µs
+      - 49.5 µs
+      - 2.7x slower
+    - - ``to_text()``
+      - 86.2 µs
+      - 235 µs
+      - 2.7x slower
+    - - ``serialize()``
+      - 138 µs
+      - 482 µs
+      - 3.5x slower
+    - - Walking every node
+      - 131 µs
+      - 653 µs
+      - 5.0x slower
+
+Parsing a whole document is nearly free, because it is one string in and one tree out. Walking that tree from Python is
+the worst case, because every node visited materializes a wrapper across the boundary. If your program parses and then
+queries with CSS or XPath -- work that stays inside C -- PyPy costs you little. If it walks the DOM node by node in a
+Python loop, expect it to be several times slower than CPython, and note that the JIT cannot recover the difference: the
+time is spent in cpyext, not in your bytecode.
+
+None of this makes PyPy the wrong choice. It makes turbohtml a poor reason to choose it. Pick PyPy because the rest of
+your program is Python that the JIT speeds up, and accept that the HTML layer is no faster than it is on CPython.
+
+*******************************
+ Behavior that differs on PyPy
+*******************************
+
+The public API behaves identically on both interpreters; the conformance suites, the tokenizer state machine, the
+selector and XPath engines, and every serializer produce byte-identical output. Three things do not carry over.
+
+**Reference cycles through a C object are never collected.** cpyext does not break a cycle that runs through both a
+Python object and a C extension object, even though every turbohtml type implements ``tp_traverse`` and ``tp_clear``. A
+cycle like ``document -> your callback -> document`` leaks on PyPy and is reclaimed on CPython. Break such cycles
+yourself, or hold the C object through a :mod:`weakref`.
+
+**Deep recursion may raise** :exc:`SystemError`. The schema validator, the XSLT processor, and the XPath engine cap
+their own recursion and report a clean error past it. On PyPy, RPython's stack check can trip on the C recursion first
+and surface as :exc:`SystemError`. The recursion stays bounded either way -- neither interpreter crashes -- but the
+exception you catch differs.
+
+**Introspection is thinner.** :func:`inspect.signature` builds no signature for a C *type* on PyPy, even though
+``__text_signature__`` is present, so ``inspect.signature(turbohtml.Minify)`` raises :exc:`ValueError` there. Functions
+and methods are unaffected. :func:`gc.is_tracked` does not exist on PyPy at all.
+
+*******************
+ The version floor
+*******************
+
+turbohtml refuses to import on PyPy older than 7.3.22, with an :exc:`ImportError` that says so. Before 7.3.21, cpyext
+ignored ``Py_TPFLAGS_DISALLOW_INSTANTIATION``, the flag that makes ``Document()`` and its siblings raise
+:exc:`TypeError`. Without it those types construct with no tree attached and segfault the interpreter on first use --
+pure Python code taking the process down. 7.3.21 honors the flag but prints a debug line to stdout for every type that
+sets it, which corrupts anything reading the CLI's output. 7.3.22 is the first release with neither problem.
+
+PyPy 3.10 reached end of life without ever honoring that flag, so it is not supported and no wheel is published for it.
+A wheel tag cannot express a PyPy floor -- ``pp311_pp73`` matches 7.3.18 as readily as 7.3.23 -- which is why the check
+lives at import rather than in the metadata.
+
+*********************
+ How the core adapts
+*********************
+
+``src/turbohtml/_c/core/pycompat.h`` holds every adaptation, and each one is an identity macro on CPython, so a CPython
+build's preprocessed token stream is unchanged and its machine code cannot shift. Three calls need it.
+
+``PyUnicode_CopyCharacters`` does not exist in cpyext, so it gets a ``PyUnicode_READ``/``PyUnicode_WRITE`` loop.
+
+``PyUnicode_FromFormat`` returns a string cpyext has not put in canonical form, so ``PyUnicode_KIND``,
+``PyUnicode_DATA``, and ``PyUnicode_GET_LENGTH`` are all undefined on it -- and with ``NDEBUG`` their assertions are
+compiled out, so ``GET_LENGTH`` silently answers one past the code point count. Every result is readied before use.
+
+A 2-byte buffer cannot be handed to cpyext at all. It materializes one by decoding it as UTF-16, so a leading U+FEFF is
+eaten as a byte-order mark, a leading U+FFFE byte-swaps the rest of the string, a surrogate pair collapses into the one
+code point it encodes, and a lone surrogate -- which a CPython ``str`` carries fine, and which HTML input and the WHATWG
+tokenizer must both preserve -- aborts the interpreter through the strict error handler. cpyext's 1-byte and 4-byte
+paths are exact, so on PyPy any result too wide for Latin-1 is built at 4-byte kind. CPython keeps the narrowest kind,
+because its ``str`` equality compares kind before content and would report a too-wide string as unequal to its own
+value.

--- a/docs/explanation/interpreters.rst
+++ b/docs/explanation/interpreters.rst
@@ -2,9 +2,9 @@
  Interpreters
 ##############
 
-turbohtml runs on CPython 3.10 and newer, on the free-threaded build, and on PyPy 3.11 (7.3.22 and newer). The same C
-core serves all of them: there is no pure-Python fallback, and no separate PyPy backend. What differs is the layer
-underneath, and it differs enough to be worth understanding before you choose PyPy for an HTML workload.
+turbohtml runs on CPython 3.10 and newer, on the free-threaded build, and on PyPy 3.10 and 3.11. The same C core serves
+all of them: there is no pure-Python fallback, and no separate PyPy backend. What differs is the layer underneath, and
+it differs enough to be worth understanding before you choose PyPy for an HTML workload.
 
 ***********************
  What cpyext costs you
@@ -84,25 +84,28 @@ exception you catch differs.
 and methods are unaffected. :func:`gc.is_tracked` does not exist on PyPy at all.
 
 *******************
- The version floor
+ Sealing the types
 *******************
 
-turbohtml refuses to import on PyPy older than 7.3.22, with an :exc:`ImportError` that says so. Before 7.3.21, cpyext
-ignored ``Py_TPFLAGS_DISALLOW_INSTANTIATION``, the flag that makes ``Document()`` and its siblings raise
-:exc:`TypeError`. Without it those types construct with no tree attached and segfault the interpreter on first use --
-pure Python code taking the process down. 7.3.21 honors the flag but prints a debug line to stdout for every type that
-sets it, which corrupts anything reading the CLI's output. 7.3.22 is the first release with neither problem.
+``Document()``, ``Node()``, ``Token()`` and eleven siblings raise :exc:`TypeError`: only a parse builds them, and one
+constructed by hand carries no tree. CPython enforces that with ``Py_TPFLAGS_DISALLOW_INSTANTIATION``. cpyext ignored
+that flag until PyPy 7.3.21, so those types would construct with no tree attached and segfault on first use, letting
+pure Python code take the interpreter down. 7.3.21 honors the flag and prints a debug line to stdout for every type that
+sets it, which corrupts anything reading the CLI's output.
 
-PyPy 3.10 reached end of life without ever honoring that flag, so it is not supported and no wheel is published for it.
-A wheel tag cannot express a PyPy floor -- ``pp311_pp73`` matches 7.3.18 as readily as 7.3.23 -- which is why the check
-lives at import rather than in the metadata.
+Neither costs anything to avoid. cpyext also seals a type through an explicit ``tp_new``, the branch the flag would
+otherwise shadow, so on PyPy the flag comes off and a ``tp_new`` that raises goes on. Every supported PyPy then refuses
+the same constructions with the same message, and 7.3.21 stays quiet because nothing sets the flag it prints for. A
+subtype declaring its own ``tp_new`` overrides the inherited one, so ``Element("div")`` and ``Text("hi")`` build as they
+do on CPython.
 
 *********************
  How the core adapts
 *********************
 
 ``src/turbohtml/_c/core/pycompat.h`` holds every adaptation, and each one is an identity macro on CPython, so a CPython
-build's preprocessed token stream is unchanged and its machine code cannot shift. Three calls need it.
+build's preprocessed token stream is unchanged and its machine code cannot shift. Besides the sealing above, three calls
+need it.
 
 ``PyUnicode_CopyCharacters`` does not exist in cpyext, so it gets a ``PyUnicode_READ``/``PyUnicode_WRITE`` loop.
 

--- a/docs/explanation/interpreters.rst
+++ b/docs/explanation/interpreters.rst
@@ -10,8 +10,8 @@ it differs enough to be worth understanding before you choose PyPy for an HTML w
  What cpyext costs you
 ***********************
 
-PyPy runs C extensions through ``cpyext``, an emulation of CPython's C API. PyPy's own objects are moved by a compacting
-garbage collector and its strings are stored as UTF-8; a C extension expects neither. So the first time a Python object
+PyPy runs C extensions through ``cpyext``, an emulation of CPython's C API. A compacting garbage collector moves PyPy's
+own objects, and PyPy stores its strings as UTF-8. A C extension expects neither. So the first time a Python object
 crosses into C, cpyext allocates a non-moving ``PyObject`` shell for it and keeps the two views in sync, and the first
 time a ``str`` is read through the PEP 393 buffer macros, cpyext transcodes its UTF-8 storage into the UCS1/2/4 buffer
 those macros hand out and caches it on the shell.
@@ -53,8 +53,8 @@ crosses per node pays it per node. Measured on a 142 KB document against CPython
       - 653 µs
       - 5.0x slower
 
-Parsing a whole document is nearly free, because it is one string in and one tree out. Walking that tree from Python is
-the worst case, because every node visited materializes a wrapper across the boundary. If your program parses and then
+Parsing a whole document costs 1.1x, because it is one string in and one tree out. Walking that tree from Python is the
+worst case, because every node visited materializes a wrapper across the boundary. If your program parses and then
 queries with CSS or XPath -- work that stays inside C -- PyPy costs you little. If it walks the DOM node by node in a
 Python loop, expect it to be several times slower than CPython, and note that the JIT cannot recover the difference: the
 time is spent in cpyext, not in your bytecode.
@@ -66,12 +66,12 @@ your program is Python that the JIT speeds up, and accept that the HTML layer is
  Behavior that differs on PyPy
 *******************************
 
-The public API behaves identically on both interpreters; the conformance suites, the tokenizer state machine, the
-selector and XPath engines, and every serializer produce byte-identical output. Three things do not carry over.
+The public API behaves the same on both interpreters. The conformance suites, the tokenizer state machine, the selector
+and XPath engines, and every serializer produce byte-identical output. Three things do not carry over.
 
 **Reference cycles through a C object are never collected.** cpyext does not break a cycle that runs through both a
 Python object and a C extension object, even though every turbohtml type implements ``tp_traverse`` and ``tp_clear``. A
-cycle like ``document -> your callback -> document`` leaks on PyPy and is reclaimed on CPython. Break such cycles
+cycle like ``document -> your callback -> document`` leaks on PyPy, where CPython reclaims it. Break such cycles
 yourself, or hold the C object through a :mod:`weakref`.
 
 **Deep recursion may raise** :exc:`SystemError`. The schema validator, the XSLT processor, and the XPath engine cap
@@ -89,9 +89,10 @@ and methods are unaffected. :func:`gc.is_tracked` does not exist on PyPy at all.
 
 ``Document()``, ``Node()``, ``Token()`` and eleven siblings raise :exc:`TypeError`: only a parse builds them, and one
 constructed by hand carries no tree. CPython enforces that with ``Py_TPFLAGS_DISALLOW_INSTANTIATION``. cpyext ignored
-that flag until PyPy 7.3.21, so those types would construct with no tree attached and segfault on first use, letting
-pure Python code take the interpreter down. 7.3.21 honors the flag and prints a debug line to stdout for every type that
-sets it, which corrupts anything reading the CLI's output.
+that flag until PyPy 7.3.21 (`pypy#5318 <https://github.com/pypy/pypy/issues/5318>`_), so those types would construct
+with no tree attached and segfault on first use, letting pure Python code take the interpreter down. 7.3.21 honors the
+flag and prints a debug line to stdout for every type that sets it (`pypy#5388
+<https://github.com/pypy/pypy/issues/5388>`_), which corrupts anything reading the CLI's output.
 
 Neither costs anything to avoid. cpyext also seals a type through an explicit ``tp_new``, the branch the flag would
 otherwise shadow, so on PyPy the flag comes off and a ``tp_new`` that raises goes on. Every supported PyPy then refuses
@@ -105,18 +106,22 @@ do on CPython.
 
 ``src/turbohtml/_c/core/pycompat.h`` holds every adaptation, and each one is an identity macro on CPython, so a CPython
 build's preprocessed token stream is unchanged and its machine code cannot shift. Besides the sealing above, three calls
-need it.
+need the header, and ``dom/node.c`` handles a fourth difference where it bites.
 
 ``PyUnicode_CopyCharacters`` does not exist in cpyext, so it gets a ``PyUnicode_READ``/``PyUnicode_WRITE`` loop.
 
 ``PyUnicode_FromFormat`` returns a string cpyext has not put in canonical form, so ``PyUnicode_KIND``,
-``PyUnicode_DATA``, and ``PyUnicode_GET_LENGTH`` are all undefined on it -- and with ``NDEBUG`` their assertions are
-compiled out, so ``GET_LENGTH`` silently answers one past the code point count. Every result is readied before use.
+``PyUnicode_DATA``, and ``PyUnicode_GET_LENGTH`` are all undefined on it, and with ``NDEBUG`` their assertions are
+compiled out, so ``GET_LENGTH`` answers one past the code point count (`pypy#5524
+<https://github.com/pypy/pypy/issues/5524>`_). The core readies every result before touching it.
 
-A 2-byte buffer cannot be handed to cpyext at all. It materializes one by decoding it as UTF-16, so a leading U+FEFF is
-eaten as a byte-order mark, a leading U+FFFE byte-swaps the rest of the string, a surrogate pair collapses into the one
-code point it encodes, and a lone surrogate -- which a CPython ``str`` carries fine, and which HTML input and the WHATWG
-tokenizer must both preserve -- aborts the interpreter through the strict error handler. cpyext's 1-byte and 4-byte
-paths are exact, so on PyPy any result too wide for Latin-1 is built at 4-byte kind. CPython keeps the narrowest kind,
-because its ``str`` equality compares kind before content and would report a too-wide string as unequal to its own
-value.
+cpyext cannot take a 2-byte buffer at all (`pypy#5525 <https://github.com/pypy/pypy/issues/5525>`_). It materializes one
+by decoding it as UTF-16, so it eats a leading U+FEFF as a byte-order mark, byte-swaps the rest of the string after a
+leading U+FFFE, collapses a surrogate pair into the one code point it encodes, and aborts the interpreter on a lone
+surrogate through the strict error handler. A CPython ``str`` carries a lone surrogate fine, and both HTML input and the
+WHATWG tokenizer have to preserve one. cpyext's 1-byte and 4-byte paths are exact, so on PyPy any result too wide for
+Latin-1 is built at 4-byte kind. CPython keeps the narrowest kind, because its ``str`` equality compares kind before
+content and would report a too-wide string as unequal to its own value.
+
+A negative subscript reaches ``sq_item`` unadjusted (`pypy#5526 <https://github.com/pypy/pypy/issues/5526>`_), where
+CPython adds the sequence length first, so ``dom/node.c`` does that adjustment itself.

--- a/docs/explanation/interpreters.rst
+++ b/docs/explanation/interpreters.rst
@@ -4,7 +4,8 @@
 
 turbohtml runs on CPython 3.10 and newer, on the free-threaded build, and on PyPy 3.10 and 3.11. The same C core serves
 all of them: there is no pure-Python fallback, and no separate PyPy backend. What differs is the layer underneath, and
-it differs enough to be worth understanding before you choose PyPy for an HTML workload.
+it differs enough to be worth understanding before you choose PyPy for an HTML workload. How the core adapts to that
+layer is a maintenance concern, covered in :doc:`/development/cpyext`.
 
 ***********************
  What cpyext costs you
@@ -16,51 +17,26 @@ crosses into C, cpyext allocates a non-moving ``PyObject`` shell for it and keep
 time a ``str`` is read through the PEP 393 buffer macros, cpyext transcodes its UTF-8 storage into the UCS1/2/4 buffer
 those macros hand out and caches it on the shell.
 
-Both costs are per-object and paid once. That shape decides where PyPy is cheap and where it is not: an operation that
-crosses the boundary once and then spends its time in C amortizes the cost over the whole document, while one that
-crosses per node pays it per node. Measured on a 142 KB document against CPython 3.13, both on the same machine:
+Both costs are per-object and paid once, and that decides where PyPy is cheap. Reading a ``str`` that C has already seen
+costs nothing extra, because the buffer is cached on the shell: turbohtml's scanners run at CPython's speed over it.
+Handing a new string back does cost, because cpyext transcodes it into PyPy's own UTF-8 form. So does handing back a
+wrapper per node.
 
-.. list-table::
-    :header-rows: 1
-    :widths: 34 22 22 22
+.. bench-table::
+    :file: bench/interpreters.json
 
-    - - Operation
-      - CPython 3.13
-      - PyPy 7.3.23
-      - PyPy is
-    - - ``parse()`` (one 142 KB ``str``)
-      - 848 µs
-      - 933 µs
-      - 1.1x slower
-    - - ``unescape()``
-      - 45.6 µs
-      - 75.7 µs
-      - 1.7x slower
-    - - ``escape()``
-      - 18.2 µs
-      - 49.5 µs
-      - 2.7x slower
-    - - ``to_text()``
-      - 86.2 µs
-      - 235 µs
-      - 2.7x slower
-    - - ``serialize()``
-      - 138 µs
-      - 482 µs
-      - 3.5x slower
-    - - Walking every node
-      - 131 µs
-      - 653 µs
-      - 5.0x slower
+Parsing pays both costs once: one string in, one tree out. Serializing a tree or collecting its visible text walks it in
+C just as fast as on CPython, then pays for the long string it hands back, which is why they trail by an order of
+magnitude while doing no per-node work in Python at all. Walking every descendant pays a shell per node. A CSS query
+costs less than either, because the match stays in C and only the elements it finds cross.
 
-Parsing a whole document costs 1.1x, because it is one string in and one tree out. Walking that tree from Python is the
-worst case, because every node visited materializes a wrapper across the boundary. If your program parses and then
-queries with CSS or XPath -- work that stays inside C -- PyPy costs you little. If it walks the DOM node by node in a
-Python loop, expect it to be several times slower than CPython, and note that the JIT cannot recover the difference: the
-time is spent in cpyext, not in your bytecode.
+The JIT recovers none of it. The time goes to cpyext rather than to your bytecode, so no amount of warm-up helps.
 
 None of this makes PyPy the wrong choice. It makes turbohtml a poor reason to choose it. Pick PyPy because the rest of
-your program is Python that the JIT speeds up, and accept that the HTML layer is no faster than it is on CPython.
+your program is Python that the JIT speeds up, and accept that the HTML layer is slower than it is on CPython.
+
+Regenerate the table with ``tox -e bench -- interpreters``, which builds the working tree under each interpreter and
+measures the same corpus in each.
 
 *******************************
  Behavior that differs on PyPy
@@ -76,52 +52,9 @@ yourself, or hold the C object through a :mod:`weakref`.
 
 **Deep recursion may raise** :exc:`SystemError`. The schema validator, the XSLT processor, and the XPath engine cap
 their own recursion and report a clean error past it. On PyPy, RPython's stack check can trip on the C recursion first
-and surface as :exc:`SystemError`. The recursion stays bounded either way -- neither interpreter crashes -- but the
+and surface as :exc:`SystemError`. The recursion stays bounded either way, since neither interpreter crashes, but the
 exception you catch differs.
 
 **Introspection is thinner.** :func:`inspect.signature` builds no signature for a C *type* on PyPy, even though
 ``__text_signature__`` is present, so ``inspect.signature(turbohtml.Minify)`` raises :exc:`ValueError` there. Functions
 and methods are unaffected. :func:`gc.is_tracked` does not exist on PyPy at all.
-
-*******************
- Sealing the types
-*******************
-
-``Document()``, ``Node()``, ``Token()`` and eleven siblings raise :exc:`TypeError`: only a parse builds them, and one
-constructed by hand carries no tree. CPython enforces that with ``Py_TPFLAGS_DISALLOW_INSTANTIATION``. cpyext ignored
-that flag until PyPy 7.3.21 (`pypy#5318 <https://github.com/pypy/pypy/issues/5318>`_), so those types would construct
-with no tree attached and segfault on first use, letting pure Python code take the interpreter down. 7.3.21 honors the
-flag and prints a debug line to stdout for every type that sets it (`pypy#5388
-<https://github.com/pypy/pypy/issues/5388>`_), which corrupts anything reading the CLI's output.
-
-Neither costs anything to avoid. cpyext also seals a type through an explicit ``tp_new``, the branch the flag would
-otherwise shadow, so on PyPy the flag comes off and a ``tp_new`` that raises goes on. Every supported PyPy then refuses
-the same constructions with the same message, and 7.3.21 stays quiet because nothing sets the flag it prints for. A
-subtype declaring its own ``tp_new`` overrides the inherited one, so ``Element("div")`` and ``Text("hi")`` build as they
-do on CPython.
-
-*********************
- How the core adapts
-*********************
-
-``src/turbohtml/_c/core/pycompat.h`` holds every adaptation, and each one is an identity macro on CPython, so a CPython
-build's preprocessed token stream is unchanged and its machine code cannot shift. Besides the sealing above, three calls
-need the header, and ``dom/node.c`` handles a fourth difference where it bites.
-
-``PyUnicode_CopyCharacters`` does not exist in cpyext, so it gets a ``PyUnicode_READ``/``PyUnicode_WRITE`` loop.
-
-``PyUnicode_FromFormat`` returns a string cpyext has not put in canonical form, so ``PyUnicode_KIND``,
-``PyUnicode_DATA``, and ``PyUnicode_GET_LENGTH`` are all undefined on it, and with ``NDEBUG`` their assertions are
-compiled out, so ``GET_LENGTH`` answers one past the code point count (`pypy#5524
-<https://github.com/pypy/pypy/issues/5524>`_). The core readies every result before touching it.
-
-cpyext cannot take a 2-byte buffer at all (`pypy#5525 <https://github.com/pypy/pypy/issues/5525>`_). It materializes one
-by decoding it as UTF-16, so it eats a leading U+FEFF as a byte-order mark, byte-swaps the rest of the string after a
-leading U+FFFE, collapses a surrogate pair into the one code point it encodes, and aborts the interpreter on a lone
-surrogate through the strict error handler. A CPython ``str`` carries a lone surrogate fine, and both HTML input and the
-WHATWG tokenizer have to preserve one. cpyext's 1-byte and 4-byte paths are exact, so on PyPy any result too wide for
-Latin-1 is built at 4-byte kind. CPython keeps the narrowest kind, because its ``str`` equality compares kind before
-content and would report a too-wide string as unequal to its own value.
-
-A negative subscript reaches ``sq_item`` unadjusted (`pypy#5526 <https://github.com/pypy/pypy/issues/5526>`_), where
-CPython adds the sequence length first, so ``dom/node.c`` does that adjustment itself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Free Threading :: 1 - Unstable",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Internet",
   "Topic :: Software Development :: Libraries",
   "Topic :: Text Processing :: Markup :: HTML",
@@ -197,7 +199,10 @@ release = [
 # APIs), so we ship a wheel per interpreter; cibuildwheel automates the matrix.
 # requires-python bounds the low end; free-threading wheels for 3.14+/3.15+ are
 # built automatically, and cpython-prerelease covers 3.15 while it is in beta.
-enable = [ "cpython-prerelease" ]
+# "pypy" selects pp311 only: cibuildwheel classes PyPy 3.10 and below as EoL, and turbohtml refuses to import on
+# PyPy below 7.3.22 anyway (core/module.c) -- earlier cpyext ignores Py_TPFLAGS_DISALLOW_INSTANTIATION, which lets the
+# C types be built without a tree and segfault on first use.
+enable = [ "cpython-prerelease", "pypy" ]
 build-frontend = "build[uv]"
 test-command = "python -c \"import turbohtml; assert turbohtml.unescape(turbohtml.escape('a & b')) == 'a & b'\""
 # Profile-guided optimization for the manylinux/musllinux wheels, where the gcc the spike measured runs. before-build
@@ -226,6 +231,17 @@ windows.archs = [ "AMD64" ]  # 64-bit only; skip the 32-bit x86 build
 # force the MSVC toolchain: meson otherwise picks up MinGW from the runner's PATH (the strip flag is a no-op on
 # MSVC, whose release .pyd carries no symbol table and which exports nothing without dllexport)
 windows.config-settings.setup-args = [ "--vsenv", "-Dstrip=true" ]
+
+# The Linux PGO hook above trains the profile by driving turbohtml from the interpreter it is building for. Under PyPy
+# that run is dominated by cpyext boundary crossings rather than by the C hot paths, so the profile it produces is a
+# picture of the wrong workload, and -Db_pgo=use would lay the object out for it. Drop PGO (and the build directory the
+# two phases share) for the PyPy wheels and keep LTO, which is interpreter-independent. Only Linux needs the override:
+# before-build and the profile arguments are set nowhere else, and matching pp*-macosx / pp*-win here would clobber
+# their own setup-args.
+[[tool.cibuildwheel.overrides]]
+select = "pp*-manylinux*"
+config-settings.setup-args = [ "-Dbuildtype=release", "-Db_lto=true", "-Dstrip=true" ]
+before-build = ""
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,10 +199,10 @@ release = [
 # APIs), so we ship a wheel per interpreter; cibuildwheel automates the matrix.
 # requires-python bounds the low end; free-threading wheels for 3.14+/3.15+ are
 # built automatically, and cpython-prerelease covers 3.15 while it is in beta.
-# "pypy" selects pp311 only: cibuildwheel classes PyPy 3.10 and below as EoL, and turbohtml refuses to import on
-# PyPy below 7.3.22 anyway (core/module.c) -- earlier cpyext ignores Py_TPFLAGS_DISALLOW_INSTANTIATION, which lets the
-# C types be built without a tree and segfault on first use.
-enable = [ "cpython-prerelease", "pypy" ]
+# "pypy" selects pp311; "pypy-eol" adds pp310, whose final PyPy release (7.3.19) still receives wheels here because
+# core/pycompat.h seals the C types through an explicit tp_new rather than through the
+# Py_TPFLAGS_DISALLOW_INSTANTIATION flag its cpyext ignores.
+enable = [ "cpython-prerelease", "pypy", "pypy-eol" ]
 build-frontend = "build[uv]"
 test-command = "python -c \"import turbohtml; assert turbohtml.unescape(turbohtml.escape('a & b')) == 'a & b'\""
 # Profile-guided optimization for the manylinux/musllinux wheels, where the gcc the spike measured runs. before-build

--- a/src/turbohtml/_c/clean/sanitize.c
+++ b/src/turbohtml/_c/clean/sanitize.c
@@ -1318,7 +1318,7 @@ static PyObject *open_tag(sanitizer *s, th_node *element) {
     if (tag == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    PyObject *out = PyUnicode_FromFormat("<%U", tag);
+    PyObject *out = th_str_format("<%U", tag);
     Py_DECREF(tag);
     if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1334,7 +1334,7 @@ static PyObject *open_tag(sanitizer *s, th_node *element) {
         }
         PyObject *piece;
         if (attr->value == NULL) {
-            piece = PyUnicode_FromFormat(" %U", name_str);
+            piece = th_str_format(" %U", name_str);
         } else {
             PyObject *value = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, attr->value, attr->value_len);
             if (value == NULL) {     /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -1342,7 +1342,7 @@ static PyObject *open_tag(sanitizer *s, th_node *element) {
                 Py_DECREF(out);      /* GCOVR_EXCL_LINE */
                 return NULL;         /* GCOVR_EXCL_LINE */
             }
-            piece = PyUnicode_FromFormat(" %U=\"%U\"", name_str, value);
+            piece = th_str_format(" %U=\"%U\"", name_str, value);
             Py_DECREF(value);
         }
         Py_DECREF(name_str);
@@ -1356,7 +1356,7 @@ static PyObject *open_tag(sanitizer *s, th_node *element) {
             return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
         }
     }
-    Py_SETREF(out, PyUnicode_FromFormat("%U>", out));
+    Py_SETREF(out, th_str_format("%U>", out));
     return out; /* NULL on allocation failure; the caller checks */
 }
 
@@ -1398,7 +1398,7 @@ static int escape_element(sanitizer *s, th_node *element) {
         if (tag == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
         }
-        PyObject *closing = PyUnicode_FromFormat("</%U>", tag);
+        PyObject *closing = th_str_format("</%U>", tag);
         Py_DECREF(tag);
         if (closing == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return -1;         /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -10,6 +10,8 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include "core/pycompat.h"
+
 #include <stdint.h>
 
 /* Mark an intentional switch fall-through. gcc turns on -Wimplicit-fallthrough with

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -229,7 +229,54 @@ static PyMethodDef html_methods[] = {
     {NULL, NULL, 0, NULL},
 };
 
+#ifdef PYPY_VERSION
+/* cpyext first honored Py_TPFLAGS_DISALLOW_INSTANTIATION in PyPy 7.3.21, and 7.3.21 itself printed a
+   debug line to stdout for every type that sets it. Below 7.3.21 the flag is ignored, so Document()
+   and its siblings construct with a NULL tree handle and segfault on first use -- pure Python code
+   crashing the interpreter. The wheel tag (pp311_pp73) cannot express a PyPy floor, so refuse the
+   import here rather than let that happen. */
+static int html_check_interpreter(void) {
+    PyObject *sys_module = PyImport_ImportModule("sys");
+    if (sys_module == NULL) {
+        return -1;
+    }
+    PyObject *version = PyObject_GetAttrString(sys_module, "pypy_version_info");
+    Py_DECREF(sys_module);
+    if (version == NULL) {
+        return -1;
+    }
+    PyObject *running = PySequence_GetSlice(version, 0, 3);
+    Py_DECREF(version);
+    if (running == NULL) {
+        return -1;
+    }
+    PyObject *floor = Py_BuildValue("(iii)", 7, 3, 22);
+    if (floor == NULL) {
+        Py_DECREF(running);
+        return -1;
+    }
+    int too_old = PyObject_RichCompareBool(running, floor, Py_LT); /* two int tuples: cannot fail */
+    Py_DECREF(floor);
+    if (too_old) {
+        PyErr_Format(PyExc_ImportError,
+                     "turbohtml needs PyPy 7.3.22 or newer, found %R: earlier cpyext versions ignore "
+                     "Py_TPFLAGS_DISALLOW_INSTANTIATION, which lets the C types be constructed without a tree "
+                     "and segfault on first use",
+                     running);
+        Py_DECREF(running);
+        return -1;
+    }
+    Py_DECREF(running);
+    return 0;
+}
+#endif
+
 static int html_exec(PyObject *module) {
+#ifdef PYPY_VERSION
+    if (html_check_interpreter() < 0) {
+        return -1;
+    }
+#endif
     module_state *state = PyModule_GetState(module);
     if (token_register(module, state) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;                           /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -408,12 +455,16 @@ static void html_free(void *module) {
     (void)html_clear((PyObject *)module);
 }
 
+/* Both slots below are CPython concepts: cpyext knows only Py_mod_create and Py_mod_exec, rejects
+   any other slot ID at import, and defines neither macro. PyPy reports PY_VERSION_HEX as 3.11
+   today, so the version guards alone already exclude them -- the PYPY_VERSION test is what keeps a
+   future PyPy that reports 3.12+ compiling. */
 static PyModuleDef_Slot html_slots[] = {
     {Py_mod_exec, html_exec},
-#if PY_VERSION_HEX >= 0x030C0000
+#if PY_VERSION_HEX >= 0x030C0000 && !defined(PYPY_VERSION)
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
 #endif
-#if PY_VERSION_HEX >= 0x030D0000
+#if PY_VERSION_HEX >= 0x030D0000 && !defined(PYPY_VERSION)
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif
     {0, NULL},

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -229,54 +229,7 @@ static PyMethodDef html_methods[] = {
     {NULL, NULL, 0, NULL},
 };
 
-#ifdef PYPY_VERSION
-/* cpyext first honored Py_TPFLAGS_DISALLOW_INSTANTIATION in PyPy 7.3.21, and 7.3.21 itself printed a
-   debug line to stdout for every type that sets it. Below 7.3.21 the flag is ignored, so Document()
-   and its siblings construct with a NULL tree handle and segfault on first use -- pure Python code
-   crashing the interpreter. The wheel tag (pp311_pp73) cannot express a PyPy floor, so refuse the
-   import here rather than let that happen. */
-static int html_check_interpreter(void) {
-    PyObject *sys_module = PyImport_ImportModule("sys");
-    if (sys_module == NULL) {
-        return -1;
-    }
-    PyObject *version = PyObject_GetAttrString(sys_module, "pypy_version_info");
-    Py_DECREF(sys_module);
-    if (version == NULL) {
-        return -1;
-    }
-    PyObject *running = PySequence_GetSlice(version, 0, 3);
-    Py_DECREF(version);
-    if (running == NULL) {
-        return -1;
-    }
-    PyObject *floor = Py_BuildValue("(iii)", 7, 3, 22);
-    if (floor == NULL) {
-        Py_DECREF(running);
-        return -1;
-    }
-    int too_old = PyObject_RichCompareBool(running, floor, Py_LT); /* two int tuples: cannot fail */
-    Py_DECREF(floor);
-    if (too_old) {
-        PyErr_Format(PyExc_ImportError,
-                     "turbohtml needs PyPy 7.3.22 or newer, found %R: earlier cpyext versions ignore "
-                     "Py_TPFLAGS_DISALLOW_INSTANTIATION, which lets the C types be constructed without a tree "
-                     "and segfault on first use",
-                     running);
-        Py_DECREF(running);
-        return -1;
-    }
-    Py_DECREF(running);
-    return 0;
-}
-#endif
-
 static int html_exec(PyObject *module) {
-#ifdef PYPY_VERSION
-    if (html_check_interpreter() < 0) {
-        return -1;
-    }
-#endif
     module_state *state = PyModule_GetState(module);
     if (token_register(module, state) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;                           /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/src/turbohtml/_c/core/pycompat.h
+++ b/src/turbohtml/_c/core/pycompat.h
@@ -1,0 +1,108 @@
+/* Where CPython's C API and PyPy's cpyext differ, for the calls this core depends on.
+
+   Most of the surface needs no adaptation. cpyext emulates the whole PEP 393 layout --
+   PyASCIIObject.state.kind, the compact/non-compact data pointer, and with them PyUnicode_KIND /
+   PyUnicode_DATA / PyUnicode_READ / PyUnicode_WRITE -- by transcoding a str's UTF-8 storage into a
+   UCS1/2/4 buffer the first time it crosses into C and caching that buffer on the PyObject. So the
+   SWAR scanners are correct there; they pay a one-time O(len) materialization per string, which a
+   whole-document parse amortizes. The heap types, module state, multi-phase init, and GC slots this
+   module is built on are all supported, and Py_BEGIN_CRITICAL_SECTION already collapses to a brace
+   no-op through tokenizer/binding.h's `#ifndef` -- the same shim CPython 3.10-3.12 take, and
+   correct for the same reason: cpyext holds the GIL across every call into this extension.
+
+   Three things differ.
+
+   PyUnicode_CopyCharacters does not exist in cpyext at all, so it gets the READ/WRITE loop below.
+
+   PyUnicode_FromFormat is the one constructor whose cpyext result is not in canonical form: it is
+   built through the legacy wstr representation and returned without _PyUnicode_Ready, so
+   PyUnicode_KIND, PyUnicode_DATA, and PyUnicode_GET_LENGTH are all undefined on it -- and with
+   NDEBUG their asserts are gone, so GET_LENGTH silently returns the wstr length, one past the code
+   point count. Every other constructor this core uses (FromString, FromStringAndSize,
+   FromKindAndData, New, Concat, Substring, FromOrdinal, DecodeUTF8, InternFromString, Join, Replace,
+   Py_BuildValue) returns a ready string. Call th_str_format, never PyUnicode_FromFormat directly.
+
+   A 2-byte buffer cannot be handed to cpyext at all. It realizes one by decoding it as UTF-16, so a
+   leading U+FEFF is eaten as a byte-order mark, a leading U+FFFE byte-swaps the rest, a surrogate
+   pair folds into the one code point it encodes, and a lone surrogate -- which a CPython str carries
+   fine, and which HTML input and the WHATWG tokenizer must both preserve -- aborts the interpreter
+   outright through the strict error handler. Its 1-byte (Latin-1) and 4-byte (UTF-32, surrogates
+   allowed) paths are exact. So on PyPy any result too wide for Latin-1 is built at 4-byte kind:
+   th_str_maxchar widens the PyUnicode_New bin and th_str_from_kind widens the buffer. CPython must
+   keep the narrowest kind instead, because its str equality compares kind before content and would
+   report a too-wide str as unequal to its own value, so both are identities there.
+
+   encoding/decode.h builds its results with PyUnicode_New directly and deliberately: every WHATWG
+   decoder replaces an ill-formed sequence with U+FFFD and no legacy encoding maps a byte to a
+   surrogate, so its 2-byte results hold no surrogate, and PyUnicode_New (unlike FromKindAndData)
+   pins the byte order, leaving U+FEFF and U+FFFE intact.
+
+   Each name is a macro expanding to the CPython spelling on CPython, so a CPython translation unit's
+   preprocessed token stream is unchanged by this file and its codegen cannot shift. */
+
+#ifndef TURBOHTML_CORE_PYCOMPAT_H
+#define TURBOHTML_CORE_PYCOMPAT_H
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#ifdef PYPY_VERSION
+
+/* how_many code points of `from` into `to` at `to_start`. The callers size `to` with a maxchar that
+   covers `from`, so the widening write always fits and this cannot fail; CPython's function returns
+   the count copied and the callers ignore it, so the fallback returns it too. */
+static inline Py_ssize_t th_copy_characters(PyObject *to, Py_ssize_t to_start, PyObject *from, Py_ssize_t from_start,
+                                            Py_ssize_t how_many) {
+    int to_kind = PyUnicode_KIND(to);
+    void *to_data = PyUnicode_DATA(to);
+    int from_kind = PyUnicode_KIND(from);
+    const void *from_data = PyUnicode_DATA(from);
+    for (Py_ssize_t index = 0; index < how_many; index++) {
+        PyUnicode_WRITE(to_kind, to_data, to_start + index, PyUnicode_READ(from_kind, from_data, from_start + index));
+    }
+    return how_many;
+}
+
+/* Canonicalize a cpyext PyUnicode_FromFormat[V] result, freeing it on the one failure
+   _PyUnicode_Ready reports (a code point outside U+0000..U+10FFFF, which no format string here can
+   produce) so the caller's existing NULL check covers this too. */
+static inline PyObject *th_str_ready(PyObject *str) {
+    if (str != NULL && PyUnicode_READY(str) < 0) {
+        Py_CLEAR(str);
+    }
+    return str;
+}
+
+/* Widen a 2-byte buffer to 4-byte before handing it over; 1-byte and 4-byte pass straight through. */
+static inline PyObject *th_str_from_kind(int kind, const void *data, Py_ssize_t size) {
+    if (kind != PyUnicode_2BYTE_KIND || size == 0) {
+        return PyUnicode_FromKindAndData(kind, data, size);
+    }
+    Py_UCS4 *wide = PyMem_Malloc((size_t)size * sizeof(Py_UCS4));
+    if (wide == NULL) {
+        return PyErr_NoMemory();
+    }
+    const Py_UCS2 *narrow = (const Py_UCS2 *)data;
+    for (Py_ssize_t index = 0; index < size; index++) {
+        wide[index] = narrow[index];
+    }
+    PyObject *result = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, wide, size);
+    PyMem_Free(wide);
+    return result;
+}
+
+#define th_str_format(...) th_str_ready(PyUnicode_FromFormat(__VA_ARGS__))
+#define th_str_format_v(format, args) th_str_ready(PyUnicode_FromFormatV((format), (args)))
+#define th_str_maxchar(maxchar) ((maxchar) > 0xFF ? (Py_UCS4)0x10FFFF : (Py_UCS4)(maxchar))
+
+#else
+
+#define th_copy_characters PyUnicode_CopyCharacters
+#define th_str_from_kind PyUnicode_FromKindAndData
+#define th_str_format(...) PyUnicode_FromFormat(__VA_ARGS__)
+#define th_str_format_v(format, args) PyUnicode_FromFormatV((format), (args))
+#define th_str_maxchar(maxchar) (maxchar)
+
+#endif /* PYPY_VERSION */
+
+#endif /* TURBOHTML_CORE_PYCOMPAT_H */

--- a/src/turbohtml/_c/core/pycompat.h
+++ b/src/turbohtml/_c/core/pycompat.h
@@ -1,52 +1,46 @@
 /* Where CPython's C API and PyPy's cpyext differ, for the calls this core depends on.
 
-   Most of the surface needs no adaptation. cpyext emulates the whole PEP 393 layout --
-   PyASCIIObject.state.kind, the compact/non-compact data pointer, and with them PyUnicode_KIND /
-   PyUnicode_DATA / PyUnicode_READ / PyUnicode_WRITE -- by transcoding a str's UTF-8 storage into a
-   UCS1/2/4 buffer the first time it crosses into C and caching that buffer on the PyObject. So the
-   SWAR scanners are correct there; they pay a one-time O(len) materialization per string, which a
-   whole-document parse amortizes. The heap types, module state, multi-phase init, and GC slots this
-   module is built on are all supported, and Py_BEGIN_CRITICAL_SECTION already collapses to a brace
-   no-op through tokenizer/binding.h's `#ifndef` -- the same shim CPython 3.10-3.12 take, and
-   correct for the same reason: cpyext holds the GIL across every call into this extension.
+   Most of the surface needs no adaptation. cpyext emulates the PEP 393 layout -- PyASCIIObject's
+   kind and data pointer, and with them PyUnicode_KIND / DATA / READ / WRITE -- by transcoding a
+   str's UTF-8 storage into a UCS1/2/4 buffer the first time it crosses into C and caching it on the
+   PyObject, so the SWAR scanners are correct there and pay one O(len) materialization per string.
+   Heap types, module state, multi-phase init, and the GC slots all work, and
+   Py_BEGIN_CRITICAL_SECTION already collapses to a brace no-op through tokenizer/binding.h's
+   `#ifndef`, correct because cpyext holds the GIL across every call into this extension.
 
-   Four things differ.
+   Four things differ. Each name below expands to the CPython spelling on CPython, so a CPython
+   translation unit's preprocessed token stream is unchanged by this file and its codegen cannot
+   shift. dom/node.c handles a fifth difference where it bites, cpyext handing sq_item a raw negative
+   index: https://github.com/pypy/pypy/issues/5526
 
-   Py_TPFLAGS_DISALLOW_INSTANTIATION is a no-op in cpyext until PyPy 7.3.21, so the sealed types
-   would construct with no tree attached and segfault on first use -- pure Python code taking the
-   interpreter down. 7.3.21 honors the flag and prints a debug line to stdout for every type that
-   sets it. Both cost nothing to avoid: cpyext seals a type through an explicit tp_new (the
-   `elif pto.c_tp_new` arm the flag would otherwise shadow), so on PyPy the flag comes off and
-   th_disallow_new goes on. Every sealed spec pairs TH_SEALED in its flags with TH_SEALED_NEW in its
-   slots. A subtype that declares its own tp_new overrides the inherited one, as it does on CPython.
+   Sealing. cpyext ignored Py_TPFLAGS_DISALLOW_INSTANTIATION before PyPy 7.3.21, so the sealed types
+   constructed with no tree attached and segfaulted on first use, and 7.3.21 prints a debug line to
+   stdout for every type that sets it (https://github.com/pypy/pypy/issues/5318, .../5388). cpyext
+   also seals through an explicit tp_new, the arm the flag would otherwise shadow, so on PyPy
+   TH_SEALED drops the flag and TH_SEALED_END adds th_disallow_new. Both are needed together. A
+   subtype declaring its own tp_new overrides the inherited one, as it does on CPython.
 
    PyUnicode_CopyCharacters does not exist in cpyext at all, so it gets the READ/WRITE loop below.
 
-   PyUnicode_FromFormat is the one constructor whose cpyext result is not in canonical form: it is
-   built through the legacy wstr representation and returned without _PyUnicode_Ready, so
-   PyUnicode_KIND, PyUnicode_DATA, and PyUnicode_GET_LENGTH are all undefined on it -- and with
-   NDEBUG their asserts are gone, so GET_LENGTH silently returns the wstr length, one past the code
-   point count. Every other constructor this core uses (FromString, FromStringAndSize,
-   FromKindAndData, New, Concat, Substring, FromOrdinal, DecodeUTF8, InternFromString, Join, Replace,
-   Py_BuildValue) returns a ready string. Call th_str_format, never PyUnicode_FromFormat directly.
+   PyUnicode_FromFormat returns a string cpyext left in the legacy wstr representation, so
+   PyUnicode_KIND, PyUnicode_DATA and PyUnicode_GET_LENGTH are all undefined on it, and with NDEBUG
+   their asserts are gone so GET_LENGTH answers one past the code point count
+   (https://github.com/pypy/pypy/issues/5524). Every other constructor this core uses returns a ready
+   string. Call th_str_format, never PyUnicode_FromFormat directly; tests/core/test_c_api_portability
+   pins that.
 
-   A 2-byte buffer cannot be handed to cpyext at all. It realizes one by decoding it as UTF-16, so a
-   leading U+FEFF is eaten as a byte-order mark, a leading U+FFFE byte-swaps the rest, a surrogate
-   pair folds into the one code point it encodes, and a lone surrogate -- which a CPython str carries
-   fine, and which HTML input and the WHATWG tokenizer must both preserve -- aborts the interpreter
-   outright through the strict error handler. Its 1-byte (Latin-1) and 4-byte (UTF-32, surrogates
-   allowed) paths are exact. So on PyPy any result too wide for Latin-1 is built at 4-byte kind:
-   th_str_maxchar widens the PyUnicode_New bin and th_str_from_kind widens the buffer. CPython must
-   keep the narrowest kind instead, because its str equality compares kind before content and would
-   report a too-wide str as unequal to its own value, so both are identities there.
+   A 2-byte buffer cannot be handed to cpyext at all (https://github.com/pypy/pypy/issues/5525). It
+   decodes one as UTF-16, eating a leading U+FEFF, byte-swapping the rest after a leading U+FFFE,
+   folding a surrogate pair into the code point it encodes, and aborting the interpreter outright on
+   a lone surrogate, which a CPython str carries fine and which the WHATWG tokenizer must preserve.
+   Its 1-byte (Latin-1) and 4-byte (UTF-32) paths are exact, so on PyPy any result too wide for
+   Latin-1 is built at 4-byte kind: th_str_maxchar widens the PyUnicode_New bin and th_str_from_kind
+   widens the buffer. CPython keeps the narrowest kind instead, because its str equality compares
+   kind before content and would report a too-wide str as unequal to its own value.
 
-   encoding/decode.h builds its results with PyUnicode_New directly and deliberately: every WHATWG
-   decoder replaces an ill-formed sequence with U+FFFD and no legacy encoding maps a byte to a
-   surrogate, so its 2-byte results hold no surrogate, and PyUnicode_New (unlike FromKindAndData)
-   pins the byte order, leaving U+FEFF and U+FFFE intact.
-
-   Each name is a macro expanding to the CPython spelling on CPython, so a CPython translation unit's
-   preprocessed token stream is unchanged by this file and its codegen cannot shift. */
+   encoding/decode.h calls PyUnicode_New directly and deliberately: every WHATWG decoder replaces an
+   ill-formed sequence with U+FFFD and no legacy encoding maps a byte to a surrogate, so its 2-byte
+   results hold no surrogate, and PyUnicode_New pins the byte order where FromKindAndData does not. */
 
 #ifndef TURBOHTML_CORE_PYCOMPAT_H
 #define TURBOHTML_CORE_PYCOMPAT_H
@@ -78,9 +72,9 @@ static inline Py_ssize_t th_copy_characters(PyObject *to, Py_ssize_t to_start, P
     return how_many;
 }
 
-/* Canonicalize a cpyext PyUnicode_FromFormat[V] result, freeing it on the one failure
-   _PyUnicode_Ready reports (a code point outside U+0000..U+10FFFF, which no format string here can
-   produce) so the caller's existing NULL check covers this too. */
+/* Canonicalize a cpyext PyUnicode_FromFormat[V] result. _PyUnicode_Ready transcodes into a fresh
+   UCS buffer, so it can fail on allocation; free the string then, letting the caller's NULL check
+   cover it. */
 static inline PyObject *th_str_ready(PyObject *str) {
     if (str != NULL && PyUnicode_READY(str) < 0) {
         Py_CLEAR(str);
@@ -110,7 +104,10 @@ static inline PyObject *th_str_from_kind(int kind, const void *data, Py_ssize_t 
 #define th_str_format_v(format, args) th_str_ready(PyUnicode_FromFormatV((format), (args)))
 #define th_str_maxchar(maxchar) ((maxchar) > 0xFF ? (Py_UCS4)0x10FFFF : (Py_UCS4)(maxchar))
 #define TH_SEALED 0
-#define TH_SEALED_NEW {Py_tp_new, th_disallow_new},
+#define TH_SEALED_END                                                                                                  \
+    {Py_tp_new, th_disallow_new}, {                                                                                    \
+        0, NULL                                                                                                        \
+    }
 
 #else
 
@@ -120,7 +117,7 @@ static inline PyObject *th_str_from_kind(int kind, const void *data, Py_ssize_t 
 #define th_str_format_v(format, args) PyUnicode_FromFormatV((format), (args))
 #define th_str_maxchar(maxchar) (maxchar)
 #define TH_SEALED Py_TPFLAGS_DISALLOW_INSTANTIATION
-#define TH_SEALED_NEW
+#define TH_SEALED_END {0, NULL}
 
 #endif /* PYPY_VERSION */
 

--- a/src/turbohtml/_c/core/pycompat.h
+++ b/src/turbohtml/_c/core/pycompat.h
@@ -10,7 +10,15 @@
    no-op through tokenizer/binding.h's `#ifndef` -- the same shim CPython 3.10-3.12 take, and
    correct for the same reason: cpyext holds the GIL across every call into this extension.
 
-   Three things differ.
+   Four things differ.
+
+   Py_TPFLAGS_DISALLOW_INSTANTIATION is a no-op in cpyext until PyPy 7.3.21, so the sealed types
+   would construct with no tree attached and segfault on first use -- pure Python code taking the
+   interpreter down. 7.3.21 honors the flag and prints a debug line to stdout for every type that
+   sets it. Both cost nothing to avoid: cpyext seals a type through an explicit tp_new (the
+   `elif pto.c_tp_new` arm the flag would otherwise shadow), so on PyPy the flag comes off and
+   th_disallow_new goes on. Every sealed spec pairs TH_SEALED in its flags with TH_SEALED_NEW in its
+   slots. A subtype that declares its own tp_new overrides the inherited one, as it does on CPython.
 
    PyUnicode_CopyCharacters does not exist in cpyext at all, so it gets the READ/WRITE loop below.
 
@@ -47,6 +55,13 @@
 #include <Python.h>
 
 #ifdef PYPY_VERSION
+
+/* tp_new for a type CPython seals with Py_TPFLAGS_DISALLOW_INSTANTIATION. tp_name carries the
+   spec's dotted name, so the message matches CPython's word for word. */
+static inline PyObject *th_disallow_new(PyTypeObject *type, PyObject *Py_UNUSED(args), PyObject *Py_UNUSED(kwds)) {
+    PyErr_Format(PyExc_TypeError, "cannot create '%s' instances", type->tp_name);
+    return NULL;
+}
 
 /* how_many code points of `from` into `to` at `to_start`. The callers size `to` with a maxchar that
    covers `from`, so the widening write always fits and this cannot fail; CPython's function returns
@@ -94,6 +109,8 @@ static inline PyObject *th_str_from_kind(int kind, const void *data, Py_ssize_t 
 #define th_str_format(...) th_str_ready(PyUnicode_FromFormat(__VA_ARGS__))
 #define th_str_format_v(format, args) th_str_ready(PyUnicode_FromFormatV((format), (args)))
 #define th_str_maxchar(maxchar) ((maxchar) > 0xFF ? (Py_UCS4)0x10FFFF : (Py_UCS4)(maxchar))
+#define TH_SEALED 0
+#define TH_SEALED_NEW {Py_tp_new, th_disallow_new},
 
 #else
 
@@ -102,6 +119,8 @@ static inline PyObject *th_str_from_kind(int kind, const void *data, Py_ssize_t 
 #define th_str_format(...) PyUnicode_FromFormat(__VA_ARGS__)
 #define th_str_format_v(format, args) PyUnicode_FromFormatV((format), (args))
 #define th_str_maxchar(maxchar) (maxchar)
+#define TH_SEALED Py_TPFLAGS_DISALLOW_INSTANTIATION
+#define TH_SEALED_NEW
 
 #endif /* PYPY_VERSION */
 

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -604,8 +604,7 @@ static int strict_raise(module_state *state, th_tree *tree, int strict) {
         return 0;
     }
     PyObject *error = parse_error_new(state, &errors[0]);
-    PyObject *message =
-        PyUnicode_FromFormat("%s at line %zd, column %zd", errors[0].code, errors[0].line, errors[0].col);
+    PyObject *message = th_str_format("%s at line %zd, column %zd", errors[0].code, errors[0].line, errors[0].col);
     /* allocation failure cannot be forced from a test */
     if (error == NULL || message == NULL) { /* GCOVR_EXCL_BR_LINE */
         Py_XDECREF(error);                  /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1314,8 +1313,8 @@ static PyObject *reconstruct_doctype(module_state *state, PyObject *data) {
         if (empty == NULL) { /* GCOVR_EXCL_BR_LINE: the empty string is interned and cannot fail */
             return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
         }
-        packed = PyUnicode_FromFormat("%U \"%U\" \"%U\"", name, has_public ? public_id : empty,
-                                      has_system ? system_id : empty);
+        packed =
+            th_str_format("%U \"%U\" \"%U\"", name, has_public ? public_id : empty, has_system ? system_id : empty);
         Py_DECREF(empty);
     }
     if (packed == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -530,7 +530,7 @@ static PyType_Slot document_slots[] = {
     {Py_tp_doc, (void *)document_doc},
     {Py_tp_getset, document_getset},
     {Py_tp_methods, document_methods},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 static PyType_Spec document_spec = {
@@ -556,7 +556,7 @@ static void handle_dealloc(PyObject *self) {
 
 static PyType_Slot handle_slots[] = {
     {Py_tp_dealloc, handle_dealloc},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 static PyType_Spec handle_spec = {

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -530,13 +530,13 @@ static PyType_Slot document_slots[] = {
     {Py_tp_doc, (void *)document_doc},
     {Py_tp_getset, document_getset},
     {Py_tp_methods, document_methods},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 static PyType_Spec document_spec = {
     .name = "turbohtml._html.Document",
     .basicsize = sizeof(NodeObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = document_slots,
 };
 
@@ -556,13 +556,13 @@ static void handle_dealloc(PyObject *self) {
 
 static PyType_Slot handle_slots[] = {
     {Py_tp_dealloc, handle_dealloc},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 static PyType_Spec handle_spec = {
     .name = "turbohtml._html._TreeHandle",
     .basicsize = sizeof(HandleObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = handle_slots,
 };
 

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -303,7 +303,7 @@ static PyType_Slot attrs_slots[] = {
     {Py_sq_contains, attrs_contains},
     {Py_tp_iter, attrs_iter},
     {Py_tp_methods, attrs_methods},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 PyType_Spec attrs_spec = {

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -303,13 +303,13 @@ static PyType_Slot attrs_slots[] = {
     {Py_sq_contains, attrs_contains},
     {Py_tp_iter, attrs_iter},
     {Py_tp_methods, attrs_methods},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 PyType_Spec attrs_spec = {
     .name = "turbohtml._html._Attrs",
     .basicsize = sizeof(AttrsObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = attrs_slots,
 };
 

--- a/src/turbohtml/_c/dom/formatters.c
+++ b/src/turbohtml/_c/dom/formatters.c
@@ -213,24 +213,23 @@ static Py_hash_t minify_hash(PyObject *self) {
 static PyObject *minify_repr(PyObject *self) {
     MinifyObject *minify = (MinifyObject *)self;
     /* mirror JSMinify's own repr (field order mangle, fold) rather than build the object */
-    PyObject *js = minify->minify_js ? PyUnicode_FromFormat("JSMinify(mangle=%s, fold=%s)",
-                                                            minify->minify_js_mangle ? "True" : "False",
-                                                            minify->minify_js_fold ? "True" : "False")
-                                     : PyUnicode_FromString("None");
+    PyObject *js = minify->minify_js
+                       ? th_str_format("JSMinify(mangle=%s, fold=%s)", minify->minify_js_mangle ? "True" : "False",
+                                       minify->minify_js_fold ? "True" : "False")
+                       : PyUnicode_FromString("None");
     if (js == NULL) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
         return NULL;  /* GCOVR_EXCL_LINE */
     }
     /* mirror CSSMinify's own dataclass repr (baseline None when the year is 0) */
-    PyObject *css =
-        minify->minify_css
-            ? (minify->minify_css_baseline ? PyUnicode_FromFormat("CSSMinify(baseline=%d)", minify->minify_css_baseline)
-                                           : PyUnicode_FromString("CSSMinify(baseline=None)"))
-            : PyUnicode_FromString("None");
+    PyObject *css = minify->minify_css ? (minify->minify_css_baseline
+                                              ? th_str_format("CSSMinify(baseline=%d)", minify->minify_css_baseline)
+                                              : PyUnicode_FromString("CSSMinify(baseline=None)"))
+                                       : PyUnicode_FromString("None");
     if (css == NULL) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
         Py_DECREF(js); /* GCOVR_EXCL_LINE */
         return NULL;   /* GCOVR_EXCL_LINE */
     }
-    PyObject *repr = PyUnicode_FromFormat(
+    PyObject *repr = th_str_format(
         "Minify(collapse_whitespace=%s, omit_optional_tags=%s, unquote_attributes=%s, "
         "strip_comments=%s, minify_js=%U, minify_css=%U)",
         minify->collapse_whitespace ? "True" : "False", minify->omit_optional_tags ? "True" : "False",
@@ -367,7 +366,7 @@ static PyObject *indent_repr(PyObject *self) {
     if (unit == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    PyObject *repr = PyUnicode_FromFormat("Indent(%R)", unit);
+    PyObject *repr = th_str_format("Indent(%R)", unit);
     Py_DECREF(unit);
     return repr;
 }

--- a/src/turbohtml/_c/dom/leaf.c
+++ b/src/turbohtml/_c/dom/leaf.c
@@ -369,7 +369,7 @@ static PyObject *parse_error_repr(PyObject *self) {
     if (code == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    PyObject *repr = PyUnicode_FromFormat("ParseError(code=%R, line=%zd, col=%zd)", code, error->line, error->col);
+    PyObject *repr = th_str_format("ParseError(code=%R, line=%zd, col=%zd)", code, error->line, error->col);
     Py_DECREF(code);
     return repr;
 }

--- a/src/turbohtml/_c/dom/leaf.c
+++ b/src/turbohtml/_c/dom/leaf.c
@@ -311,7 +311,7 @@ PyDoc_STRVAR(doctype_doc, "A document type declaration.");
 static PyType_Slot doctype_slots[] = {
     {Py_tp_doc, (void *)doctype_doc},
     {Py_tp_getset, doctype_getset},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 PyType_Spec doctype_spec = {
@@ -414,7 +414,7 @@ static PyType_Slot parse_error_slots[] = {
     {Py_tp_hash, parse_error_hash},
     {Py_tp_richcompare, parse_error_richcompare},
     {Py_tp_getset, parse_error_getset},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 PyType_Spec parse_error_spec = {

--- a/src/turbohtml/_c/dom/leaf.c
+++ b/src/turbohtml/_c/dom/leaf.c
@@ -311,13 +311,13 @@ PyDoc_STRVAR(doctype_doc, "A document type declaration.");
 static PyType_Slot doctype_slots[] = {
     {Py_tp_doc, (void *)doctype_doc},
     {Py_tp_getset, doctype_getset},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 PyType_Spec doctype_spec = {
     .name = "turbohtml._html.Doctype",
     .basicsize = sizeof(NodeObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = doctype_slots,
 };
 
@@ -414,12 +414,12 @@ static PyType_Slot parse_error_slots[] = {
     {Py_tp_hash, parse_error_hash},
     {Py_tp_richcompare, parse_error_richcompare},
     {Py_tp_getset, parse_error_getset},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 PyType_Spec parse_error_spec = {
     .name = "turbohtml._html.ParseError",
     .basicsize = sizeof(ParseErrorObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE | TH_SEALED,
     .slots = parse_error_slots,
 };

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -187,13 +187,13 @@ static PyType_Slot walker_slots[] = {
     {Py_tp_dealloc, walker_dealloc},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, walker_next},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 PyType_Spec walker_spec = {
     .name = "turbohtml._html._NodeIterator",
     .basicsize = sizeof(WalkerObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = walker_slots,
 };
 
@@ -256,13 +256,13 @@ static PyType_Slot string_walker_slots[] = {
     {Py_tp_dealloc, string_walker_dealloc},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, string_walker_next},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 PyType_Spec string_walker_spec = {
     .name = "turbohtml._html._StringIterator",
     .basicsize = sizeof(StringWalkerObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = string_walker_slots,
 };
 
@@ -330,13 +330,13 @@ static PyType_Slot serialize_iter_slots[] = {
     {Py_tp_dealloc, serialize_iter_dealloc},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, serialize_iter_next},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 PyType_Spec serialize_iter_spec = {
     .name = "turbohtml._html._SerializeIterator",
     .basicsize = sizeof(SerializeIterObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = serialize_iter_slots,
 };
 
@@ -1769,13 +1769,13 @@ static PyType_Slot node_slots[] = {
     {Py_tp_hash, node_hash},       {Py_tp_getset, node_getset},
     {Py_tp_methods, node_methods}, {Py_tp_iter, node_iter},
     {Py_sq_length, node_length},   {Py_sq_item, node_item},
-    {Py_nb_bool, node_bool},       {0, NULL},
+    {Py_nb_bool, node_bool},       TH_SEALED_NEW{0, NULL},
 };
 
 PyType_Spec node_spec = {
     .name = "turbohtml._html.Node",
     .basicsize = sizeof(NodeObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | TH_SEALED,
     .slots = node_slots,
 };
 

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -1334,6 +1334,14 @@ static Py_ssize_t node_length(PyObject *self) {
 
 static PyObject *node_item(PyObject *self, Py_ssize_t index) {
     NodeObject *node = (NodeObject *)self;
+#ifdef PYPY_VERSION
+    /* CPython's PySequence_GetItem adds sq_length to a negative subscript before dispatching here;
+       cpyext hands sq_item the raw index, so node[-1] would walk zero steps and answer the first
+       child. Do the adjustment cpyext skips. */
+    if (index < 0) {
+        index += node_length(self);
+    }
+#endif
     /* CPython's PySequence_GetItem adds sq_length to a negative subscript but never rechecks it, so
        node[-len - 1] still arrives negative. Without this it would walk zero steps and answer the
        first child rather than raise, as list does. */
@@ -1377,7 +1385,7 @@ static PyObject *node_repr(PyObject *self) {
         if (tag == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
         }
-        PyObject *repr = PyUnicode_FromFormat("Element(%R)", tag);
+        PyObject *repr = th_str_format("Element(%R)", tag);
         Py_DECREF(tag);
         return repr;
     }
@@ -1393,7 +1401,7 @@ static PyObject *node_repr(PyObject *self) {
                             : node->type == TH_NODE_COMMENT ? "Comment"
                             : node->type == TH_NODE_CDATA   ? "CData"
                                                             : "Doctype";
-        PyObject *repr = PyUnicode_FromFormat("%s(%R)", label, data);
+        PyObject *repr = th_str_format("%s(%R)", label, data);
         Py_DECREF(data);
         return repr;
     }
@@ -1405,7 +1413,7 @@ static PyObject *node_repr(PyObject *self) {
             Py_XDECREF(data);                 /* GCOVR_EXCL_LINE: allocation-failure path */
             return NULL;                      /* GCOVR_EXCL_LINE: allocation-failure path */
         }
-        PyObject *repr = PyUnicode_FromFormat("ProcessingInstruction(%R, %R)", target, data);
+        PyObject *repr = th_str_format("ProcessingInstruction(%R, %R)", target, data);
         Py_DECREF(target);
         Py_DECREF(data);
         return repr;

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -1334,6 +1334,13 @@ static Py_ssize_t node_length(PyObject *self) {
 
 static PyObject *node_item(PyObject *self, Py_ssize_t index) {
     NodeObject *node = (NodeObject *)self;
+    /* CPython's PySequence_GetItem adds sq_length to a negative subscript but never rechecks it, so
+       node[-len - 1] still arrives negative. Without this it would walk zero steps and answer the
+       first child rather than raise, as list does. */
+    if (index < 0) {
+        PyErr_SetString(PyExc_IndexError, "node child index out of range");
+        return NULL;
+    }
     th_node *child;
     Py_BEGIN_CRITICAL_SECTION(node->handle);
     child = node->node->first_child;

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -187,7 +187,7 @@ static PyType_Slot walker_slots[] = {
     {Py_tp_dealloc, walker_dealloc},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, walker_next},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 PyType_Spec walker_spec = {
@@ -256,7 +256,7 @@ static PyType_Slot string_walker_slots[] = {
     {Py_tp_dealloc, string_walker_dealloc},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, string_walker_next},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 PyType_Spec string_walker_spec = {
@@ -330,7 +330,7 @@ static PyType_Slot serialize_iter_slots[] = {
     {Py_tp_dealloc, serialize_iter_dealloc},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, serialize_iter_next},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 PyType_Spec serialize_iter_spec = {
@@ -1337,7 +1337,7 @@ static PyObject *node_item(PyObject *self, Py_ssize_t index) {
 #ifdef PYPY_VERSION
     /* CPython's PySequence_GetItem adds sq_length to a negative subscript before dispatching here;
        cpyext hands sq_item the raw index, so node[-1] would walk zero steps and answer the first
-       child. Do the adjustment cpyext skips. */
+       child. Do the adjustment cpyext skips: https://github.com/pypy/pypy/issues/5526 */
     if (index < 0) {
         index += node_length(self);
     }
@@ -1769,7 +1769,7 @@ static PyType_Slot node_slots[] = {
     {Py_tp_hash, node_hash},       {Py_tp_getset, node_getset},
     {Py_tp_methods, node_methods}, {Py_tp_iter, node_iter},
     {Py_sq_length, node_length},   {Py_sq_item, node_item},
-    {Py_nb_bool, node_bool},       TH_SEALED_NEW{0, NULL},
+    {Py_nb_bool, node_bool},       TH_SEALED_END,
 };
 
 PyType_Spec node_spec = {

--- a/src/turbohtml/_c/dom/range.c
+++ b/src/turbohtml/_c/dom/range.c
@@ -1076,8 +1076,8 @@ static PyObject *range_repr(PyObject *self) {
         Py_XDECREF(end);                /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;                    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    PyObject *result = PyUnicode_FromFormat("<Range start=(%R, %zd) end=(%R, %zd)>", start, range->start_offset, end,
-                                            range->end_offset);
+    PyObject *result =
+        th_str_format("<Range start=(%R, %zd) end=(%R, %zd)>", start, range->start_offset, end, range->end_offset);
     Py_DECREF(start);
     Py_DECREF(end);
     return result;

--- a/src/turbohtml/_c/dom/shadow.c
+++ b/src/turbohtml/_c/dom/shadow.c
@@ -443,12 +443,12 @@ static PyType_Slot shadow_root_slots[] = {
     {Py_tp_doc, (void *)shadow_root_doc},
     {Py_tp_getset, shadow_root_getset},
     {Py_tp_methods, shadow_root_methods},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 PyType_Spec shadow_root_spec = {
     .name = "turbohtml._html.ShadowRoot",
     .basicsize = sizeof(NodeObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = shadow_root_slots,
 };

--- a/src/turbohtml/_c/dom/shadow.c
+++ b/src/turbohtml/_c/dom/shadow.c
@@ -443,7 +443,7 @@ static PyType_Slot shadow_root_slots[] = {
     {Py_tp_doc, (void *)shadow_root_doc},
     {Py_tp_getset, shadow_root_getset},
     {Py_tp_methods, shadow_root_methods},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 PyType_Spec shadow_root_spec = {

--- a/src/turbohtml/_c/extract/annotation.c
+++ b/src/turbohtml/_c/extract/annotation.c
@@ -190,7 +190,7 @@ static Py_ssize_t annotation_write_tag(PyObject *out, Py_ssize_t written, PyObje
         PyUnicode_WRITE(kind, data, written++, '/');
     }
     Py_ssize_t label_len = PyUnicode_GET_LENGTH(label);
-    PyUnicode_CopyCharacters(out, written, label, 0, label_len); /* out's kind covers label: cannot fail */
+    th_copy_characters(out, written, label, 0, label_len); /* out's kind covers label: cannot fail */
     written += label_len;
     PyUnicode_WRITE(kind, data, written++, '>');
     return written;
@@ -225,7 +225,7 @@ PyObject *turbohtml_annotation_tags(PyObject *Py_UNUSED(module), PyObject *args)
         events[2 * index + 1] = (annotation_event){items[index].end, 0, items[index].start, index, items[index].label};
     }
     qsort(events, (size_t)(2 * count), sizeof(annotation_event), annotation_event_cmp);
-    PyObject *out = PyUnicode_New(out_len, maxchar);
+    PyObject *out = PyUnicode_New(out_len, th_str_maxchar(maxchar));
     if (out == NULL) {      /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         PyMem_Free(events); /* GCOVR_EXCL_LINE: allocation-failure path */
         PyMem_Free(items);  /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -234,14 +234,14 @@ PyObject *turbohtml_annotation_tags(PyObject *Py_UNUSED(module), PyObject *args)
     Py_ssize_t cursor = 0, written = 0;
     for (Py_ssize_t index = 0; index < 2 * count; index++) {
         if (events[index].pos > cursor) {
-            PyUnicode_CopyCharacters(out, written, text, cursor, events[index].pos - cursor);
+            th_copy_characters(out, written, text, cursor, events[index].pos - cursor);
             written += events[index].pos - cursor;
             cursor = events[index].pos;
         }
         written = annotation_write_tag(out, written, events[index].label, events[index].is_open);
     }
     if (text_len > cursor) {
-        PyUnicode_CopyCharacters(out, written, text, cursor, text_len - cursor);
+        th_copy_characters(out, written, text, cursor, text_len - cursor);
     }
     PyMem_Free(events);
     PyMem_Free(items);

--- a/src/turbohtml/_c/query/methods.c
+++ b/src/turbohtml/_c/query/methods.c
@@ -1233,7 +1233,7 @@ static PyGetSetDef xpath_compiled_getset[] = {
 };
 
 static PyObject *xpath_compiled_repr(PyObject *self) {
-    return PyUnicode_FromFormat("XPath(%R)", ((XPathObject *)self)->expression);
+    return th_str_format("XPath(%R)", ((XPathObject *)self)->expression);
 }
 
 PyDoc_STRVAR(xpath_compiled_doc, "XPath(expression, *, smart_strings=False, extensions=None)\n--\n\n"

--- a/src/turbohtml/_c/serialize/escape.c
+++ b/src/turbohtml/_c/serialize/escape.c
@@ -326,6 +326,27 @@ PyObject *turbohtml_escape(PyObject *Py_UNUSED(module), PyObject *args, PyObject
         return PyUnicode_FromObject(text);
     }
 
+#ifdef PYPY_VERSION
+    /* cpyext cannot realize a 2-byte buffer (core/pycompat.h): a lone surrogate in one aborts the
+       interpreter, and a str reaching escape() may hold one. Build the result at 4-byte kind and
+       fill it code point by code point -- the block copies below copy at the input's width, which
+       only holds while the output kind matches it. A Latin-1 or 4-byte input keeps its own kind and
+       falls through to its fast path. */
+    if (kind == PyUnicode_2BYTE_KIND) {
+        PyObject *wide = PyUnicode_New(length + extra, 0x10FFFF);
+        if (wide == NULL) {
+            return NULL;
+        }
+        void *wide_data = PyUnicode_DATA(wide);
+        const uint16_t *input = (const uint16_t *)data;
+        Py_ssize_t written = 0;
+        for (Py_ssize_t pos = 0; pos < length; pos++) {
+            written += write_escaped(PyUnicode_4BYTE_KIND, wide_data, written, input[pos], quote);
+        }
+        return wide;
+    }
+#endif
+
     /* maxchar comes from the input and escapes are ASCII, so the output kind
        always matches the input kind and clean blocks can be copied bytewise */
     Py_UCS4 maxchar = PyUnicode_MAX_CHAR_VALUE(text);

--- a/src/turbohtml/_c/serialize/markup.c
+++ b/src/turbohtml/_c/serialize/markup.c
@@ -216,7 +216,7 @@ static PyObject *markup_escape_str(PyObject *markup_type, PyObject *text) {
     }
 
     Py_UCS4 maxchar = PyUnicode_MAX_CHAR_VALUE(text);
-    PyObject *escaped = PyUnicode_New(length + extra, maxchar);
+    PyObject *escaped = PyUnicode_New(length + extra, th_str_maxchar(maxchar));
     if (escaped == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
     }

--- a/src/turbohtml/_c/serialize/unescape.c
+++ b/src/turbohtml/_c/serialize/unescape.c
@@ -338,7 +338,7 @@ PyObject *turbohtml_unescape(PyObject *Py_UNUSED(module), PyObject *arg) {
     }
     /* the OR accumulator can exceed 0x10FFFF only when an astral character was
        emitted, and everything above 0xFFFF lands in the same PyUnicode_New bin */
-    PyObject *result = PyUnicode_New(count, seen > 0xFFFF ? 0x10FFFF : seen);
+    PyObject *result = PyUnicode_New(count, th_str_maxchar(seen > 0xFFFF ? 0x10FFFF : seen));
     if (result == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         PyMem_Free(out);  /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/src/turbohtml/_c/tokenizer/binding.h
+++ b/src/turbohtml/_c/tokenizer/binding.h
@@ -12,12 +12,14 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
+#include "core/pycompat.h"
 #include "tokenizer/statemachine.h"
 
 /* Py_BEGIN_CRITICAL_SECTION arrived in 3.13 for the free-threaded build; on a GIL
    build it is a brace no-op, and before 3.13 (always GIL) we define the same no-op,
    so the tokenizer's per-object locking compiles on every supported interpreter
-   while only the free-threaded build pays for a real lock. */
+   while only the free-threaded build pays for a real lock. PyPy's cpyext defines
+   neither, and takes the same no-op for the same reason: it holds the GIL. */
 #ifndef Py_BEGIN_CRITICAL_SECTION
 #define Py_BEGIN_CRITICAL_SECTION(op) {
 #define Py_END_CRITICAL_SECTION() }

--- a/src/turbohtml/_c/tokenizer/rewrite.c
+++ b/src/turbohtml/_c/tokenizer/rewrite.c
@@ -902,7 +902,7 @@ static PyType_Slot rw_handle_slots[] = {
     {Py_tp_dealloc, rw_handle_dealloc},
     {Py_tp_methods, rw_handle_methods},
     {Py_tp_getset, rw_handle_getset},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 static PyType_Spec rw_handle_spec = {

--- a/src/turbohtml/_c/tokenizer/rewrite.c
+++ b/src/turbohtml/_c/tokenizer/rewrite.c
@@ -788,9 +788,9 @@ static PyObject *rw_text_get(rw_handle *self, void *Py_UNUSED(closure)) {
            filled buffer; realize it from the tokenizer's input storage */
         int kind;
         const char *base = th_tok_input_data(self->ctx->sm, &kind);
-        return PyUnicode_FromKindAndData(kind, base + self->token->src_start * kind, self->token->src_len);
+        return th_str_from_kind(kind, base + self->token->src_start * kind, self->token->src_len);
     }
-    return PyUnicode_FromKindAndData(self->token->text.kind, self->token->text.data, self->token->text.len);
+    return th_str_from_kind(self->token->text.kind, self->token->text.data, self->token->text.len);
 }
 
 static PyObject *rw_set_text(rw_handle *self, PyObject *value) {
@@ -817,7 +817,7 @@ static PyObject *rw_doctype_name_get(rw_handle *self, void *Py_UNUSED(closure)) 
     if (self->token->name.len == 0) {
         Py_RETURN_NONE;
     }
-    return PyUnicode_FromKindAndData(self->token->name.kind, self->token->name.data, self->token->name.len);
+    return th_str_from_kind(self->token->name.kind, self->token->name.data, self->token->name.len);
 }
 
 static PyObject *rw_doctype_public_get(rw_handle *self, void *Py_UNUSED(closure)) {
@@ -827,8 +827,7 @@ static PyObject *rw_doctype_public_get(rw_handle *self, void *Py_UNUSED(closure)
     if (!self->token->has_public_id) {
         Py_RETURN_NONE;
     }
-    return PyUnicode_FromKindAndData(self->token->public_id.kind, self->token->public_id.data,
-                                     self->token->public_id.len);
+    return th_str_from_kind(self->token->public_id.kind, self->token->public_id.data, self->token->public_id.len);
 }
 
 static PyObject *rw_doctype_system_get(rw_handle *self, void *Py_UNUSED(closure)) {
@@ -838,8 +837,7 @@ static PyObject *rw_doctype_system_get(rw_handle *self, void *Py_UNUSED(closure)
     if (!self->token->has_system_id) {
         Py_RETURN_NONE;
     }
-    return PyUnicode_FromKindAndData(self->token->system_id.kind, self->token->system_id.data,
-                                     self->token->system_id.len);
+    return th_str_from_kind(self->token->system_id.kind, self->token->system_id.data, self->token->system_id.len);
 }
 
 static PyObject *rw_kind_get(rw_handle *self, void *Py_UNUSED(closure)) {

--- a/src/turbohtml/_c/tokenizer/rewrite.c
+++ b/src/turbohtml/_c/tokenizer/rewrite.c
@@ -902,13 +902,13 @@ static PyType_Slot rw_handle_slots[] = {
     {Py_tp_dealloc, rw_handle_dealloc},
     {Py_tp_methods, rw_handle_methods},
     {Py_tp_getset, rw_handle_getset},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 static PyType_Spec rw_handle_spec = {
     .name = "turbohtml._html._RewriteHandle",
     .basicsize = sizeof(rw_handle),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = rw_handle_slots,
 };
 

--- a/src/turbohtml/_c/tokenizer/sax.c
+++ b/src/turbohtml/_c/tokenizer/sax.c
@@ -237,13 +237,13 @@ static PyType_Slot sax_iter_slots[] = {
     {Py_tp_clear, sax_clear},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, sax_iter_next},
-    {0, NULL},
+    TH_SEALED_NEW{0, NULL},
 };
 
 static PyType_Spec sax_iter_spec = {
     .name = "turbohtml._html._SaxEvents",
     .basicsize = sizeof(SaxEventsObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | TH_SEALED,
     .slots = sax_iter_slots,
 };
 

--- a/src/turbohtml/_c/tokenizer/sax.c
+++ b/src/turbohtml/_c/tokenizer/sax.c
@@ -237,7 +237,7 @@ static PyType_Slot sax_iter_slots[] = {
     {Py_tp_clear, sax_clear},
     {Py_tp_iter, PyObject_SelfIter},
     {Py_tp_iternext, sax_iter_next},
-    TH_SEALED_NEW{0, NULL},
+    TH_SEALED_END,
 };
 
 static PyType_Spec sax_iter_spec = {

--- a/src/turbohtml/_c/tokenizer/token.c
+++ b/src/turbohtml/_c/tokenizer/token.c
@@ -31,7 +31,7 @@ static PyObject *buf_to_str(const th_buf *buf) {
     if (buf->len == 0) {
         return PyUnicode_New(0, 0);
     }
-    return PyUnicode_FromKindAndData(buf->kind, buf->data, buf->len);
+    return th_str_from_kind(buf->kind, buf->data, buf->len);
 }
 
 /* Copy src into dst with every buffer packed into one arena allocation, so a
@@ -104,7 +104,7 @@ PyObject *token_from_record(module_state *state, const th_tokenizer *sm, PyObjec
             /* the machine owns the storage and a later feed may move it */
             int kind;
             const char *data = th_tok_input_data(sm, &kind);
-            self->data_str = PyUnicode_FromKindAndData(kind, data + record->src_start * kind, record->src_len);
+            self->data_str = th_str_from_kind(kind, data + record->src_start * kind, record->src_len);
             if (self->data_str == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
                 Py_DECREF(self);          /* GCOVR_EXCL_LINE: allocation-failure path */
                 return NULL;              /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -137,7 +137,7 @@ PyObject *token_from_record(module_state *state, const th_tokenizer *sm, PyObjec
                so resolve the span now while it is still valid */
             int kind;
             const char *data = th_tok_input_data(sm, &kind);
-            self->src_str = PyUnicode_FromKindAndData(kind, data + record->src_off * kind, record->src_span);
+            self->src_str = th_str_from_kind(kind, data + record->src_off * kind, record->src_span);
             if (self->src_str == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
                 Py_DECREF(self);         /* GCOVR_EXCL_LINE: allocation-failure path */
                 return NULL;             /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -372,7 +372,7 @@ static PyObject *token_repr(PyObject *self) {
         if (name == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
         }
-        PyObject *repr = PyUnicode_FromFormat("Token(%s, tag=%R)", kind, name);
+        PyObject *repr = th_str_format("Token(%s, tag=%R)", kind, name);
         Py_DECREF(name);
         return repr;
     }
@@ -381,7 +381,7 @@ static PyObject *token_repr(PyObject *self) {
         if (name == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
         }
-        PyObject *repr = PyUnicode_FromFormat("Token(DOCTYPE, name=%R)", name);
+        PyObject *repr = th_str_format("Token(DOCTYPE, name=%R)", name);
         Py_DECREF(name);
         return repr;
     }
@@ -389,7 +389,7 @@ static PyObject *token_repr(PyObject *self) {
     if (data == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    PyObject *repr = PyUnicode_FromFormat("Token(%s, data=%R)", kind, data);
+    PyObject *repr = th_str_format("Token(%s, data=%R)", kind, data);
     Py_DECREF(data);
     return repr;
 }

--- a/src/turbohtml/_c/tokenizer/token.c
+++ b/src/turbohtml/_c/tokenizer/token.c
@@ -406,7 +406,7 @@ PyDoc_STRVAR(token_doc, "An HTML token produced by Tokenizer or tokenize(). Immu
    collector: no tracking on creation, nothing to traverse on collection. */
 static PyType_Slot token_slots[] = {
     {Py_tp_doc, (void *)token_doc}, {Py_tp_dealloc, token_dealloc}, {Py_tp_repr, token_repr},
-    {Py_tp_getset, token_getset},   {Py_tp_methods, token_methods}, TH_SEALED_NEW{0, NULL},
+    {Py_tp_getset, token_getset},   {Py_tp_methods, token_methods}, TH_SEALED_END,
 };
 
 static PyType_Spec token_spec = {

--- a/src/turbohtml/_c/tokenizer/token.c
+++ b/src/turbohtml/_c/tokenizer/token.c
@@ -406,13 +406,13 @@ PyDoc_STRVAR(token_doc, "An HTML token produced by Tokenizer or tokenize(). Immu
    collector: no tracking on creation, nothing to traverse on collection. */
 static PyType_Slot token_slots[] = {
     {Py_tp_doc, (void *)token_doc}, {Py_tp_dealloc, token_dealloc}, {Py_tp_repr, token_repr},
-    {Py_tp_getset, token_getset},   {Py_tp_methods, token_methods}, {0, NULL},
+    {Py_tp_getset, token_getset},   {Py_tp_methods, token_methods}, TH_SEALED_NEW{0, NULL},
 };
 
 static PyType_Spec token_spec = {
     .name = "turbohtml._html.Token",
     .basicsize = sizeof(TokenObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | TH_SEALED,
     .slots = token_slots,
 };
 

--- a/src/turbohtml/_c/tokenizer/tokenizer.c
+++ b/src/turbohtml/_c/tokenizer/tokenizer.c
@@ -342,28 +342,28 @@ static PyObject *record_as_test_tuple(const th_tokenizer *sm, const th_token *re
     if (record->is_slice) {
         int kind;
         const char *data = th_tok_input_data(sm, &kind);
-        PyObject *text = PyUnicode_FromKindAndData(kind, data + record->src_start * kind, record->src_len);
+        PyObject *text = th_str_from_kind(kind, data + record->src_start * kind, record->src_len);
         if (text == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
         }
         return Py_BuildValue("(sN)", "Character", text);
     }
     if (record->kind == TH_TEXT || record->kind == TH_COMMENT) {
-        PyObject *data = PyUnicode_FromKindAndData(record->text.kind, record->text.data, record->text.len);
+        PyObject *data = th_str_from_kind(record->text.kind, record->text.data, record->text.len);
         if (data == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
         }
         return Py_BuildValue("(sN)", record->kind == TH_TEXT ? "Character" : "Comment", data);
     }
     if (record->kind == TH_END_TAG) {
-        PyObject *name = PyUnicode_FromKindAndData(record->name.kind, record->name.data, record->name.len);
+        PyObject *name = th_str_from_kind(record->name.kind, record->name.data, record->name.len);
         if (name == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
         }
         return Py_BuildValue("(sN)", "EndTag", name);
     }
     if (record->kind == TH_START_TAG) {
-        PyObject *name = PyUnicode_FromKindAndData(record->name.kind, record->name.data, record->name.len);
+        PyObject *name = th_str_from_kind(record->name.kind, record->name.data, record->name.len);
         PyObject *attrs = PyDict_New();
         if (name == NULL || attrs == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             Py_XDECREF(name);                /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -372,14 +372,14 @@ static PyObject *record_as_test_tuple(const th_tokenizer *sm, const th_token *re
         }
         for (Py_ssize_t index = 0; index < record->attr_count; index++) {
             const th_attr *attr = &record->attrs[index];
-            PyObject *key = PyUnicode_FromKindAndData(attr->name.kind, attr->name.data, attr->name.len);
+            PyObject *key = th_str_from_kind(attr->name.kind, attr->name.data, attr->name.len);
             if (key == NULL) {    /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
                 Py_DECREF(name);  /* GCOVR_EXCL_LINE: allocation-failure path */
                 Py_DECREF(attrs); /* GCOVR_EXCL_LINE: allocation-failure path */
                 return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
             }
             /* the tokenizer already dropped duplicate attribute names, so each key is unique */
-            PyObject *value = PyUnicode_FromKindAndData(attr->value.kind, attr->value.data, attr->value.len);
+            PyObject *value = th_str_from_kind(attr->value.kind, attr->value.data, attr->value.len);
             /* allocation failure cannot be forced from a test */
             if (value == NULL || PyDict_SetItem(attrs, key, value) < 0) { /* GCOVR_EXCL_BR_LINE */
                 Py_XDECREF(value);                                        /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -397,17 +397,14 @@ static PyObject *record_as_test_tuple(const th_tokenizer *sm, const th_token *re
         return Py_BuildValue("(sNN)", "StartTag", name, attrs);
     }
     /* DOCTYPE */
-    PyObject *name = record->name.len
-                         ? PyUnicode_FromKindAndData(record->name.kind, record->name.data, record->name.len)
-                         : Py_NewRef(Py_None);
-    PyObject *public_id =
-        record->has_public_id
-            ? PyUnicode_FromKindAndData(record->public_id.kind, record->public_id.data, record->public_id.len)
-            : Py_NewRef(Py_None);
-    PyObject *system_id =
-        record->has_system_id
-            ? PyUnicode_FromKindAndData(record->system_id.kind, record->system_id.data, record->system_id.len)
-            : Py_NewRef(Py_None);
+    PyObject *name = record->name.len ? th_str_from_kind(record->name.kind, record->name.data, record->name.len)
+                                      : Py_NewRef(Py_None);
+    PyObject *public_id = record->has_public_id
+                              ? th_str_from_kind(record->public_id.kind, record->public_id.data, record->public_id.len)
+                              : Py_NewRef(Py_None);
+    PyObject *system_id = record->has_system_id
+                              ? th_str_from_kind(record->system_id.kind, record->system_id.data, record->system_id.len)
+                              : Py_NewRef(Py_None);
     /* allocation failure cannot be forced from a test */
     if (name == NULL || public_id == NULL || system_id == NULL) { /* GCOVR_EXCL_BR_LINE */
         Py_XDECREF(name);                                         /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/src/turbohtml/_c/tokenizer/tokenizer.c
+++ b/src/turbohtml/_c/tokenizer/tokenizer.c
@@ -125,19 +125,15 @@ static PyObject *iter_next(PyObject *self) {
 PyDoc_STRVAR(iter_doc, "Iterator over the tokens a Tokenizer has buffered. Yields Token objects.");
 
 static PyType_Slot iter_slots[] = {
-    {Py_tp_doc, (void *)iter_doc},
-    {Py_tp_dealloc, iter_dealloc},
-    {Py_tp_traverse, iter_traverse},
-    {Py_tp_clear, iter_clear},
-    {Py_tp_iter, PyObject_SelfIter},
-    {Py_tp_iternext, iter_next},
-    {0, NULL},
+    {Py_tp_doc, (void *)iter_doc}, {Py_tp_dealloc, iter_dealloc},   {Py_tp_traverse, iter_traverse},
+    {Py_tp_clear, iter_clear},     {Py_tp_iter, PyObject_SelfIter}, {Py_tp_iternext, iter_next},
+    TH_SEALED_NEW{0, NULL},
 };
 
 static PyType_Spec iter_spec = {
     .name = "turbohtml._html._TokenIterator",
     .basicsize = sizeof(IterObject),
-    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_DISALLOW_INSTANTIATION,
+    .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC | TH_SEALED,
     .slots = iter_slots,
 };
 

--- a/src/turbohtml/_c/tokenizer/tokenizer.c
+++ b/src/turbohtml/_c/tokenizer/tokenizer.c
@@ -125,9 +125,13 @@ static PyObject *iter_next(PyObject *self) {
 PyDoc_STRVAR(iter_doc, "Iterator over the tokens a Tokenizer has buffered. Yields Token objects.");
 
 static PyType_Slot iter_slots[] = {
-    {Py_tp_doc, (void *)iter_doc}, {Py_tp_dealloc, iter_dealloc},   {Py_tp_traverse, iter_traverse},
-    {Py_tp_clear, iter_clear},     {Py_tp_iter, PyObject_SelfIter}, {Py_tp_iternext, iter_next},
-    TH_SEALED_NEW{0, NULL},
+    {Py_tp_doc, (void *)iter_doc},
+    {Py_tp_dealloc, iter_dealloc},
+    {Py_tp_traverse, iter_traverse},
+    {Py_tp_clear, iter_clear},
+    {Py_tp_iter, PyObject_SelfIter},
+    {Py_tp_iternext, iter_next},
+    TH_SEALED_END,
 };
 
 static PyType_Spec iter_spec = {

--- a/src/turbohtml/_c/unicode/normalize.c
+++ b/src/turbohtml/_c/unicode/normalize.c
@@ -255,7 +255,7 @@ static PyObject *build_result(const Py_UCS4 *buf, Py_ssize_t len) {
             maxchar = buf[index];
         }
     }
-    PyObject *result = PyUnicode_New(len, maxchar);
+    PyObject *result = PyUnicode_New(len, th_str_maxchar(maxchar));
     if (result == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }

--- a/src/turbohtml/_c/validate/conformance.c
+++ b/src/turbohtml/_c/validate/conformance.c
@@ -316,7 +316,7 @@ static void report(confctx *ctx, th_node *node, const char *code, const char *se
     }
     va_list args;
     va_start(args, fmt);
-    PyObject *message = PyUnicode_FromFormatV(fmt, args);
+    PyObject *message = th_str_format_v(fmt, args);
     va_end(args);
     Py_ssize_t line = 0, col = 0;
     th_node_source_position(ctx->tree, node, &line, &col);

--- a/src/turbohtml/_c/validate/schema.c
+++ b/src/turbohtml/_c/validate/schema.c
@@ -300,7 +300,7 @@ static void report(valctx *ctx, th_node *node, const char *type, const char *fmt
     }
     va_list args;
     va_start(args, fmt);
-    PyObject *message = PyUnicode_FromFormatV(fmt, args);
+    PyObject *message = th_str_format_v(fmt, args);
     va_end(args);
     Py_ssize_t line = 0, col = 0;
     if (node != NULL) { /* GCOVR_EXCL_BR_LINE: every report call site passes a real node */

--- a/tests/core/test_c_api_portability.py
+++ b/tests/core/test_c_api_portability.py
@@ -1,14 +1,17 @@
-"""Guard the C-API calls whose contract differs between CPython and PyPy's cpyext.
+"""Guard the C-API spellings whose meaning differs between CPython and PyPy's cpyext.
 
-``core/pycompat.h`` wraps each of them behind a ``th_`` spelling that is an identity macro on
-CPython and an adaptation on PyPy. The wrappers only help where they are used, and a direct call to
-the wrapped name compiles and passes every CPython test while being silently wrong on PyPy -- a
-dropped BOM, a byte-swapped string, a one-past length, or an aborted interpreter. Nothing in the
-compiler catches that, so pin it here: the C sources may name each wrapped symbol only inside
-``pycompat.h`` itself, and must reach it through the wrapper everywhere else.
+``core/pycompat.h`` wraps each of them behind a ``th_`` or ``TH_`` name that is an identity macro on
+CPython and an adaptation on PyPy. The wrappers only help where they are used, and reaching for the
+wrapped spelling directly compiles and passes every CPython test while being silently wrong on PyPy:
+a dropped BOM, a byte-swapped string, a one-past length, or a type that constructs without a tree and
+segfaults on first use. Nothing in the compiler catches that, so pin it here. The C sources may name
+each wrapped spelling only inside ``pycompat.h`` itself, and must reach it through the wrapper
+everywhere else.
 
 ``PyUnicode_FromKindAndData`` is exempt when its kind argument is the ``PyUnicode_4BYTE_KIND``
 literal: cpyext's 4-byte path is exact, and the wrapper exists only to widen a 2-byte buffer.
+
+Upstream: https://github.com/pypy/pypy/issues/5524 and https://github.com/pypy/pypy/issues/5525.
 """
 
 from __future__ import annotations
@@ -21,8 +24,9 @@ import pytest
 _C_ROOT = Path(__file__).parents[2] / "src" / "turbohtml" / "_c"
 _COMPAT_HEADER = _C_ROOT / "core" / "pycompat.h"
 
-# the wrapper each wrapped CPython symbol must be reached through, and the pattern finding a direct call
+# the wrapper each guarded spelling must be reached through, and the pattern finding a direct use
 _WRAPPERS = {
+    "TH_SEALED": re.compile(r"\bPy_TPFLAGS_DISALLOW_INSTANTIATION\b"),
     "th_copy_characters": re.compile(r"\bPyUnicode_CopyCharacters\s*\("),
     "th_str_format": re.compile(r"\bPyUnicode_FromFormatV?\s*\("),
     # the 4-byte literal is the one safe kind, so it stays a direct call
@@ -40,7 +44,7 @@ def test_the_c_sources_are_discovered() -> None:
 
 
 @pytest.mark.parametrize("wrapper", sorted(_WRAPPERS), ids=sorted(_WRAPPERS))
-def test_no_direct_call_outside_the_compat_header(wrapper: str) -> None:
+def test_no_direct_use_outside_the_compat_header(wrapper: str) -> None:
     pattern = _WRAPPERS[wrapper]
     offenders = [
         f"{path.relative_to(_C_ROOT)}:{number}"
@@ -48,11 +52,11 @@ def test_no_direct_call_outside_the_compat_header(wrapper: str) -> None:
         for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1)
         if pattern.search(line)
     ]
-    assert offenders == [], f"reach {wrapper} instead of the wrapped call at: {', '.join(offenders)}"
+    assert offenders == [], f"reach {wrapper} instead of the wrapped spelling at: {', '.join(offenders)}"
 
 
 @pytest.mark.parametrize("wrapper", sorted(_WRAPPERS), ids=sorted(_WRAPPERS))
 def test_the_wrapper_is_defined_and_used(wrapper: str) -> None:
     # deleting a wrapper together with its call sites would satisfy the guard above on its own
     assert re.search(rf"^#define {wrapper}\b", _COMPAT_HEADER.read_text(encoding="utf-8"), re.MULTILINE)
-    assert any(re.search(rf"\b{wrapper}\s*\(", path.read_text(encoding="utf-8")) for path in _sources())
+    assert any(re.search(rf"\b{wrapper}\b", path.read_text(encoding="utf-8")) for path in _sources())

--- a/tests/core/test_c_api_portability.py
+++ b/tests/core/test_c_api_portability.py
@@ -1,0 +1,58 @@
+"""Guard the C-API calls whose contract differs between CPython and PyPy's cpyext.
+
+``core/pycompat.h`` wraps each of them behind a ``th_`` spelling that is an identity macro on
+CPython and an adaptation on PyPy. The wrappers only help where they are used, and a direct call to
+the wrapped name compiles and passes every CPython test while being silently wrong on PyPy -- a
+dropped BOM, a byte-swapped string, a one-past length, or an aborted interpreter. Nothing in the
+compiler catches that, so pin it here: the C sources may name each wrapped symbol only inside
+``pycompat.h`` itself, and must reach it through the wrapper everywhere else.
+
+``PyUnicode_FromKindAndData`` is exempt when its kind argument is the ``PyUnicode_4BYTE_KIND``
+literal: cpyext's 4-byte path is exact, and the wrapper exists only to widen a 2-byte buffer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_C_ROOT = Path(__file__).parents[2] / "src" / "turbohtml" / "_c"
+_COMPAT_HEADER = _C_ROOT / "core" / "pycompat.h"
+
+# the wrapper each wrapped CPython symbol must be reached through, and the pattern finding a direct call
+_WRAPPERS = {
+    "th_copy_characters": re.compile(r"\bPyUnicode_CopyCharacters\s*\("),
+    "th_str_format": re.compile(r"\bPyUnicode_FromFormatV?\s*\("),
+    # the 4-byte literal is the one safe kind, so it stays a direct call
+    "th_str_from_kind": re.compile(r"\bPyUnicode_FromKindAndData\s*\((?!PyUnicode_4BYTE_KIND)"),
+}
+
+
+def _sources() -> list[Path]:
+    return sorted(path for path in _C_ROOT.rglob("*") if path.suffix in {".c", ".h"} and path != _COMPAT_HEADER)
+
+
+def test_the_c_sources_are_discovered() -> None:
+    # a broken glob would make every guard below vacuously pass
+    assert len(_sources()) > 50
+
+
+@pytest.mark.parametrize("wrapper", sorted(_WRAPPERS), ids=sorted(_WRAPPERS))
+def test_no_direct_call_outside_the_compat_header(wrapper: str) -> None:
+    pattern = _WRAPPERS[wrapper]
+    offenders = [
+        f"{path.relative_to(_C_ROOT)}:{number}"
+        for path in _sources()
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1)
+        if pattern.search(line)
+    ]
+    assert offenders == [], f"reach {wrapper} instead of the wrapped call at: {', '.join(offenders)}"
+
+
+@pytest.mark.parametrize("wrapper", sorted(_WRAPPERS), ids=sorted(_WRAPPERS))
+def test_the_wrapper_is_defined_and_used(wrapper: str) -> None:
+    # deleting a wrapper together with its call sites would satisfy the guard above on its own
+    assert re.search(rf"^#define {wrapper}\b", _COMPAT_HEADER.read_text(encoding="utf-8"), re.MULTILINE)
+    assert any(re.search(rf"\b{wrapper}\s*\(", path.read_text(encoding="utf-8")) for path in _sources())

--- a/tests/dom/test_tree_navigation.py
+++ b/tests/dom/test_tree_navigation.py
@@ -98,6 +98,12 @@ def test_index_out_of_range(body: Element) -> None:
         _ = body[0][5]
 
 
+def test_negative_index_out_of_range(body: Element) -> None:
+    # a negative subscript past the start is out of range, as it is for a list, rather than the first child
+    with pytest.raises(IndexError):
+        _ = body[0][-3]
+
+
 def test_iteration_yields_children(body: Element) -> None:
     paragraph = body[0]
     assert list(paragraph) == list(paragraph.children)

--- a/tests/migration/test_markupsafe.py
+++ b/tests/migration/test_markupsafe.py
@@ -313,8 +313,8 @@ def test_justify_keeps_markup(op: Callable[[Markup], Markup], expected: str) -> 
 )
 def test_justify_escapes_fill_then_str_rejects_it(op: Callable[[Markup], Markup]) -> None:
     # The fill character is escaped for safety, so a special expands past one character and str rejects it; this
-    # matches markupsafe's behavior.
-    with pytest.raises(TypeError, match="fill character"):
+    # matches markupsafe's behavior. CPython and PyPy word the same TypeError differently.
+    with pytest.raises(TypeError, match=r"fill character|single character"):
         op(Markup("ab"))
 
 

--- a/tests/query/xpath/test_xpath_compiled.py
+++ b/tests/query/xpath/test_xpath_compiled.py
@@ -10,8 +10,11 @@ garbage collection. The evaluation-semantics tests live in ``test_xpath_eval.py`
 from __future__ import annotations
 
 import gc
+import sys
 import threading
 from typing import TYPE_CHECKING
+
+import pytest
 
 import turbohtml
 from turbohtml import Element, XPath
@@ -66,6 +69,7 @@ def test_concurrent_evaluation_on_one_document_is_memory_safe() -> None:
     assert counts == [100] * 200
 
 
+@pytest.mark.skipif(sys.implementation.name == "pypy", reason="PyPy's gc exposes no is_tracked")
 def test_object_is_gc_tracked() -> None:
     selector = XPath("//a")
     assert gc.is_tracked(selector)
@@ -84,6 +88,11 @@ def test_collect_with_live_objects_traverses_them() -> None:
     assert with_extensions(doc) == "x"
 
 
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy",
+    reason="cpyext never breaks a cycle that runs through both a C extension object and a Python one, "
+    "so this cycle leaks there; see docs/explanation/interpreters.rst",
+)
 def test_extension_reference_cycle_is_collected() -> None:
     class Holder:
         ref: XPath | None = None

--- a/tests/test_stub_signature_parity.py
+++ b/tests/test_stub_signature_parity.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -206,5 +207,15 @@ def test_runtime_signature_skips_a_signature_inspect_cannot_build(mocker: Mocker
 
 def test_the_parity_check_covers_the_public_surface() -> None:
     # a stub-parsing regression that silently dropped entries would drop these simple, every-version signatures too
-    assert {"parse", "escape", "Minify", "Document.opengraph"} <= set(_COMPARABLE)
+    assert {"parse", "escape", "Document.opengraph"} <= set(_COMPARABLE)
     assert len(_COMPARABLE) > 40
+
+
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy",
+    reason="PyPy's inspect builds no signature from a heap type's __text_signature__, so _runtime_signature "
+    "drops every C type and there is nothing to compare its stub against",
+)
+def test_the_parity_check_covers_a_c_type() -> None:
+    # the C types reach _COMPARABLE by a different runtime path than the functions above
+    assert "Minify" in _COMPARABLE

--- a/tests/test_stub_signature_parity.py
+++ b/tests/test_stub_signature_parity.py
@@ -205,17 +205,13 @@ def test_runtime_signature_skips_a_signature_inspect_cannot_build(mocker: Mocker
     assert _runtime_signature(html.parse) is None
 
 
-def test_the_parity_check_covers_the_public_surface() -> None:
-    # a stub-parsing regression that silently dropped entries would drop these simple, every-version signatures too
-    assert {"parse", "escape", "Document.opengraph"} <= set(_COMPARABLE)
-    assert len(_COMPARABLE) > 40
-
-
 @pytest.mark.skipif(
     sys.implementation.name == "pypy",
-    reason="PyPy's inspect builds no signature from a heap type's __text_signature__, so _runtime_signature "
-    "drops every C type and there is nothing to compare its stub against",
+    reason="how much of __text_signature__ cpyext exposes varies by PyPy release: 7.3.23 answers for a heap type's "
+    "methods where 7.3.19 answers only for module functions, so _COMPARABLE holds 120 entries on one and 8 on the "
+    "other. The stub parser this guards is exercised on the CPython matrix",
 )
-def test_the_parity_check_covers_a_c_type() -> None:
-    # the C types reach _COMPARABLE by a different runtime path than the functions above
-    assert "Minify" in _COMPARABLE
+def test_the_parity_check_covers_the_public_surface() -> None:
+    # a stub-parsing regression that silently dropped entries would drop these simple, every-version signatures too
+    assert {"parse", "escape", "Minify", "Document.opengraph"} <= set(_COMPARABLE)
+    assert len(_COMPARABLE) > 40

--- a/tests/tokenizer/test_saxparse.py
+++ b/tests/tokenizer/test_saxparse.py
@@ -11,6 +11,7 @@ documents.
 from __future__ import annotations
 
 import gc
+import sys
 import weakref
 from types import GeneratorType
 from typing import cast
@@ -223,6 +224,11 @@ def test_iter_events_is_lazy() -> None:
     assert isinstance(next(events), StartElement)
 
 
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy",
+    reason="cpyext never breaks a cycle that runs through both a C extension object and a Python one, "
+    "so this cycle leaks there; see docs/explanation/interpreters.rst",
+)
 def test_gc_reclaims_a_reference_cycle_through_the_source() -> None:
     class _Cyclic(str):  # noqa: FURB189  # a real str subclass: _sax_events requires str, and the slots let it cycle
         __slots__ = ("loop", "sentinel")

--- a/tests/tokenizer/test_tokenizer.py
+++ b/tests/tokenizer/test_tokenizer.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import gc
 import threading
-import tracemalloc
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING
 
@@ -576,6 +575,9 @@ def test_tag_names_are_lowercased() -> None:
 def test_streaming_tokenizer_reclaims_consumed_input() -> None:
     # feed() compacts the consumed prefix, so a long-lived streaming tokenizer stays memory
     # bounded instead of growing its input buffer with every chunk (issue #80).
+    # PyPy ships no _tracemalloc, and its GC frees the buffer on its own schedule, so there is
+    # no peak to assert there; the compaction itself is C and covered by the CPython run.
+    tracemalloc = pytest.importorskip("tracemalloc")
     tokenizer = Tokenizer()
     for _ in range(200):  # warm up so one-time allocations settle out of the measurement
         list(tokenizer.feed("<p>hello world</p>"))

--- a/tests/validate/test_edge_cases.py
+++ b/tests/validate/test_edge_cases.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from turbohtml import parse_xml
@@ -995,6 +997,11 @@ def test_rng_data_param_without_name() -> None:
     assert rng_ok(schema, "<e>hello</e>")
 
 
+@pytest.mark.skipif(
+    sys.implementation.name == "pypy",
+    reason="RPython's own stack check trips on the C validator's recursion before its depth cap can "
+    "report, raising SystemError instead; the recursion stays bounded either way",
+)
 def test_xsd_deep_nesting_is_bounded() -> None:
     schema = XMLSchema(
         f'<xs:schema {XS}><xs:element name="a"><xs:complexType><xs:sequence>'

--- a/tools/bench/__main__.py
+++ b/tools/bench/__main__.py
@@ -1,7 +1,8 @@
 """
 CLI entry point: ``python -m bench [--pgo] <command>``.
 
-Commands: ``core`` (turbohtml baseline for every operation), ``all`` (every operation table), an operation name
+Commands: ``core`` (turbohtml baseline for every operation), ``all`` (every operation table), ``interpreters`` (the
+same turbohtml under each interpreter it supports, written straight to its docs feed), an operation name
 (cross-package table), or a package name (that package's own report). Anything after the command is forwarded verbatim
 to pyperf in every worker (e.g. ``--rigorous``, ``--affinity=2``). ``--pgo``, before the command so pyperf never sees
 it, builds the turbohtml ``core`` baseline with the shipped release recipe -- the two-phase profile-guided,
@@ -30,7 +31,10 @@ def main() -> None:
     if pgo:
         arguments.remove("--pgo")
     if not arguments:
-        msg = "usage: python -m bench [--table-json DIR] [--pgo] <core|all|operation|package> [pyperf options...]"
+        msg = (
+            "usage: python -m bench [--table-json DIR] [--pgo] <core|all|interpreters|operation|package> "
+            "[pyperf options...]"
+        )
         raise SystemExit(msg)
     orchestrator.run(arguments[0], tuple(arguments[1:]), pgo=pgo)
 

--- a/tools/bench/corpus.py
+++ b/tools/bench/corpus.py
@@ -13,8 +13,6 @@ import html
 import random
 from pathlib import Path
 
-from httpfetch import fetch_bytes
-
 _TOOLS = Path(__file__).resolve().parent.parent
 
 CORPUS_DIR = _TOOLS / "html5lib-python" / "benchmarks" / "data"
@@ -94,11 +92,25 @@ STYLESHEETS: tuple[tuple[str, str, str], ...] = (
 
 def large_text(filename: str, url: str) -> str:
     """Return a multi-megabyte document, downloading and caching it on first use."""
+    return _cached(filename, url).read_text(encoding="utf-8")
+
+
+def _cached(filename: str, url: str) -> Path:
+    """
+    Return the cache path for a downloaded corpus, fetching it on a miss.
+
+    httpfetch pulls in httpx2, which a worker venv holds no reason to install: it carries pyperf, turbohtml, and at
+    most one competitor. So this module imports under the standard library alone, as its docstring promises, and the
+    import that needs the network sits at the miss. :func:`prefetch` fills the cache from the orchestrator, which does
+    have httpx2, before any worker starts, so a worker only ever hits.
+    """
     target = _LARGE_DIR / filename
     if not target.exists():
         target.parent.mkdir(parents=True, exist_ok=True)
+        from httpfetch import fetch_bytes  # noqa: PLC0415  # see the docstring above
+
         target.write_bytes(fetch_bytes(url))
-    return target.read_text(encoding="utf-8")
+    return target
 
 
 _DATA_DIR = _TOOLS / "bench-data"
@@ -212,3 +224,10 @@ def unescape_cases() -> tuple[tuple[str, str], ...]:
         ("dense refs (4 MiB)", _tile(_references_of(rng, _ASCII_WORDS, 1, _CHUNK, _REFERENCES), LARGE)),
         ("UCS-2 refs (4 MiB)", _tile(_references_of(rng, _UCS2_WORDS, 10, _CHUNK, _REFERENCES), LARGE)),
     )
+
+
+def prefetch() -> None:
+    """Download every cached corpus that is missing, so the worker venvs only ever read from the cache."""
+    for table in (LARGE_FILES, REAL_PAGES, STYLESHEETS, JS_FILES):
+        for _name, filename, url in table:
+            _cached(filename, url)

--- a/tools/bench/interpreters.py
+++ b/tools/bench/interpreters.py
@@ -1,0 +1,88 @@
+"""
+Pivot the benchmark matrix by interpreter: the same turbohtml, the same corpus, one column per interpreter.
+
+Where the per-operation tables slice the matrix by operation with every competitor as a column, this slices it by the
+interpreter underneath. cpyext charges PyPy a boundary crossing per object, so an operation that crosses once and then
+works inside C amortizes that cost over a whole document, while one that crosses per node pays it per node. Only a
+measurement separates the two, and ``docs/explanation/interpreters.rst`` renders this feed rather than quoting figures
+that go stale the next time the C core moves.
+
+Run it with ``tox -e bench -- interpreters``, optionally with pyperf options (``--fast`` while iterating,
+``--rigorous`` for the committed feed). It provisions one turbohtml-only venv per interpreter, builds the working tree
+in each, and writes ``docs/explanation/bench/interpreters.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from bench import operations, orchestrator
+from bench.report import rst_safe
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_FEED: Final[Path] = Path(__file__).resolve().parents[2] / "docs" / "explanation" / "bench" / "interpreters.json"
+
+# Each label carries "turbohtml" so the bench-table directive anchors its ratios on a turbohtml column, and the first
+# entry is the baseline the others are read against. The value is the uv Python spec the venv is built on.
+INTERPRETERS: Final[tuple[tuple[str, str], ...]] = (
+    ("turbohtml on CPython 3.14", "3.14"),
+    ("turbohtml on PyPy 3.11", "pypy3.11"),
+)
+
+# One operation per shape the cpyext boundary charges for: a whole-document parse that crosses once, two string
+# transforms, two tree-to-string walks, a query that stays inside C, and a traversal that wraps every node it visits.
+OPERATIONS: Final[tuple[str, ...]] = (
+    "parse",
+    "escape",
+    "unescape",
+    "serialize",
+    "text-content",
+    "select",
+    "navigate",
+)
+
+
+def build(workdir: Path, pyperf_args: tuple[str, ...]) -> None:
+    """Measure every operation under every interpreter and write the docs feed."""
+    measured = _measure(workdir, pyperf_args)
+    _FEED.parent.mkdir(parents=True, exist_ok=True)
+    feed = {
+        "label": "operation",
+        "parties": [party for party, _ in INTERPRETERS],
+        "metrics": [],
+        "rows": list(_rows(measured)),
+    }
+    _FEED.write_text(json.dumps(feed, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"wrote {_FEED}: {len(feed['rows'])} rows")
+
+
+def _measure(workdir: Path, pyperf_args: tuple[str, ...]) -> dict[str, dict[str, dict[str, float | str]]]:
+    """Return ``{operation: {case: {party: mean seconds, or the message naming why the cell is empty}}}``."""
+    measured: dict[str, dict[str, dict[str, float | str]]] = {operation: {} for operation in OPERATIONS}
+    for party, interpreter in INTERPRETERS:
+        # the working tree, not the built wheel: a wheel carries one interpreter's ABI tag and cannot install elsewhere
+        python = orchestrator.venv_python(
+            workdir, interpreter.replace(".", "-"), (str(orchestrator.REPO_ROOT),), interpreter=interpreter
+        )
+        for operation in OPERATIONS:
+            for key, entry in orchestrator.run_worker(python, "core", operation, workdir, pyperf_args).items():
+                case = key.split("|")[1]
+                measured[operation].setdefault(case, {})[party] = entry.get(
+                    "mean", entry.get("error", "no measurement")
+                )
+    return measured
+
+
+def _rows(measured: dict[str, dict[str, dict[str, float | str]]]) -> Iterator[list[str | float | None]]:
+    """One row per operation-case; the label carries the operation title because the table spans several."""
+    for operation in OPERATIONS:
+        for case, cells in measured[operation].items():
+            label = rst_safe(f"{operations.OPERATIONS[operation].title} — {case}")
+            yield [label, *(cells.get(party) for party, _ in INTERPRETERS)]
+
+
+__all__ = ["INTERPRETERS", "OPERATIONS", "build"]

--- a/tools/bench/migration.py
+++ b/tools/bench/migration.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Final
 
 from bench import operations
+from bench.report import rst_safe
 
 _SIZE_OPS: Final = frozenset({"minify", "minify-css", "minify-js"})
 
@@ -73,11 +74,6 @@ def _case_names(operation: str, stats: dict[str, dict[str, float]]) -> list[str]
     return names
 
 
-def _rst_safe(label: str) -> str:
-    """Escape the RST inline-markup starters (an XPath case can carry ``*`` or ``|``); the directive parses labels."""
-    return label.replace("\\", "\\\\").replace("*", "\\*").replace("|", "\\|").replace("`", "\\`")
-
-
 def _rows(op_labels: dict[str, str], stats: dict[str, dict[str, float]]) -> list[list[str | float | None]]:
     """Build a library's rows across every shared operation-case; prefix the label with the op title if it spans ops."""
     prefixed = len(op_labels) > 1
@@ -89,7 +85,7 @@ def _rows(op_labels: dict[str, str], stats: dict[str, dict[str, float]]) -> list
             other = stats.get(f"{operation}|{case}|{label}")
             if turbo is None or other is None:
                 continue
-            row_label = _rst_safe(f"{meta.title} — {case}" if prefixed else case)
+            row_label = rst_safe(f"{meta.title} — {case}" if prefixed else case)
             if operation in _SIZE_OPS:
                 rows.append([row_label, turbo["size"], turbo["mean"], other["size"], other["mean"]])
             else:

--- a/tools/bench/orchestrator.py
+++ b/tools/bench/orchestrator.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import pgo_build
 import tomllib
 
-from bench import operations, report
+from bench import corpus, operations, report
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _TOOLS_DIR = Path(__file__).resolve().parents[1]
@@ -220,6 +220,7 @@ def run(command: str, pyperf_args: tuple[str, ...] = (), *, pgo: bool = False) -
         "pyperf options like --rigorous or --affinity=<cpu> after the command to control sampling and CPU pinning.",
         file=sys.stderr,
     )
+    corpus.prefetch()  # the worker venvs carry no HTTP client; fill the download cache here, where one is installed
     with tempfile.TemporaryDirectory() as tmp:
         workdir = Path(tmp)
         if command in COMPETITORS:

--- a/tools/bench/orchestrator.py
+++ b/tools/bench/orchestrator.py
@@ -22,7 +22,7 @@ import tomllib
 
 from bench import corpus, operations, report
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 _TOOLS_DIR = Path(__file__).resolve().parents[1]
 _COMPETITOR_DIR = Path(__file__).resolve().parent / "competitors"
 _COMPETITOR_TIMEOUT = 900.0  # seconds for one competitor's whole operation; past it the library is hanging, not slow
@@ -72,13 +72,22 @@ def _uv(*args: str) -> None:
 
 def _build_wheel(workdir: Path) -> Path:
     """Build the turbohtml wheel once; only the core baseline venv installs it."""
-    _uv("build", "--wheel", "--out-dir", str(workdir), str(_REPO_ROOT))
+    _uv("build", "--wheel", "--out-dir", str(workdir), str(REPO_ROOT))
     return next(workdir.glob("*.whl"))
 
 
-def _venv_python(workdir: Path, name: str, reqs: tuple[str, ...], pip_options: tuple[str, ...] = ()) -> Path:
+def venv_python(
+    workdir: Path,
+    name: str,
+    reqs: tuple[str, ...],
+    pip_options: tuple[str, ...] = (),
+    interpreter: str | None = None,
+) -> Path:
     """
     Provision an isolated venv holding pyperf and the given requirements; return its interpreter.
+
+    ``interpreter`` names the uv Python spec to build the venv on, for the interpreter comparison that runs the same
+    turbohtml under several of them; the default takes whichever Python uv resolves.
 
     Idempotent within one workdir: a target that already has its venv (a competitor appearing in several operations of
     an ``all`` sweep, or the core baseline shared across every operation) is provisioned once and reused, so the whole
@@ -88,7 +97,7 @@ def _venv_python(workdir: Path, name: str, reqs: tuple[str, ...], pip_options: t
     python = venv / ("Scripts" if os.name == "nt" else "bin") / "python"
     if python.exists():
         return python
-    _uv("venv", str(venv))
+    _uv("venv", *(("--python", interpreter) if interpreter else ()), str(venv))
     _uv("pip", "install", "--python", str(python), "pyperf>=2.10", *pip_options, *reqs)
     return python
 
@@ -103,15 +112,15 @@ def _core_python(workdir: Path, *, pgo: bool) -> Path:
     venv), leaving the baseline measured against a release-representative binary.
     """
     if not pgo:
-        return _venv_python(workdir, "core", (str(_build_wheel(workdir)),))
-    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        return venv_python(workdir, "core", (str(_build_wheel(workdir)),))
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     build_backend = tuple(pyproject["build-system"]["requires"])
-    python = _venv_python(workdir, "core", build_backend)
-    pgo_build.build(str(python), workdir / "core-pgo-build", _REPO_ROOT, "full", system=False)
+    python = venv_python(workdir, "core", build_backend)
+    pgo_build.build(str(python), workdir / "core-pgo-build", REPO_ROOT, "full", system=False)
     return python
 
 
-def _run_worker(
+def run_worker(
     python: Path, target: str, operation: str, workdir: Path, pyperf_args: tuple[str, ...]
 ) -> dict[str, dict[str, float | str]]:
     """
@@ -166,12 +175,12 @@ def _try_competitor(
     library or input cannot stall the whole sweep.
     """
     try:
-        python = _venv_python(workdir, competitor, COMPETITORS[competitor][0], COMPETITORS[competitor][2])
+        python = venv_python(workdir, competitor, COMPETITORS[competitor][0], COMPETITORS[competitor][2])
     except subprocess.CalledProcessError:
         print(f"skipping {competitor}: it did not install in its isolated venv", file=sys.stderr)
         return {}
     try:
-        return _run_worker(python, competitor, operation, workdir, pyperf_args)
+        return run_worker(python, competitor, operation, workdir, pyperf_args)
     except subprocess.TimeoutExpired:
         print(
             f"skipping {competitor}: it did not finish {operation} within {_COMPETITOR_TIMEOUT:.0f}s", file=sys.stderr
@@ -186,7 +195,7 @@ def _try_competitor(
 
 def report_operation(operation: str, pyperf_args: tuple[str, ...], *, workdir: Path, core_python: Path) -> None:
     """Render one operation: the turbohtml baseline against every competitor that implements it, each isolated."""
-    stats = _run_worker(core_python, "core", operation, workdir, pyperf_args)
+    stats = run_worker(core_python, "core", operation, workdir, pyperf_args)
     for competitor in _packages_for(operation):
         stats.update(_try_competitor(workdir, competitor, operation, pyperf_args))
     report.render(operation, stats)
@@ -195,17 +204,17 @@ def report_operation(operation: str, pyperf_args: tuple[str, ...], *, workdir: P
 def report_package(competitor: str, pyperf_args: tuple[str, ...], *, workdir: Path, core_python: Path) -> None:
     """Render one competitor's report: it against the turbohtml baseline across every operation it implements."""
     reqs, operation_names, pip_options = COMPETITORS[competitor]
-    competitor_python = _venv_python(workdir, competitor, reqs, pip_options)
+    competitor_python = venv_python(workdir, competitor, reqs, pip_options)
     for operation in operation_names:
-        stats = _run_worker(core_python, "core", operation, workdir, pyperf_args)
-        stats.update(_run_worker(competitor_python, competitor, operation, workdir, pyperf_args))
+        stats = run_worker(core_python, "core", operation, workdir, pyperf_args)
+        stats.update(run_worker(competitor_python, competitor, operation, workdir, pyperf_args))
         report.render(operation, stats)
 
 
 def report_core(pyperf_args: tuple[str, ...], *, workdir: Path, core_python: Path) -> None:
     """Render turbohtml's own baseline for every operation in a turbohtml-only venv."""
     for operation in operations.OPERATIONS:
-        report.render(operation, _run_worker(core_python, "core", operation, workdir, pyperf_args))
+        report.render(operation, run_worker(core_python, "core", operation, workdir, pyperf_args))
 
 
 def run(command: str, pyperf_args: tuple[str, ...] = (), *, pgo: bool = False) -> None:
@@ -227,6 +236,10 @@ def run(command: str, pyperf_args: tuple[str, ...] = (), *, pgo: bool = False) -
             report_package(command, pyperf_args, workdir=workdir, core_python=_core_python(workdir, pgo=pgo))
         elif command == "core":
             report_core(pyperf_args, workdir=workdir, core_python=_core_python(workdir, pgo=pgo))
+        elif command == "interpreters":
+            from bench import interpreters  # noqa: PLC0415  # imports orchestrator, so bind it once the command asks
+
+            interpreters.build(workdir, pyperf_args)
         elif command == "all":
             core_python = _core_python(workdir, pgo=pgo)
             for operation in operations.OPERATIONS:
@@ -234,6 +247,6 @@ def run(command: str, pyperf_args: tuple[str, ...] = (), *, pgo: bool = False) -
         elif command in operations.OPERATIONS:
             report_operation(command, pyperf_args, workdir=workdir, core_python=_core_python(workdir, pgo=pgo))
         else:
-            choices = ", ".join(["core", "all", *operations.OPERATIONS, *COMPETITORS])
+            choices = ", ".join(["core", "all", "interpreters", *operations.OPERATIONS, *COMPETITORS])
             msg = f"unknown command {command!r}; choose one of: {choices}"
             raise SystemExit(msg)

--- a/tools/bench/report.py
+++ b/tools/bench/report.py
@@ -123,6 +123,11 @@ def _cells(stat: _Stat | None, *, extra: str | None) -> list[float | str | None]
     return [stat[extra], stat["mean"]] if extra else [stat["mean"]]
 
 
+def rst_safe(label: str) -> str:
+    """Escape the RST inline-markup starters (an XPath case can carry ``*`` or ``|``); the directive parses labels."""
+    return label.replace("\\", "\\\\").replace("*", "\\*").replace("|", "\\|").replace("`", "\\`")
+
+
 def _emit_table_json(operation: str, stats: dict[str, _Stat], directory: Path) -> None:
     """Write one operation's raw means (plus size or peak memory) as the docs' bench-table feed DIR/<op>.json."""
     competitors = _labels(operation, stats)[1:]

--- a/tox.toml
+++ b/tox.toml
@@ -7,6 +7,7 @@ env_list = [
   "3.11",
   "3.10",
   "pypy3.11",
+  "pypy3.10",
   "3.14t",
   "3.15t",
   "docs",
@@ -442,11 +443,39 @@ commands = [
   ],
 ]
 
+[env."pypy3.10"]
+description = "run the test suite under PyPy 3.10 through cpyext"
+base_python = [ "pypy3.10" ]
+deps = []
+commands_pre = [
+  [
+    "uv",
+    "pip",
+    "install",
+    "--reinstall",
+    "--no-deps",
+    "--no-build-isolation",
+    "--editable",
+    "{tox_root}",
+    "--config-settings=build-dir={env_dir}{/}cbuild",
+  ],
+]
+commands = [
+  [
+    "pytest",
+    "--durations",
+    "10",
+    "--no-cov",
+    "--ignore={tox_root}{/}tests{/}conformance",
+    { replace = "posargs", default = [ "tests" ], extend = true },
+  ],
+]
+
 [env."pypy3.11"]
 description = "run the test suite under PyPy 3.11 through cpyext"
 base_python = [ "pypy3.11" ]
 # gcovr reaches cpyext through lxml, which publishes no PyPy wheels, and there is no gcov for a cpyext build
-# to feed it anyway. The C and Python coverage gates both run on the CPython matrix; this env proves behavior.
+# to feed it anyway. The C and Python coverage gates both run on the CPython matrix; these envs prove behavior.
 deps = []
 commands_pre = [
   [

--- a/tox.toml
+++ b/tox.toml
@@ -203,6 +203,37 @@ commands = [
   ],
 ]
 
+# tox cannot resolve a `ref` into a dotted environment name, so the shared body lives in an
+# environment with a plain one and both PyPy environments splice it in.
+[env._pypy]
+description = "shared body of the PyPy environments; not run on its own"
+# gcovr reaches cpyext through lxml, which publishes no PyPy wheels, and a cpyext build has no gcov
+# to feed it anyway. The C and Python coverage gates both run on the CPython matrix.
+deps = []
+commands_pre = [
+  [
+    "uv",
+    "pip",
+    "install",
+    "--reinstall",
+    "--no-deps",
+    "--no-build-isolation",
+    "--editable",
+    "{tox_root}",
+    "--config-settings=build-dir={env_dir}{/}cbuild",
+  ],
+]
+commands = [
+  [
+    "pytest",
+    "--durations",
+    "10",
+    "--no-cov",
+    "--ignore={tox_root}{/}tests{/}conformance",
+    { replace = "posargs", default = [ "tests" ], extend = true },
+  ],
+]
+
 [env.asan-js]
 description = "compile the JS minifier engine standalone and fuzz the corpus under ASan/UBSan (+LSan on Linux)"
 package = "skip"
@@ -446,57 +477,13 @@ commands = [
 [env."pypy3.10"]
 description = "run the test suite under PyPy 3.10 through cpyext"
 base_python = [ "pypy3.10" ]
-deps = []
-commands_pre = [
-  [
-    "uv",
-    "pip",
-    "install",
-    "--reinstall",
-    "--no-deps",
-    "--no-build-isolation",
-    "--editable",
-    "{tox_root}",
-    "--config-settings=build-dir={env_dir}{/}cbuild",
-  ],
-]
-commands = [
-  [
-    "pytest",
-    "--durations",
-    "10",
-    "--no-cov",
-    "--ignore={tox_root}{/}tests{/}conformance",
-    { replace = "posargs", default = [ "tests" ], extend = true },
-  ],
-]
+deps = { replace = "ref", of = [ "env", "_pypy", "deps" ] }
+commands_pre = [ { replace = "ref", of = [ "env", "_pypy", "commands_pre" ], extend = true } ]
+commands = [ { replace = "ref", of = [ "env", "_pypy", "commands" ], extend = true } ]
 
 [env."pypy3.11"]
 description = "run the test suite under PyPy 3.11 through cpyext"
 base_python = [ "pypy3.11" ]
-# gcovr reaches cpyext through lxml, which publishes no PyPy wheels, and there is no gcov for a cpyext build
-# to feed it anyway. The C and Python coverage gates both run on the CPython matrix; these envs prove behavior.
-deps = []
-commands_pre = [
-  [
-    "uv",
-    "pip",
-    "install",
-    "--reinstall",
-    "--no-deps",
-    "--no-build-isolation",
-    "--editable",
-    "{tox_root}",
-    "--config-settings=build-dir={env_dir}{/}cbuild",
-  ],
-]
-commands = [
-  [
-    "pytest",
-    "--durations",
-    "10",
-    "--no-cov",
-    "--ignore={tox_root}{/}tests{/}conformance",
-    { replace = "posargs", default = [ "tests" ], extend = true },
-  ],
-]
+deps = { replace = "ref", of = [ "env", "_pypy", "deps" ] }
+commands_pre = [ { replace = "ref", of = [ "env", "_pypy", "commands_pre" ], extend = true } ]
+commands = [ { replace = "ref", of = [ "env", "_pypy", "commands" ], extend = true } ]

--- a/tox.toml
+++ b/tox.toml
@@ -6,6 +6,7 @@ env_list = [
   "3.12",
   "3.11",
   "3.10",
+  "pypy3.11",
   "3.14t",
   "3.15t",
   "docs",
@@ -438,5 +439,35 @@ commands = [
     "--parallel-threads=auto",
     "--iterations=20",
     "{tox_root}{/}tests{/}dom{/}test_tree_freethread.py",
+  ],
+]
+
+[env."pypy3.11"]
+description = "run the test suite under PyPy 3.11 through cpyext"
+base_python = [ "pypy3.11" ]
+# gcovr reaches cpyext through lxml, which publishes no PyPy wheels, and there is no gcov for a cpyext build
+# to feed it anyway. The C and Python coverage gates both run on the CPython matrix; this env proves behavior.
+deps = []
+commands_pre = [
+  [
+    "uv",
+    "pip",
+    "install",
+    "--reinstall",
+    "--no-deps",
+    "--no-build-isolation",
+    "--editable",
+    "{tox_root}",
+    "--config-settings=build-dir={env_dir}{/}cbuild",
+  ],
+]
+commands = [
+  [
+    "pytest",
+    "--durations",
+    "10",
+    "--no-cov",
+    "--ignore={tox_root}{/}tests{/}conformance",
+    { replace = "posargs", default = [ "tests" ], extend = true },
   ],
 ]


### PR DESCRIPTION
turbohtml ships no pure-Python fallback, so PyPy users get nothing today. The C core needs little of what makes most C extensions unportable: it names no private `_Py*` API, builds its types with `PyType_FromModuleAndSpec`, keeps its state in module state, and uses multi-phase init. Of 66 translation units, 65 compiled against cpyext on the first try. 🎯

The 66th exposed three cpyext contracts that differ from CPython's. None of them produces a compiler error, a CPython behavior change, or a byte of different CPython machine code. PyPy corrupts data or dies. `PyUnicode_CopyCharacters` does not exist. `PyUnicode_FromFormat` returns a string cpyext left in the legacy wstr representation, so `PyUnicode_KIND`, `PyUnicode_DATA` and `PyUnicode_GET_LENGTH` are undefined on it; under `NDEBUG` their assertions compile away and `GET_LENGTH` answers one past the code point count. That is how `sanitize("<script>x</script>")` came to weave NUL bytes into its escaped tags. A 2-byte buffer cannot reach cpyext. cpyext materializes one by decoding it as UTF-16, which eats a leading U+FEFF as a byte-order mark, byte-swaps the rest of the string after a leading U+FFFE, folds a surrogate pair into the single code point it encodes, and aborts the interpreter on a lone surrogate through the strict error handler. A CPython `str` carries a lone surrogate, and both HTML input and the WHATWG tokenizer have to preserve one. `escape("\ud800<")` took the process down with SIGABRT.

`src/turbohtml/_c/core/pycompat.h` holds the whole adaptation, and every name in it expands to the CPython spelling on CPython. That is what keeps the CPython build unchanged. 64 of the 65 translation units compile to byte-identical machine code against `main` at `-O3`, so the PGO and LTO layouts the release wheels depend on cannot shift. The odd one out is `dom/node.c`, which carries the bug fix below. On PyPy the core builds any result too wide for Latin-1 at 4-byte kind, where cpyext is exact, while CPython keeps the narrowest kind its `str` equality demands. `escape()` takes a separate 2-byte path there, because its block copies assume the output width matches the input's.

Two more gaps needed handling. cpyext hands `sq_item` a raw negative index instead of adding `sq_length` first, so `node[-1]` answered the first child. While chasing that I found a CPython bug, fixed in its own commit: `PySequence_GetItem` adds `sq_length` but never rechecks, so `node[-len - 1]` still arrived negative and `node_item` returned `first_child` where `list` raises `IndexError`.

cpyext also ignored `Py_TPFLAGS_DISALLOW_INSTANTIATION` until PyPy 7.3.21, which let `Document()` and its thirteen siblings construct without a tree and then segfault on first use, so pure Python code could crash the interpreter. 7.3.21 honors the flag and prints a debug line to stdout for every type that carries it. Both cost nothing to avoid, because cpyext seals a type through an explicit `tp_new` as well, the branch the flag would otherwise shadow. Setting that slot instead of the flag seals every PyPy with CPython's own error message and leaves 7.3.21 quiet, since its debug line fires only for a type carrying the flag. `Element("div")` and `Text("hi")` still build, because a subtype declaring its own `tp_new` overrides the inherited one. That removes the need for a version floor, and PyPy 3.10 joins the wheel matrix.

I rejected the approach the closest analogues take. [MarkupSafe](https://github.com/pallets/markupsafe/blob/main/setup.py) and [msgpack](https://github.com/msgpack/msgpack-python/blob/main/setup.py) detect PyPy at build time and ship a pure-Python fallback instead, because cpyext turns their `PyUnicode_KIND` fast path into a decode-and-allocate. [Cython disables the same family of fast paths on PyPy](https://github.com/cython/cython/blob/master/Cython/Utility/ModuleSetupCode.c) with `CYTHON_USE_UNICODE_INTERNALS=0`. That trade does not exist here, since no Python implementation of this core exists to fall back to. [HPy](https://docs.hpyproject.org/en/latest/api-reference/function-index.html) offers no kind-dispatched buffer access and has not released since 2023.

`docs/explanation/interpreters.rst` states what PyPy costs, from a table the bench harness generates rather than from figures typed into prose. `tox -e bench -- interpreters` builds the working tree under CPython 3.14 and PyPy 3.11, runs the same seven operations over the same vendored corpora in each, and writes `docs/explanation/bench/interpreters.json` for the existing `bench-table` directive to render. Parsing a whole document stays within a small factor. Anything that hands Python an object per node runs an order of magnitude slower and past it: walking every descendant, collecting visible text, serializing a tree. The JIT recovers none of it, because the time goes to cpyext rather than to bytecode. turbohtml is a poor reason to choose PyPy, and the page says so.

Reviewers should look hardest at `core/pycompat.h` and at the codegen-neutrality claim. I checked it by compiling every translation unit from `main` and from this branch at `-O3 -g0 -DNDEBUG` and comparing normalized `objdump -d` output. cibuildwheel's `pypy` and `pypy-eol` groups together select `pp310` and `pp311`. The PyPy wheels skip PGO, since training a profile by driving turbohtml from PyPy measures cpyext instead of the C hot paths. On PyPy 7.3.19, 7.3.21 and 7.3.23 the library produces byte-identical output to CPython 3.13 across the operations I compared, down to lone surrogates, byte-order marks and surrogate pairs, and every sealed type refuses construction with the same message on all four interpreters. ⚙️

Three upstream cpyext defects fell out of this work. Each reproduces on the current 7.3.23, violates a documented CPython contract, and is filed with a standalone reproducer: [pypy#5524](https://github.com/pypy/pypy/issues/5524) for the non-canonical `PyUnicode_FromFormat` result, [pypy#5525](https://github.com/pypy/pypy/issues/5525) for the UTF-16 materialization of 2-byte buffers, and [pypy#5526](https://github.com/pypy/pypy/issues/5526) for the unadjusted negative `sq_item` index. The sealing flag and the 7.3.21 debug line were already reported as [pypy#5318](https://github.com/pypy/pypy/issues/5318) and [pypy#5388](https://github.com/pypy/pypy/issues/5388), and both are fixed upstream. The `tp_new` seal here works whichever release a user runs. Every one of the five is linked from the code that works around it, in `core/pycompat.h`, `dom/node.c` and `docs/explanation/interpreters.rst`.
