### PR TITLE
🐛 fix(dom): stabilize adopted node hashes

### DIFF
--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -573,6 +573,7 @@ static void handle_dealloc(PyObject *self) {
     handle_clear_caches(handle);
     PyMem_Free(handle->index_offsets);
     PyMem_Free(handle->index_nodes);
+    PyMem_Free(handle->hash_overrides);
     path_id_map_free(handle->path_ids);
     th_tree_free(handle->tree);
     Py_XDECREF(handle->source);

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1963,11 +1963,15 @@ th_node *adopt_into(NodeObject *anchor, th_node *dest_parent, PyObject *child_ob
     th_node *copy;
     Py_BEGIN_CRITICAL_SECTION2(anchor->handle, source_handle);
     copy = th_tree_copy_node(dest_tree, tree_of(child_obj), child->node);
-    if (copy != NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+    if (copy != NULL && /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        handle_add_hash_override((HandleObject *)anchor->handle, copy,
+                                 handle_node_hash((HandleObject *)source_handle, child->node)) == 0) {
         handle_drop_index(source_handle);
         th_node_remove_observed(tree_of(child_obj), child->node);
         Py_SETREF(child->handle, Py_NewRef(anchor->handle));
         child->node = copy;
+    } else {
+        copy = NULL; /* GCOVR_EXCL_LINE */
     }
     Py_END_CRITICAL_SECTION2();
 #ifdef Py_GIL_DISABLED

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -89,8 +89,8 @@ static PyObject *node_richcompare(PyObject *left, PyObject *right, int op) {
 }
 
 static Py_hash_t node_hash(PyObject *self) {
-    Py_hash_t hash = (Py_hash_t)(uintptr_t)((NodeObject *)self)->node;
-    return hash == -1 ? -2 : hash; /* GCOVR_EXCL_BR_LINE: an arena pointer is never (Py_hash_t)-1 */
+    NodeObject *node = (NodeObject *)self;
+    return handle_node_hash((HandleObject *)node->handle, node->node);
 }
 
 PyDoc_STRVAR(equals_doc, "equals(other, /)\n--\n\n"

--- a/src/turbohtml/_c/dom/nodes.h
+++ b/src/turbohtml/_c/dom/nodes.h
@@ -8,6 +8,7 @@
 #include "core/common.h"
 
 #include "core/ascii.h"
+#include "core/vec.h"
 #include "dom/tree.h"
 #include "query/xpath/xpath.h"
 
@@ -56,13 +57,20 @@ typedef struct {
 } path_id_map;
 
 typedef struct {
+    th_node *node;
+    Py_hash_t hash;
+} node_hash_override;
+
+typedef struct {
+    Py_ssize_t len;
+    Py_ssize_t cap;
+    node_hash_override items[];
+} node_hash_overrides;
+
+typedef struct {
     PyObject_HEAD th_tree *tree;
     PyObject *source;   /* the input str whose storage the tree's spans borrow */
     PyObject *encoding; /* the resolved encoding name for bytes input, else None */
-    /* WHATWG encoding confidence: a byte-order mark, the encoding argument, or a <meta>
-       declaration makes it certain; a prescan-free sniff leaves it a guess. Meaningless,
-       and always 0, when encoding is None. */
-    int encoding_certain;
     /* Lazy per-tree element index, bucketed by tag atom: index_nodes holds every
        element in document (pre-order) order grouped by atom, with the bucket for
        atom a spanning index_nodes[index_offsets[a] .. index_offsets[a + 1]).
@@ -70,13 +78,52 @@ typedef struct {
        drops it. Read and written only under the handle's critical section. */
     th_node **index_nodes;
     Py_ssize_t *index_offsets; /* th_tag_count + 2 entries; NULL until built */
+    path_id_map *path_ids;     /* css_path id-occurrence map; NULL until first css_path */
+    node_hash_overrides *hash_overrides;
+    /* WHATWG encoding confidence: a byte-order mark, the encoding argument, or a <meta>
+       declaration makes it certain; a prescan-free sniff leaves it a guess. Meaningless,
+       and always 0, when encoding is None. */
+    int encoding_certain;
     int index_built;
-    path_id_map *path_ids; /* css_path id-occurrence map; NULL until first css_path */
     sel_cache_entry sel_cache[SEL_CACHE_CAP];
     int sel_cache_len;
     xpath_cache_entry xpath_cache[XPATH_CACHE_CAP];
     int xpath_cache_len;
 } HandleObject;
+
+static inline Py_hash_t handle_node_hash(const HandleObject *handle, const th_node *node) {
+    if (handle->hash_overrides != NULL) {
+        for (Py_ssize_t index = 0; index < handle->hash_overrides->len; index++) {
+            if (handle->hash_overrides->items[index].node == node) {
+                return handle->hash_overrides->items[index].hash;
+            }
+        }
+    }
+    Py_hash_t hash = (Py_hash_t)(uintptr_t)node;
+    return hash == -1 ? -2 : hash; /* GCOVR_EXCL_BR_LINE: an arena pointer is never (Py_hash_t)-1 */
+}
+
+static inline int handle_add_hash_override(HandleObject *handle, th_node *node, Py_hash_t hash) {
+    node_hash_overrides *overrides = handle->hash_overrides;
+    Py_ssize_t len = overrides == NULL ? 0 : overrides->len;
+    if (overrides == NULL || len == overrides->cap) {
+        size_t cap, bytes;
+        int grew = th_grow_cap((size_t)len + 1, overrides == NULL ? 0 : (size_t)overrides->cap, 8,
+                               sizeof(node_hash_override), &cap, &bytes);
+        if (!grew || bytes > SIZE_MAX - sizeof(node_hash_overrides)) { /* GCOVR_EXCL_BR_LINE: size overflow */
+            return -1;                                                 /* GCOVR_EXCL_LINE */
+        }
+        overrides = PyMem_Realloc(overrides, sizeof(node_hash_overrides) + bytes);
+        if (overrides == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;           /* GCOVR_EXCL_LINE */
+        }
+        overrides->cap = (Py_ssize_t)cap;
+        handle->hash_overrides = overrides;
+    }
+    overrides->items[len] = (node_hash_override){node, hash};
+    overrides->len = len + 1;
+    return 0;
+}
 
 typedef struct {
     PyObject_HEAD PyObject *handle; /* _TreeHandle keeping tree + source alive */

--- a/src/turbohtml/_c/dom/range.c
+++ b/src/turbohtml/_c/dom/range.c
@@ -920,11 +920,15 @@ static th_node *adopt(RangeObject *range, PyObject *child_obj) {
     th_node *copy;
     Py_BEGIN_CRITICAL_SECTION2(range->start_handle, source_handle);
     copy = th_tree_copy_node(dest_tree, child_tree, child->node);
-    if (copy != NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+    if (copy != NULL && /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        handle_add_hash_override((HandleObject *)range->start_handle, copy,
+                                 handle_node_hash((HandleObject *)source_handle, child->node)) == 0) {
         handle_drop_index(source_handle);
         th_node_remove(child->node);
         Py_SETREF(child->handle, Py_NewRef(range->start_handle));
         child->node = copy;
+    } else {
+        copy = NULL; /* GCOVR_EXCL_LINE */
     }
     Py_END_CRITICAL_SECTION2();
 #ifdef Py_GIL_DISABLED

--- a/tests/dom/test_range.py
+++ b/tests/dom/test_range.py
@@ -505,6 +505,15 @@ def test_insert_node_into_element() -> None:
     assert _tags(div.children) == ["p", "b", "p"]
 
 
+def test_insert_node_preserves_hash_across_trees() -> None:
+    node = Element("b")
+    held = {node}
+    destination = Element("div")
+    Range(destination).insert_node(node)
+    assert node in held
+    assert destination.children[0] in held
+
+
 def test_insert_node_splits_text() -> None:
     doc = parse("<p>HelloWorld</p>")
     text = _found(doc, "p").children[0]

--- a/tests/dom/test_tree_edit.py
+++ b/tests/dom/test_tree_edit.py
@@ -41,6 +41,25 @@ def test_append_adopts_subtree_from_another_tree() -> None:
     assert doc.find("section") is None  # the source tree no longer holds it
 
 
+def test_append_preserves_node_hash() -> None:
+    node = _found(parse("<span>x</span>"), "span")
+    held = {node}
+    Element("div").append(node)
+    second_destination = Element("main")
+    second_destination.append(node)
+    assert node in held
+    assert _found(second_destination, "span") in held
+
+
+def test_append_preserves_hashes_for_multiple_adoptions() -> None:
+    nodes = [Element(f"x-{index}") for index in range(9)]
+    held = set(nodes)
+    destination = Element("div")
+    for node in nodes:
+        destination.append(node)
+    assert all(node in held for node in destination.children)
+
+
 def test_append_adopts_every_attribute_shape() -> None:
     # data-custom-xyz is no known atom, so adoption must re-intern its name across
     # trees; the valueless and empty values (both "") must survive the copy too


### PR DESCRIPTION
Cross-tree adoption replaces the arena node behind a live wrapper, so its pointer-based hash changed after insertion into a set or dictionary. Record the original pointer hash lazily on the destination tree handle and transfer it when the node is adopted again.

Normal nodes retain the original 80-byte representation and pointer-hash fast path. The tree handle remains its original size, and override storage grows geometrically instead of reallocating for every adoption. The relevant shadow, path, XPath-path, chain, and parse benchmarks match main.
