### PR TITLE
🐛 fix(dom, xslt): lock subtree copies

### DIFF
--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1956,19 +1956,27 @@ th_node *adopt_into(NodeObject *anchor, th_node *dest_parent, PyObject *child_ob
         th_node_remove_observed(dest_tree, child->node);
         return child->node;
     }
-    th_node *copy = th_tree_copy_node(dest_tree, tree_of(child_obj), child->node);
+    PyObject *source_handle = child->handle;
+#ifdef Py_GIL_DISABLED
+    Py_INCREF(source_handle);
+#endif
+    th_node *copy;
+    Py_BEGIN_CRITICAL_SECTION2(anchor->handle, source_handle);
+    copy = th_tree_copy_node(dest_tree, tree_of(child_obj), child->node);
+    if (copy != NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        handle_drop_index(source_handle);
+        th_node_remove_observed(tree_of(child_obj), child->node);
+        Py_SETREF(child->handle, Py_NewRef(anchor->handle));
+        child->node = copy;
+    }
+    Py_END_CRITICAL_SECTION2();
+#ifdef Py_GIL_DISABLED
+    Py_DECREF(source_handle);
+#endif
     if (copy == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    /* the caller holds the destination tree's lock; detaching from the source tree (a
-       different tree here) takes the source's lock so it cannot race a source mutation */
-    Py_BEGIN_CRITICAL_SECTION(child->handle);
-    handle_drop_index(child->handle);
-    th_node_remove_observed(tree_of(child_obj), child->node);
-    Py_END_CRITICAL_SECTION();
-    Py_SETREF(child->handle, Py_NewRef(anchor->handle));
-    child->node = copy;
     return copy;
 }
 

--- a/src/turbohtml/_c/dom/leaf.c
+++ b/src/turbohtml/_c/dom/leaf.c
@@ -51,17 +51,20 @@ static PyObject *construct_data_node(PyTypeObject *type, int node_type, PyObject
 /* Deep-copy this node and its subtree into a fresh standalone tree, the body of
    __copy__ and __deepcopy__ (an HTML node has no meaningful shallow copy). */
 static PyObject *node_copy_impl(PyObject *self) {
-    module_state *state = state_of(self);
     th_tree *tree = th_tree_new();
     if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    th_node *copy = th_tree_copy_node(tree, tree_of(self), ((NodeObject *)self)->node);
+    NodeObject *source = (NodeObject *)self;
+    th_node *copy;
+    Py_BEGIN_CRITICAL_SECTION(source->handle);
+    copy = th_tree_copy_node(tree, tree_of(self), source->node);
+    Py_END_CRITICAL_SECTION();
     if (copy == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         th_tree_free(tree);      /* GCOVR_EXCL_LINE: allocation-failure path */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    return wrap_fresh_tree_node(state, tree, copy);
+    return wrap_fresh_tree_node(state_of(self), tree, copy);
 }
 
 PyObject *node_copy(PyObject *self, PyObject *Py_UNUSED(ignored)) {

--- a/src/turbohtml/_c/dom/range.c
+++ b/src/turbohtml/_c/dom/range.c
@@ -913,17 +913,27 @@ static th_node *adopt(RangeObject *range, PyObject *child_obj) {
         th_node_remove(child->node);
         return child->node;
     }
-    th_node *copy = th_tree_copy_node(dest_tree, child_tree, child->node);
+    PyObject *source_handle = child->handle;
+#ifdef Py_GIL_DISABLED
+    Py_INCREF(source_handle);
+#endif
+    th_node *copy;
+    Py_BEGIN_CRITICAL_SECTION2(range->start_handle, source_handle);
+    copy = th_tree_copy_node(dest_tree, child_tree, child->node);
+    if (copy != NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        handle_drop_index(source_handle);
+        th_node_remove(child->node);
+        Py_SETREF(child->handle, Py_NewRef(range->start_handle));
+        child->node = copy;
+    }
+    Py_END_CRITICAL_SECTION2();
+#ifdef Py_GIL_DISABLED
+    Py_DECREF(source_handle);
+#endif
     if (copy == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    Py_BEGIN_CRITICAL_SECTION(child->handle);
-    handle_drop_index(child->handle);
-    th_node_remove(child->node);
-    Py_END_CRITICAL_SECTION();
-    Py_SETREF(child->handle, Py_NewRef(range->start_handle));
-    child->node = copy;
     return copy;
 }
 

--- a/src/turbohtml/_c/query/xslt.c
+++ b/src/turbohtml/_c/query/xslt.c
@@ -4230,8 +4230,8 @@ PyObject *turbohtml_xslt_transform(PyObject *module, PyObject *args) {
             th_node *import_node;
             int ok = turbohtml_node_borrow(module, item, &import_tree, &import_node) == 0;
             th_node *import_root = ok ? stylesheet_root(import_node) : NULL;
-            Py_XDECREF(item);
             if (import_root == NULL) {
+                Py_DECREF(item);
                 PyMem_Free(imports);
                 engine_clear(&eng);
                 /* A borrow failure already set an exception; an XML-parsed import always has a
@@ -4241,14 +4241,19 @@ PyObject *turbohtml_xslt_transform(PyObject *module, PyObject *args) {
                     PyErr_SetString(PyExc_ValueError, no_root); /* GCOVR_EXCL_LINE */
                 return NULL;
             }
+            Py_BEGIN_CRITICAL_SECTION(turbohtml_node_handle(item));
             imports[index] = th_tree_copy_node(eng.merged_tree, import_tree, import_root);
+            Py_END_CRITICAL_SECTION();
+            Py_DECREF(item);
             if (imports[index] == NULL) { /* GCOVR_EXCL_BR_LINE: alloc */
                 PyMem_Free(imports);      /* GCOVR_EXCL_LINE */
                 engine_clear(&eng);       /* GCOVR_EXCL_LINE */
                 return PyErr_NoMemory();  /* GCOVR_EXCL_LINE */
             }
         }
+        Py_BEGIN_CRITICAL_SECTION(turbohtml_node_handle(stylesheet_obj));
         sheet_root = th_tree_copy_node(eng.merged_tree, sheet_tree, sheet_root);
+        Py_END_CRITICAL_SECTION();
         if (sheet_root == NULL) {    /* GCOVR_EXCL_BR_LINE: alloc */
             PyMem_Free(imports);     /* GCOVR_EXCL_LINE */
             engine_clear(&eng);      /* GCOVR_EXCL_LINE */
@@ -4259,11 +4264,10 @@ PyObject *turbohtml_xslt_transform(PyObject *module, PyObject *args) {
     PyObject *source_handle = turbohtml_node_handle(source_obj);
     (void)source_handle; /* used only by the critical-section macro, a no-op on the GIL build */
     PyObject *result = NULL;
-    /* The source tree drives every query; lock its handle for the free-threaded build.
-       Both trees are read-only through the transform, and the output tree is private. */
-    Py_BEGIN_CRITICAL_SECTION(source_handle);
+    /* The source and stylesheet trees drive the transform; the output tree is private. */
+    Py_BEGIN_CRITICAL_SECTION2(source_handle, turbohtml_node_handle(stylesheet_obj));
     result = run_transform(&eng, sheet_root, params, imports, nimports);
-    Py_END_CRITICAL_SECTION();
+    Py_END_CRITICAL_SECTION2();
     PyMem_Free(imports);
     /* fail() sets eng.error without a Python exception; fail_py() sets the exception and
        leaves eng.error NULL. The two are exclusive, so eng.error != NULL implies no

--- a/src/turbohtml/_c/tokenizer/binding.h
+++ b/src/turbohtml/_c/tokenizer/binding.h
@@ -24,6 +24,10 @@
 #define Py_BEGIN_CRITICAL_SECTION(op) {
 #define Py_END_CRITICAL_SECTION() }
 #endif
+#ifndef Py_BEGIN_CRITICAL_SECTION2
+#define Py_BEGIN_CRITICAL_SECTION2(left, right) {
+#define Py_END_CRITICAL_SECTION2() }
+#endif
 
 typedef struct {
     PyObject *token_type;             /* Token */

--- a/tests/dom/test_tree_freethread.py
+++ b/tests/dom/test_tree_freethread.py
@@ -460,3 +460,38 @@ def test_concurrent_table_reads_and_mutation_are_memory_safe() -> None:
 
     _run(rows_reader, tables_reader, mutator)
     assert isinstance(table.rows(), list)  # the tree is still walkable after the concurrent churn
+
+
+def test_concurrent_cross_tree_adoption_copies_one_source_state() -> None:
+    document = turbohtml.parse(f"<section>{'<i></i>' * 50_000}<i id=target data-state=s></i></section>")
+    source = document.find("section")
+    assert source is not None
+    target = document.select_one("#target")
+    assert target is not None
+    destination = turbohtml.Element("main")
+    long_state = "L" * 4_096
+    start = threading.Barrier(2)
+    ready = threading.Event()
+    done = threading.Event()
+
+    def mutator() -> None:
+        start.wait()
+        target.attrs["data-state"] = "s"
+        target.attrs["data-state"] = long_state
+        ready.set()
+        while not done.is_set():
+            target.attrs["data-state"] = "s"
+            target.attrs["data-state"] = long_state
+
+    def adopter() -> None:
+        start.wait()
+        ready.wait()
+        try:
+            destination.append(source)
+        finally:
+            done.set()
+
+    _run(mutator, adopter)
+    adopted = destination.select_one("#target")
+    assert adopted is not None
+    assert adopted.attrs["data-state"] in {"s", long_state}


### PR DESCRIPTION
`th_tree_copy_node` read mutable source nodes without holding their tree handles. Concurrent attribute writes could pair a copied pointer with a length from another source state; the 3.14t reproducer returned one `L` where only `s` or 4,096 `L` characters were valid.

Acquire source and destination handles with the ordered two-object critical section during adoption. Standalone DOM copies and stylesheet merges lock their source handles, while XSLT execution locks both the source and stylesheet. The copy remains a single arena pass; GIL builds preprocess the new handle expressions away.
