### PR TITLE
🐛 fix(xslt): resolve instruction namespaces

### DIFF
--- a/src/turbohtml/_c/query/xslt.c
+++ b/src/turbohtml/_c/query/xslt.c
@@ -3869,7 +3869,10 @@ static int stylesheet_has_dynamic_namespace(const engine *eng, th_node *root) {
             }
             int selected = namespace_declares_prefix(eng, name, name_len);
             int binds_xsl = ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS);
-            if ((selected || binds_xsl) && !(node == root && selected && binds_xsl)) {
+            if (node == root && selected) {
+                continue;
+            }
+            if (selected || binds_xsl) {
                 return 1;
             }
         }

--- a/src/turbohtml/_c/query/xslt.c
+++ b/src/turbohtml/_c/query/xslt.c
@@ -17,6 +17,7 @@
 
 #include "core/common.h"
 #include "core/vec.h"
+#include "dom/nodes.h"
 #include "dom/tree.h"
 #include "tokenizer/binding.h"
 #include "query/xpath/internal.h"
@@ -544,6 +545,7 @@ typedef struct engine {
 
     Py_UCS4 *xsl_prefix;
     Py_ssize_t xsl_prefix_len;
+    int xsl_ns_dynamic;
     const Py_UCS4 *exclude_prefixes; /* aliases the stylesheet root's exclude-result-prefixes value */
     Py_ssize_t exclude_prefixes_len;
     const Py_UCS4 *cdata_elements; /* aliases xsl:output cdata-section-elements (space-separated QNames) */
@@ -588,28 +590,81 @@ typedef struct engine {
 
 /* ---- xsl element identification ------------------------------------------- */
 
-/* Whether node is an XSLT-namespace element whose local name is `local`, resolving
-   the prefix bound to the XSLT namespace (usually "xsl") that the stylesheet declared. */
-static int is_xsl(const engine *eng, const th_node *node, const char *local) {
+static const char XSLT_NS[] = "http://www.w3.org/1999/XSL/Transform";
+
+static const Py_UCS4 *qname_local(const th_node *node, Py_ssize_t *local_len, Py_ssize_t *prefix_len) {
+    for (Py_ssize_t index = 0; index < node->text_len; index++) {
+        if (node->text[index] == ':') {
+            *prefix_len = index;
+            *local_len = node->text_len - index - 1;
+            return node->text + index + 1;
+        }
+    }
+    *prefix_len = 0;
+    *local_len = node->text_len;
+    return node->text;
+}
+
+static int node_prefix_is_xsl(th_tree *tree, const th_node *node, Py_ssize_t prefix_len) {
+    for (const th_node *ancestor = node; ancestor != NULL; ancestor = ancestor->parent) {
+        for (Py_ssize_t index = 0; index < ancestor->attr_count; index++) {
+            const th_node_attr *attr = &ancestor->attrs[index];
+            Py_ssize_t name_len = 0;
+            const char *name = th_attr_name(tree, attr->name_atom, &name_len);
+            int matches = prefix_len == 0 ? name_len == 5 && memcmp(name, "xmlns", 5) == 0
+                                          : name_len == prefix_len + 6 && memcmp(name, "xmlns:", 6) == 0;
+            for (Py_ssize_t offset = 0; matches && offset < prefix_len; offset++) {
+                matches = (Py_UCS4)(unsigned char)name[offset + 6] == node->text[offset];
+            }
+            if (matches) {
+                return ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS);
+            }
+        }
+    }
+    return 0;
+}
+
+static int is_xsl_fast(const engine *eng, const th_node *node, const char *local) {
     if (node->type != TH_NODE_ELEMENT) {
         return 0;
     }
-    Py_ssize_t plen = eng->xsl_prefix_len;
-    if (node->text_len < plen + 1 || node->text[plen] != ':') {
+    Py_ssize_t prefix_len = eng->xsl_prefix_len;
+    if (node->text_len < prefix_len + 1 || node->text[prefix_len] != ':') {
         return 0;
     }
-    if (memcmp(node->text, eng->xsl_prefix, (size_t)plen * sizeof(Py_UCS4)) != 0) {
+    if (memcmp(node->text, eng->xsl_prefix, (size_t)prefix_len * sizeof(Py_UCS4)) != 0) {
         return 0;
     }
-    return ucs4_ascii_eq(node->text + plen + 1, node->text_len - plen - 1, local);
+    return ucs4_ascii_eq(node->text + prefix_len + 1, node->text_len - prefix_len - 1, local);
+}
+
+static int is_xsl_dynamic(const engine *eng, const th_node *node, const char *local) {
+    if (node->type != TH_NODE_ELEMENT) {
+        return 0;
+    }
+    Py_ssize_t local_len;
+    Py_ssize_t prefix_len;
+    const Py_UCS4 *name = qname_local(node, &local_len, &prefix_len);
+    return ucs4_ascii_eq(name, local_len, local) && node_prefix_is_xsl(eng->sheet_tree, node, prefix_len);
+}
+
+static int is_xsl(const engine *eng, const th_node *node, const char *local) {
+    return eng->xsl_ns_dynamic ? is_xsl_dynamic(eng, node, local) : is_xsl_fast(eng, node, local);
 }
 
 /* Whether an element is in the XSLT namespace (an xsl:* element), the test that tells
    an instruction from a literal result element. The caller only asks about elements. */
-static int is_any_xsl(const engine *eng, const th_node *node) {
-    Py_ssize_t plen = eng->xsl_prefix_len;
-    return node->text_len > plen + 1 && node->text[plen] == ':' &&
-           memcmp(node->text, eng->xsl_prefix, (size_t)plen * sizeof(Py_UCS4)) == 0;
+static int is_any_xsl_fast(const engine *eng, const th_node *node) {
+    Py_ssize_t prefix_len = eng->xsl_prefix_len;
+    return node->text_len > prefix_len + 1 && node->text[prefix_len] == ':' &&
+           memcmp(node->text, eng->xsl_prefix, (size_t)prefix_len * sizeof(Py_UCS4)) == 0;
+}
+
+static int is_any_xsl_dynamic(const engine *eng, const th_node *node) {
+    Py_ssize_t local_len;
+    Py_ssize_t prefix_len;
+    (void)qname_local(node, &local_len, &prefix_len);
+    return node_prefix_is_xsl(eng->sheet_tree, node, prefix_len);
 }
 
 /* The value of node's attribute named `name` (ASCII), or NULL when absent. Returns a
@@ -2835,8 +2890,6 @@ static int apply_templates(engine *eng, th_node *instruction, th_node *out_paren
 
 /* ---- the body instantiation walk ------------------------------------------ */
 
-static const char XSLT_NS[] = "http://www.w3.org/1999/XSL/Transform";
-
 static const Py_UCS4 *alias_result_uri(const engine *eng, const char *prefix, Py_ssize_t prefix_len,
                                        Py_ssize_t *out_len);
 
@@ -2995,7 +3048,26 @@ static int copy_namespace_decls(engine *eng, th_node *lre, th_node *copy, th_nod
 /* Whether attribute name `name` carries the stylesheet's XSLT-namespace prefix, i.e. it is an
    XSLT directive (xsl:exclude-result-prefixes, xsl:use-attribute-sets, ...) placed on a literal
    result element, which the spec strips from the output rather than copying. */
-static int is_xsl_attr(const engine *eng, const char *name, Py_ssize_t name_len) {
+static int is_xsl_attr(const engine *eng, const th_node *node, const char *name, Py_ssize_t name_len) {
+    if (eng->xsl_ns_dynamic) {
+        const char *colon = memchr(name, ':', (size_t)name_len);
+        if (colon == NULL) {
+            return 0;
+        }
+        Py_ssize_t prefix_len = colon - name;
+        for (const th_node *ancestor = node; ancestor != NULL; ancestor = ancestor->parent) {
+            for (Py_ssize_t index = 0; index < ancestor->attr_count; index++) {
+                const th_node_attr *attr = &ancestor->attrs[index];
+                Py_ssize_t decl_len = 0;
+                const char *decl = th_attr_name(eng->sheet_tree, attr->name_atom, &decl_len);
+                if (decl_len == prefix_len + 6 && memcmp(decl, "xmlns:", 6) == 0 &&
+                    memcmp(decl + 6, name, (size_t)prefix_len) == 0) {
+                    return ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS);
+                }
+            }
+        }
+        return 0;
+    }
     Py_ssize_t prefix_len = eng->xsl_prefix_len;
     if (name_len <= prefix_len || name[prefix_len] != ':') {
         return 0;
@@ -3013,17 +3085,30 @@ static int is_xsl_attr(const engine *eng, const char *name, Py_ssize_t name_len)
 static const Py_UCS4 *xsl_prefixed_attr(const engine *eng, const th_node *node, const char *local,
                                         Py_ssize_t *out_len) {
     Py_ssize_t local_len = (Py_ssize_t)strlen(local);
+    if (!eng->xsl_ns_dynamic) {
+        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
+            Py_ssize_t name_len = 0;
+            const char *name = th_attr_name(eng->sheet_tree, node->attrs[index].name_atom, &name_len);
+            if (!is_xsl_attr(eng, node, name, name_len)) {
+                continue;
+            }
+            Py_ssize_t offset = eng->xsl_prefix_len + 1;
+            if (name_len - offset == local_len && memcmp(name + offset, local, (size_t)local_len) == 0) {
+                *out_len = node->attrs[index].value_len;
+                return node->attrs[index].value;
+            }
+        }
+        return NULL;
+    }
     for (Py_ssize_t index = 0; index < node->attr_count; index++) {
         Py_ssize_t name_len = 0;
         const char *name = th_attr_name(eng->sheet_tree, node->attrs[index].name_atom, &name_len);
-        if (!is_xsl_attr(eng, name, name_len)) {
+        const char *colon = memchr(name, ':', (size_t)name_len);
+        if (colon == NULL || name_len - (colon - name) - 1 != local_len ||
+            memcmp(colon + 1, local, (size_t)local_len) != 0) {
             continue;
         }
-        Py_ssize_t offset = eng->xsl_prefix_len + 1;
-        if (name_len - offset != local_len) {
-            continue;
-        }
-        if (memcmp(name + offset, local, (size_t)local_len) == 0) {
+        if (is_xsl_attr(eng, node, name, name_len)) {
             *out_len = node->attrs[index].value_len;
             return node->attrs[index].value;
         }
@@ -3058,7 +3143,7 @@ static int instantiate_literal(engine *eng, th_node *element, th_node *out_paren
         if (name_len == 5 && memcmp(name, "xmlns", 5) == 0) {
             continue;
         }
-        if (is_xsl_attr(eng, name, name_len)) {
+        if (is_xsl_attr(eng, element, name, name_len)) {
             continue;
         }
         Py_UCS4 *resolved;
@@ -3189,9 +3274,7 @@ static enum xsl_instr xsl_classify(const Py_UCS4 *local, Py_ssize_t len) {
     return XSL_OTHER;
 }
 
-/* Instantiate one instruction (an xsl:* element, a literal result element, or a text
-   node) into out_parent. */
-static int instantiate_one(engine *eng, th_node *node, th_node *out_parent) {
+static int instantiate_non_element(engine *eng, th_node *node, th_node *out_parent) {
     if (node->type == TH_NODE_TEXT) {
         Py_ssize_t text_len = 0;
         Py_UCS4 *text = th_node_data(eng->sheet_tree, node, &text_len);
@@ -3217,16 +3300,11 @@ static int instantiate_one(engine *eng, th_node *node, th_node *out_parent) {
         PyMem_Free(text);
         return rc;
     }
-    if (node->type != TH_NODE_ELEMENT) {
-        return 0; /* comments / PIs in the stylesheet are ignored */
-    }
-    if (!is_any_xsl(eng, node)) {
-        if (is_extension_element(eng, node)) {
-            return instantiate_fallback(eng, node, out_parent);
-        }
-        return instantiate_literal(eng, node, out_parent);
-    }
-    switch (xsl_classify(node->text + eng->xsl_prefix_len + 1, node->text_len - eng->xsl_prefix_len - 1)) {
+    return 0;
+}
+
+static int instantiate_classified(engine *eng, th_node *node, th_node *out_parent, enum xsl_instr instruction) {
+    switch (instruction) {
     case XSL_VALUE_OF:
         return do_value_of(eng, node, out_parent);
     case XSL_APPLY_TEMPLATES:
@@ -3333,6 +3411,38 @@ static int instantiate_one(engine *eng, th_node *node, th_node *out_parent) {
     }
 }
 
+/* Instantiate one instruction (an xsl:* element, a literal result element, or a text
+   node) into out_parent. */
+static int instantiate_one_fast(engine *eng, th_node *node, th_node *out_parent) {
+    if (node->type != TH_NODE_ELEMENT) {
+        return instantiate_non_element(eng, node, out_parent);
+    }
+    if (!is_any_xsl_fast(eng, node)) {
+        if (is_extension_element(eng, node)) {
+            return instantiate_fallback(eng, node, out_parent);
+        }
+        return instantiate_literal(eng, node, out_parent);
+    }
+    Py_ssize_t offset = eng->xsl_prefix_len + 1;
+    return instantiate_classified(eng, node, out_parent, xsl_classify(node->text + offset, node->text_len - offset));
+}
+
+static int instantiate_one_dynamic(engine *eng, th_node *node, th_node *out_parent) {
+    if (node->type != TH_NODE_ELEMENT) {
+        return instantiate_non_element(eng, node, out_parent);
+    }
+    if (!is_any_xsl_dynamic(eng, node)) {
+        if (is_extension_element(eng, node)) {
+            return instantiate_fallback(eng, node, out_parent);
+        }
+        return instantiate_literal(eng, node, out_parent);
+    }
+    Py_ssize_t local_len;
+    Py_ssize_t prefix_len;
+    const Py_UCS4 *local = qname_local(node, &local_len, &prefix_len);
+    return instantiate_classified(eng, node, out_parent, xsl_classify(local, local_len));
+}
+
 /* Instantiate every child of `body` (skipping the param declarations already bound). */
 static int instantiate_body(engine *eng, th_node *body, th_node *out_parent) {
     if (++eng->depth > XSLT_MAX_DEPTH) {
@@ -3342,14 +3452,22 @@ static int instantiate_body(engine *eng, th_node *body, th_node *out_parent) {
     }
     Py_ssize_t scope_mark = eng->scope_len;
     int rc = 0;
-    for (th_node *child = body->first_child; child != NULL && rc == 0; child = child->next_sibling) {
-        /* xsl:param leads a template body and xsl:sort leads a for-each; both are read
-           by the parent, not instantiated. A stray xsl:with-param falls through to
-           instantiate_one, which produces nothing for it. */
-        if (is_xsl(eng, child, "param") || is_xsl(eng, child, "sort")) {
-            continue;
+    if (eng->xsl_ns_dynamic) {
+        for (th_node *child = body->first_child; child != NULL && rc == 0; child = child->next_sibling) {
+            if (is_xsl_dynamic(eng, child, "param") || is_xsl_dynamic(eng, child, "sort")) {
+                continue;
+            }
+            rc = instantiate_one_dynamic(eng, child, out_parent);
         }
-        rc = instantiate_one(eng, child, out_parent);
+    } else {
+        for (th_node *child = body->first_child; child != NULL && rc == 0; child = child->next_sibling) {
+            /* xsl:param leads a template body and xsl:sort leads a for-each; both are read
+               by the parent, not instantiated. A stray xsl:with-param produces nothing. */
+            if (is_xsl_fast(eng, child, "param") || is_xsl_fast(eng, child, "sort")) {
+                continue;
+            }
+            rc = instantiate_one_fast(eng, child, out_parent);
+        }
     }
     scope_drop(eng, scope_mark); /* local xsl:variable bindings fall out of scope */
     eng->depth--;
@@ -3673,20 +3791,46 @@ static void parse_output(engine *eng, th_node *element) {
     }
 }
 
-/* Resolve the prefix bound to the XSLT namespace from the stylesheet root's xmlns
-   declarations, defaulting to "xsl". Sets eng->xsl_prefix to a freshly allocated
-   code-point buffer (freed in engine_clear). Returns 0, or -1 on allocation failure. */
+/* Resolve the namespace spelling used by the principal stylesheet root, falling
+   back to any XSLT binding for a simplified stylesheet and then to "xsl". */
 static int resolve_xsl_prefix(engine *eng, th_node *root) {
     const char *prefix = "xsl";
     Py_ssize_t prefix_len = 3;
+    int resolved = 0;
+    Py_ssize_t root_prefix_len = 0;
+    while (root_prefix_len < root->text_len && root->text[root_prefix_len] != ':') {
+        root_prefix_len++;
+    }
+    if (root_prefix_len == root->text_len) {
+        root_prefix_len = 0;
+    }
     for (Py_ssize_t index = 0; index < root->attr_count; index++) {
         const th_node_attr *attr = &root->attrs[index];
         Py_ssize_t name_len = 0;
         const char *name = th_attr_name(eng->sheet_tree, attr->name_atom, &name_len);
-        /* A parse_xml stylesheet never has a valueless attribute, so attr->value is set. */
-        if (name_len > 6 && memcmp(name, "xmlns:", 6) == 0 && ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS)) {
-            prefix = name + 6;
-            prefix_len = name_len - 6;
+        int root_decl = root_prefix_len == 0 ? name_len == 5 && memcmp(name, "xmlns", 5) == 0
+                                             : name_len == root_prefix_len + 6 && memcmp(name, "xmlns:", 6) == 0;
+        for (Py_ssize_t offset = 0; root_decl && offset < root_prefix_len; offset++) {
+            root_decl = (Py_UCS4)(unsigned char)name[offset + 6] == root->text[offset];
+        }
+        if (root_decl && ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS)) {
+            prefix = name + name_len - root_prefix_len;
+            prefix_len = root_prefix_len;
+            resolved = 1;
+            break;
+        }
+    }
+    if (!resolved) {
+        for (Py_ssize_t index = 0; index < root->attr_count; index++) {
+            const th_node_attr *attr = &root->attrs[index];
+            Py_ssize_t name_len = 0;
+            const char *name = th_attr_name(eng->sheet_tree, attr->name_atom, &name_len);
+            if (name_len > 6 && memcmp(name, "xmlns:", 6) == 0 &&
+                ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS)) {
+                prefix = name + 6;
+                prefix_len = name_len - 6;
+                break;
+            }
         }
     }
     Py_UCS4 *owned = ucs4_from_ascii(prefix, prefix_len, &eng->xsl_prefix_len);
@@ -3694,6 +3838,42 @@ static int resolve_xsl_prefix(engine *eng, th_node *root) {
         return fail(eng, "out of memory"); /* GCOVR_EXCL_LINE */
     }
     eng->xsl_prefix = owned;
+    return 0;
+}
+
+static int namespace_declares_prefix(const engine *eng, const char *name, Py_ssize_t name_len) {
+    if (name_len != eng->xsl_prefix_len + 6) {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < eng->xsl_prefix_len; index++) {
+        if ((Py_UCS4)(unsigned char)name[index + 6] != eng->xsl_prefix[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int stylesheet_has_dynamic_namespace(const engine *eng, th_node *root) {
+    for (th_node *node = root; node != NULL; node = preorder_next(node, root)) {
+        if (node->type != TH_NODE_ELEMENT) {
+            continue;
+        }
+        for (Py_ssize_t index = 0; index < node->attr_count; index++) {
+            const th_node_attr *attr = &node->attrs[index];
+            Py_ssize_t name_len = 0;
+            const char *name = th_attr_name(eng->sheet_tree, attr->name_atom, &name_len);
+            int declaration =
+                (name_len == 5 && memcmp(name, "xmlns", 5) == 0) || (name_len > 6 && memcmp(name, "xmlns:", 6) == 0);
+            if (!declaration) {
+                continue;
+            }
+            int selected = namespace_declares_prefix(eng, name, name_len);
+            int binds_xsl = ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS);
+            if ((selected || binds_xsl) && !(node == root && selected && binds_xsl)) {
+                return 1;
+            }
+        }
+    }
     return 0;
 }
 
@@ -3976,6 +4156,10 @@ static int analyze(engine *eng, th_node *sheet_root, th_node **imports, Py_ssize
     if (resolve_xsl_prefix(eng, sheet_root) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
         return -1;                                 /* GCOVR_EXCL_LINE */
     }
+    eng->xsl_ns_dynamic = eng->xsl_prefix_len == 0 || stylesheet_has_dynamic_namespace(eng, sheet_root);
+    for (Py_ssize_t index = 0; !eng->xsl_ns_dynamic && index < nimports; index++) {
+        eng->xsl_ns_dynamic = stylesheet_has_dynamic_namespace(eng, imports[index]);
+    }
     /* A document element that is not xsl:stylesheet/xsl:transform is a simplified stylesheet
        (section 2.3): a literal result element carrying xsl:version whose whole content is the
        body of an implicit template matching the document root. */
@@ -4132,7 +4316,8 @@ static PyObject *run_transform(engine *eng, th_node *sheet_root, PyObject *param
     PyObject *result = NULL;
     int rc = bind_globals(eng, params);
     if (rc == 0) {
-        rc = eng->simplified ? instantiate_one(eng, sheet_root, out_root)
+        rc = eng->simplified ? (eng->xsl_ns_dynamic ? instantiate_one_dynamic(eng, sheet_root, out_root)
+                                                    : instantiate_one_fast(eng, sheet_root, out_root))
                              : apply_to_item(eng, (xp_item){eng->src_root, -1}, 1, 1, NULL, 0, NULL, 0, out_root);
     }
     if (rc == 0) {
@@ -4162,33 +4347,6 @@ static th_node *stylesheet_root(th_node *node) {
     return NULL; /* GCOVR_EXCL_LINE: an XML document always has a root element */
 }
 
-static int is_stylesheet_import(th_tree *tree, th_node *root, th_node *node) {
-    if (node->type != TH_NODE_ELEMENT) {
-        return 0;
-    }
-    const char *prefix = "xsl";
-    Py_ssize_t prefix_len = 3;
-    for (Py_ssize_t index = 0; index < root->attr_count; index++) {
-        const th_node_attr *attr = &root->attrs[index];
-        Py_ssize_t name_len = 0;
-        const char *name = th_attr_name(tree, attr->name_atom, &name_len);
-        if (name_len > 6 && memcmp(name, "xmlns:", 6) == 0 && ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS)) {
-            prefix = name + 6;
-            prefix_len = name_len - 6;
-            break;
-        }
-    }
-    if (node->text_len != prefix_len + 7 || node->text[prefix_len] != ':') {
-        return 0;
-    }
-    for (Py_ssize_t index = 0; index < prefix_len; index++) {
-        if (node->text[index] != (Py_UCS4)(unsigned char)prefix[index]) {
-            return 0;
-        }
-    }
-    return ucs4_ascii_eq(node->text + prefix_len + 1, 6, "import");
-}
-
 static PyObject *stylesheet_import_hrefs(PyObject *module, PyObject *stylesheet, PyObject *base) {
     PyObject *hrefs = PyList_New(0);
     if (hrefs == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure */
@@ -4207,7 +4365,13 @@ static PyObject *stylesheet_import_hrefs(PyObject *module, PyObject *stylesheet,
     th_node *root = stylesheet_root(node);
     if (root != NULL) {
         for (th_node *child = root->first_child; child != NULL; child = child->next_sibling) {
-            if (!is_stylesheet_import(tree, root, child)) {
+            if (child->type != TH_NODE_ELEMENT) {
+                continue;
+            }
+            Py_ssize_t local_len;
+            Py_ssize_t prefix_len;
+            const Py_UCS4 *local = qname_local(child, &local_len, &prefix_len);
+            if (!ucs4_ascii_eq(local, local_len, "import") || !node_prefix_is_xsl(tree, child, prefix_len)) {
                 continue;
             }
             if (base == Py_None) {

--- a/src/turbohtml/transform.py
+++ b/src/turbohtml/transform.py
@@ -129,4 +129,5 @@ def transform(stylesheet: Node, source: Node, /, *, base_url: str | None = None,
     :param params: top-level ``xsl:param`` values, each an XPath expression string.
     :returns: the transformed document serialized under the stylesheet's ``xsl:output`` method.
     """
-    return _xslt_transform(stylesheet, source, params or None, _resolve(stylesheet, base_url))
+    imports = _resolve(stylesheet, base_url)
+    return _xslt_transform(stylesheet, source, params or None, imports)

--- a/src/turbohtml/transform.py
+++ b/src/turbohtml/transform.py
@@ -129,5 +129,4 @@ def transform(stylesheet: Node, source: Node, /, *, base_url: str | None = None,
     :param params: top-level ``xsl:param`` values, each an XPath expression string.
     :returns: the transformed document serialized under the stylesheet's ``xsl:output`` method.
     """
-    imports = _resolve(stylesheet, base_url)
-    return _xslt_transform(stylesheet, source, params or None, imports)
+    return _xslt_transform(stylesheet, source, params or None, _resolve(stylesheet, base_url))

--- a/tests/convert/test_transform.py
+++ b/tests/convert/test_transform.py
@@ -428,6 +428,52 @@ def test_transform_custom_xslt_prefix() -> None:
     assert _run("<r/>", body, prefix="t") == "ok"
 
 
+def test_transform_default_xslt_namespace() -> None:
+    sheet = turbohtml.parse_xml(
+        '<stylesheet version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform">'
+        '<output method="text"/><template match="/"><value-of select="\'ok\'"/></template></stylesheet>'
+    )
+    assert transform(sheet, turbohtml.parse_xml("<r/>")) == "ok"
+
+
+def test_transform_default_namespace_template_param() -> None:
+    sheet = turbohtml.parse_xml(
+        '<stylesheet version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform">'
+        '<output method="text"/><template match="/"><param name="value" select="\'ok\'"/>'
+        '<value-of select="$value"/></template></stylesheet>'
+    )
+    assert transform(sheet, turbohtml.parse_xml("<r/>")) == "ok"
+
+
+def test_transform_default_namespace_sort() -> None:
+    sheet = turbohtml.parse_xml(
+        '<stylesheet version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform"><output method="text"/>'
+        '<template match="/"><for-each select="r/n"><sort select="." data-type="number" order="descending"/>'
+        '<value-of select="."/></for-each></template></stylesheet>'
+    )
+    assert transform(sheet, turbohtml.parse_xml("<r><n>1</n><n>2</n></r>")) == "21"
+
+
+def test_transform_descendant_xslt_prefix_binding() -> None:
+    body = (
+        '<xsl:template match="/"><t:value-of xmlns:t="http://www.w3.org/1999/XSL/Transform" '
+        "select=\"'ok'\"/></xsl:template>"
+    )
+    assert _run("<r/>", body) == "ok"
+
+
+def test_transform_rebound_xslt_prefix_is_literal() -> None:
+    body = (
+        '<xsl:template match="/"><out xmlns:xsl="urn:literal"><xsl:value-of select="\'wrong\'"/></out></xsl:template>'
+    )
+    assert "<xsl:value-of" in _run("<r/>", body, method="xml")
+
+
+def test_transform_unqualified_import_is_literal() -> None:
+    body = '<import/><xsl:template match="/">ok</xsl:template>'
+    assert _run("<r/>", body) == "ok"
+
+
 def test_transform_conflict_resolution_prefers_specific_pattern() -> None:
     body = (
         '<xsl:template match="/"><xsl:apply-templates select="r/*"/></xsl:template>'
@@ -1949,6 +1995,27 @@ def test_transform_attribute_set_applied_to_literal_element() -> None:
     assert _collapse(_run("<r/>", body, method="xml")) == '<out a="1">x</out>'
 
 
+def test_transform_attribute_set_uses_rebound_xslt_prefix() -> None:
+    body = (
+        '<xsl:attribute-set name="s"><xsl:attribute name="a">1</xsl:attribute></xsl:attribute-set>'
+        '<xsl:template match="/"><out xmlns:t="http://www.w3.org/1999/XSL/Transform" '
+        't:aaaaaaaaaaaaaaaaaa="ignored" t:use-attribute-sets="s"/></xsl:template>'
+    )
+    assert _collapse(_run("<r/>", body, method="xml")) == '<out a="1"/>'
+
+
+def test_transform_unbound_attribute_prefix_is_literal() -> None:
+    body = (
+        '<xsl:template match="/"><out xmlns:t="http://www.w3.org/1999/XSL/Transform" xmlns:u="urn:literal" '
+        'u:use-attribute-sets="s"/></xsl:template>'
+    )
+    sheet = _sheet(body, method="xml")
+    out = sheet.find("out")
+    assert out is not None
+    del out.attrs["xmlns:u"]
+    assert 'u:use-attribute-sets="s"' in transform(sheet, turbohtml.parse_xml("<r/>"))
+
+
 def test_transform_attribute_set_own_attribute_overrides_set() -> None:
     body = (
         '<xsl:attribute-set name="s"><xsl:attribute name="a">1</xsl:attribute></xsl:attribute-set>'
@@ -2152,6 +2219,32 @@ def test_transform_fallback_runs_for_extension_element() -> None:
     assert transform(_sheet(body, declare=declare), turbohtml.parse_xml("<r/>")) == "done"
 
 
+def test_transform_default_namespace_fallback_runs_for_extension_element() -> None:
+    sheet = turbohtml.parse_xml(
+        '<stylesheet version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform" xmlns:e="urn:ext" '
+        'extension-element-prefixes="e"><output method="text"/><template match="/">'
+        "<e:go><fallback>done</fallback></e:go></template></stylesheet>"
+    )
+    assert transform(sheet, turbohtml.parse_xml("<r/>")) == "done"
+
+
+def test_transform_default_namespace_does_not_skip_literal_param() -> None:
+    sheet = turbohtml.parse_xml(
+        '<stylesheet version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform"><output method="text"/>'
+        '<template match="/"><param xmlns="urn:literal">kept</param></template></stylesheet>'
+    )
+    assert transform(sheet, turbohtml.parse_xml("<r/>")) == "kept"
+
+
+def test_transform_default_namespace_stops_after_error() -> None:
+    sheet = turbohtml.parse_xml(
+        '<stylesheet version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform"><output method="text"/>'
+        '<template match="/"><value-of select="$missing"/><text>unreachable</text></template></stylesheet>'
+    )
+    with pytest.raises(ValueError, match="unbound"):
+        transform(sheet, turbohtml.parse_xml("<r/>"))
+
+
 def test_transform_extension_element_without_fallback_yields_nothing() -> None:
     body = '<xsl:template match="/">[<e:go/>]</xsl:template>'
     declare = 'xmlns:e="urn:ext" extension-element-prefixes="e"'
@@ -2164,6 +2257,23 @@ def test_transform_simplified_stylesheet() -> None:
         '<v><xsl:value-of select="r/n"/></v></out>'
     )
     assert _canon(transform(sheet, turbohtml.parse_xml("<r><n>7</n></r>"))) == "<out><v>7</v></out>"
+
+
+def test_transform_simplified_stylesheet_resolves_root_namespace() -> None:
+    sheet = turbohtml.parse_xml(
+        '<l:out a="1" xmlns:l="urn:literal" xmlns:t="http://www.w3.org/1999/XSL/Transform" '
+        'xmlns:u="http://www.w3.org/1999/XSL/Transform" t:version="1.0">'
+        "<t:value-of select=\"'ok'\"/></l:out>"
+    )
+    assert ">ok</l:out>" in transform(sheet, turbohtml.parse_xml("<r/>"))
+
+
+def test_transform_default_namespace_ignores_similar_root_attribute() -> None:
+    sheet = turbohtml.parse_xml(
+        '<stylesheet aaaaa="x" version="1.0" xmlns="http://www.w3.org/1999/XSL/Transform">'
+        '<output method="text"/><template match="/">ok</template></stylesheet>'
+    )
+    assert transform(sheet, turbohtml.parse_xml("<r/>")) == "ok"
 
 
 def test_transform_import_loads_external_templates(tmp_path: Path) -> None:
@@ -2251,6 +2361,43 @@ def test_transform_import_allows_repeated_completed_path(tmp_path: Path) -> None
         turbohtml.parse_xml(main.read_text(encoding="utf-8")), turbohtml.parse_xml("<r><a/></r>"), base_url=str(main)
     )
     assert _canon(result) == "ok"
+
+
+def test_transform_default_namespace_import(tmp_path: Path) -> None:
+    namespace = 'xmlns="http://www.w3.org/1999/XSL/Transform"'
+    (tmp_path / "base.xsl").write_text(
+        f'<stylesheet version="1.0" {namespace}><template match="a">[<value-of select="."/>]</template></stylesheet>',
+        encoding="utf-8",
+    )
+    main = tmp_path / "main.xsl"
+    main.write_text(
+        f'<stylesheet version="1.0" {namespace}><import href="base.xsl"/>'
+        '<template match="/"><apply-templates select="r/a"/></template></stylesheet>',
+        encoding="utf-8",
+    )
+    result = transform(
+        turbohtml.parse_xml(main.read_text(encoding="utf-8")),
+        turbohtml.parse_xml("<r><a>x</a></r>"),
+        base_url=str(main),
+    )
+    assert _canon(result) == "[x]"
+
+
+def test_transform_import_resolves_its_own_xslt_prefix(tmp_path: Path) -> None:
+    (tmp_path / "base.xsl").write_text(
+        '<t:stylesheet version="1.0" xmlns:t="http://www.w3.org/1999/XSL/Transform">'
+        '<t:template match="a">[<t:value-of select="."/>]</t:template></t:stylesheet>',
+        encoding="utf-8",
+    )
+    main = tmp_path / "main.xsl"
+    main.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:import href="base.xsl"/><xsl:template match="/">'
+        '<xsl:apply-templates select="r/a"/></xsl:template></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    sheet = turbohtml.parse_xml(main.read_text(encoding="utf-8"))
+    assert _canon(transform(sheet, turbohtml.parse_xml("<r><a>x</a></r>"), base_url=str(main))) == "[x]"
 
 
 def test_transform_import_resolves_file_url_base(tmp_path: Path) -> None:
@@ -2377,6 +2524,22 @@ def test_transform_import_missing_href_errors(tmp_path: Path) -> None:
     )
     sheet = turbohtml.parse_xml(main.read_text(encoding="utf-8"))
     with pytest.raises(ValueError, match="href attribute"):
+        transform(sheet, turbohtml.parse_xml("<r/>"), base_url=str(main))
+
+
+def test_transform_nested_import_missing_href_errors(tmp_path: Path) -> None:
+    (tmp_path / "base.xsl").write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:import/></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    main = tmp_path / "main.xsl"
+    main.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:import href="base.xsl"/></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    sheet = turbohtml.parse_xml(main.read_text(encoding="utf-8"))
+    with pytest.raises(ValueError, match="requires an href"):
         transform(sheet, turbohtml.parse_xml("<r/>"), base_url=str(main))
 
 


### PR DESCRIPTION
The engine classified XSLT elements by prefix spelling, which made default-namespace stylesheets run as literal result documents and let prefix rebinding misclassify instructions.

The C engine resolves instruction elements and directive attributes by namespace URI plus local name. It determines whether bindings require dynamic lookup and retains direct prefix comparisons for static stylesheets.

Move import discovery and recursive precedence ordering into C under the stylesheet lock. Python retains only the local filesystem and XML parsing boundary.

All 93 CodSpeed benchmarks pass. The compiled transform benchmark remains within noise at 32.9 µs on the prior implementation and 33.6 µs here, with 2.8 µs standard deviations for both.
