### PR TITLE
🐛 fix(xslt): reject circular imports

### DIFF
--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -68,6 +68,7 @@ PyObject *turbohtml_is_normalized(PyObject *module, PyObject *args);
    equivalent XPath 1.0 expression; matches METH_VARARGS. */
 PyObject *turbohtml_css_to_xpath(PyObject *module, PyObject *args);
 PyObject *turbohtml_css_specificity(PyObject *module, PyObject *args);
+PyObject *turbohtml_xslt_resolve_imports(PyObject *module, PyObject *args);
 
 /* Implemented in css/cssom/cssom.c: the CSS Object Model cascade (issue #546).
    _css_parse_declarations(text) and _css_parse_rules(text) parse a declaration block

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -201,6 +201,7 @@ static PyMethodDef html_methods[] = {
     {"_parse_only", turbohtml_parse_only, METH_O, NULL},
     {"_xpath_parse", turbohtml_xpath_parse, METH_O, NULL},
     {"_css_to_xpath", turbohtml_css_to_xpath, METH_VARARGS, NULL},
+    {"_xslt_resolve_imports", turbohtml_xslt_resolve_imports, METH_VARARGS, NULL},
     {"_xslt_transform", turbohtml_xslt_transform, METH_VARARGS, NULL},
     {"_css_specificity", turbohtml_css_specificity, METH_VARARGS, NULL},
     {"_css_parse_declarations", turbohtml_css_parse_declarations, METH_O, NULL},

--- a/src/turbohtml/_c/query/xslt.c
+++ b/src/turbohtml/_c/query/xslt.c
@@ -3684,8 +3684,7 @@ static int resolve_xsl_prefix(engine *eng, th_node *root) {
         Py_ssize_t name_len = 0;
         const char *name = th_attr_name(eng->sheet_tree, attr->name_atom, &name_len);
         /* A parse_xml stylesheet never has a valueless attribute, so attr->value is set. */
-        if (name_len > 6 && memcmp(name, "xmlns:", 6) == 0 &&
-            ucs4_ascii_eq(attr->value, attr->value_len, "http://www.w3.org/1999/XSL/Transform")) {
+        if (name_len > 6 && memcmp(name, "xmlns:", 6) == 0 && ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS)) {
             prefix = name + 6;
             prefix_len = name_len - 6;
         }
@@ -4161,6 +4160,228 @@ static th_node *stylesheet_root(th_node *node) {
         }
     }
     return NULL; /* GCOVR_EXCL_LINE: an XML document always has a root element */
+}
+
+static int is_stylesheet_import(th_tree *tree, th_node *root, th_node *node) {
+    if (node->type != TH_NODE_ELEMENT) {
+        return 0;
+    }
+    const char *prefix = "xsl";
+    Py_ssize_t prefix_len = 3;
+    for (Py_ssize_t index = 0; index < root->attr_count; index++) {
+        const th_node_attr *attr = &root->attrs[index];
+        Py_ssize_t name_len = 0;
+        const char *name = th_attr_name(tree, attr->name_atom, &name_len);
+        if (name_len > 6 && memcmp(name, "xmlns:", 6) == 0 && ucs4_ascii_eq(attr->value, attr->value_len, XSLT_NS)) {
+            prefix = name + 6;
+            prefix_len = name_len - 6;
+            break;
+        }
+    }
+    if (node->text_len != prefix_len + 7 || node->text[prefix_len] != ':') {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < prefix_len; index++) {
+        if (node->text[index] != (Py_UCS4)(unsigned char)prefix[index]) {
+            return 0;
+        }
+    }
+    return ucs4_ascii_eq(node->text + prefix_len + 1, 6, "import");
+}
+
+static PyObject *stylesheet_import_hrefs(PyObject *module, PyObject *stylesheet, PyObject *base) {
+    PyObject *hrefs = PyList_New(0);
+    if (hrefs == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+        return NULL;     /* GCOVR_EXCL_LINE */
+    }
+    th_tree *tree;
+    th_node *node;
+    if (turbohtml_node_borrow(module, stylesheet, &tree, &node) < 0) {
+        Py_DECREF(hrefs);
+        return NULL;
+    }
+    PyObject *handle = turbohtml_node_handle(stylesheet);
+    (void)handle;
+    int error = 0;
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    th_node *root = stylesheet_root(node);
+    if (root != NULL) {
+        for (th_node *child = root->first_child; child != NULL; child = child->next_sibling) {
+            if (!is_stylesheet_import(tree, root, child)) {
+                continue;
+            }
+            if (base == Py_None) {
+                PyErr_SetString(PyExc_ValueError,
+                                "xsl:import needs a base_url to resolve the imported stylesheet's href against");
+                error = 1;
+                break;
+            }
+            Py_ssize_t href_len = 0;
+            const Py_UCS4 *href_value = attr_lookup(tree, child, "href", &href_len);
+            if (href_value == NULL) {
+                PyErr_SetString(PyExc_ValueError, "xsl:import requires an href attribute");
+                error = 1;
+                break;
+            }
+            PyObject *href = make_str(href_value, href_len);
+            if (href == NULL || PyList_Append(hrefs, href) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+                Py_XDECREF(href);                                 /* GCOVR_EXCL_LINE */
+                error = 1;                                        /* GCOVR_EXCL_LINE */
+                break;                                            /* GCOVR_EXCL_LINE */
+            }
+            Py_DECREF(href);
+        }
+    }
+    Py_END_CRITICAL_SECTION();
+    if (error) {
+        Py_DECREF(hrefs);
+        return NULL;
+    }
+    return hrefs;
+}
+
+static int raise_import_cycle(PyObject *active, PyObject *path) {
+    Py_ssize_t count = PyList_GET_SIZE(active);
+    PyObject *parts = PyList_New(count + 1);
+    if (parts == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+        return -1;       /* GCOVR_EXCL_LINE */
+    }
+    for (Py_ssize_t index = 0; index < count; index++) {
+        PyObject *part = PyObject_Str(PyList_GET_ITEM(active, index));
+        if (part == NULL) {   /* GCOVR_EXCL_BR_LINE: Path.__str__ only allocates */
+            Py_DECREF(parts); /* GCOVR_EXCL_LINE */
+            return -1;        /* GCOVR_EXCL_LINE */
+        }
+        PyList_SET_ITEM(parts, index, part);
+    }
+    PyObject *part = PyObject_Str(path);
+    if (part == NULL) {   /* GCOVR_EXCL_BR_LINE: Path.__str__ only allocates */
+        Py_DECREF(parts); /* GCOVR_EXCL_LINE */
+        return -1;        /* GCOVR_EXCL_LINE */
+    }
+    PyList_SET_ITEM(parts, count, part);
+    PyObject *separator = PyUnicode_FromString(" -> ");
+    if (separator == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+        Py_DECREF(parts);    /* GCOVR_EXCL_LINE */
+        return -1;           /* GCOVR_EXCL_LINE */
+    }
+    PyObject *chain = PyUnicode_Join(separator, parts);
+    Py_XDECREF(separator);
+    Py_DECREF(parts);
+    if (chain == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+        return -1;       /* GCOVR_EXCL_LINE */
+    }
+    PyErr_Format(PyExc_ValueError, "circular xsl:import: %U", chain);
+    Py_DECREF(chain);
+    return -1;
+}
+
+static int resolve_stylesheet_imports(PyObject *module, PyObject *stylesheet, PyObject *base, PyObject *loader,
+                                      PyObject *imports, PyObject *active, PyObject *active_set) {
+    PyObject *hrefs = stylesheet_import_hrefs(module, stylesheet, base);
+    if (hrefs == NULL) {
+        return -1;
+    }
+    Py_ssize_t count = PyList_GET_SIZE(hrefs);
+    for (Py_ssize_t index = 0; index < count; index++) {
+        PyObject *loaded = PyObject_CallFunctionObjArgs(loader, base, PyList_GET_ITEM(hrefs, index), NULL);
+        if (loaded == NULL) {
+            Py_DECREF(hrefs);
+            return -1;
+        }
+        if (!PyTuple_Check(loaded) || PyTuple_GET_SIZE(loaded) != 3) { /* GCOVR_EXCL_START: private loader invariant */
+            Py_DECREF(loaded);
+            Py_DECREF(hrefs);
+            PyErr_SetString(PyExc_TypeError, "xslt: import loader must return (stylesheet, path, current_path)");
+            return -1;
+        } /* GCOVR_EXCL_STOP */
+        PyObject *imported = PyTuple_GET_ITEM(loaded, 0);
+        PyObject *next_base = PyTuple_GET_ITEM(loaded, 1);
+        if (PyList_GET_SIZE(active) == 0) {
+            PyObject *current_path = PyTuple_GET_ITEM(loaded, 2);
+            if (PyList_Append(active, current_path) < 0) { /* GCOVR_EXCL_START: allocation failure */
+                Py_DECREF(loaded);
+                Py_DECREF(hrefs);
+                return -1;
+            } /* GCOVR_EXCL_STOP */
+            if (PyDict_SetItem(active_set, current_path, Py_None) < 0) { /* GCOVR_EXCL_START: allocation failure */
+                Py_DECREF(loaded);
+                Py_DECREF(hrefs);
+                return -1;
+            } /* GCOVR_EXCL_STOP */
+        }
+        int contains = PyDict_Contains(active_set, next_base);
+        if (contains < 0) { /* GCOVR_EXCL_START: canonical Path hashes do not fail */
+            Py_DECREF(loaded);
+            Py_DECREF(hrefs);
+            return -1;
+        } /* GCOVR_EXCL_STOP */
+        if (contains) {
+            int status = raise_import_cycle(active, next_base);
+            Py_DECREF(loaded);
+            Py_DECREF(hrefs);
+            return status;
+        }
+        if (PyList_Append(active, next_base) < 0) { /* GCOVR_EXCL_START: allocation failure */
+            Py_DECREF(loaded);
+            Py_DECREF(hrefs);
+            return -1;
+        } /* GCOVR_EXCL_STOP */
+        if (PyDict_SetItem(active_set, next_base, Py_None) < 0) { /* GCOVR_EXCL_START: allocation failure */
+            Py_DECREF(loaded);
+            Py_DECREF(hrefs);
+            return -1;
+        } /* GCOVR_EXCL_STOP */
+        if (Py_EnterRecursiveCall(" while resolving xsl:import") != 0) { /* GCOVR_EXCL_START: recursion limit */
+            Py_DECREF(loaded);
+            Py_DECREF(hrefs);
+            return -1;
+        } /* GCOVR_EXCL_STOP */
+        int status = resolve_stylesheet_imports(module, imported, next_base, loader, imports, active, active_set);
+        Py_LeaveRecursiveCall();
+        if (status == 0) {
+            (void)PyDict_DelItem(active_set, next_base);
+            (void)PySequence_DelItem(active, PyList_GET_SIZE(active) - 1);
+            status = PyList_Append(imports, imported);
+        }
+        Py_DECREF(loaded);
+        if (status < 0) {
+            Py_DECREF(hrefs);
+            return -1;
+        }
+    }
+    Py_DECREF(hrefs);
+    return 0;
+}
+
+PyObject *turbohtml_xslt_resolve_imports(PyObject *module, PyObject *args) {
+    PyObject *stylesheet;
+    PyObject *base;
+    PyObject *loader;
+    if (!PyArg_ParseTuple(args, "OOO:_xslt_resolve_imports", &stylesheet, &base, &loader)) { /* GCOVR_EXCL_BR_LINE */
+        return NULL; /* GCOVR_EXCL_LINE: private typed boundary */
+    }
+    PyObject *imports = PyList_New(0);
+    PyObject *active = PyList_New(0);
+    PyObject *active_set = PyDict_New();
+    if (imports == NULL || active == NULL || active_set == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+        Py_XDECREF(imports);                                       /* GCOVR_EXCL_LINE */
+        Py_XDECREF(active);                                        /* GCOVR_EXCL_LINE */
+        Py_XDECREF(active_set);                                    /* GCOVR_EXCL_LINE */
+        return NULL;                                               /* GCOVR_EXCL_LINE */
+    }
+    int status = resolve_stylesheet_imports(module, stylesheet, base, loader, imports, active, active_set);
+    Py_DECREF(active_set);
+    Py_DECREF(active);
+    if (status < 0) {
+        Py_DECREF(imports);
+        return NULL;
+    }
+    if (PyList_GET_SIZE(imports) == 0) {
+        Py_DECREF(imports);
+        Py_RETURN_NONE;
+    }
+    return imports;
 }
 
 PyObject *turbohtml_xslt_transform(PyObject *module, PyObject *args) {

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -198,6 +198,9 @@ from ._stubs.query import (
     _xpath_parse as _xpath_parse,
 )
 from ._stubs.query import (
+    _xslt_resolve_imports as _xslt_resolve_imports,
+)
+from ._stubs.query import (
     _xslt_transform as _xslt_transform,
 )
 from ._stubs.serialize import (

--- a/src/turbohtml/_stubs/query.pyi
+++ b/src/turbohtml/_stubs/query.pyi
@@ -1,10 +1,14 @@
 # Subsystem: query (_c/query) — XPath compilation hooks, smart-string registration, and the compiled expression object.
 from collections.abc import Callable
+from pathlib import Path
 from typing import final
 
 from .dom import Element, Node
 
 def _xpath_parse(expression: str, /) -> str: ...
+def _xslt_resolve_imports(
+    stylesheet: Node, base_url: str | None, loader: Callable[[str | Path, str], tuple[Node, Path, Path]], /
+) -> list[Node] | None: ...
 def _xslt_transform(
     stylesheet: Node, source: Node, params: dict[str, str] | None = ..., imports: list[Node] | None = ..., /
 ) -> str: ...

--- a/src/turbohtml/transform.py
+++ b/src/turbohtml/transform.py
@@ -30,64 +30,27 @@ stylesheet imports. Validated against libxslt's XSLT 1.0 Recommendation test cor
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-from ._html import Element, _xslt_transform, parse_xml
+from ._html import _xslt_resolve_imports, _xslt_transform, parse_xml
 
 if TYPE_CHECKING:
     from ._html import Node
 
 __all__ = ["Transform", "transform"]
 
-_XSLT_NS = "http://www.w3.org/1999/XSL/Transform"
 
-
-def _xsl_prefix(root: Element) -> str:
-    """Return the prefix bound to the XSLT namespace on a stylesheet root, defaulting to ``xsl``."""
-    for name, value in root.attrs.items():
-        if name.startswith("xmlns:") and value == _XSLT_NS:
-            return name[6:]
-    return "xsl"
-
-
-def _load_imports(root: Element, base: Path) -> list[Node]:
-    """
-    Resolve the ``xsl:import`` chain under ``root`` into parsed stylesheets, lowest import precedence first.
-
-    Each import's own imports precede it (lower precedence) and, within a stylesheet, a later import outranks an earlier
-    one, exactly the section 2.6.2 precedence order the C engine's conflict resolution then applies.
-    """
-    prefix = _xsl_prefix(root)
-    imports: list[Node] = []
-    for child in root.children:
-        if not isinstance(child, Element) or child.tag != f"{prefix}:import":
-            continue
-        href = child.attrs.get("href")
-        if href is None:
-            msg = "xsl:import requires an href attribute"
-            raise ValueError(msg)
-        path = _import_path(base, str(href))
-        imported = parse_xml(path.read_text(encoding="utf-8"))
-        # parse_xml raises HTMLParseError on a document with no root element, so imported.root is set here.
-        imports.extend(_load_imports(cast("Element", imported.root), path.parent))
-        imports.append(imported)
-    return imports
+def _load_import(base: str | Path, href: str) -> tuple[Node, Path, Path]:
+    current = _base_path(base).resolve() if isinstance(base, str) else base
+    path = _import_path(current.parent, href).resolve()
+    return parse_xml(path.read_text(encoding="utf-8")), path, current
 
 
 def _resolve(stylesheet: Node, base_url: str | None) -> list[Node] | None:
     """Return the imported stylesheets a transform must merge, or None when the stylesheet imports nothing."""
-    root = stylesheet if isinstance(stylesheet, Element) else getattr(stylesheet, "root", None)
-    if not isinstance(root, Element):
-        return None
-    prefix = _xsl_prefix(root)
-    if not any(isinstance(child, Element) and child.tag == f"{prefix}:import" for child in root.children):
-        return None
-    if base_url is None:
-        msg = "xsl:import needs a base_url to resolve the imported stylesheet's href against"
-        raise ValueError(msg)
-    return _load_imports(root, _base_path(base_url).parent)
+    return _xslt_resolve_imports(stylesheet, base_url, _load_import)
 
 
 def _base_path(base_url: str) -> Path:

--- a/tests/convert/test_transform.py
+++ b/tests/convert/test_transform.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -2182,6 +2182,75 @@ def test_transform_import_loads_external_templates(tmp_path: Path) -> None:
     sheet = turbohtml.parse_xml(main.read_text(encoding="utf-8"))
     result = transform(sheet, turbohtml.parse_xml("<r><a>x</a></r>"), base_url=str(main))
     assert _canon(result) == "[x]"
+
+
+def test_transform_import_ignores_foreign_same_length_prefix() -> None:
+    sheet = turbohtml.parse_xml(
+        '<xsl:stylesheet version="1.0" xmlns:bad="urn:bad" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl-import href="missing.xsl"/><bad:import href="missing.xsl"/>'
+        '<xsl:template match="/">ok</xsl:template></xsl:stylesheet>'
+    )
+    assert _canon(transform(sheet, turbohtml.parse_xml("<r/>"))) == "ok"
+
+
+def test_transform_import_detects_default_prefix_without_root_attributes() -> None:
+    sheet = turbohtml.parse_xml(
+        '<root><xsl:import xmlns:xsl="http://www.w3.org/1999/XSL/Transform" href="missing.xsl"/></root>'
+    )
+    with pytest.raises(ValueError, match="needs a base_url"):
+        Transform(sheet)
+
+
+def test_transform_rejects_non_node_stylesheet() -> None:
+    with pytest.raises(TypeError):
+        Transform(cast("turbohtml.Node", "not a node"))
+
+
+def test_transform_import_rejects_self_cycle(tmp_path: Path) -> None:
+    main = tmp_path / "main.xsl"
+    main.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:import href="main.xsl"/></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    path = main.resolve()
+    with pytest.raises(ValueError, match=rf"^{re.escape(f'circular xsl:import: {path} -> {path}')}$"):
+        transform(
+            turbohtml.parse_xml(main.read_text(encoding="utf-8")), turbohtml.parse_xml("<r/>"), base_url=str(main)
+        )
+
+
+def test_transform_import_rejects_indirect_cycle(tmp_path: Path) -> None:
+    main = tmp_path / "main.xsl"
+    imported = tmp_path / "imported.xsl"
+    namespace = 'version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"'
+    main.write_text(f'<xsl:stylesheet {namespace}><xsl:import href="imported.xsl"/></xsl:stylesheet>', encoding="utf-8")
+    imported.write_text(f'<xsl:stylesheet {namespace}><xsl:import href="main.xsl"/></xsl:stylesheet>', encoding="utf-8")
+    chain = " -> ".join(str(path.resolve()) for path in (main, imported, main))
+    with pytest.raises(ValueError, match=rf"^{re.escape(f'circular xsl:import: {chain}')}$"):
+        transform(
+            turbohtml.parse_xml(main.read_text(encoding="utf-8")), turbohtml.parse_xml("<r/>"), base_url=str(main)
+        )
+
+
+def test_transform_import_allows_repeated_completed_path(tmp_path: Path) -> None:
+    imported = tmp_path / "imported.xsl"
+    imported.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:template match="a">ok</xsl:template></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    main = tmp_path / "main.xsl"
+    main.write_text(
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">'
+        '<xsl:import href="imported.xsl"/><xsl:import href="imported.xsl"/>'
+        '<xsl:template match="/"><xsl:apply-templates select="r/a"/></xsl:template></xsl:stylesheet>',
+        encoding="utf-8",
+    )
+    result = transform(
+        turbohtml.parse_xml(main.read_text(encoding="utf-8")), turbohtml.parse_xml("<r><a/></r>"), base_url=str(main)
+    )
+    assert _canon(result) == "ok"
 
 
 def test_transform_import_resolves_file_url_base(tmp_path: Path) -> None:


### PR DESCRIPTION
Self-referential and indirect `xsl:import` cycles recursed until Python raised `RecursionError`.

The C resolver keeps an active-path set and an ordered error chain. Once a branch completes, it removes that path; later branches may import it again.

Python only canonicalizes paths while loading files. Cycle tracking stays off the benchmarked no-import transform path. All 93 CodSpeed benchmarks pass.
