### PR TITLE
📝 docs(changelog): backfill fixes since 1.3.1

### DIFF
--- a/docs/changelog/634.bugfix.rst
+++ b/docs/changelog/634.bugfix.rst
@@ -1,0 +1,1 @@
+Keep a :class:`turbohtml.Node` hash stable across cross-document adoption so sets and dictionaries can still find it.

--- a/docs/changelog/635.bugfix.rst
+++ b/docs/changelog/635.bugfix.rst
@@ -1,0 +1,1 @@
+Copy source subtrees from one state during DOM adoption, Range operations, and XSLT under free-threaded Python.

--- a/docs/changelog/636.bugfix.rst
+++ b/docs/changelog/636.bugfix.rst
@@ -1,0 +1,2 @@
+Recognize XSLT instructions by namespace URI and local name, including stylesheets with a default XSLT namespace or
+rebound prefix.

--- a/docs/changelog/637.bugfix.rst
+++ b/docs/changelog/637.bugfix.rst
@@ -1,0 +1,1 @@
+Raise :exc:`ValueError` with the import chain for circular ``xsl:import`` references.

--- a/docs/changelog/638.bugfix.rst
+++ b/docs/changelog/638.bugfix.rst
@@ -1,0 +1,2 @@
+Return :meth:`turbohtml.query.Query.find` results in document order across connected roots; retain root input order
+across disconnected trees.


### PR DESCRIPTION
PRs #634 through #638 merged after `1.3.1` without Towncrier fragments, leaving five fixes absent from the next release notes.

Each compact bug-fix fragment states the corrected behavior and uses the merged PR number for the issue link.
