### PR TITLE
⚡ perf(idna): bypass ASCII table searches

### DIFF
--- a/src/turbohtml/_c/url/idna.c
+++ b/src/turbohtml/_c/url/idna.c
@@ -74,6 +74,9 @@ static const th_idna_map_row *map_row(Py_UCS4 cp) {
 
 /* The canonical combining class of `cp`, 0 when the sorted table has no row for it (the default, and every starter). */
 static uint8_t ccc_of(Py_UCS4 cp) {
+    if (cp < th_idna_ccc[0].code) {
+        return 0;
+    }
     int lo = 0;
     int hi = th_idna_ccc_count;
     while (lo < hi) {
@@ -93,6 +96,9 @@ static uint8_t ccc_of(Py_UCS4 cp) {
 /* The full canonical decomposition row for `cp`, or NULL when it does not decompose (Hangul is handled by the caller).
  */
 static const th_idna_decomp_row *decomp_row(Py_UCS4 cp) {
+    if (cp < th_idna_decomp[0].code) {
+        return NULL;
+    }
     int lo = 0;
     int hi = th_idna_decomp_count;
     while (lo < hi) {
@@ -152,13 +158,18 @@ static Py_UCS4 pair_compose(Py_UCS4 first, Py_UCS4 second) {
 static Py_ssize_t map_host(const Py_UCS4 *input, Py_ssize_t in_len, Py_UCS4 *out) {
     Py_ssize_t at = 0;
     for (Py_ssize_t index = 0; index < in_len; index++) {
-        const th_idna_map_row *row = map_row(input[index]);
+        Py_UCS4 cp = input[index];
+        if (cp < 0x80) {
+            out[at++] = cp >= 'A' && cp <= 'Z' ? cp + ('a' - 'A') : cp;
+            continue;
+        }
+        const th_idna_map_row *row = map_row(cp);
         if (row->status == 1) {
             for (uint8_t offset = 0; offset < row->length; offset++) {
                 out[at++] = th_idna_map_pool[row->offset + offset];
             }
         } else if (row->status != 2) { /* 0 keeps the code point; 2 drops it (the ignored set) */
-            out[at++] = input[index];
+            out[at++] = cp;
         }
     }
     return at;

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -812,6 +812,12 @@ def normalize(text: str) -> None:
     _normalize("NFC", text)
 
 
+def idna(urls: tuple[str, ...]) -> None:
+    """Overflow the 1,024-entry cache so each IDNA conversion runs."""
+    for url in urls:
+        _normalize_url(url)
+
+
 def translate(selector: str) -> None:
     """Translate one CSS selector to XPath 1.0 with turbohtml's C translator."""
     _css_to_xpath(selector)
@@ -898,6 +904,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "linkify": (linkify, "turbohtml"),
     "detect": (detect, "turbohtml"),
     "normalize": (normalize, "turbohtml"),
+    "idna": (idna, "turbohtml"),
     "markdown": (markdown, "turbohtml"),
     "markdown-google": (markdown_google, "turbohtml"),
     "tables": (tables, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -337,6 +337,7 @@ OPERATIONS: dict[str, Operation] = {
     "decode": Operation("decode a legacy byte stream", "us"),
     "normalize": Operation("normalize text to Unicode NFC", "us"),
     "detect-language": Operation("detect a text's natural language", "us"),
+    "idna": Operation("normalize 4,100 URLs with Unicode hosts", "ms"),
     "urls-clean": Operation("clean and normalize 100 URLs", "us"),
     "links-filter": Operation("extract filtered page links", "us"),
 }
@@ -676,6 +677,7 @@ _URL_SHAPES = (
     "http://münchen.example/straße/{index}?b=2&a=1",
 )
 _URL_BATCH = tuple(shape.format(index=index) for index in range(20) for shape in _URL_SHAPES)
+_IDNA_URLS: Final[tuple[str, ...]] = tuple(f"https://münchen-{index}.example/" for index in range(4100))
 
 _ENCODING_ASCII = "The quick brown fox jumps over the lazy dog near the river bank early today. "
 _ENCODING_FRENCH = "Précédemment, la créativité française était très développée près de Paris ici. "
@@ -874,6 +876,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "decode": _decode_cases,
     "normalize": _normalize_cases,
     "detect-language": _language_cases,
+    "idna": lambda: (("4,100 uncached Unicode hosts", _IDNA_URLS),),
     "urls-clean": lambda: (
         ("clean 100 URLs", ("clean", _URL_BATCH)),
         ("normalize 100 URLs", ("normalize", _URL_BATCH)),


### PR DESCRIPTION
ASCII code points dominate typical Unicode hosts. The IDNA mapping and NFC passes search generated tables for each code point, even when its value falls below the first normalization row.

The IDNA loop maps ASCII without a table lookup. For normalization, code points below the first combining-class or decomposition row return the default value; a public `normalize_url` benchmark rotates 4,100 Unicode hosts through the 1,024-entry cache so each timed URL reaches C ToASCII.

On Apple M-series CPython 3.14, the 4,100-host benchmark drops from 15.8 ms to 11.9 ms, a 24.7% reduction.
