### PR TITLE
⚡ perf(extract): search suffix tables

### DIFF
--- a/src/turbohtml/_c/url/registrable.c
+++ b/src/turbohtml/_c/url/registrable.c
@@ -17,6 +17,17 @@
 
 enum { PSL_NORMAL = 0, PSL_WILDCARD = 1, PSL_EXCEPTION = 2 };
 
+static int rule_compare(const Py_UCS4 *candidate, Py_ssize_t length, const char *rule, Py_ssize_t rule_length) {
+    Py_ssize_t shared = length < rule_length ? length : rule_length;
+    for (Py_ssize_t index = 0; index < shared; index++) {
+        Py_UCS4 right = (unsigned char)rule[index];
+        if (candidate[index] != right) {
+            return candidate[index] < right ? -1 : 1;
+        }
+    }
+    return length < rule_length ? -1 : length > rule_length;
+}
+
 /* Is the single label [cand, cand+len) an IANA TLD? Bucketed on its first byte in tld_table.h, matched
    case-insensitively; a digit-led label (an IPv4 octet) buckets into an empty range and falls through to 0. */
 static int is_iana_tld(const Py_UCS4 *cand, Py_ssize_t len) {
@@ -25,19 +36,19 @@ static int is_iana_tld(const Py_UCS4 *cand, Py_ssize_t len) {
     if (first > 255) {
         return 0;
     }
-    for (int index = th_tld_first[first]; index < th_tld_first[first + 1]; index++) {
-        if (th_tld_table[index].name_len != len) {
-            continue;
-        }
-        int matched = 1;
-        for (Py_ssize_t offset = 0; offset < len; offset++) {
-            if ((Py_UCS4)(unsigned char)th_tld_table[index].name[offset] != cand[offset]) {
-                matched = 0;
-                break;
-            }
-        }
-        if (matched) {
+    int low = th_tld_first[first];
+    int high = th_tld_first[first + 1];
+    while (low < high) {
+        int middle = low + (high - low) / 2;
+        const th_tld_entry *entry = &th_tld_table[middle];
+        int order = rule_compare(cand, len, entry->name, entry->name_len);
+        if (order == 0) {
             return 1;
+        }
+        if (order < 0) {
+            high = middle;
+        } else {
+            low = middle + 1;
         }
     }
     return 0;
@@ -51,19 +62,19 @@ static int psl_kind(const Py_UCS4 *cand, Py_ssize_t len) {
     if (first > 255) {
         return -1;
     }
-    for (int index = th_psl_first[first]; index < th_psl_first[first + 1]; index++) {
-        if (th_psl_table[index].name_len != len) {
-            continue;
+    int low = th_psl_first[first];
+    int high = th_psl_first[first + 1];
+    while (low < high) {
+        int middle = low + (high - low) / 2;
+        const th_psl_entry *entry = &th_psl_table[middle];
+        int order = rule_compare(cand, len, entry->name, entry->name_len);
+        if (order == 0) {
+            return entry->kind;
         }
-        int matched = 1;
-        for (Py_ssize_t offset = 0; offset < len; offset++) {
-            if ((Py_UCS4)(unsigned char)th_psl_table[index].name[offset] != cand[offset]) {
-                matched = 0;
-                break;
-            }
-        }
-        if (matched) {
-            return th_psl_table[index].kind;
+        if (order < 0) {
+            high = middle;
+        } else {
+            low = middle + 1;
         }
     }
     return -1;

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -841,6 +841,11 @@ def links_filter(text: str) -> None:
     _extract_links(text, _LINKS_BASE)
 
 
+def links_external(text: str) -> None:
+    """Collect links outside the base URL's registrable domain."""
+    _extract_links(text, "https://www.example.co.uk/", external_only=True)
+
+
 OPERATIONS: dict[str, tuple[object, str]] = {
     "build": (build, "turbohtml"),
     "build-e": (build_e, "turbohtml"),
@@ -937,4 +942,5 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "detect-language": (detect_language, "turbohtml"),
     "urls-clean": (urls_clean, "turbohtml"),
     "links-filter": (links_filter, "turbohtml"),
+    "links-external": (links_external, "turbohtml"),
 }

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -340,6 +340,7 @@ OPERATIONS: dict[str, Operation] = {
     "idna": Operation("normalize 4,100 URLs with Unicode hosts", "ms"),
     "urls-clean": Operation("clean and normalize 100 URLs", "us"),
     "links-filter": Operation("extract filtered page links", "us"),
+    "links-external": Operation("extract links outside the base site", "ms"),
 }
 
 
@@ -678,6 +679,11 @@ _URL_SHAPES = (
 )
 _URL_BATCH = tuple(shape.format(index=index) for index in range(20) for shape in _URL_SHAPES)
 _IDNA_URLS: Final[tuple[str, ...]] = tuple(f"https://münchen-{index}.example/" for index in range(4100))
+_EXTERNAL_LINKS_HTML: Final = "".join(
+    f'<a href="https://{host}/post/{index}">link</a>'
+    for index in range(300)
+    for host in (f"news-{index}.example.co.uk", f"tenant-{index}.github.io", f"bucket-{index}.s3.amazonaws.com")
+)
 
 _ENCODING_ASCII = "The quick brown fox jumps over the lazy dog near the river bank early today. "
 _ENCODING_FRENCH = "Précédemment, la créativité française était très développée près de Paris ici. "
@@ -882,4 +888,5 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("normalize 100 URLs", ("normalize", _URL_BATCH)),
     ),
     "links-filter": _readpath_cases,
+    "links-external": lambda: (("900 mixed-site links", _EXTERNAL_LINKS_HTML),),
 }


### PR DESCRIPTION
External link filtering classifies each candidate by registrable domain. The IANA TLD and public suffix lookups scanned first-byte buckets one rule at a time; the largest bucket contains 958 rules. Binary search bounds each lookup by the bucket depth.

An Apple M-series CPython 3.14 benchmark with 900 mixed-site links measured 3.53 ms ± 0.10 ms on `upstream/main` and 3.03-3.18 ms ± 0.13 ms on this branch, a 10-14% reduction. The benchmark remains in `tools/bench` as `links-external`.

A fixed-depth branchless prototype measured 4.30 ms because variable-length string comparisons retain branches and the search cannot return on an exact match. The patch keeps the branchy binary search and changes no behavior or public API.
