### PR TITLE
⚡ perf(cssom): cache stylesheets

### DIFF
--- a/src/turbohtml/_c/css/cssom/cssom.c
+++ b/src/turbohtml/_c/css/cssom/cssom.c
@@ -964,6 +964,13 @@ static void css_free_sheets(css_sheet *sheets, Py_ssize_t count) {
     PyMem_Free(sheets);
 }
 
+void handle_clear_css_cache(HandleObject *handle) {
+    css_free_sheets(handle->css_sheets, handle->css_sheet_count);
+    handle->css_sheets = NULL;
+    handle->css_sheet_count = 0;
+    handle->css_sheets_ready = 0;
+}
+
 /* Collect every <style> element's text under root (document order), parsing each
    into a sheet whose selectors are compiled against tree. A selector that fails to
    compile leaves compiled[rule] NULL so the rule matches nothing. Returns the sheet
@@ -1041,6 +1048,25 @@ fail:                               /* GCOVR_EXCL_LINE: allocation-failure path 
     css_free_sheets(sheets, count); /* GCOVR_EXCL_LINE: allocation-failure path */
     *out_count = -1;                /* GCOVR_EXCL_LINE: allocation-failure path */
     return NULL;                    /* GCOVR_EXCL_LINE: allocation-failure path */
+}
+
+static css_sheet *css_cached_sheets(module_state *state, HandleObject *handle, Py_ssize_t *out_count) {
+    uint32_t attr_gen = th_tree_attr_generation(handle->tree);
+    if (!handle->css_sheets_ready || handle->css_sheet_attr_gen != attr_gen) {
+        handle_clear_css_cache(handle);
+        Py_ssize_t count = 0;
+        css_sheet *sheets = css_collect_sheets(state, handle->tree, th_tree_document(handle->tree), &count);
+        if (count < 0) {     /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            *out_count = -1; /* GCOVR_EXCL_LINE: allocation-failure path */
+            return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        handle->css_sheets = sheets;
+        handle->css_sheet_count = count;
+        handle->css_sheet_attr_gen = attr_gen;
+        handle->css_sheets_ready = 1;
+    }
+    *out_count = handle->css_sheet_count;
+    return handle->css_sheets;
 }
 
 /* Run the whole cascade for element against the collected sheets plus its inline
@@ -1149,19 +1175,20 @@ PyObject *turbohtml_css_computed_style(PyObject *module, PyObject *arg) {
         PyErr_SetString(PyExc_TypeError, "computed style requires an Element");
         return NULL;
     }
-    PyObject *handle = ((NodeObject *)arg)->handle;
+    PyObject *handle_obj = ((NodeObject *)arg)->handle;
+    HandleObject *handle = (HandleObject *)handle_obj;
     th_node *element = ((NodeObject *)arg)->node;
-    th_tree *tree = ((HandleObject *)handle)->tree;
+    th_tree *tree = handle->tree;
     css_value final_map[NUM_PROPS] = {0};
     int failed = 0;
-    Py_BEGIN_CRITICAL_SECTION(handle); /* per-tree lock: sheet collection and matching read the tree */
+    Py_BEGIN_CRITICAL_SECTION(handle_obj); /* per-tree lock: sheet collection and matching read the tree */
     th_node **chain = NULL;
     Py_ssize_t chain_len = css_ancestor_chain(element, &chain);
     if (chain_len < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         failed = 1;      /* GCOVR_EXCL_LINE: allocation-failure path */
     } else {             /* GCOVR_EXCL_LINE: brace of the never-taken alloc-failure branch */
         Py_ssize_t sheet_count = 0;
-        css_sheet *sheets = css_collect_sheets(state, tree, th_tree_document(tree), &sheet_count);
+        css_sheet *sheets = css_cached_sheets(state, handle, &sheet_count);
         if (sheet_count < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             failed = 1;        /* GCOVR_EXCL_LINE: allocation-failure path */
         } else {               /* GCOVR_EXCL_LINE: brace of the never-taken alloc-failure branch */
@@ -1178,7 +1205,6 @@ PyObject *turbohtml_css_computed_style(PyObject *module, PyObject *arg) {
                 }
             }
             memcpy(final_map, parent, sizeof(final_map)); /* the last element resolved is the target */
-            css_free_sheets(sheets, sheet_count);
         }
     }
     PyMem_Free(chain);

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1062,6 +1062,7 @@ static PyObject *element_attr(PyObject *self, PyObject *args, PyObject *kwds) {
    under the handle's critical section from every structural mutator. */
 void handle_drop_index(PyObject *handle_obj) {
     HandleObject *handle = (HandleObject *)handle_obj;
+    handle_clear_css_cache(handle);
     PyMem_Free(handle->index_offsets);
     PyMem_Free(handle->index_nodes);
     handle->index_offsets = NULL;

--- a/src/turbohtml/_c/dom/leaf.c
+++ b/src/turbohtml/_c/dom/leaf.c
@@ -176,6 +176,7 @@ static int node_set_data(PyObject *self, PyObject *value, void *Py_UNUSED(closur
     int rc;
     Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
     rc = th_node_set_data(tree_of(self), ((NodeObject *)self)->node, points, len);
+    handle_clear_css_cache((HandleObject *)((NodeObject *)self)->handle);
     Py_END_CRITICAL_SECTION();
     PyMem_Free(points);
     return rc < 0 ? -1 : 0; /* GCOVR_EXCL_BR_LINE: th_node_set_data only fails on OOM */

--- a/src/turbohtml/_c/dom/nodes.h
+++ b/src/turbohtml/_c/dom/nodes.h
@@ -89,6 +89,10 @@ typedef struct {
     int sel_cache_len;
     xpath_cache_entry *xpath_cache;
     int xpath_cache_len;
+    void *css_sheets;
+    Py_ssize_t css_sheet_count;
+    uint32_t css_sheet_attr_gen;
+    int css_sheets_ready;
 } HandleObject;
 
 static inline Py_hash_t handle_node_hash(const HandleObject *handle, const th_node *node) {
@@ -581,6 +585,9 @@ static inline int append_wrapped(PyObject *out, module_state *state, PyObject *h
 /* Free a handle's compiled-selector and compiled-XPath caches. Lives in query/methods.c
    with the bindings that populate them. */
 void handle_clear_caches(HandleObject *handle);
+
+/* Defined in cssom.c, where the private css_sheet type lives. */
+void handle_clear_css_cache(HandleObject *handle);
 
 /* Drop a handle's cached selector index and id map after a structural mutation. Lives in
    element.c beside the mutation bindings; query/methods.c calls it from prune/remove/strip. */

--- a/src/turbohtml/_c/query/methods.c
+++ b/src/turbohtml/_c/query/methods.c
@@ -9,6 +9,7 @@
 #include "css/select/selector.h"
 
 void handle_clear_caches(HandleObject *handle) {
+    handle_clear_css_cache(handle);
     for (int index = 0; index < handle->sel_cache_len; index++) {
         selector_free(handle->sel_cache[index].compiled);
         Py_DECREF(handle->sel_cache[index].key);

--- a/tests/query/css/test_cssom.py
+++ b/tests/query/css/test_cssom.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from turbohtml import Element, parse
+from turbohtml import Element, Text, parse
 from turbohtml.build import E
 from turbohtml.cssom import ComputedStyle, RuleList, StyleDeclaration, StyleRule, StyleSheet, computed_style
 
@@ -404,6 +404,46 @@ def test_computed_style_reads_multiple_style_sheets_in_document_order() -> None:
     paragraph = document.select_one("p")
     assert isinstance(paragraph, Element)
     assert computed_style(paragraph)["color"] == "blue"
+
+
+def test_computed_style_repeated_call_keeps_value() -> None:
+    document = parse("<style>p { color: red }</style><p></p>")
+    paragraph = document.select_one("p")
+    assert isinstance(paragraph, Element)
+    assert computed_style(paragraph)["color"] == computed_style(paragraph)["color"] == "red"
+
+
+def test_computed_style_tracks_stylesheet_text_mutation() -> None:
+    document = parse("<style>p { color: red }</style><p></p>")
+    style = document.select_one("style")
+    paragraph = document.select_one("p")
+    assert isinstance(style, Element)
+    assert isinstance(paragraph, Element)
+    assert computed_style(paragraph)["color"] == "red"
+    text = style.children[0]
+    assert isinstance(text, Text)
+    text.data = "p { color: blue }"
+    assert computed_style(paragraph)["color"] == "blue"
+
+
+def test_computed_style_tracks_stylesheet_insertion() -> None:
+    document = parse("<head><style>p { color: red }</style></head><body><p></p></body>")
+    head = document.select_one("head")
+    paragraph = document.select_one("p")
+    assert isinstance(head, Element)
+    assert isinstance(paragraph, Element)
+    assert computed_style(paragraph)["color"] == "red"
+    head.append(Element("style", children=[Text("p { color: blue }")]))
+    assert computed_style(paragraph)["color"] == "blue"
+
+
+def test_computed_style_recompiles_after_new_attribute_name() -> None:
+    document = parse("<style>p[data-late] { color: red }</style><p></p>")
+    paragraph = document.select_one("p")
+    assert isinstance(paragraph, Element)
+    assert computed_style(paragraph)["color"] == "canvastext"
+    paragraph.attrs["data-late"] = "yes"
+    assert computed_style(paragraph)["color"] == "red"
 
 
 def test_computed_style_surface() -> None:


### PR DESCRIPTION
Each `computed_style()` call parses every `<style>` element and compiles its selectors. This patch retains parsed stylesheets and compiled selectors on the tree handle and reuses them across element calls.

Structural and character-data mutations clear the cache. A change to the attribute-name generation rebuilds it so selectors can resolve attributes introduced after the first call; changes to existing attribute values use the current tree without recompilation.

The dense computed-style benchmark measured 7.52 ms ± 0.37 ms on `upstream/main` and 4.95 ms ± 0.66 ms on this branch, reducing end-to-end time by 34%.

Validation includes `tox run -e fix`, 63,260 tests, type checking, warnings-as-errors, sanitizer smoke tests, exact Ruff checks, and 100% Python and C line/branch coverage. This changes no public API or output and needs no documentation or changelog update.
