### PR TITLE
⚡ perf(clean): accelerate linkify

### DIFF
--- a/src/turbohtml/_c/clean/linkify.c
+++ b/src/turbohtml/_c/clean/linkify.c
@@ -138,18 +138,28 @@ static int is_known_tld(int kind, const void *data, Py_ssize_t start, Py_ssize_t
     if (first < 'a' || first > 'z') {
         return tuple_has_label(extra_tlds, kind, data, start, end);
     }
-    for (int index = th_tld_first[first]; index < th_tld_first[first + 1]; index++) {
-        if (th_tld_table[index].name_len != length) {
-            continue;
-        }
-        int matched = 1;
-        for (Py_ssize_t offset = 0; offset < length; offset++) {
-            if ((Py_UCS4)(unsigned char)th_tld_table[index].name[offset] != lower_ascii(READ(start + offset))) {
-                matched = 0;
+    int low = th_tld_first[first];
+    int high = th_tld_first[first + 1];
+    while (low < high) {
+        int middle = low + (high - low) / 2;
+        Py_ssize_t compared = length < th_tld_table[middle].name_len ? length : th_tld_table[middle].name_len;
+        int order = 0;
+        for (Py_ssize_t offset = 0; offset < compared; offset++) {
+            Py_UCS4 candidate = lower_ascii(READ(start + offset));
+            Py_UCS4 table = (unsigned char)th_tld_table[middle].name[offset];
+            if (candidate != table) {
+                order = candidate < table ? -1 : 1;
                 break;
             }
         }
-        if (matched) {
+        if (order == 0 && length != th_tld_table[middle].name_len) {
+            order = length < th_tld_table[middle].name_len ? -1 : 1;
+        }
+        if (order < 0) {
+            high = middle;
+        } else if (order > 0) {
+            low = middle + 1;
+        } else {
             return 1;
         }
     }

--- a/src/turbohtml/clean/_linkify.py
+++ b/src/turbohtml/clean/_linkify.py
@@ -245,6 +245,11 @@ class Linker:
             url = matched
         else:
             url = "http://" + matched
+        if len(self.callbacks) == 1 and self.callbacks[0] is nofollow:
+            attrs = {"href": url}
+            if _is_web_url(url):
+                attrs["rel"] = "nofollow"
+            return Element("a", attrs, [Text(matched)])
         link = LinkCandidate(url, matched)
         for callback in self.callbacks:
             result = callback(link)

--- a/tests/clean/test_linkify.py
+++ b/tests/clean/test_linkify.py
@@ -175,6 +175,11 @@ def test_linkify_email_when_enabled() -> None:
     assert out == 'reach <a href="mailto:bob@example.com">bob@example.com</a> now'
 
 
+def test_linkify_default_callback_leaves_email_rel_absent() -> None:
+    out = linkify("reach bob@example.com now", Linkify(parse_email=True))
+    assert out == 'reach <a href="mailto:bob@example.com">bob@example.com</a> now'
+
+
 def test_linkify_email_local_part_ends_at_unicode_space() -> None:
     # Unicode whitespace bounds the email local part the way an ASCII space does (issue #53)
     out = linkify("foo\xa0bar@example.com", Linkify(parse_email=True, callbacks=_no_callbacks()))


### PR DESCRIPTION
Link detection validates email and bare-domain suffixes against a 1,437-entry IANA table. The C scanner now binary-searches the matching first-byte bucket, and the Python layer avoids `LinkCandidate` allocation and callback dispatch when the callback list contains the unchanged default and nothing else; custom callbacks keep the existing path.

Rigorous Apple M-series CPython 3.14 release-wheel runs measured the reverse-order baseline at 4.58 µs, 73.6 µs, and 188 µs for the comment, 1 KiB prose, and 4 KiB markup linkify cases; the candidate measured 4.28 µs, 64.7 µs, and 173 µs, improvements of 6.6%, 12.1%, and 8.0%. The detector cases that validate a built-in TLD improved from 927 to 850 ns for a comment, from 12.9 to 12.3 µs for 1 KiB prose, and from 387 to 342 ns for `has_link()` on the comment.

Validation includes 63,257 passing tests, 98 expected skips, 100% Python and C line/branch coverage, type checking, a warnings-as-errors build, sanitizer fuzz smoke tests, and every repository hook. The patch changes no public behavior or API, so it needs no changelog or documentation update.
