### PR TITLE
⚡ perf(validate): index XSD globals

### DIFF
--- a/src/turbohtml/_c/validate/schema.c
+++ b/src/turbohtml/_c/validate/schema.c
@@ -408,7 +408,9 @@ typedef struct {
 
 typedef struct {
     named_node *items;
+    named_node **slots;
     Py_ssize_t len, cap;
+    size_t slot_cap;
 } named_vec;
 
 typedef struct pattern pattern;
@@ -463,11 +465,57 @@ static int named_push(th_schema *schema, named_vec *vec, const Py_UCS4 *name, Py
     return 0;
 }
 
-static th_node *named_find(const named_vec *vec, const Py_UCS4 *name, Py_ssize_t len) {
+static uint64_t named_hash(const Py_UCS4 *name, Py_ssize_t len) {
+    uint64_t hash = UINT64_C(1469598103934665603);
+    for (Py_ssize_t index = 0; index < len; index++) {
+        hash ^= name[index];
+        hash *= UINT64_C(1099511628211);
+    }
+    return hash;
+}
+
+static int named_index(th_schema *schema, named_vec *vec) {
+    if (vec->len < 8) {
+        return 0;
+    }
+    size_t cap = 8;
+    while (cap < (size_t)vec->len * 2) {
+        cap *= 2;
+    }
+    named_node **slots = arena_alloc(&schema->mem, cap * sizeof(named_node *));
+    if (slots == NULL) { /* GCOVR_EXCL_BR_LINE: arena OOM is unforceable */
+        return -1;       /* GCOVR_EXCL_LINE */
+    }
+    memset(slots, 0, cap * sizeof(named_node *));
     for (Py_ssize_t index = 0; index < vec->len; index++) {
-        if (u_eq_u(vec->items[index].name, vec->items[index].len, name, len)) {
-            return vec->items[index].node;
+        named_node *item = &vec->items[index];
+        size_t slot = (size_t)named_hash(item->name, item->len) & (cap - 1);
+        while (slots[slot] != NULL) {
+            slot = (slot + 1) & (cap - 1);
         }
+        slots[slot] = item;
+    }
+    vec->slots = slots;
+    vec->slot_cap = cap;
+    return 0;
+}
+
+static th_node *named_find(const named_vec *vec, const Py_UCS4 *name, Py_ssize_t len) {
+    if (vec->slots == NULL) {
+        for (Py_ssize_t index = 0; index < vec->len; index++) {
+            if (u_eq_u(vec->items[index].name, vec->items[index].len, name, len)) {
+                return vec->items[index].node;
+            }
+        }
+        return NULL;
+    }
+    size_t slot = (size_t)named_hash(name, len) & (vec->slot_cap - 1);
+    while (vec->slots[slot] != NULL) {
+        named_node *item = vec->slots[slot];
+        if (u_eq_u(item->name, item->len, name, len)) {
+            return item->node;
+        }
+        slot = (slot + 1) & (vec->slot_cap - 1);
     }
     return NULL;
 }

--- a/src/turbohtml/_c/validate/xsd.h
+++ b/src/turbohtml/_c/validate/xsd.h
@@ -907,6 +907,14 @@ static int xsd_compile(th_schema *schema) {
             named_push(schema, bucket, name, name_len, child);
         }
     }
+    named_vec *tables[] = {&schema->elements,   &schema->complex_types, &schema->simple_types,
+                           &schema->attributes, &schema->groups,        &schema->attr_groups};
+    for (size_t index = 0; index < sizeof(tables) / sizeof(tables[0]); index++) {
+        if (named_index(schema, tables[index]) < 0) { /* GCOVR_EXCL_BR_LINE: arena OOM is unforceable */
+            PyErr_NoMemory();                         /* GCOVR_EXCL_LINE */
+            return 0;                                 /* GCOVR_EXCL_LINE */
+        }
+    }
     return 1;
 }
 

--- a/tests/validate/test_edge_cases.py
+++ b/tests/validate/test_edge_cases.py
@@ -240,9 +240,6 @@ def test_occurs_multi_digit_and_bounds() -> None:
     assert not xsd_ok(schema, "<r><a>1</a><a>2</a><a>3</a><a>4</a></r>")
 
 
-# ---- RELAX NG edges ----
-
-
 def rwrap(body: str) -> str:
     return f'<element name="doc" xmlns="{R}">{body}</element>'
 
@@ -350,10 +347,17 @@ def test_rng_xml_prefixed_name() -> None:
     assert rng_ok(schema, "<xml:space>preserve</xml:space>")
 
 
-def test_many_global_elements_growth() -> None:
-    globals_ = "".join(f'<xs:element name="g{n}" type="xs:string"/>' for n in range(12))
+@pytest.mark.parametrize(
+    ("document", "valid"),
+    [
+        pytest.param("<g31>x</g31>", True, id="found-after-collision"),
+        pytest.param("<missing>x</missing>", False, id="absent"),
+    ],
+)
+def test_many_global_elements_growth(document: str, *, valid: bool) -> None:
+    globals_ = "".join(f'<xs:element name="g{number}" type="xs:string"/>' for number in (*range(11), 31))
     schema = f"<xs:schema {XS}>{globals_}</xs:schema>"
-    assert xsd_ok(schema, "<g5>x</g5>")
+    assert xsd_ok(schema, document) is valid
 
 
 def test_instance_comment_before_root() -> None:

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -151,6 +151,16 @@ _VALIDATE_XSD = (
     "</xs:complexType></xs:element>"
     "</xs:sequence></xs:complexType></xs:element></xs:schema>"
 )
+_VALIDATE_GLOBAL_XSD: Final = (
+    '<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">'
+    + "".join(f'<xs:element name="element{index}" type="xs:string"/>' for index in range(512))
+    + "".join(
+        f'<xs:simpleType name="Type{index}"><xs:restriction base="xs:string"/></xs:simpleType>' for index in range(512)
+    )
+    + '<xs:simpleType name="TargetType"><xs:restriction base="xs:string"/></xs:simpleType>'
+    '<xs:element name="target" type="TargetType"/></xs:schema>'
+)
+_VALIDATE_GLOBAL_DOC: Final = "<target>value</target>"
 # the same records catalog described in RELAX NG (XML syntax): grammar/define/ref, an interleave over the record's four
 # child patterns, oneOrMore, and XSD datatypes. RelaxNG drives a separate C compiler and validator (relaxng.h) that the
 # XSD validate op never reaches, so this is the only bench that exercises the RELAX NG engine.
@@ -780,7 +790,10 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "shadow": lambda: _ROWS,
     "parse": _parse_cases,
     "parse-xml": lambda: (("catalog XML", _XML_DOC),),
-    "validate": lambda: (("catalog XSD + doc", (_VALIDATE_XSD, _VALIDATE_DOC)),),
+    "validate": lambda: (
+        ("catalog XSD + doc", (_VALIDATE_XSD, _VALIDATE_DOC)),
+        ("1,024 global declarations", (_VALIDATE_GLOBAL_XSD, _VALIDATE_GLOBAL_DOC)),
+    ),
     "validate-rng": lambda: (("catalog RNG + doc", (_VALIDATE_RNG, _VALIDATE_DOC)),),
     "parse-scripting": _readpath_cases,  # the real pages carry <noscript>, so the scripting rawtext path runs
     "parse-locations": _readpath_cases,  # real attribute-dense pages exercise the per-attribute span stamping


### PR DESCRIPTION
## Summary

Large XSD global declaration tables now use an open-address index after eight entries. Small schemas stay linear. This avoids an allocation when an index cannot pay for itself, while a collision regression test and a benchmark with 1,024 global declarations cover the new path.

## Performance

Rigorous pyperf runs on CPython 3.14 release builds measured validation with 1,024 globals at 1.10 µs, down from 1.72 µs by 36.0%. Catalog validation remained within noise at 2.02 ms versus 2.07 ms. Compiling the large schema also remained within noise at 396 µs versus 390 µs.

## Validation

`tox run -e 3.14` passed 63,261 tests, skipped 99, and reached 100% Python and C line and branch coverage. `tox run -e type,warnings,fuzz-smoke,fix`, `ruff format .`, and `ruff check . --fix --unsafe-fixes . --output-format=concise` also passed.
