### PR TITLE
⚡ perf(validate): index Relax NG definitions

### DIFF
--- a/src/turbohtml/_c/validate/relaxng.h
+++ b/src/turbohtml/_c/validate/relaxng.h
@@ -135,6 +135,107 @@ static pattern *pat_onemore(th_schema *schema, pattern *p1) {
 
 static pattern *rng_resolve(th_schema *schema, int def_index);
 
+static uint64_t def_hash(const Py_UCS4 *name, Py_ssize_t len) {
+    uint64_t hash = UINT64_C(1469598103934665603);
+    for (Py_ssize_t index = 0; index < len; index++) {
+        hash ^= name[index];
+        hash *= UINT64_C(1099511628211);
+    }
+    return hash;
+}
+
+static void def_slot_add(def_vec *defines, Py_ssize_t index) {
+    def_entry *entry = &defines->items[index];
+    size_t slot = (size_t)def_hash(entry->name, entry->len) & (defines->slot_cap - 1);
+    while (defines->slots[slot] != 0) {
+        slot = (slot + 1) & (defines->slot_cap - 1);
+    }
+    defines->slots[slot] = (size_t)index + 1;
+}
+
+static int def_index(th_schema *schema) {
+    def_vec *defines = &schema->defines;
+    size_t cap = defines->slot_cap == 0 ? 32 : defines->slot_cap * 2;
+    size_t *slots = arena_alloc(&schema->mem, cap * sizeof(size_t));
+    if (slots == NULL) { /* GCOVR_EXCL_BR_LINE: arena OOM is unforceable */
+        return -1;       /* GCOVR_EXCL_LINE */
+    }
+    memset(slots, 0, cap * sizeof(size_t));
+    defines->slots = slots;
+    defines->slot_cap = cap;
+    for (Py_ssize_t index = 0; index < defines->len; index++) {
+        def_slot_add(defines, index);
+    }
+    return 0;
+}
+
+static Py_ssize_t def_find(const def_vec *defines, const Py_UCS4 *name, Py_ssize_t len) {
+    if (defines->slots == NULL) {
+        for (Py_ssize_t index = 0; index < defines->len; index++) {
+            if (u_eq_u(defines->items[index].name, defines->items[index].len, name, len)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+    size_t slot = (size_t)def_hash(name, len) & (defines->slot_cap - 1);
+    while (defines->slots[slot] != 0) {
+        Py_ssize_t index = (Py_ssize_t)defines->slots[slot] - 1;
+        if (u_eq_u(defines->items[index].name, defines->items[index].len, name, len)) {
+            return index;
+        }
+        slot = (slot + 1) & (defines->slot_cap - 1);
+    }
+    return -1;
+}
+
+static int def_add(th_schema *schema, const th_node_attr *name, th_node *node) {
+    def_vec *defines = &schema->defines;
+    Py_ssize_t index = def_find(defines, name->value, name->value_len);
+    if (index >= 0) {
+        def_entry *entry = &defines->items[index];
+        def_part *part = arena_alloc(&schema->mem, sizeof(*part));
+        if (part == NULL) { /* GCOVR_EXCL_BR_LINE: arena OOM is unforceable */
+            return -1;      /* GCOVR_EXCL_LINE */
+        }
+        part->node = node;
+        part->next = NULL;
+        if (entry->last == NULL) {
+            entry->extra = part;
+        } else {
+            entry->last->next = part;
+        }
+        entry->last = part;
+        return 0;
+    }
+    if (defines->len == defines->cap) {
+        Py_ssize_t cap = defines->cap ? defines->cap * 2 : 8;
+        def_entry *items = arena_alloc(&schema->mem, (size_t)cap * sizeof(def_entry));
+        if (items == NULL) { /* GCOVR_EXCL_BR_LINE: arena OOM is unforceable */
+            return -1;       /* GCOVR_EXCL_LINE */
+        }
+        if (defines->len > 0) {
+            memcpy(items, defines->items, (size_t)defines->len * sizeof(def_entry));
+        }
+        defines->items = items;
+        defines->cap = cap;
+    }
+    index = defines->len++;
+    defines->items[index] = (def_entry){
+        .name = name->value,
+        .len = name->value_len,
+        .first = node,
+    };
+    if ((defines->slots == NULL && defines->len == 8) ||
+        (defines->slots != NULL && (size_t)defines->len * 2 > defines->slot_cap)) {
+        return def_index(schema);
+    }
+    if (defines->slots != NULL) {
+        def_slot_add(defines, index);
+    }
+    return 0;
+}
+
 /* The RELAX NG `ns` in scope at `node` (inherited from the nearest ancestor-or-self
    ns attribute), or (NULL, 0) for no namespace. */
 static void rng_scope_ns(th_tree *tree, th_node *node, const Py_UCS4 **uri, Py_ssize_t *uri_len) {
@@ -434,13 +535,11 @@ static pattern *rng_build(th_schema *schema, th_node *node) {
     }
     if (is_schema_el(tree, node, RNG_NS, "ref")) {
         const th_node_attr *name = attr_exact(tree, node, "name", 4);
-        for (Py_ssize_t index = 0; index < schema->defines.len; index++) {
-            if (u_eq_u(schema->defines.items[index].name, schema->defines.items[index].len, name->value,
-                       name->value_len)) {
-                pattern *node_pat = pat_new(schema, P_REF);
-                node_pat->def_index = (int)index;
-                return node_pat;
-            }
+        Py_ssize_t index = def_find(&schema->defines, name->value, name->value_len);
+        if (index >= 0) {
+            pattern *node_pat = pat_new(schema, P_REF);
+            node_pat->def_index = (int)index;
+            return node_pat;
         }
         return schema->p_notallowed;
     }
@@ -454,17 +553,9 @@ static pattern *rng_resolve(th_schema *schema, int def_index) {
     }
     entry->built = schema->p_empty; /* placeholder guards direct build recursion */
     pattern *combined = NULL;
-    for (th_node *define = schema->root->first_child; define != NULL; define = define->next_sibling) {
-        if (!is_schema_el(schema->tree, define, RNG_NS, "define")) {
-            continue;
-        }
-        const th_node_attr *name = attr_exact(schema->tree, define, "name", 4);
-        if (name == NULL) {
-            continue;
-        }
-        if (!u_eq_u(name->value, name->value_len, entry->name, entry->len)) {
-            continue;
-        }
+    th_node *define = entry->first;
+    def_part *part = entry->extra;
+    for (;;) {
         pattern *body = rng_build_children(schema, define, NULL);
         const th_node_attr *combine = attr_exact(schema->tree, define, "combine", 7);
         int interleave = 0;
@@ -478,10 +569,12 @@ static pattern *rng_resolve(th_schema *schema, int def_index) {
         } else {
             combined = pat_choice(schema, combined, body);
         }
+        if (part == NULL) {
+            break;
+        }
+        define = part->node;
+        part = part->next;
     }
-    if (combined == NULL) {              /* GCOVR_EXCL_BR_LINE: every def_index has at least one matching define */
-        combined = schema->p_notallowed; /* GCOVR_EXCL_LINE */
-    } /* GCOVR_EXCL_LINE: llvm miscredits the closing brace of the unexecuted guard */
     entry->built = combined;
     return entry->built;
 }
@@ -880,32 +973,10 @@ static int rng_compile(th_schema *schema) {
             if (name == NULL) {
                 continue;
             }
-            int found = 0;
-            for (Py_ssize_t index = 0; index < schema->defines.len && !found; index++) {
-                found = u_eq_u(schema->defines.items[index].name, schema->defines.items[index].len, name->value,
-                               name->value_len);
+            if (def_add(schema, name, child) < 0) { /* GCOVR_EXCL_BR_LINE: arena OOM is unforceable */
+                PyErr_NoMemory();                   /* GCOVR_EXCL_LINE */
+                return 0;                           /* GCOVR_EXCL_LINE */
             }
-            if (found) {
-                continue;
-            }
-            if (schema->defines.len == schema->defines.cap) {
-                Py_ssize_t cap = schema->defines.cap ? schema->defines.cap * 2 : 8;
-                def_entry *items = arena_alloc(&schema->mem, (size_t)cap * sizeof(def_entry));
-                if (items == NULL) { /* GCOVR_EXCL_BR_LINE: arena OOM is unforceable */
-                    return 0;        /* GCOVR_EXCL_LINE */
-                }
-                if (schema->defines.len > 0) {
-                    memcpy(items, schema->defines.items, (size_t)schema->defines.len * sizeof(def_entry));
-                }
-                schema->defines.items = items;
-                schema->defines.cap = cap;
-            }
-            def_entry *entry = &schema->defines.items[schema->defines.len++];
-            entry->name = name->value;
-            entry->len = name->value_len;
-            entry->first = child;
-            entry->built = NULL;
-            entry->building = 0;
         }
     }
     th_node *start = first_schema_child(tree, schema->root, RNG_NS, "start");

--- a/src/turbohtml/_c/validate/schema.c
+++ b/src/turbohtml/_c/validate/schema.c
@@ -415,17 +415,25 @@ typedef struct {
 
 typedef struct pattern pattern;
 
+typedef struct def_part {
+    th_node *node;
+    struct def_part *next;
+} def_part;
+
 typedef struct def_entry {
     const Py_UCS4 *name;
     Py_ssize_t len;
     th_node *first; /* first <define> element for this name */
+    def_part *extra, *last;
     pattern *built; /* memoized pattern, NULL until first resolved */
     int building;   /* recursion guard */
 } def_entry;
 
 typedef struct {
     def_entry *items;
+    size_t *slots;
     Py_ssize_t len, cap;
+    size_t slot_cap;
 } def_vec;
 
 typedef struct th_schema {

--- a/tests/validate/test_edge_cases.py
+++ b/tests/validate/test_edge_cases.py
@@ -296,11 +296,19 @@ def test_rng_recursive_attribute_ref() -> None:
 
 
 def test_rng_many_defines_growth() -> None:
-    defines = "".join(f'<define name="d{n}"><element name="e{n}"><text/></element></define>' for n in range(12))
-    refs = "".join(f'<ref name="d{n}"/>' for n in range(12))
-    body = "".join(f"<e{n}>x</e{n}>" for n in range(12))
+    numbers = range(21)
+    defines = "".join(
+        f'<define name="d{number}"><element name="e{number}"><text/></element></define>' for number in numbers
+    )
+    refs = "".join(f'<ref name="d{number}"/>' for number in numbers)
+    body = "".join(f"<e{number}>x</e{number}>" for number in numbers)
     schema = rgrammar(f'<start><element name="r"><group>{refs}</group></element></start>{defines}')
     assert rng_ok(schema, f"<r>{body}</r>")
+
+
+def test_rng_many_defines_missing_ref() -> None:
+    defines = "".join(f'<define name="d{number}"><empty/></define>' for number in (*range(10), 19, 20))
+    assert not rng_ok(rgrammar(f'<start><ref name="missing"/></start>{defines}'), "<r/>")
 
 
 def test_rng_start_requires_two_top_level() -> None:
@@ -1168,15 +1176,23 @@ def test_rng_data_with_whitespace_and_nonparam_child() -> None:
     assert not rng_ok(schema, "<s>a</s>")
 
 
-def test_rng_multiple_defines_dedup_and_combine() -> None:
+@pytest.mark.parametrize(
+    "document",
+    [
+        pytest.param("<r><a>1</a></r>", id="first"),
+        pytest.param("<r><b>2</b></r>", id="second"),
+        pytest.param("<r><c>3</c></r>", id="third"),
+    ],
+)
+def test_rng_multiple_defines_dedup_and_combine(document: str) -> None:
     schema = (
         f'<grammar xmlns="{R}"><start><element name="r"><ref name="x"/></element></start>'
         '<define name="x"><element name="a"><text/></element></define>'
         '<define name="x" combine="choice"><element name="b"><text/></element></define>'
+        '<define name="x" combine="choice"><element name="c"><text/></element></define>'
         '<define name="y"><empty/></define></grammar>'
     )
-    assert rng_ok(schema, "<r><a>1</a></r>")
-    assert rng_ok(schema, "<r><b>2</b></r>")
+    assert rng_ok(schema, document)
 
 
 def test_schema_with_unnamespaced_sequence_is_not_recognized() -> None:

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -200,6 +200,11 @@ def validate_rng(case: tuple[str, str]) -> None:
     validator.validate(turbohtml.parse_xml(document))
 
 
+def compile_rng(schema: str) -> None:
+    """Measure schema construction rather than the cached validation path."""
+    _RelaxNG(schema)
+
+
 def parse_scripting(text: str) -> None:
     """Parse with the WHATWG scripting flag on, so <noscript> content tokenizes as raw text."""
     turbohtml.parse(text, scripting=True)
@@ -856,6 +861,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "parse-xml": (parse_xml, "turbohtml"),
     "validate": (validate, "turbohtml"),
     "validate-rng": (validate_rng, "turbohtml"),
+    "compile-rng": (compile_rng, "turbohtml"),
     "parse-scripting": (parse_scripting, "turbohtml"),
     "parse-locations": (parse_locations, "turbohtml"),
     "parse-shadow": (parse_shadow, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -180,6 +180,11 @@ _VALIDATE_RNG = (
     "</element></define>"
     "</grammar>"
 )
+_COMPILE_RNG: Final = (
+    '<grammar xmlns="http://relaxng.org/ns/structure/1.0"><start><ref name="target"/></start>'
+    + "".join(f'<define name="definition{index}"><empty/></define>' for index in range(1_023))
+    + '<define name="target"><element name="target"><text/></element></define></grammar>'
+)
 
 _SANITIZE_TEMPLATES = dedent("""\
     <article class=card>
@@ -264,6 +269,7 @@ OPERATIONS: dict[str, Operation] = {
     "parse-xml": Operation("parse XML to a tree", "us"),
     "validate": Operation("validate a document against an XSD schema", "us"),
     "validate-rng": Operation("validate a document against a RELAX NG schema", "us"),
+    "compile-rng": Operation("compile a RELAX NG schema", "us"),
     "parse-scripting": Operation("parse to a tree (scripting on)", "us"),
     "parse-locations": Operation("parse to a tree (source locations)", "us"),
     "parse-shadow": Operation("parse declarative shadow roots", "us"),
@@ -801,6 +807,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("1,024 global declarations", (_VALIDATE_GLOBAL_XSD, _VALIDATE_GLOBAL_DOC)),
     ),
     "validate-rng": lambda: (("catalog RNG + doc", (_VALIDATE_RNG, _VALIDATE_DOC)),),
+    "compile-rng": lambda: (("catalog grammar", _VALIDATE_RNG), ("1,024 definitions", _COMPILE_RNG)),
     "parse-scripting": _readpath_cases,  # the real pages carry <noscript>, so the scripting rawtext path runs
     "parse-locations": _readpath_cases,  # real attribute-dense pages exercise the per-attribute span stamping
     "parse-shadow": lambda: (("component gallery", _SHADOW_DOC),),


### PR DESCRIPTION
## Summary

Large RELAX NG grammars now use an open-address index after eight unique definitions.

Small grammars stay linear. They avoid hash allocation where it cannot pay for itself.

Duplicate definition nodes link to their owner, so resolution no longer rescans unrelated schema children.

The benchmark suite adds a distinct schema construction measure alongside cached validation.

## Performance

Rigorous pyperf runs used CPython 3.14 release builds in both baseline and candidate order.

Construction with 1,024 definitions fell from 1.80 ms to 367 µs, a 79.6% reduction.

The two-definition catalog remained within noise at 7.86 µs versus 7.11 µs.

## Validation

`tox run -e 3.14` passed 63,266 tests, skipped 100, and reached 100% Python and C line and branch coverage.

`tox run -e type,warnings,fuzz-smoke,fix` passed.

`ruff format .` and `ruff check . --fix --unsafe-fixes . --output-format=concise` passed.
