### PR TITLE
⚡ perf(parser): index tag atoms

### DIFF
--- a/src/turbohtml/_c/data/tag_atom.h
+++ b/src/turbohtml/_c/data/tag_atom.h
@@ -335,6 +335,69 @@ static const th_tag_entry th_tag_table[] = {
     {"xmp", 3u, TH_TAG_XMP, TH_TAG_SPECIAL | TH_TAG_RAWTEXT, 707u},
 };
 
+/* Collision-free index over the fixed tag set. A lookup still verifies the
+   spelling because an unknown name can share a generated slot. */
+#define TH_TAG_HASH_LENGTH 845u
+#define TH_TAG_HASH_FIRST 797u
+#define TH_TAG_HASH_LAST 163u
+#define TH_TAG_HASH_SECOND 777u
+#define TH_TAG_HASH_MASK 1023u
+static const uint8_t th_tag_hash[TH_TAG_HASH_MASK + 1] = {
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   107u, 0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   135u, 0u,   71u,  0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   118u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   91u,  0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   10u,  18u,  0u,   76u,  0u,   149u, 0u,   115u, 0u,   9u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   45u,  134u, 0u,
+    0u,   50u,  0u,   75u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   24u,  0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   15u,  0u,   37u,  43u,  0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   32u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    65u,  0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   143u, 0u,   0u,   0u,   0u,   58u,
+    0u,   0u,   0u,   0u,  98u,  0u,   0u,   0u,   0u,   29u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   99u,
+    0u,   0u,   0u,   0u,  0u,   0u,   112u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   35u,  0u,   85u,  0u,   0u,   0u,   0u,   0u,   123u,
+    0u,   0u,   0u,   0u,  108u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   117u, 0u,   0u,
+    0u,   0u,   141u, 62u, 0u,   0u,   0u,   57u,  0u,   78u,  104u, 0u,   0u,   0u,   0u,   11u,  0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   49u,  0u,   0u,   0u,   0u,   0u,   0u,   139u, 0u,   0u,   0u,   0u,   0u,
+    0u,   31u,  0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   94u,  0u,   0u,   147u, 0u,   82u,  0u,   83u,  0u,
+    0u,   0u,   14u,  0u,  0u,   126u, 67u,  0u,   0u,   2u,   0u,   0u,   0u,   150u, 0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  41u,  0u,   0u,   131u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   56u,  0u,   0u,   0u,
+    0u,   0u,   142u, 0u,  0u,   0u,   111u, 0u,   0u,   0u,   13u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   130u, 0u,   42u,  0u,   0u,   1u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   72u,  46u,  0u,   90u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   84u,  0u,   0u,   0u,   0u,   140u, 0u,   0u,   0u,
+    0u,   0u,   152u, 0u,  55u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   146u, 0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  120u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   92u,  0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   63u,  3u,   0u,   0u,   0u,   0u,   0u,
+    89u,  0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   93u,  0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   54u,  0u,   0u,   0u,   87u,  0u,   0u,
+    30u,  0u,   0u,   0u,  0u,   110u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   20u,  0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   33u,  0u,   0u,   124u, 0u,   0u,   95u,  0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   52u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   34u,  0u,   17u,  127u, 0u,
+    0u,   0u,   0u,   0u,  121u, 0u,   0u,   0u,   0u,   74u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   19u,
+    0u,   53u,  0u,   0u,  0u,   0u,   109u, 0u,   0u,   144u, 0u,   0u,   0u,   102u, 132u, 0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   137u, 0u,   151u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   39u,  0u,   0u,   0u,   0u,   0u,   0u,   105u,
+    0u,   0u,   0u,   0u,  66u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   119u, 0u,   0u,  0u,   0u,   0u,   0u,   25u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   60u,  0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   106u, 0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   4u,  27u,  0u,   0u,   47u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    79u,  0u,   0u,   0u,  0u,   0u,   129u, 0u,   0u,   136u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   6u,   0u,
+    0u,   80u,  0u,   0u,  0u,   86u,  96u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    125u, 0u,   0u,   38u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   81u,  0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   68u,  0u,  0u,   0u,   0u,   0u,   0u,   0u,   23u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  59u,  0u,   0u,   0u,   0u,   48u,  100u, 0u,   103u, 0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   16u, 0u,   0u,   0u,   44u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  101u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   36u,  7u,
+    0u,   148u, 0u,   0u,  0u,   0u,   0u,   0u,   0u,   70u,  113u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   128u, 88u,  0u,  0u,   0u,   0u,   0u,   61u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   5u,   116u, 0u,   0u,   0u,   0u,   77u,  0u,   0u,   0u,   97u,  0u,
+    0u,   0u,   0u,   0u,  21u,  0u,   133u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,
+    0u,   0u,   0u,   0u,  0u,   0u,   0u,   0u,   64u,  0u,   0u,   0u,   0u,   0u,   0u,   22u,  0u,   12u,  145u,
+    26u,  0u,   0u,   0u,  0u,   0u,   0u,   0u,   0u,   0u,   0u,   51u,  0u,   0u,   0u,   8u,   0u,   0u,   0u,
+    138u, 0u,   40u,  0u,  0u,   0u,   0u,   69u,  0u,   28u,  0u,   0u,   0u,   0u,   73u,  0u,   0u,   0u,   114u,
+    0u,   0u,   0u,   0u,  122u, 0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u,   0u};
+
 static const uint32_t th_tag_wide_names[] = {
     97u,  97u,  98u,  98u,  114u, 97u,  100u, 100u, 114u, 101u, 115u, 115u, 97u,  110u, 110u, 111u, 116u, 97u,  116u,
     105u, 111u, 110u, 45u,  120u, 109u, 108u, 97u,  112u, 112u, 108u, 101u, 116u, 97u,  114u, 101u, 97u,  97u,  114u,

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -74,34 +74,19 @@ static uint16_t intern_atom(const th_buf *name, uint8_t *out_flags) {
         return TH_TAG_UNKNOWN;                                  /* non-ASCII / empty tag names are never atoms */
     }
     const unsigned char *str = (const unsigned char *)name->data;
-    /* dispatch on the first byte to one small bucket, then linear-scan it: the
-       length pre-check rejects most candidates before any memcmp, and the
-       compared tail skips the shared first byte */
-    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Assign): a tag-name buffer is always initialized
-    unsigned first = str[0];
-    int index = th_tag_first[first];
-    int end = th_tag_first[first + 1];
-    for (; index < end; index++) {
-        const th_tag_entry *entry = &th_tag_table[index];
-        if (entry->name_len != name->len) {
-            continue;
-        }
-        /* Compare the tail (the first byte is the bucket) with an inline loop:
-           tag names are short, so this beats a libc memcmp call's overhead. */
-        const unsigned char *en = (const unsigned char *)entry->name + 1;
-        int eq = 1;
-        for (Py_ssize_t pos = 1; pos < name->len; pos++) {
-            if (str[pos] != en[pos - 1]) {
-                eq = 0;
-                break;
-            }
-        }
-        if (eq) {
-            *out_flags = entry->flags;
-            return entry->atom;
-        }
+    size_t slot = ((size_t)name->len * TH_TAG_HASH_LENGTH + (size_t)str[0] * TH_TAG_HASH_FIRST +
+                   (size_t)str[name->len - 1] * TH_TAG_HASH_LAST + (size_t)str[name->len > 1] * TH_TAG_HASH_SECOND) &
+                  TH_TAG_HASH_MASK;
+    uint8_t index = th_tag_hash[slot];
+    if (index == 0) {
+        return TH_TAG_UNKNOWN;
     }
-    return TH_TAG_UNKNOWN;
+    const th_tag_entry *entry = &th_tag_table[index - 1];
+    if (entry->name_len != name->len || memcmp(entry->name, str, (size_t)name->len) != 0) {
+        return TH_TAG_UNKNOWN;
+    }
+    *out_flags = entry->flags;
+    return entry->atom;
 }
 
 /* The token's interned tag atom, cached on the token by the run loop once per

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -357,7 +357,10 @@ OPERATIONS: dict[str, Operation] = {
 
 def _parse_cases() -> tuple[tuple[str, object], ...]:
     """Return the corpus documents the parse suite runs over (loaded from the html5lib-python submodule)."""
-    return tuple((name, corpus.corpus_text(relative, encoding)) for name, relative, encoding in corpus.CORPUS_FILES)
+    return (
+        *((name, corpus.corpus_text(relative, encoding)) for name, relative, encoding in corpus.CORPUS_FILES),
+        ("common tags (13 kB)", "<div><span>x</span></div>" * 500),
+    )
 
 
 def _readpath_cases() -> tuple[tuple[str, object], ...]:

--- a/tools/generate_tags.py
+++ b/tools/generate_tags.py
@@ -2,12 +2,12 @@
 Generate src/turbohtml/_c/data/tag_atom.h from the HTML element categories.
 
 The tree builder compares element identities as integers, never strings: the
-tokenizer's lowercased tag name is interned once at element insertion via a
-first-byte bucket lookup over the sorted name table here, and every later check
-(is this a special element? a formatting element? in scope?) reads an integer
-atom and its category bitmask. The category sets (special / formatting / scoping) are the
-ones the WHATWG tree-construction algorithm special-cases; keeping them in a
-generated table means a spec change is a regeneration, not a code edit.
+tokenizer's lowercased tag name is interned once through a generated index, and
+every later check (is this a special element? a formatting element? in scope?)
+reads an integer atom and its category bitmask. The category sets (special /
+formatting / scoping) are the ones the WHATWG tree-construction algorithm
+special-cases; keeping them in a generated table means a spec change is a
+regeneration, not a code edit.
 
 Usage:  python tools/generate_tags.py src/turbohtml/_c/data/tag_atom.h
 """
@@ -16,6 +16,12 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Final
+
+__all__ = ["generate"]
+
+_TAG_HASH_COEFFICIENTS: Final = (845, 797, 163, 777)
+_TAG_HASH_MASK: Final = 1023
 
 # Element categories the tree-construction algorithm tests against, in the HTML
 # namespace. The foreign-content insertion mode handles MathML/SVG scoping
@@ -207,6 +213,20 @@ CATEGORY_FLAGS = {
 }
 
 
+def _tag_hash_rows(names: list[str]) -> str:
+    slots = [0] * (_TAG_HASH_MASK + 1)
+    length, first, last, second = _TAG_HASH_COEFFICIENTS
+    for index, name in enumerate(names, start=1):
+        slot = (
+            len(name) * length + ord(name[0]) * first + ord(name[-1]) * last + ord(name[min(1, len(name) - 1)]) * second
+        ) & _TAG_HASH_MASK
+        if slots[slot]:
+            msg = f"tag hash collision between {names[slots[slot] - 1]!r} and {name!r}"
+            raise RuntimeError(msg)
+        slots[slot] = index
+    return ", ".join(f"{index}u" for index in slots)
+
+
 def generate(out_path: Path) -> None:
     """Write the generated tag-atom C header to *out_path*."""
     names = sorted(SPECIAL | FORMATTING | SCOPING | RAWTEXT | RCDATA | FOREIGN | EXTRA)
@@ -227,8 +247,7 @@ def generate(out_path: Path) -> None:
     # Names are sorted, so entries sharing a first byte are contiguous.
     # first_index[b] holds the offset of the first entry whose name starts with a
     # byte >= b, so the bucket for byte b is [first_index[b], first_index[b + 1]).
-    # Interning then scans one first-byte bucket rather than binary-searching the
-    # whole table.
+    # Shared query and mutation lookups scan one bucket rather than the whole table.
     first_index = [len(names)] * 257
     for index, name in enumerate(names):
         first_byte = ord(name[0])
@@ -263,6 +282,16 @@ def generate(out_path: Path) -> None:
         f"static const int th_tag_count = {len(names)};\n"
         "static const th_tag_entry th_tag_table[] = {\n"
         f"{chr(10).join(table_lines)}\n"
+        "};\n\n"
+        "/* Collision-free index over the fixed tag set. A lookup still verifies the\n"
+        "   spelling because an unknown name can share a generated slot. */\n"
+        f"#define TH_TAG_HASH_LENGTH {_TAG_HASH_COEFFICIENTS[0]}u\n"
+        f"#define TH_TAG_HASH_FIRST {_TAG_HASH_COEFFICIENTS[1]}u\n"
+        f"#define TH_TAG_HASH_LAST {_TAG_HASH_COEFFICIENTS[2]}u\n"
+        f"#define TH_TAG_HASH_SECOND {_TAG_HASH_COEFFICIENTS[3]}u\n"
+        f"#define TH_TAG_HASH_MASK {_TAG_HASH_MASK}u\n"
+        "static const uint8_t th_tag_hash[TH_TAG_HASH_MASK + 1] = {\n"
+        f"    {_tag_hash_rows(names)}\n"
         "};\n\n"
         "static const uint32_t th_tag_wide_names[] = {\n"
         f"    {', '.join(f'{char}u' for char in wide_names)}\n"


### PR DESCRIPTION
## Summary

HTML parsing resolved the tag atom for each token by scanning its first-byte bucket, which holds as many as 18 entries. The generated tag table now includes a 1 KiB collision-free index keyed by the tag length and three bytes. A hit needs one verified string comparison; empty slots and colliding unknown names remain unknown. Query and mutation lookups keep their existing path, limiting this change to parsing.

## Performance

Rigorous pyperf runs on CPython 3.14 arm64 measured 13 KiB of common `div` and `span` markup at 77.4 µs, down from 84.8 µs by 8.7%. Unknown `s-*` custom-element markup improved from 57.6 µs to 51.4 µs by 10.8%. A 92 KiB WPT page remained within noise at 283 µs versus 284 µs. A reverse-order run held the common-tag candidate at 77.4 ± 1.1 µs.

## Validation

`tox run -e 3.14` passed 63,309 tests, skipped 100, and reached 100% Python and C line and branch coverage. `tox run -e type,warnings,fuzz-smoke,fix`, `ruff format .`, and `ruff check . --fix --unsafe-fixes . --output-format=concise` also passed.
