### PR TITLE
⚡ perf(xpath): bound substring search

### DIFF
--- a/src/turbohtml/_c/query/xpath/functions.c
+++ b/src/turbohtml/_c/query/xpath/functions.c
@@ -39,13 +39,67 @@ static int func_is(const xn *fn, const char *kw) {
     return index == fn->str_len;
 }
 
+static Py_ssize_t ucs4_find_kmp(const Py_UCS4 *hay, Py_ssize_t hlen, const Py_UCS4 *needle, Py_ssize_t nlen,
+                                Py_ssize_t offset) {
+    Py_ssize_t *prefix = PyMem_Malloc((size_t)nlen * sizeof(*prefix));
+    if (prefix == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -2;        /* GCOVR_EXCL_LINE */
+    }
+    prefix[0] = 0;
+    for (Py_ssize_t index = 1, matched = 0; index < nlen; index++) {
+        while (matched > 0 && needle[index] != needle[matched]) {
+            matched = prefix[matched - 1];
+        }
+        if (needle[index] == needle[matched]) {
+            matched++;
+        }
+        prefix[index] = matched;
+    }
+    Py_ssize_t matched = 0;
+    for (Py_ssize_t index = offset; index < hlen; index++) {
+        while (matched > 0 && hay[index] != needle[matched]) {
+            matched = prefix[matched - 1];
+        }
+        if (hay[index] == needle[matched]) {
+            matched++;
+            if (matched == nlen) {
+                PyMem_Free(prefix);
+                return index - nlen + 1;
+            }
+        }
+    }
+    PyMem_Free(prefix);
+    return -1;
+}
+
 static Py_ssize_t ucs4_find(const Py_UCS4 *hay, Py_ssize_t hlen, const Py_UCS4 *needle, Py_ssize_t nlen) {
     if (nlen == 0) {
         return 0;
     }
-    for (Py_ssize_t index = 0; index + nlen <= hlen; index++) {
+    if (nlen > hlen) {
+        return -1;
+    }
+    if (memcmp(hay, needle, (size_t)nlen * sizeof(Py_UCS4)) == 0) {
+        return 0;
+    }
+    size_t candidates = nlen > 64 && hlen >= 256 ? 64 : SIZE_MAX;
+    Py_ssize_t last = nlen - 1;
+    for (Py_ssize_t index = 1; index + nlen <= hlen; index++) {
+        if (hay[index + last] != needle[last]) {
+            continue;
+        }
         if (memcmp(hay + index, needle, (size_t)nlen * sizeof(Py_UCS4)) == 0) {
             return index;
+        }
+        if (candidates != SIZE_MAX) {
+            candidates--;
+            if (candidates == 0) {
+                Py_ssize_t found = ucs4_find_kmp(hay, hlen, needle, nlen, index + 1);
+                if (found != -2) { /* GCOVR_EXCL_BR_LINE: -2 only after unforceable allocation failure */
+                    return found;
+                }
+                candidates = SIZE_MAX; /* GCOVR_EXCL_LINE: retain the allocation-free scan */
+            } /* GCOVR_EXCL_LINE: brace of the allocation-failure fallback */
         }
     }
     return -1;

--- a/tests/query/xpath/test_xpath_functions.py
+++ b/tests/query/xpath/test_xpath_functions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import math
 import re
+from typing import Final
 from xml.etree import ElementTree as ET  # noqa: S405
 
 import pytest
@@ -27,6 +28,8 @@ HTML = (
     "<ul><li>1</li><li>2</li><li>3</li></ul>"
     "<a href='/y'>L</a><input disabled><!--note--></body></html>"
 )
+_LONG_NEEDLE: Final = "a" * 65 + "ba"
+_LATE_HAY: Final = "a" * 200 + _LONG_NEEDLE
 
 
 @pytest.fixture
@@ -180,6 +183,40 @@ def doc() -> turbohtml.Node:
 )
 def test_scalar_and_boolean(doc: turbohtml.Node, expr: str, expected: object) -> None:
     assert doc.xpath(expr) == expected
+
+
+@pytest.mark.parametrize(
+    ("expression", "hay", "needle", "expected"),
+    [
+        pytest.param("contains($hay, $needle)", "a" * 400, "a" * 65 + "b", False, id="prefilter-miss"),
+        pytest.param(
+            "contains($hay, $needle)",
+            _LATE_HAY,
+            _LONG_NEEDLE,
+            True,
+            id="late-match",
+        ),
+        pytest.param("contains($hay, $needle)", "a" * 200 + "c" + "a" * 199, _LONG_NEEDLE, False, id="kmp-miss"),
+        pytest.param(
+            "substring-before($hay, $needle)",
+            _LATE_HAY,
+            _LONG_NEEDLE,
+            "a" * 200,
+            id="substring-before",
+        ),
+        pytest.param(
+            "substring-after($hay, $needle)",
+            _LATE_HAY + "z",
+            _LONG_NEEDLE,
+            "z",
+            id="substring-after",
+        ),
+        pytest.param("contains($hay, $needle)", "a" * 65, _LONG_NEEDLE, False, id="needle-longer"),
+        pytest.param("contains($hay, $needle)", _LONG_NEEDLE, _LONG_NEEDLE, True, id="short-hay"),
+    ],
+)
+def test_long_string_search(doc: turbohtml.Node, expression: str, hay: str, needle: str, expected: object) -> None:
+    assert doc.xpath(expression, hay=hay, needle=needle) == expected
 
 
 def test_number_parse_edge_cases(doc: turbohtml.Node) -> None:

--- a/tests/query/xpath/test_xpath_functions.py
+++ b/tests/query/xpath/test_xpath_functions.py
@@ -213,6 +213,7 @@ def test_scalar_and_boolean(doc: turbohtml.Node, expr: str, expected: object) ->
         ),
         pytest.param("contains($hay, $needle)", "a" * 65, _LONG_NEEDLE, False, id="needle-longer"),
         pytest.param("contains($hay, $needle)", _LONG_NEEDLE, _LONG_NEEDLE, True, id="short-hay"),
+        pytest.param("contains($hay, $needle)", "x" + "a" * 65 + "ca", _LONG_NEEDLE, False, id="short-hay-miss"),
     ],
 )
 def test_long_string_search(doc: turbohtml.Node, expression: str, hay: str, needle: str, expected: object) -> None:


### PR DESCRIPTION
XPath `contains()`, `substring-before()`, and `substring-after()` compared the full needle at every position, making self-overlapping misses quadratic.

The shared search now checks the first position, filters later positions by the final needle code point, and switches to KMP after 64 failed full comparisons. Allocation failure keeps the existing allocation-free scan.

On Apple M-series CPython 3.14, a 100,000-character miss with a 4,097-character needle fell from 27.7 ms to 55.8 µs, or 496×. Short and long non-overlapping misses took 102 µs and 69.6 µs instead of 181 µs and 146 µs. An early long match stayed within 1%, at 26.9 µs on main and 27.2 µs on the branch.
