### PR TITLE
⚡ perf(dom): grow arena blocks

### DIFF
--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #define ARENA_BLOCK ((Py_ssize_t)64 * 1024)
+#define ARENA_MAX_BLOCK ((Py_ssize_t)256 * 1024)
 
 typedef struct arena_block {
     struct arena_block *next;
@@ -115,7 +116,13 @@ static inline void *arena_alloc(th_tree *tree, Py_ssize_t size) {
     size = (size + 15) & ~(Py_ssize_t)15; /* 16-byte align */
     arena_block *block = tree->arena;
     if (block == NULL || block->used + size > block->cap) {
-        Py_ssize_t cap = size > ARENA_BLOCK ? size : ARENA_BLOCK;
+        Py_ssize_t cap = ARENA_BLOCK;
+        if (block != NULL) {
+            cap = block->cap < ARENA_MAX_BLOCK ? block->cap * 2 : ARENA_MAX_BLOCK;
+        }
+        if (cap < size) {
+            cap = size;
+        }
         arena_block *fresh = PyMem_Malloc(sizeof(arena_block) + (size_t)cap);
         if (fresh == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             tree->failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -858,6 +858,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "emit": (emit, "turbohtml"),
     "shadow": (shadow, "turbohtml"),
     "parse": (parse, "turbohtml"),
+    "parse-dense": (parse, "turbohtml"),
     "parse-xml": (parse_xml, "turbohtml"),
     "validate": (validate, "turbohtml"),
     "validate-rng": (validate_rng, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -254,9 +254,8 @@ class Operation:
 # functions return the minified text; the worker records its byte length once (deterministic) beside the timing.
 SIZE_OPS: Final[frozenset[str]] = frozenset({"minify", "minify-css", "minify-js"})
 
-# The streaming rewrite never builds a tree; a full-parse peer must. This op's table carries the peak resident memory
-# of doing the task in a fresh process alongside time, so the tree turbohtml avoids surfaces as bytes it never holds.
-MEMORY_OPS: Final[frozenset[str]] = frozenset({"rewrite"})
+# Peak RSS runs in a fresh process so allocator reuse from pyperf's timed loops cannot hide the retained tree or buffer.
+MEMORY_OPS: Final[frozenset[str]] = frozenset({"parse-dense", "rewrite"})
 
 
 OPERATIONS: dict[str, Operation] = {
@@ -266,6 +265,7 @@ OPERATIONS: dict[str, Operation] = {
     "emit": Operation("emit a built tree", "us"),
     "shadow": Operation("attach a shadow tree with slots and flatten", "us"),
     "parse": Operation("parse to a tree", "us"),
+    "parse-dense": Operation("parse a node-dense document", "ms"),
     "parse-xml": Operation("parse XML to a tree", "us"),
     "validate": Operation("validate a document against an XSD schema", "us"),
     "validate-rng": Operation("validate a document against a RELAX NG schema", "us"),
@@ -804,6 +804,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "emit": lambda: _ROWS,
     "shadow": lambda: _ROWS,
     "parse": _parse_cases,
+    "parse-dense": lambda: (("2.6 MB / 200k nodes", "<div><span>x</span></div>" * 100_000),),
     "parse-xml": lambda: (("catalog XML", _XML_DOC),),
     "validate": lambda: (
         ("catalog XSD + doc", (_VALIDATE_XSD, _VALIDATE_DOC)),


### PR DESCRIPTION
Large DOMs allocated every arena chunk at 64 KiB, leaving the allocator to manage hundreds of independent blocks for node-dense pages.

Keep the first block at 64 KiB, then double later blocks through a 256 KiB ceiling. Oversized individual allocations still receive an exact-size block, and small documents retain the existing allocation profile.

On Apple M-series CPython 3.14 release builds, the new 2.6 MB `parse-dense` case reduced peak process footprint from 48.5 MiB to 43.9 MiB, or 9.5%, while best process-time runs moved from 15.2 ms to 14.9 ms. A 13 kB page measured 76.0 µs on main and 75.1 µs on this branch. The benchmark records both peak RSS and parse time.
