### PR TITLE
⚡ perf(tables): grow grid rows

### DIFF
--- a/src/turbohtml/_c/extract/tables.c
+++ b/src/turbohtml/_c/extract/tables.c
@@ -35,6 +35,7 @@ typedef struct {
 /* One grid row, its cells grown on demand as cells and colspans reach further right. */
 typedef struct {
     grid_cell *cells;
+    Py_ssize_t width;
     Py_ssize_t cap;
 } grid_row;
 
@@ -91,20 +92,29 @@ static Py_ssize_t parse_span(th_node *cell, uint32_t name_atom) {
 
 /* Grow row so column index `needed - 1` is addressable, zero-initializing the new slots. -1 on allocation failure. */
 static int ensure_columns(grid_row *row, Py_ssize_t needed) {
+    if (needed > row->width) {
+        row->width = needed;
+    }
     if (needed <= row->cap) {
         return 0;
     }
-    grid_cell *cells = PyMem_Realloc(row->cells, (size_t)needed * sizeof(grid_cell));
+    size_t cap;
+    size_t bytes;
+    int grew = th_grow_cap((size_t)needed, (size_t)row->cap, 8, sizeof(grid_cell), &cap, &bytes);
+    if (!grew) {   /* GCOVR_EXCL_BR_LINE: size overflow needs a table no allocation could hold */
+        return -1; /* GCOVR_EXCL_LINE: size-overflow path, unreachable from a test */
+    }
+    grid_cell *cells = PyMem_Realloc(row->cells, bytes);
     if (cells == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;       /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    for (Py_ssize_t index = row->cap; index < needed; index++) {
+    for (Py_ssize_t index = row->cap; index < (Py_ssize_t)cap; index++) {
         cells[index].text = NULL;
         cells[index].len = 0;
         cells[index].present = 0;
     }
     row->cells = cells;
-    row->cap = needed;
+    row->cap = (Py_ssize_t)cap;
     return 0;
 }
 
@@ -294,8 +304,8 @@ static int build_grid_locked(th_tree *tree, th_node *table, table_grid *grid) {
 static Py_ssize_t grid_width(const table_grid *grid) {
     Py_ssize_t width = 0;
     for (Py_ssize_t row = 0; row < grid->row_count; row++) {
-        if (grid->rows[row].cap > width) {
-            width = grid->rows[row].cap;
+        if (grid->rows[row].width > width) {
+            width = grid->rows[row].width;
         }
     }
     return width;
@@ -303,7 +313,7 @@ static Py_ssize_t grid_width(const table_grid *grid) {
 
 /* The text at (row, col) as a str: the trimmed cell text, or "" for an empty or never-filled slot. */
 static PyObject *cell_to_str(const grid_row *row, Py_ssize_t col) {
-    if (col < row->cap && row->cells[col].present && row->cells[col].text != NULL) {
+    if (col < row->width && row->cells[col].present && row->cells[col].text != NULL) {
         return PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, row->cells[col].text, row->cells[col].len);
     }
     return PyUnicode_FromString("");

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -919,6 +919,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "markdown": (markdown, "turbohtml"),
     "markdown-google": (markdown_google, "turbohtml"),
     "tables": (tables, "turbohtml"),
+    "tables-wide": (tables, "turbohtml"),
     "article": (article, "turbohtml"),
     "boilerplate": (boilerplate, "turbohtml"),
     "date": (date, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -325,6 +325,7 @@ OPERATIONS: dict[str, Operation] = {
     "markdown": Operation("HTML to Markdown", "us"),
     "markdown-google": Operation("Google Docs export to Markdown", "us"),
     "tables": Operation("extract table grids", "us"),
+    "tables-wide": Operation("extract a wide table grid", "us"),
     "article": Operation("article extraction", "us"),
     "boilerplate": Operation("paragraph boilerplate classification", "us"),
     "date": Operation("publication-date extraction", "us"),
@@ -894,6 +895,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("rows (1000 rows)", ("rows", _table_html(1_000))),
         ("records (1000 rows)", ("records", _table_html(1_000))),
     ),
+    "tables-wide": lambda: (("10k columns", ("rows", "<table><tr>" + "<td>x</td>" * 10_000 + "</tr></table>")),),
     "article": lambda: (("post (4 KiB)", _article_page(16)), ("longform (16 KiB)", _article_page(72))),
     "boilerplate": lambda: (("post (4 KiB)", _article_page(16)), ("longform (16 KiB)", _article_page(72))),
     "date": lambda: (


### PR DESCRIPTION
Each dense table row allocated only its exact required width. A 10,000-cell row therefore made 10,000 `realloc` calls.

Start at eight slots, then double capacity. A separate logical width preserves ragged-row padding and returned column counts; shared growth arithmetic handles overflow.

On Apple M-series CPython 3.14 release builds, best process-time runs for a 10,000-column `rows()` call fell from 613 µs on main to 471 µs on this branch, or 23%. The 1,000-column case fell from 67.5 µs to 47.2 µs, and the 100-column case from 7.02 µs to 5.02 µs. The benchmark suite adds `tables-wide` to retain the allocator-heavy case.
