### PR TITLE
⚡ perf(xml): grow name buffers

### DIFF
--- a/src/turbohtml/_c/tokenizer/xml.c
+++ b/src/turbohtml/_c/tokenizer/xml.c
@@ -14,6 +14,8 @@
 #include "dom/tree.h"
 #include "dom/tree_internal.h" /* arena, node_new, node_append, copy_input_span */
 
+#include "core/vec.h"
+
 #include <string.h>
 
 static int xml_is_space(Py_UCS4 ch) {
@@ -166,13 +168,20 @@ static int scratch_push(xml_parser *parser, Py_UCS4 ch) {
 /* Widen the input range [start, start+len) into the reusable name buffer. */
 static Py_UCS4 *widen(xml_parser *parser, Py_ssize_t start, Py_ssize_t len) {
     if (len > parser->names_cap) {
-        Py_UCS4 *grown = PyMem_Realloc(parser->names, (size_t)len * sizeof(Py_UCS4));
+        size_t cap;
+        size_t bytes;
+        int grew = th_grow_cap((size_t)len, (size_t)parser->names_cap, 64, sizeof(Py_UCS4), &cap, &bytes);
+        if (!grew) {                  /* GCOVR_EXCL_BR_LINE: size overflow needs an input no allocation could hold */
+            parser->tree->failed = 1; /* GCOVR_EXCL_LINE: size-overflow path, unreachable from a test */
+            return NULL;              /* GCOVR_EXCL_LINE: size-overflow path, unreachable from a test */
+        }
+        Py_UCS4 *grown = PyMem_Realloc(parser->names, bytes);
         if (grown == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             parser->tree->failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
             return NULL;              /* GCOVR_EXCL_LINE: allocation-failure path */
         }
         parser->names = grown;
-        parser->names_cap = len;
+        parser->names_cap = (Py_ssize_t)cap;
     }
     for (Py_ssize_t index = 0; index < len; index++) {
         parser->names[index] = cp(parser, start + index);
@@ -183,15 +192,21 @@ static Py_UCS4 *widen(xml_parser *parser, Py_ssize_t start, Py_ssize_t len) {
 /* Encode the input range [start, start+len) as UTF-8 into the reusable buffer;
  *out_len receives the byte count. NULL on allocation failure. */
 static const char *encode_utf8(xml_parser *parser, Py_ssize_t start, Py_ssize_t len, Py_ssize_t *out_len) {
-    Py_ssize_t needed = len * 4;
-    if (needed > parser->u8_cap) {
-        char *grown = PyMem_Realloc(parser->u8, (size_t)needed);
+    if (len > parser->u8_cap) {
+        size_t cap;
+        size_t bytes;
+        int grew = th_grow_cap((size_t)len, (size_t)parser->u8_cap, 64, 4, &cap, &bytes);
+        if (!grew) {                  /* GCOVR_EXCL_BR_LINE: size overflow needs an input no allocation could hold */
+            parser->tree->failed = 1; /* GCOVR_EXCL_LINE: size-overflow path, unreachable from a test */
+            return NULL;              /* GCOVR_EXCL_LINE: size-overflow path, unreachable from a test */
+        }
+        char *grown = PyMem_Realloc(parser->u8, bytes);
         if (grown == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             parser->tree->failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
             return NULL;              /* GCOVR_EXCL_LINE: allocation-failure path */
         }
         parser->u8 = grown;
-        parser->u8_cap = needed;
+        parser->u8_cap = (Py_ssize_t)cap;
     }
     Py_ssize_t out = 0;
     for (Py_ssize_t index = 0; index < len; index++) {

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -859,6 +859,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "shadow": (shadow, "turbohtml"),
     "parse": (parse, "turbohtml"),
     "parse-xml": (parse_xml, "turbohtml"),
+    "parse-xml-names": (parse_xml, "turbohtml"),
     "validate": (validate, "turbohtml"),
     "validate-rng": (validate_rng, "turbohtml"),
     "compile-rng": (compile_rng, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -267,6 +267,7 @@ OPERATIONS: dict[str, Operation] = {
     "shadow": Operation("attach a shadow tree with slots and flatten", "us"),
     "parse": Operation("parse to a tree", "us"),
     "parse-xml": Operation("parse XML to a tree", "us"),
+    "parse-xml-names": Operation("parse growing XML names", "ms"),
     "validate": Operation("validate a document against an XSD schema", "us"),
     "validate-rng": Operation("validate a document against a RELAX NG schema", "us"),
     "compile-rng": Operation("compile a RELAX NG schema", "us"),
@@ -805,6 +806,12 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "shadow": lambda: _ROWS,
     "parse": _parse_cases,
     "parse-xml": lambda: (("catalog XML", _XML_DOC),),
+    "parse-xml-names": lambda: (
+        (
+            "1k growing attributes",
+            "<r>" + "".join("<e " + "a" * length + '="x"/>' for length in range(1, 1_001)) + "</r>",
+        ),
+    ),
     "validate": lambda: (
         ("catalog XSD + doc", (_VALIDATE_XSD, _VALIDATE_DOC)),
         ("1,024 global declarations", (_VALIDATE_GLOBAL_XSD, _VALIDATE_GLOBAL_DOC)),


### PR DESCRIPTION
The XML parser reused one UCS-4 name buffer and one UTF-8 attribute-name buffer, but each new maximum name length resized both buffers to the exact request. Documents with increasing attribute-name lengths repeated allocation and copying.

Grow both capacities by powers of two from 64 code points. The shared growth helper also makes the size arithmetic overflow-safe; short-name documents retain one small allocation per buffer.

On Apple M-series CPython 3.14 release builds, paired process-time measurements for 1,000 increasing attribute names fell from 2.95 ms on main to 2.79 ms on this branch, or 5.4%. A 200-attribute case fell from 144 µs to 117 µs, while the existing catalog workload remained within its 500 to 511 µs run-to-run range. The benchmark suite adds `parse-xml-names` to retain the growth pattern.
