### PR TITLE
⚡ perf(xpath): hash id tokens

### DIFF
--- a/src/turbohtml/_c/query/xpath/functions.c
+++ b/src/turbohtml/_c/query/xpath/functions.c
@@ -2,6 +2,7 @@
    parsel and scrapy lean on, and the Python hook the parser conformance tests call. */
 
 #include "core/common.h"
+#include "core/vec.h"
 #include "dom/tree.h"
 #include "query/xpath/internal.h"
 #include "query/xpath/xpath.h"
@@ -327,11 +328,22 @@ static int node_lang(xp_ctx *ctx, xp_result *arg) {
     return result;
 }
 
-/* True when `token` appears as a whitespace-delimited entry in `list`. */
-static int token_in_list(const Py_UCS4 *list, Py_ssize_t list_len, const Py_UCS4 *token, Py_ssize_t token_len) {
-    if (token_len == 0) {
-        return 0;
+typedef struct {
+    const Py_UCS4 *value;
+    Py_ssize_t len;
+} xp_id_token;
+
+static uint64_t id_token_hash(const Py_UCS4 *value, Py_ssize_t len) {
+    uint64_t hash = 14695981039346656037u;
+    for (Py_ssize_t index = 0; index < len; index++) {
+        hash ^= value[index];
+        hash *= 1099511628211u;
     }
+    return hash;
+}
+
+static int id_token_set_build(const Py_UCS4 *list, Py_ssize_t list_len, xp_id_token **slots, size_t *mask) {
+    Py_ssize_t count = 0;
     Py_ssize_t index = 0;
     while (index < list_len) {
         while (index < list_len && xp_is_space(list[index])) {
@@ -341,7 +353,56 @@ static int token_in_list(const Py_UCS4 *list, Py_ssize_t list_len, const Py_UCS4
         while (index < list_len && !xp_is_space(list[index])) {
             index++;
         }
-        if (index - start == token_len && memcmp(list + start, token, (size_t)token_len * sizeof(Py_UCS4)) == 0) {
+        count += index > start;
+    }
+    if (count == 0) {
+        *slots = NULL;
+        *mask = 0;
+        return 0;
+    }
+    size_t cap;
+    size_t bytes;
+    int grew = th_grow_cap((size_t)count * 2, 0, 8, sizeof(xp_id_token), &cap, &bytes);
+    if (!grew) {   /* GCOVR_EXCL_BR_LINE: the string cannot hold enough tokens to overflow */
+        return -1; /* GCOVR_EXCL_LINE: unreachable size-overflow path */
+    }
+    *slots = PyMem_Calloc(1, bytes);
+    if (*slots == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;        /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    *mask = cap - 1;
+    index = 0;
+    while (index < list_len) {
+        while (index < list_len && xp_is_space(list[index])) {
+            index++;
+        }
+        Py_ssize_t start = index;
+        while (index < list_len && !xp_is_space(list[index])) {
+            index++;
+        }
+        Py_ssize_t len = index - start;
+        if (len == 0) {
+            continue;
+        }
+        size_t probe = id_token_hash(list + start, len) & *mask;
+        while ((*slots)[probe].value != NULL &&
+               ((*slots)[probe].len != len ||
+                memcmp((*slots)[probe].value, list + start, (size_t)len * sizeof(Py_UCS4)) != 0)) {
+            probe = (probe + 1) & *mask;
+        }
+        if ((*slots)[probe].value == NULL) {
+            (*slots)[probe] = (xp_id_token){list + start, len};
+        }
+    }
+    return 0;
+}
+
+static int id_token_set_contains(const xp_id_token *slots, size_t mask, const Py_UCS4 *value, Py_ssize_t len) {
+    if (slots == NULL || len == 0) {
+        return 0;
+    }
+    for (size_t probe = id_token_hash(value, len) & mask; slots[probe].value != NULL; probe = (probe + 1) & mask) {
+        if (slots[probe].len == len && memcmp(slots[probe].value, value, (size_t)len * sizeof(Py_UCS4)) == 0) {
             return 1;
         }
     }
@@ -382,6 +443,12 @@ static int eval_id(xp_ctx *ctx, xp_result *arg, xp_result *out) {
             return -1;      /* GCOVR_EXCL_LINE */
         }
     }
+    xp_id_token *ids;
+    size_t id_mask;
+    if (id_token_set_build(list, list_len, &ids, &id_mask) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+        PyMem_Free(list);                                         /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;                                                /* GCOVR_EXCL_LINE */
+    }
     int rc = 0;
     for (struct th_node *node = th_tree_document(ctx->tree); node != NULL; node = document_next(node)) {
         if (node->type != TH_NODE_ELEMENT) {
@@ -389,7 +456,7 @@ static int eval_id(xp_ctx *ctx, xp_result *arg, xp_result *out) {
         }
         for (Py_ssize_t index = 0; index < node->attr_count; index++) {
             if (node->attrs[index].name_atom == TH_ATTR_ID &&
-                token_in_list(list, list_len, node->attrs[index].value, node->attrs[index].value_len)) {
+                id_token_set_contains(ids, id_mask, node->attrs[index].value, node->attrs[index].value_len)) {
                 if (ns_push(&out->nodes, node, -1) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
                     rc = -1;                              /* GCOVR_EXCL_LINE */
                 } /* GCOVR_EXCL_LINE: brace of the never-taken alloc-failure branch */
@@ -397,6 +464,7 @@ static int eval_id(xp_ctx *ctx, xp_result *arg, xp_result *out) {
             }
         }
     }
+    PyMem_Free(ids);
     PyMem_Free(list);
     if (rc < 0) {                     /* GCOVR_EXCL_BR_LINE: alloc */
         xp_nodeset_free(&out->nodes); /* GCOVR_EXCL_LINE */

--- a/tests/query/xpath/test_xpath_node_functions.py
+++ b/tests/query/xpath/test_xpath_node_functions.py
@@ -69,6 +69,11 @@ def test_id_string_value(ids: turbohtml.Node) -> None:
     assert ids.xpath("string(id('b'))") == "two"
 
 
+def test_id_hash_collisions_keep_document_order() -> None:
+    document = turbohtml.parse("<p id=a></p><div id=ba></div><span id=q></span><i id=x></i>")
+    assert tags(document.xpath("id('a ba q a missing')")) == ["p", "div", "span"]
+
+
 @pytest.fixture
 def foreign() -> turbohtml.Node:
     return turbohtml.parse(NS_HTML)

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -740,6 +740,7 @@ _SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
 _COUNT_EXTENSIONS = {(None, "ext_count"): _count_ext}
 _NODESET_EXTENSIONS = {(None, "ext_first_two"): _first_two_ext}
 _REUSE = turbohtml.XPath("//a[@href]")
+_ID_REUSE = turbohtml.XPath("id('" + " ".join(f"r{index}" for index in range(1_000)) + "')")
 
 
 @functools.cache
@@ -781,6 +782,11 @@ def xpath(case: tuple[str, str]) -> None:
     """Evaluate one XPath feature class with turbohtml's compiled-program engine, by case kind."""
     kind, text = case
     _XPATH_CALLS[kind](_parsed(text), text)
+
+
+def xpath_id(text: str) -> None:
+    """Resolve a large precompiled id() token set against a cached parsed document."""
+    _ID_REUSE(_parsed(text))
 
 
 def minify_css(css: str) -> str:
@@ -939,6 +945,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "translate": (translate, "turbohtml"),
     "specificity": (specificity, "turbohtml"),
     "xpath": (xpath, "turbohtml"),
+    "xpath-id": (xpath_id, "turbohtml"),
     "transform": (transform, "turbohtml"),
     "transform-sort": (transform, "turbohtml"),
     "transform-dense": (transform, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -344,6 +344,7 @@ OPERATIONS: dict[str, Operation] = {
     "translate": Operation("CSS selector to XPath 1.0", "us"),
     "specificity": Operation("CSS selector specificity", "us"),
     "xpath": Operation("XPath feature surface (9.6 kB)", "us"),
+    "xpath-id": Operation("resolve 1,000 XPath id tokens", "us"),
     "transform": Operation("XSLT transform a catalog (120 rows)", "us"),
     "transform-sort": Operation("XSLT sort node sets", "ms"),
     "transform-dense": Operation("XSLT transform an instruction-dense sheet", "us"),
@@ -503,6 +504,7 @@ _XPATH_PARITY = (
     ("$rows/div (node-set variable)", "node_set_variable"),
     ("//a[@href] (precompiled, reused)", "precompiled"),
 )
+_XPATH_ID_DOC: Final = "".join(f"<i id=r{index}></i>" for index in range(5_000))
 
 
 def _table_html(data_rows: int) -> str:
@@ -921,6 +923,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "translate": lambda: _TRANSLATE_CASES,
     "specificity": lambda: _TRANSLATE_CASES,
     "xpath": _xpath_cases,
+    "xpath-id": lambda: (("1,000 ids among 5,000 elements", _XPATH_ID_DOC),),
     "transform": _transform_cases,
     "transform-sort": _transform_sort_cases,
     "transform-dense": _transform_dense_cases,


### PR DESCRIPTION
XPath `id()` scanned the whitespace-delimited argument for every ID attribute in the document. Queries with many requested IDs therefore repeated the same token comparisons across every element.

Build an open-addressed token set once per evaluation and probe it while walking the document. Results stay in document order, duplicate argument tokens remain harmless, and keeping the set local to the call avoids cache invalidation after DOM mutations.

On Apple M-series CPython 3.14 release builds, a precompiled query selecting 1,000 IDs from 5,000 elements fell from 9.58 ms ± 0.24 ms on main to 37.3 µs ± 0.7 µs on this branch, about 99.6% less. A one-ID query over 100 elements fell from 533 ns ± 9 ns to 362 ns ± 7 ns, about 32% less. The benchmark suite adds `xpath-id` to retain the multi-token case.
