### PR TITLE
⚡ perf(normalize): avoid search branches

### DIFF
--- a/src/turbohtml/_c/unicode/normalize.c
+++ b/src/turbohtml/_c/unicode/normalize.c
@@ -56,18 +56,18 @@ static const th_norm_decomp_row *decomp_row(const th_norm_decomp_row *table, int
     if (cp < table[0].code) {
         return NULL;
     }
-    int lo = 0;
-    int hi = count;
-    while (lo < hi) {
-        int mid = (lo + hi) / 2;
-        if (table[mid].code < cp) {
-            lo = mid + 1;
-        } else {
-            hi = mid;
-        }
+    /* Code points vary independently, so selecting either half is unpredictable. */
+    int left = 0;
+    int remaining = count;
+    while (remaining > 1) {
+        int half = remaining / 2;
+        int middle = left + half;
+        left = table[middle].code < cp ? middle : left;
+        remaining -= half;
     }
-    if (lo < count && table[lo].code == cp) {
-        return &table[lo];
+    left += table[left].code < cp;
+    if (left < count && table[left].code == cp) {
+        return &table[left];
     }
     return NULL;
 }

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -147,6 +147,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "markup": ("markup-book", _book_text),
     "markup-op": ("markup-op-book", lambda: ("striptags", _book_html())),
     "detect": ("detect-book", lambda: ("find", _book_text())),
+    "normalize": ("normalize-decomposed", lambda: INPUTS["normalize"]()[2][1]),
 }
 
 


### PR DESCRIPTION
Unicode normalization probes decomposition tables for every non-Hangul code point in a full normalization run. The classic lower-bound loop makes an input-dependent left-or-right branch at every round.

Use a fixed-round lower-bound search that updates one index through a conditional select. Other table searches stay unchanged because prototypes regressed their predictable workloads.

I rebuilt `702424f0` and `f8fed317` as frozen non-editable wheels and remeasured. NFD French improves 4%, from 52.7 µs to 50.3 µs; the 34% first reported here does not reproduce. The randomized 8,192-code-point NFD case gains 12%, from 287 µs to 253 µs, and the NFC quick check holds at 4.93 µs against 4.88 µs. Each number is the median of five alternating rounds, run base-first and candidate-first on an arm64 build. The direction holds in both orders, so the branchless search still earns its place at a smaller margin.

The complete local gate passes with 63,354 tests, 104 expected skips, and 100% Python and C coverage.
