### PR TITLE
⚡ perf(decode): avoid GB18030 branches

### DIFF
--- a/src/turbohtml/_c/encoding/decode.h
+++ b/src/turbohtml/_c/encoding/decode.h
@@ -314,7 +314,7 @@ static TH_HOT int th_dec_euc_jp(th_decoder *dec, Py_UCS4 *point) {
     }
 }
 
-/* The spec's "index gb18030 ranges code point", a binary search over the sorted range starts. */
+/* The spec's "index gb18030 ranges code point", using fixed rounds because four-byte pointers vary independently. */
 static int th_dec_gb18030_range(uint32_t pointer, Py_UCS4 *point) {
     if ((pointer > 39419 && pointer < 189000) || pointer > 1237575) {
         return 0;
@@ -323,17 +323,15 @@ static int th_dec_gb18030_range(uint32_t pointer, Py_UCS4 *point) {
         *point = 0xE7C7;
         return 1;
     }
-    size_t low = 0;
-    size_t high = sizeof(th_gb18030_ranges) / sizeof(th_gb18030_ranges[0]);
-    while (low + 1 < high) {
-        size_t mid = low + (high - low) / 2;
-        if (th_gb18030_ranges[mid].pointer <= pointer) {
-            low = mid;
-        } else {
-            high = mid;
-        }
+    size_t left = 0;
+    size_t remaining = sizeof(th_gb18030_ranges) / sizeof(th_gb18030_ranges[0]);
+    while (remaining > 1) {
+        size_t half = remaining / 2;
+        size_t middle = left + half;
+        left = th_gb18030_ranges[middle].pointer <= pointer ? middle : left;
+        remaining -= half;
     }
-    *point = th_gb18030_ranges[low].code_point + (pointer - th_gb18030_ranges[low].pointer);
+    *point = th_gb18030_ranges[left].code_point + (pointer - th_gb18030_ranges[left].pointer);
     return 1;
 }
 

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -148,6 +148,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "markup-op": ("markup-op-book", lambda: ("striptags", _book_html())),
     "detect": ("detect-book", lambda: ("find", _book_text())),
     "normalize": ("normalize-decomposed", lambda: INPUTS["normalize"]()[2][1]),
+    "decode": ("decode-gb18030-ranges", lambda: INPUTS["decode"]()[1][1]),
 }
 
 

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -775,6 +775,10 @@ def _decode_cases() -> tuple[tuple[str, object], ...]:
     japanese = _decode_page(_ENCODING_JAPANESE)
     return (
         ("shift_jis japanese (8 kB)", ("shift_jis", japanese.encode("cp932"))),
+        (
+            "gb18030 astral (16 kB)",
+            ("gb18030", "".join(chr(0x10000 + (index * 7919) % 0xE0000) for index in range(4096)).encode("gb18030")),
+        ),
         ("windows-1252 french (9 kB)", ("windows-1252", _decode_page(_ENCODING_FRENCH).encode("cp1252"))),
         ("gb18030 japanese (8 kB)", ("gb18030", japanese.encode("gb18030"))),
         ("iso-2022-jp japanese (8 kB)", ("iso-2022-jp", japanese.encode("iso2022_jp"))),


### PR DESCRIPTION
GB18030 maps each four-byte pointer through a sorted range table. The classic predecessor search chooses an input-dependent branch at every round, and astral text makes those choices unpredictable.

Use fixed rounds and update one candidate index through a conditional select. This leaves the common two-byte state-machine path intact.

Frozen-wheel benchmarks across five alternating rounds measure 32.2 to 33.6 µs before and 17.8 to 18.2 µs after for 4,096 astral code points, about 45% less time. Two-byte Japanese holds at 13.2 µs.

The complete local gate passes with 100% Python and C coverage.
