### PR TITLE
⚡ perf(tokenizer): thread state dispatch

### DIFF
--- a/src/turbohtml/_c/tokenizer/statemachine.c
+++ b/src/turbohtml/_c/tokenizer/statemachine.c
@@ -1068,7 +1068,7 @@ enum run_result { RUN_EMITTED, RUN_NEED_MORE, RUN_DONE };
     {                                                                                                                  \
         self->eof_code = NULL;                                                                                         \
         self->state = ST_BOGUS_DOCTYPE;                                                                                \
-        continue;                                                                                                      \
+        TH_DISPATCH();                                                                                                 \
     }
 
 #define TH_ONES UINT64_C(0x0101010101010101)

--- a/src/turbohtml/_c/tokenizer/statemachine_run.h
+++ b/src/turbohtml/_c/tokenizer/statemachine_run.h
@@ -283,1015 +283,1121 @@ static int TH_NAME(match_kw)(const th_tokenizer *self, const char *keyword, int 
     return avail >= klen ? 2 : 1;
 }
 
-static enum run_result TH_NAME(run)(th_tokenizer *self) {
-    for (;;) {
-        int at_eof;
-        Py_UCS4 ch;
-        if (self->pos < self->input.len) {
-            ch = TH_READ(self->pos);
-            at_eof = 0;
-        } else if (self->eof) {
-            ch = 0;
-            at_eof = 1;
-        } else {
-            return RUN_NEED_MORE;
-        }
-
-        /* The first time EOF is reached with a tag/comment/doctype construct
-           still open, report it once; eof_code names the construct (cleared when
-           it is emitted), so a clean DATA-state EOF leaves it NULL. */
-        if (at_eof && !self->eof_reported && self->eof_code != NULL) {
-            tok_error(self, self->eof_code);
-            self->eof_reported = 1;
-        }
-
-        switch (self->state) { /* GCOVR_EXCL_BR_LINE: enum-complete switch; the out-of-range edge is unreachable */
-        case ST_DATA:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-#if TH_UCS1
-            /* '\n' is ordinary text in DATA -- the only per-newline work is
-               line/column tracking, so a single SIMD pass runs straight through
-               newlines to the next markup (a paragraph between tags becomes one
-               sweep, not one per wrapped line) and folds the newline count and
-               last-newline column in along the way. The wider widths keep the
-               generic newline-stopping scan: they are rarer and the dedicated
-               1-byte pass is where real documents live. */
-            if (ch != '&' && ch != '<' && ch != 0) {
-                Py_ssize_t newlines;
-                Py_ssize_t last_nl;
-                Py_ssize_t stop = scan_data_ucs1(self, self->pos, &newlines, &last_nl);
-                text_append_run_lc(self, stop, newlines, last_nl < 0 ? 0 : stop - last_nl - 1);
-                continue;
-            }
+/* Threaded dispatch. The switch form routes all 71 states through one indirect branch, so the
+   predictor sees a single site with 71 targets and every transition aliases every other. Giving each
+   state its own fetch-and-jump gives each transition its own prediction history, at the cost of
+   replicating the fetch. Compilers without computed goto (MSVC) keep the switch, so both forms share
+   one state block and one fetch, the way CPython's ceval.c carries its two dispatch forms. */
+#if defined(__GNUC__)
+#define TH_THREADED 1
 #else
-            if (ch != '&' && ch != '<' && ch != '\n' && ch != 0) {
-                Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '&', '<', '\n', 0);
-                text_append_run(self, stop);
-                continue;
-            }
+#define TH_THREADED 0
 #endif
-            if (ch == 0) {
-                /* the data state keeps the NUL, where every other text state replaces it */
-                tok_error(self, "unexpected-null-character");
-                text_begin(self);
-                text_push(self, 0);
-                CONSUME();
-                continue;
-            }
-            if (ch == '&') {
-                if (self->resolve_references) {
-                    text_begin(self);
-                    text_materialize(self);
-                    Py_ssize_t consumed = TH_NAME(consume_charref)(self, &self->text, 0, NULL);
-                    if (consumed == -1) {
-                        return RUN_NEED_MORE;
-                    }
-                    self->pos += consumed;
-                    self->col += consumed;
-                    continue;
-                }
-                switch (TH_NAME(text_charref)(self)) {
-                case RUN_NEED_MORE:
-                    return RUN_NEED_MORE;
-                case RUN_EMITTED:
-                    return RUN_EMITTED;
-                default: /* a literal ampersand sequence joined the text run */
-                    continue;
-                }
-            }
+
+#if TH_THREADED
+#define TH_STATE(name) L_##name:
+#define TH_DISPATCH()                                                                                                  \
+    do {                                                                                                               \
+        TH_FETCH();                                                                                                    \
+        goto *th_targets[self->state];                                                                                 \
+    } while (0)
+#else
+#define TH_STATE(name) case name:
+#define TH_DISPATCH() goto th_dispatch
+#endif
+
+/* Read the character under the cursor, or suspend when the input is exhausted and more may follow.
+   The first time EOF is reached with a tag/comment/doctype construct still open, report it once;
+   eof_code names the construct (cleared when it is emitted), so a clean DATA-state EOF leaves it
+   NULL. Threaded dispatch runs this once per state rather than once per loop turn, so it stays a
+   macro: an inline function cannot carry the suspend out of the caller. */
+#define TH_FETCH()                                                                                                     \
+    do {                                                                                                               \
+        if (self->pos < self->input.len) {                                                                             \
+            ch = TH_READ(self->pos);                                                                                   \
+            at_eof = 0;                                                                                                \
+        } else if (self->eof) {                                                                                        \
+            ch = 0;                                                                                                    \
+            at_eof = 1;                                                                                                \
+        } else {                                                                                                       \
+            return RUN_NEED_MORE;                                                                                      \
+        }                                                                                                              \
+        if (at_eof && !self->eof_reported && self->eof_code != NULL) {                                                 \
+            tok_error(self, self->eof_code);                                                                           \
+            self->eof_reported = 1;                                                                                    \
+        }                                                                                                              \
+    } while (0)
+
+static enum run_result TH_NAME(run)(th_tokenizer *self) {
+#if TH_THREADED
+    static void *const th_targets[] = {
+        [ST_DATA] = &&L_ST_DATA,
+        [ST_RCDATA] = &&L_ST_RCDATA,
+        [ST_RAWTEXT] = &&L_ST_RAWTEXT,
+        [ST_SCRIPT] = &&L_ST_SCRIPT,
+        [ST_PLAINTEXT] = &&L_ST_PLAINTEXT,
+        [ST_TAG_OPEN] = &&L_ST_TAG_OPEN,
+        [ST_END_TAG_OPEN] = &&L_ST_END_TAG_OPEN,
+        [ST_TAG_NAME] = &&L_ST_TAG_NAME,
+        [ST_RCDATA_LT] = &&L_ST_RCDATA_LT,
+        [ST_RCDATA_END_OPEN] = &&L_ST_RCDATA_END_OPEN,
+        [ST_RCDATA_END_NAME] = &&L_ST_RCDATA_END_NAME,
+        [ST_RAWTEXT_LT] = &&L_ST_RAWTEXT_LT,
+        [ST_RAWTEXT_END_OPEN] = &&L_ST_RAWTEXT_END_OPEN,
+        [ST_RAWTEXT_END_NAME] = &&L_ST_RAWTEXT_END_NAME,
+        [ST_SCRIPT_LT] = &&L_ST_SCRIPT_LT,
+        [ST_SCRIPT_END_OPEN] = &&L_ST_SCRIPT_END_OPEN,
+        [ST_SCRIPT_END_NAME] = &&L_ST_SCRIPT_END_NAME,
+        [ST_SCRIPT_ESC_START] = &&L_ST_SCRIPT_ESC_START,
+        [ST_SCRIPT_ESC_START_DASH] = &&L_ST_SCRIPT_ESC_START_DASH,
+        [ST_SCRIPT_ESCAPED] = &&L_ST_SCRIPT_ESCAPED,
+        [ST_SCRIPT_ESCAPED_DASH] = &&L_ST_SCRIPT_ESCAPED_DASH,
+        [ST_SCRIPT_ESCAPED_DASH_DASH] = &&L_ST_SCRIPT_ESCAPED_DASH_DASH,
+        [ST_SCRIPT_ESCAPED_LT] = &&L_ST_SCRIPT_ESCAPED_LT,
+        [ST_SCRIPT_ESCAPED_END_OPEN] = &&L_ST_SCRIPT_ESCAPED_END_OPEN,
+        [ST_SCRIPT_ESCAPED_END_NAME] = &&L_ST_SCRIPT_ESCAPED_END_NAME,
+        [ST_SCRIPT_DOUBLE_ESC_START] = &&L_ST_SCRIPT_DOUBLE_ESC_START,
+        [ST_SCRIPT_DOUBLE_ESCAPED] = &&L_ST_SCRIPT_DOUBLE_ESCAPED,
+        [ST_SCRIPT_DOUBLE_ESCAPED_DASH] = &&L_ST_SCRIPT_DOUBLE_ESCAPED_DASH,
+        [ST_SCRIPT_DOUBLE_ESCAPED_DASH_DASH] = &&L_ST_SCRIPT_DOUBLE_ESCAPED_DASH_DASH,
+        [ST_SCRIPT_DOUBLE_ESCAPED_LT] = &&L_ST_SCRIPT_DOUBLE_ESCAPED_LT,
+        [ST_SCRIPT_DOUBLE_ESC_END] = &&L_ST_SCRIPT_DOUBLE_ESC_END,
+        [ST_BEFORE_ATTR_NAME] = &&L_ST_BEFORE_ATTR_NAME,
+        [ST_ATTR_NAME] = &&L_ST_ATTR_NAME,
+        [ST_AFTER_ATTR_NAME] = &&L_ST_AFTER_ATTR_NAME,
+        [ST_BEFORE_ATTR_VALUE] = &&L_ST_BEFORE_ATTR_VALUE,
+        [ST_ATTR_VALUE_DQ] = &&L_ST_ATTR_VALUE_DQ,
+        [ST_ATTR_VALUE_SQ] = &&L_ST_ATTR_VALUE_SQ,
+        [ST_ATTR_VALUE_UNQ] = &&L_ST_ATTR_VALUE_UNQ,
+        [ST_AFTER_ATTR_VALUE_QUOTED] = &&L_ST_AFTER_ATTR_VALUE_QUOTED,
+        [ST_SELF_CLOSING_START_TAG] = &&L_ST_SELF_CLOSING_START_TAG,
+        [ST_BOGUS_COMMENT] = &&L_ST_BOGUS_COMMENT,
+        [ST_MARKUP_DECL_OPEN] = &&L_ST_MARKUP_DECL_OPEN,
+        [ST_COMMENT_START] = &&L_ST_COMMENT_START,
+        [ST_COMMENT_START_DASH] = &&L_ST_COMMENT_START_DASH,
+        [ST_COMMENT] = &&L_ST_COMMENT,
+        [ST_COMMENT_LT] = &&L_ST_COMMENT_LT,
+        [ST_COMMENT_LT_BANG] = &&L_ST_COMMENT_LT_BANG,
+        [ST_COMMENT_LT_BANG_DASH] = &&L_ST_COMMENT_LT_BANG_DASH,
+        [ST_COMMENT_LT_BANG_DASH_DASH] = &&L_ST_COMMENT_LT_BANG_DASH_DASH,
+        [ST_COMMENT_END_DASH] = &&L_ST_COMMENT_END_DASH,
+        [ST_COMMENT_END] = &&L_ST_COMMENT_END,
+        [ST_COMMENT_END_BANG] = &&L_ST_COMMENT_END_BANG,
+        [ST_DOCTYPE] = &&L_ST_DOCTYPE,
+        [ST_BEFORE_DOCTYPE_NAME] = &&L_ST_BEFORE_DOCTYPE_NAME,
+        [ST_DOCTYPE_NAME] = &&L_ST_DOCTYPE_NAME,
+        [ST_AFTER_DOCTYPE_NAME] = &&L_ST_AFTER_DOCTYPE_NAME,
+        [ST_AFTER_DOCTYPE_PUBLIC_KW] = &&L_ST_AFTER_DOCTYPE_PUBLIC_KW,
+        [ST_BEFORE_DOCTYPE_PUBLIC_ID] = &&L_ST_BEFORE_DOCTYPE_PUBLIC_ID,
+        [ST_DOCTYPE_PUBLIC_ID_DQ] = &&L_ST_DOCTYPE_PUBLIC_ID_DQ,
+        [ST_DOCTYPE_PUBLIC_ID_SQ] = &&L_ST_DOCTYPE_PUBLIC_ID_SQ,
+        [ST_AFTER_DOCTYPE_PUBLIC_ID] = &&L_ST_AFTER_DOCTYPE_PUBLIC_ID,
+        [ST_BETWEEN_DOCTYPE_PUB_SYS] = &&L_ST_BETWEEN_DOCTYPE_PUB_SYS,
+        [ST_AFTER_DOCTYPE_SYSTEM_KW] = &&L_ST_AFTER_DOCTYPE_SYSTEM_KW,
+        [ST_BEFORE_DOCTYPE_SYSTEM_ID] = &&L_ST_BEFORE_DOCTYPE_SYSTEM_ID,
+        [ST_DOCTYPE_SYSTEM_ID_DQ] = &&L_ST_DOCTYPE_SYSTEM_ID_DQ,
+        [ST_DOCTYPE_SYSTEM_ID_SQ] = &&L_ST_DOCTYPE_SYSTEM_ID_SQ,
+        [ST_AFTER_DOCTYPE_SYSTEM_ID] = &&L_ST_AFTER_DOCTYPE_SYSTEM_ID,
+        [ST_BOGUS_DOCTYPE] = &&L_ST_BOGUS_DOCTYPE,
+        [ST_CDATA] = &&L_ST_CDATA,
+        [ST_CDATA_BRACKET] = &&L_ST_CDATA_BRACKET,
+        [ST_CDATA_END] = &&L_ST_CDATA_END,
+    };
+#endif
+    int at_eof;
+    Py_UCS4 ch;
+
+    TH_DISPATCH();
+#if !TH_THREADED
+th_dispatch:
+    TH_FETCH();
+    switch (self->state) /* GCOVR_EXCL_BR_LINE: enum-complete switch; the out-of-range edge is unreachable */
+#endif
+    {
+        TH_STATE(ST_DATA)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
 #if TH_UCS1
-            /* the run branch consumed every character but '&' and '<', and '&' is
-               handled above, so ch is '<' here: open a tag with no further test
-               (the wider widths still fall through a bare-newline text_push) */
+        /* '\n' is ordinary text in DATA -- the only per-newline work is
+           line/column tracking, so a single SIMD pass runs straight through
+           newlines to the next markup (a paragraph between tags becomes one
+           sweep, not one per wrapped line) and folds the newline count and
+           last-newline column in along the way. The wider widths keep the
+           generic newline-stopping scan: they are rarer and the dedicated
+           1-byte pass is where real documents live. */
+        if (ch != '&' && ch != '<' && ch != 0) {
+            Py_ssize_t newlines;
+            Py_ssize_t last_nl;
+            Py_ssize_t stop = scan_data_ucs1(self, self->pos, &newlines, &last_nl);
+            text_append_run_lc(self, stop, newlines, last_nl < 0 ? 0 : stop - last_nl - 1);
+            TH_DISPATCH();
+        }
+#else
+        if (ch != '&' && ch != '<' && ch != '\n' && ch != 0) {
+            Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '&', '<', '\n', 0);
+            text_append_run(self, stop);
+            TH_DISPATCH();
+        }
+#endif
+        if (ch == 0) {
+            /* the data state keeps the NUL, where every other text state replaces it */
+            tok_error(self, "unexpected-null-character");
+            text_begin(self);
+            text_push(self, 0);
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '&') {
+            if (self->resolve_references) {
+                text_begin(self);
+                text_materialize(self);
+                Py_ssize_t consumed = TH_NAME(consume_charref)(self, &self->text, 0, NULL);
+                if (consumed == -1) {
+                    return RUN_NEED_MORE;
+                }
+                self->pos += consumed;
+                self->col += consumed;
+                TH_DISPATCH();
+            }
+            switch (TH_NAME(text_charref)(self)) {
+            case RUN_NEED_MORE:
+                return RUN_NEED_MORE;
+            case RUN_EMITTED:
+                return RUN_EMITTED;
+            default: /* a literal ampersand sequence joined the text run */
+                TH_DISPATCH();
+            }
+        }
+#if TH_UCS1
+        /* the run branch consumed every character but '&' and '<', and '&' is
+           handled above, so ch is '<' here: open a tag with no further test
+           (the wider widths still fall through a bare-newline text_push) */
+        MARK();
+        CONSUME();
+        self->state = ST_TAG_OPEN;
+        TH_DISPATCH();
+#else
+        if (ch == '<') {
             MARK();
             CONSUME();
             self->state = ST_TAG_OPEN;
-            continue;
-#else
-            if (ch == '<') {
-                MARK();
-                CONSUME();
-                self->state = ST_TAG_OPEN;
-                continue;
-            }
-            text_push(self, ch);
-            CONSUME();
-            continue;
+            TH_DISPATCH();
+        }
+        text_push(self, ch);
+        CONSUME();
+        TH_DISPATCH();
 #endif
 
-        case ST_RCDATA:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (ch != '&' && ch != '<' && ch != '\n' && ch != 0) {
-                Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '&', '<', '\n', 0);
-                text_append_run(self, stop);
-                continue;
-            }
-            if (ch == '&') {
-                if (self->resolve_references) {
-                    text_begin(self);
-                    text_materialize(self);
-                    Py_ssize_t consumed = TH_NAME(consume_charref)(self, &self->text, 0, NULL);
-                    if (consumed == -1) {
-                        return RUN_NEED_MORE;
-                    }
-                    self->pos += consumed;
-                    self->col += consumed;
-                    continue;
-                }
-                switch (TH_NAME(text_charref)(self)) {
-                case RUN_NEED_MORE:
+        TH_STATE(ST_RCDATA)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (ch != '&' && ch != '<' && ch != '\n' && ch != 0) {
+            Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '&', '<', '\n', 0);
+            text_append_run(self, stop);
+            TH_DISPATCH();
+        }
+        if (ch == '&') {
+            if (self->resolve_references) {
+                text_begin(self);
+                text_materialize(self);
+                Py_ssize_t consumed = TH_NAME(consume_charref)(self, &self->text, 0, NULL);
+                if (consumed == -1) {
                     return RUN_NEED_MORE;
-                case RUN_EMITTED:
-                    return RUN_EMITTED;
-                default: /* a literal ampersand sequence joined the text run */
-                    continue;
                 }
+                self->pos += consumed;
+                self->col += consumed;
+                TH_DISPATCH();
             }
-            if (ch == '<') {
-                MARK();
-                CONSUME();
-                self->state = ST_RCDATA_LT;
-                continue;
+            switch (TH_NAME(text_charref)(self)) {
+            case RUN_NEED_MORE:
+                return RUN_NEED_MORE;
+            case RUN_EMITTED:
+                return RUN_EMITTED;
+            default: /* a literal ampersand sequence joined the text run */
+                TH_DISPATCH();
             }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
+        }
+        if (ch == '<') {
+            MARK();
             CONSUME();
-            continue;
+            self->state = ST_RCDATA_LT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        TH_DISPATCH();
 
-        case ST_RAWTEXT:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (ch != '<' && ch != '\n' && ch != 0) {
-                Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '<', '\n', 0, 0);
-                text_append_run(self, stop);
-                continue;
-            }
-            if (ch == '<') {
-                MARK();
-                CONSUME();
-                self->state = ST_RAWTEXT_LT;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
+        TH_STATE(ST_RAWTEXT)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (ch != '<' && ch != '\n' && ch != 0) {
+            Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '<', '\n', 0, 0);
+            text_append_run(self, stop);
+            TH_DISPATCH();
+        }
+        if (ch == '<') {
+            MARK();
             CONSUME();
-            continue;
+            self->state = ST_RAWTEXT_LT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        TH_DISPATCH();
 
-        case ST_SCRIPT:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (ch != '<' && ch != '\n' && ch != 0) {
-                Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '<', '\n', 0, 0);
-                text_append_run(self, stop);
-                continue;
-            }
-            if (ch == '<') {
-                MARK();
-                CONSUME();
-                self->state = ST_SCRIPT_LT;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
+        TH_STATE(ST_SCRIPT)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (ch != '<' && ch != '\n' && ch != 0) {
+            Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '<', '\n', 0, 0);
+            text_append_run(self, stop);
+            TH_DISPATCH();
+        }
+        if (ch == '<') {
+            MARK();
             CONSUME();
-            continue;
+            self->state = ST_SCRIPT_LT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        TH_DISPATCH();
 
-        case ST_PLAINTEXT:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (ch != '\n' && ch != 0) {
-                Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '\n', 0, 0, 0);
-                text_append_run(self, stop);
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
-            CONSUME();
-            continue;
+        TH_STATE(ST_PLAINTEXT)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (ch != '\n' && ch != 0) {
+            Py_ssize_t stop = TH_SCAN(self, self->pos + 1, '\n', 0, 0, 0);
+            text_append_run(self, stop);
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        TH_DISPATCH();
 
-        case ST_TAG_OPEN:
-            if (at_eof) {
-                tok_error(self, "eof-before-tag-name");
-                text_begin_mark(self);
-                text_push(self, '<');
-                EOF_FLUSH();
-            }
-            if (ch == '!') {
-                CONSUME();
-                self->state = ST_MARKUP_DECL_OPEN;
-                continue;
-            }
-            if (ch == '/') {
-                CONSUME();
-                self->state = ST_END_TAG_OPEN;
-                continue;
-            }
-            if (is_ascii_alpha(ch)) {
-                start_tag(self, 0, lower_ascii(ch));
-                CONSUME();
-                self->state = ST_TAG_NAME;
-                continue;
-            }
-            if (ch == '?') {
-                tok_error(self, "unexpected-question-mark-instead-of-tag-name");
-                init_markup(self, TH_COMMENT);
-                self->tok.is_pi = 1; /* a `<?` bogus comment the SAX walk reports as a processing instruction */
-                self->state = ST_BOGUS_COMMENT;
-                continue;
-            }
-            tok_error(self, "invalid-first-character-of-tag-name");
+        TH_STATE(ST_TAG_OPEN)
+        if (at_eof) {
+            tok_error(self, "eof-before-tag-name");
             text_begin_mark(self);
             text_push(self, '<');
-            self->state = ST_DATA;
-            continue;
-
-        case ST_END_TAG_OPEN:
-            if (at_eof) {
-                tok_error(self, "eof-before-tag-name");
-                text_begin_mark(self);
-                text_push(self, '<');
-                text_push(self, '/');
-                EOF_FLUSH();
-            }
-            if (is_ascii_alpha(ch)) {
-                start_tag(self, 1, lower_ascii(ch));
-                CONSUME();
-                self->state = ST_TAG_NAME;
-                continue;
-            }
-            if (ch == '>') {
-                tok_error(self, "missing-end-tag-name");
-                CONSUME();
-                self->state = ST_DATA;
-                continue;
-            }
-            tok_error(self, "invalid-first-character-of-tag-name");
+            EOF_FLUSH();
+        }
+        if (ch == '!') {
+            CONSUME();
+            self->state = ST_MARKUP_DECL_OPEN;
+            TH_DISPATCH();
+        }
+        if (ch == '/') {
+            CONSUME();
+            self->state = ST_END_TAG_OPEN;
+            TH_DISPATCH();
+        }
+        if (is_ascii_alpha(ch)) {
+            start_tag(self, 0, lower_ascii(ch));
+            CONSUME();
+            self->state = ST_TAG_NAME;
+            TH_DISPATCH();
+        }
+        if (ch == '?') {
+            tok_error(self, "unexpected-question-mark-instead-of-tag-name");
             init_markup(self, TH_COMMENT);
+            self->tok.is_pi = 1; /* a `<?` bogus comment the SAX walk reports as a processing instruction */
             self->state = ST_BOGUS_COMMENT;
-            continue;
+            TH_DISPATCH();
+        }
+        tok_error(self, "invalid-first-character-of-tag-name");
+        text_begin_mark(self);
+        text_push(self, '<');
+        self->state = ST_DATA;
+        TH_DISPATCH();
 
-        case ST_TAG_NAME:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                self->state = ST_BEFORE_ATTR_NAME;
-                continue;
-            }
-            if (ch == '/') {
-                CONSUME();
-                self->state = ST_SELF_CLOSING_START_TAG;
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            push(self, &self->tok.name, ch == 0 ? REPLACEMENT : lower_ascii(ch));
-            CONSUME();
-            continue;
-
-        case ST_RCDATA_LT:
-            if (!at_eof && ch == '/') {
-                CONSUME();
-                buf_reset(&self->temp);
-                self->state = ST_RCDATA_END_OPEN;
-                continue;
-            }
-            text_begin_mark(self);
-            text_push(self, '<');
-            self->state = ST_RCDATA;
-            continue;
-
-        case ST_RCDATA_END_OPEN:
-            if (!at_eof && is_ascii_alpha(ch)) {
-                start_tag(self, 1, lower_ascii(ch));
-                self->eof_code = NULL; /* speculative until it proves to be the appropriate end tag */
-                push(self, &self->temp, ch);
-                CONSUME();
-                self->state = ST_RCDATA_END_NAME;
-                continue;
-            }
+        TH_STATE(ST_END_TAG_OPEN)
+        if (at_eof) {
+            tok_error(self, "eof-before-tag-name");
             text_begin_mark(self);
             text_push(self, '<');
             text_push(self, '/');
-            self->state = ST_RCDATA;
-            continue;
-
-        case ST_RCDATA_END_NAME:
-            if (!at_eof && is_space(ch) && appropriate_end_tag(self)) {
-                CONSUME();
-                self->eof_code = "eof-in-tag"; /* the end tag is the appropriate one, so it is now open */
-                self->state = ST_BEFORE_ATTR_NAME;
-                continue;
-            }
-            if (!at_eof && ch == '/' && appropriate_end_tag(self)) {
-                CONSUME();
-                self->eof_code = "eof-in-tag";
-                self->state = ST_SELF_CLOSING_START_TAG;
-                continue;
-            }
-            if (!at_eof && ch == '>' && appropriate_end_tag(self)) {
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            if (!at_eof && is_ascii_alpha(ch)) {
-                push(self, &self->tok.name, lower_ascii(ch));
-                push(self, &self->temp, ch);
-                CONSUME();
-                continue;
-            }
-            rawtext_fallback(self, ST_RCDATA);
-            continue;
-
-        case ST_RAWTEXT_LT:
-            if (!at_eof && ch == '/') {
-                CONSUME();
-                buf_reset(&self->temp);
-                self->state = ST_RAWTEXT_END_OPEN;
-                continue;
-            }
-            text_begin_mark(self);
-            text_push(self, '<');
-            self->state = ST_RAWTEXT;
-            continue;
-
-        case ST_RAWTEXT_END_OPEN:
-            if (!at_eof && is_ascii_alpha(ch)) {
-                start_tag(self, 1, lower_ascii(ch));
-                self->eof_code = NULL; /* speculative until it proves to be the appropriate end tag */
-                push(self, &self->temp, ch);
-                CONSUME();
-                self->state = ST_RAWTEXT_END_NAME;
-                continue;
-            }
-            text_begin_mark(self);
-            text_push(self, '<');
-            text_push(self, '/');
-            self->state = ST_RAWTEXT;
-            continue;
-
-        case ST_RAWTEXT_END_NAME:
-            if (!at_eof && is_space(ch) && appropriate_end_tag(self)) {
-                CONSUME();
-                self->eof_code = "eof-in-tag"; /* the end tag is the appropriate one, so it is now open */
-                self->state = ST_BEFORE_ATTR_NAME;
-                continue;
-            }
-            if (!at_eof && ch == '/' && appropriate_end_tag(self)) {
-                CONSUME();
-                self->eof_code = "eof-in-tag";
-                self->state = ST_SELF_CLOSING_START_TAG;
-                continue;
-            }
-            if (!at_eof && ch == '>' && appropriate_end_tag(self)) {
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            if (!at_eof && is_ascii_alpha(ch)) {
-                push(self, &self->tok.name, lower_ascii(ch));
-                push(self, &self->temp, ch);
-                CONSUME();
-                continue;
-            }
-            rawtext_fallback(self, ST_RAWTEXT);
-            continue;
-
-        case ST_SCRIPT_LT:
-            if (!at_eof && ch == '/') {
-                CONSUME();
-                buf_reset(&self->temp);
-                self->state = ST_SCRIPT_END_OPEN;
-                continue;
-            }
-            if (!at_eof && ch == '!') {
-                CONSUME();
-                text_begin_mark(self);
-                text_push(self, '<');
-                text_push(self, '!');
-                self->state = ST_SCRIPT_ESC_START;
-                continue;
-            }
-            text_begin_mark(self);
-            text_push(self, '<');
-            self->state = ST_SCRIPT;
-            continue;
-
-        case ST_SCRIPT_END_OPEN:
-            if (!at_eof && is_ascii_alpha(ch)) {
-                start_tag(self, 1, lower_ascii(ch));
-                self->eof_code = NULL; /* speculative until it proves to be the appropriate end tag */
-                push(self, &self->temp, ch);
-                CONSUME();
-                self->state = ST_SCRIPT_END_NAME;
-                continue;
-            }
-            text_begin_mark(self);
-            text_push(self, '<');
-            text_push(self, '/');
-            self->state = ST_SCRIPT;
-            continue;
-
-        case ST_SCRIPT_END_NAME:
-            if (!at_eof && is_space(ch) && appropriate_end_tag(self)) {
-                CONSUME();
-                self->eof_code = "eof-in-tag"; /* the end tag is the appropriate one, so it is now open */
-                self->state = ST_BEFORE_ATTR_NAME;
-                continue;
-            }
-            if (!at_eof && ch == '/' && appropriate_end_tag(self)) {
-                CONSUME();
-                self->eof_code = "eof-in-tag";
-                self->state = ST_SELF_CLOSING_START_TAG;
-                continue;
-            }
-            if (!at_eof && ch == '>' && appropriate_end_tag(self)) {
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            if (!at_eof && is_ascii_alpha(ch)) {
-                push(self, &self->tok.name, lower_ascii(ch));
-                push(self, &self->temp, ch);
-                CONSUME();
-                continue;
-            }
-            rawtext_fallback(self, ST_SCRIPT);
-            continue;
-
-        case ST_SCRIPT_ESC_START:
-            if (!at_eof && ch == '-') {
-                CONSUME();
-                text_push(self, '-');
-                self->state = ST_SCRIPT_ESC_START_DASH;
-                continue;
-            }
-            self->state = ST_SCRIPT;
-            continue;
-
-        case ST_SCRIPT_ESC_START_DASH:
-            if (!at_eof && ch == '-') {
-                CONSUME();
-                text_push(self, '-');
-                self->state = ST_SCRIPT_ESCAPED_DASH_DASH;
-                continue;
-            }
-            self->state = ST_SCRIPT;
-            continue;
-
-        case ST_SCRIPT_ESCAPED:
-            if (at_eof) {
-                tok_error(self, "eof-in-script-html-comment-like-text");
-                EOF_FLUSH();
-            }
-            if (ch == '-') {
-                CONSUME();
-                text_push(self, '-');
-                self->state = ST_SCRIPT_ESCAPED_DASH;
-                continue;
-            }
-            if (ch == '<') {
-                MARK();
-                CONSUME();
-                self->state = ST_SCRIPT_ESCAPED_LT;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
+            EOF_FLUSH();
+        }
+        if (is_ascii_alpha(ch)) {
+            start_tag(self, 1, lower_ascii(ch));
             CONSUME();
-            continue;
-
-        case ST_SCRIPT_ESCAPED_DASH:
-            if (at_eof) {
-                tok_error(self, "eof-in-script-html-comment-like-text");
-                EOF_FLUSH();
-            }
-            if (ch == '-') {
-                CONSUME();
-                text_push(self, '-');
-                self->state = ST_SCRIPT_ESCAPED_DASH_DASH;
-                continue;
-            }
-            if (ch == '<') {
-                MARK();
-                CONSUME();
-                self->state = ST_SCRIPT_ESCAPED_LT;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
+            self->state = ST_TAG_NAME;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            tok_error(self, "missing-end-tag-name");
             CONSUME();
-            self->state = ST_SCRIPT_ESCAPED;
-            continue;
+            self->state = ST_DATA;
+            TH_DISPATCH();
+        }
+        tok_error(self, "invalid-first-character-of-tag-name");
+        init_markup(self, TH_COMMENT);
+        self->state = ST_BOGUS_COMMENT;
+        TH_DISPATCH();
 
-        case ST_SCRIPT_ESCAPED_DASH_DASH:
-            if (at_eof) {
-                tok_error(self, "eof-in-script-html-comment-like-text");
-                EOF_FLUSH();
-            }
-            if (ch == '-') {
-                CONSUME();
-                text_push(self, '-');
-                continue;
-            }
-            if (ch == '<') {
-                MARK();
-                CONSUME();
-                self->state = ST_SCRIPT_ESCAPED_LT;
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                text_push(self, '>');
-                self->state = ST_SCRIPT;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
+        TH_STATE(ST_TAG_NAME)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (is_space(ch)) {
             CONSUME();
-            self->state = ST_SCRIPT_ESCAPED;
-            continue;
-
-        case ST_SCRIPT_ESCAPED_LT:
-            if (!at_eof && ch == '/') {
-                CONSUME();
-                buf_reset(&self->temp);
-                self->state = ST_SCRIPT_ESCAPED_END_OPEN;
-                continue;
-            }
-            if (!at_eof && is_ascii_alpha(ch)) {
-                buf_reset(&self->temp);
-                text_begin_mark(self);
-                text_push(self, '<');
-                self->state = ST_SCRIPT_DOUBLE_ESC_START;
-                continue;
-            }
-            text_begin_mark(self);
-            text_push(self, '<');
-            self->state = ST_SCRIPT_ESCAPED;
-            continue;
-
-        case ST_SCRIPT_ESCAPED_END_OPEN:
-            if (!at_eof && is_ascii_alpha(ch)) {
-                start_tag(self, 1, lower_ascii(ch));
-                self->eof_code = NULL; /* speculative until it proves to be the appropriate end tag */
-                push(self, &self->temp, ch);
-                CONSUME();
-                self->state = ST_SCRIPT_ESCAPED_END_NAME;
-                continue;
-            }
-            text_begin_mark(self);
-            text_push(self, '<');
-            text_push(self, '/');
-            self->state = ST_SCRIPT_ESCAPED;
-            continue;
-
-        case ST_SCRIPT_ESCAPED_END_NAME:
-            if (!at_eof && is_space(ch) && appropriate_end_tag(self)) {
-                CONSUME();
-                self->eof_code = "eof-in-tag"; /* the end tag is the appropriate one, so it is now open */
-                self->state = ST_BEFORE_ATTR_NAME;
-                continue;
-            }
-            if (!at_eof && ch == '/' && appropriate_end_tag(self)) {
-                CONSUME();
-                self->eof_code = "eof-in-tag";
-                self->state = ST_SELF_CLOSING_START_TAG;
-                continue;
-            }
-            if (!at_eof && ch == '>' && appropriate_end_tag(self)) {
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            if (!at_eof && is_ascii_alpha(ch)) {
-                push(self, &self->tok.name, lower_ascii(ch));
-                push(self, &self->temp, ch);
-                CONSUME();
-                continue;
-            }
-            rawtext_fallback(self, ST_SCRIPT_ESCAPED);
-            continue;
-
-        case ST_SCRIPT_DOUBLE_ESC_START:
-            if (!at_eof && (is_space(ch) || ch == '/' || ch == '>')) {
-                CONSUME();
-                text_push(self, ch);
-                self->state = (self->temp.len == 6 && memcmp(self->temp.data, "script", 6) == 0)
-                                  ? ST_SCRIPT_DOUBLE_ESCAPED
-                                  : ST_SCRIPT_ESCAPED;
-                continue;
-            }
-            if (!at_eof && is_ascii_alpha(ch)) {
-                push(self, &self->temp, lower_ascii(ch));
-                text_push(self, ch);
-                CONSUME();
-                continue;
-            }
-            self->state = ST_SCRIPT_ESCAPED;
-            continue;
-
-        case ST_SCRIPT_DOUBLE_ESCAPED:
-            if (at_eof) {
-                tok_error(self, "eof-in-script-html-comment-like-text");
-                EOF_FLUSH();
-            }
-            if (ch == '-') {
-                CONSUME();
-                text_push(self, '-');
-                self->state = ST_SCRIPT_DOUBLE_ESCAPED_DASH;
-                continue;
-            }
-            if (ch == '<') {
-                CONSUME();
-                text_push(self, '<');
-                self->state = ST_SCRIPT_DOUBLE_ESCAPED_LT;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
-            CONSUME();
-            continue;
-
-        case ST_SCRIPT_DOUBLE_ESCAPED_DASH:
-            if (at_eof) {
-                tok_error(self, "eof-in-script-html-comment-like-text");
-                EOF_FLUSH();
-            }
-            if (ch == '-') {
-                CONSUME();
-                text_push(self, '-');
-                self->state = ST_SCRIPT_DOUBLE_ESCAPED_DASH_DASH;
-                continue;
-            }
-            if (ch == '<') {
-                CONSUME();
-                text_push(self, '<');
-                self->state = ST_SCRIPT_DOUBLE_ESCAPED_LT;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
-            CONSUME();
-            self->state = ST_SCRIPT_DOUBLE_ESCAPED;
-            continue;
-
-        case ST_SCRIPT_DOUBLE_ESCAPED_DASH_DASH:
-            if (at_eof) {
-                tok_error(self, "eof-in-script-html-comment-like-text");
-                EOF_FLUSH();
-            }
-            if (ch == '-') {
-                CONSUME();
-                text_push(self, '-');
-                continue;
-            }
-            if (ch == '<') {
-                CONSUME();
-                text_push(self, '<');
-                self->state = ST_SCRIPT_DOUBLE_ESCAPED_LT;
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                text_push(self, '>');
-                self->state = ST_SCRIPT;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            text_push(self, ch == 0 ? REPLACEMENT : ch);
-            CONSUME();
-            self->state = ST_SCRIPT_DOUBLE_ESCAPED;
-            continue;
-
-        case ST_SCRIPT_DOUBLE_ESCAPED_LT:
-            if (!at_eof && ch == '/') {
-                CONSUME();
-                buf_reset(&self->temp);
-                text_push(self, '/');
-                self->state = ST_SCRIPT_DOUBLE_ESC_END;
-                continue;
-            }
-            self->state = ST_SCRIPT_DOUBLE_ESCAPED;
-            continue;
-
-        case ST_SCRIPT_DOUBLE_ESC_END:
-            if (!at_eof && (is_space(ch) || ch == '/' || ch == '>')) {
-                CONSUME();
-                text_push(self, ch);
-                self->state = (self->temp.len == 6 && memcmp(self->temp.data, "script", 6) == 0)
-                                  ? ST_SCRIPT_ESCAPED
-                                  : ST_SCRIPT_DOUBLE_ESCAPED;
-                continue;
-            }
-            if (!at_eof && is_ascii_alpha(ch)) {
-                push(self, &self->temp, lower_ascii(ch));
-                text_push(self, ch);
-                CONSUME();
-                continue;
-            }
-            self->state = ST_SCRIPT_DOUBLE_ESCAPED;
-            continue;
-
-        case ST_BEFORE_ATTR_NAME:
-            if (at_eof || ch == '/' || ch == '>') {
-                self->state = ST_AFTER_ATTR_NAME;
-                continue;
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                continue;
-            }
-            new_attr(self);
-            if (ch == '=') {
-                tok_error(self, "unexpected-equals-sign-before-attribute-name");
-                if (self->capture_attributes) {
-                    push(self, &self->attr->name, ch);
-                }
-                CONSUME();
-            }
-            self->state = ST_ATTR_NAME;
-            continue;
-
-        case ST_ATTR_NAME:
-            if (at_eof || is_space(ch) || ch == '/' || ch == '>') {
-                finish_attr_name(self);
-                self->state = ST_AFTER_ATTR_NAME;
-                continue;
-            }
-            if (ch == '=') {
-                finish_attr_name(self);
-                CONSUME();
-                self->state = ST_BEFORE_ATTR_VALUE;
-                continue;
-            }
-            if (ch == '"' || ch == '\'' || ch == '<') {
-                tok_error(self, "unexpected-character-in-attribute-name");
-            } else if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            if (self->capture_attributes) {
-                push(self, &self->attr->name, ch == 0 ? REPLACEMENT : lower_ascii(ch));
-            }
-            CONSUME();
-            continue;
-
-        case ST_AFTER_ATTR_NAME:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                continue;
-            }
-            if (ch == '/') {
-                CONSUME();
-                self->state = ST_SELF_CLOSING_START_TAG;
-                continue;
-            }
-            if (ch == '=') {
-                CONSUME();
-                self->state = ST_BEFORE_ATTR_VALUE;
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            new_attr(self);
-            self->state = ST_ATTR_NAME;
-            continue;
-
-        case ST_BEFORE_ATTR_VALUE:
-            if (!at_eof && is_space(ch)) {
-                CONSUME();
-                continue;
-            }
-            if (self->capture_attributes) {
-                self->attr->has_value = 1;
-            }
-            if (!at_eof && ch == '"') {
-                CONSUME();
-                self->state = ST_ATTR_VALUE_DQ;
-                continue;
-            }
-            if (!at_eof && ch == '\'') {
-                CONSUME();
-                self->state = ST_ATTR_VALUE_SQ;
-                continue;
-            }
-            if (!at_eof && ch == '>') {
-                tok_error(self, "missing-attribute-value");
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            self->state = ST_ATTR_VALUE_UNQ;
-            continue;
-
-        case ST_ATTR_VALUE_DQ:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (ch != '"' && ch != '&' && ch != '\n' && ch != 0) {
-                /* bulk-copy the ordinary value run; '\n' is a stop so line/col
-                   stay accurate, and &/" /NUL keep their dedicated handling */
-                Py_ssize_t stop = TH_SCAN(self, self->pos, '"', '&', '\n', 0);
-                if (self->capture_attributes) {
-                    buf_append_input(self, &self->attr->value, self->pos, stop - self->pos);
-                }
-                self->col += stop - self->pos;
-                self->pos = stop;
-                continue;
-            }
-            if (ch == '"') {
-                CONSUME();
-                attr_end_here(self); /* the closing quote is part of the attribute span */
-                self->state = ST_AFTER_ATTR_VALUE_QUOTED;
-                continue;
-            }
-            if (ch == '&') {
-                Py_ssize_t consumed =
-                    TH_NAME(consume_charref)(self, self->capture_attributes ? &self->attr->value : NULL, 1, NULL);
-                if (consumed == -1) {
-                    return RUN_NEED_MORE;
-                }
-                self->pos += consumed;
-                self->col += consumed;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            if (self->capture_attributes) {
-                push(self, &self->attr->value, ch == 0 ? REPLACEMENT : ch);
-            }
-            CONSUME();
-            continue;
-
-        case ST_ATTR_VALUE_SQ:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (ch != '\'' && ch != '&' && ch != '\n' && ch != 0) {
-                Py_ssize_t stop = TH_SCAN(self, self->pos, '\'', '&', '\n', 0);
-                if (self->capture_attributes) {
-                    buf_append_input(self, &self->attr->value, self->pos, stop - self->pos);
-                }
-                self->col += stop - self->pos;
-                self->pos = stop;
-                continue;
-            }
-            if (ch == '\'') {
-                CONSUME();
-                attr_end_here(self); /* the closing quote is part of the attribute span */
-                self->state = ST_AFTER_ATTR_VALUE_QUOTED;
-                continue;
-            }
-            if (ch == '&') {
-                Py_ssize_t consumed =
-                    TH_NAME(consume_charref)(self, self->capture_attributes ? &self->attr->value : NULL, 1, NULL);
-                if (consumed == -1) {
-                    return RUN_NEED_MORE;
-                }
-                self->pos += consumed;
-                self->col += consumed;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            if (self->capture_attributes) {
-                push(self, &self->attr->value, ch == 0 ? REPLACEMENT : ch);
-            }
-            CONSUME();
-            continue;
-
-        case ST_ATTR_VALUE_UNQ:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (is_space(ch)) {
-                attr_end_here(self); /* the value ends at the delimiting whitespace */
-                CONSUME();
-                self->state = ST_BEFORE_ATTR_NAME;
-                continue;
-            }
-            if (ch == '&') {
-                Py_ssize_t consumed =
-                    TH_NAME(consume_charref)(self, self->capture_attributes ? &self->attr->value : NULL, 1, NULL);
-                if (consumed == -1) {
-                    return RUN_NEED_MORE;
-                }
-                self->pos += consumed;
-                self->col += consumed;
-                continue;
-            }
-            if (ch == '>') {
-                attr_end_here(self); /* the value ends at the closing '>' */
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            if (ch == '"' || ch == '\'' || ch == '<' || ch == '=' || ch == '`') {
-                tok_error(self, "unexpected-character-in-unquoted-attribute-value");
-            } else if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            if (self->capture_attributes) {
-                push(self, &self->attr->value, ch == 0 ? REPLACEMENT : ch);
-            }
-            CONSUME();
-            continue;
-
-        case ST_AFTER_ATTR_VALUE_QUOTED:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                self->state = ST_BEFORE_ATTR_NAME;
-                continue;
-            }
-            if (ch == '/') {
-                CONSUME();
-                self->state = ST_SELF_CLOSING_START_TAG;
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            tok_error(self, "missing-whitespace-between-attributes");
             self->state = ST_BEFORE_ATTR_NAME;
-            continue;
-
-        case ST_SELF_CLOSING_START_TAG:
-            if (at_eof) {
-                EOF_FLUSH();
-            }
-            if (ch == '>') {
-                CONSUME();
-                self->tok.self_closing = 1;
-                finish_tag(self);
-                return RUN_EMITTED;
-            }
-            tok_error(self, "unexpected-solidus-in-tag");
-            self->state = ST_BEFORE_ATTR_NAME;
-            continue;
-
-        case ST_BOGUS_COMMENT:
-            if (at_eof) {
-                EMIT_MARKUP();
-            }
-            if (ch == '>') {
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            push(self, &self->tok.text, ch == 0 ? REPLACEMENT : ch);
+            TH_DISPATCH();
+        }
+        if (ch == '/') {
             CONSUME();
-            continue;
+            self->state = ST_SELF_CLOSING_START_TAG;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        push(self, &self->tok.name, ch == 0 ? REPLACEMENT : lower_ascii(ch));
+        CONSUME();
+        TH_DISPATCH();
 
-        case ST_MARKUP_DECL_OPEN: {
+        TH_STATE(ST_RCDATA_LT)
+        if (!at_eof && ch == '/') {
+            CONSUME();
+            buf_reset(&self->temp);
+            self->state = ST_RCDATA_END_OPEN;
+            TH_DISPATCH();
+        }
+        text_begin_mark(self);
+        text_push(self, '<');
+        self->state = ST_RCDATA;
+        TH_DISPATCH();
+
+        TH_STATE(ST_RCDATA_END_OPEN)
+        if (!at_eof && is_ascii_alpha(ch)) {
+            start_tag(self, 1, lower_ascii(ch));
+            self->eof_code = NULL; /* speculative until it proves to be the appropriate end tag */
+            push(self, &self->temp, ch);
+            CONSUME();
+            self->state = ST_RCDATA_END_NAME;
+            TH_DISPATCH();
+        }
+        text_begin_mark(self);
+        text_push(self, '<');
+        text_push(self, '/');
+        self->state = ST_RCDATA;
+        TH_DISPATCH();
+
+        TH_STATE(ST_RCDATA_END_NAME)
+        if (!at_eof && is_space(ch) && appropriate_end_tag(self)) {
+            CONSUME();
+            self->eof_code = "eof-in-tag"; /* the end tag is the appropriate one, so it is now open */
+            self->state = ST_BEFORE_ATTR_NAME;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '/' && appropriate_end_tag(self)) {
+            CONSUME();
+            self->eof_code = "eof-in-tag";
+            self->state = ST_SELF_CLOSING_START_TAG;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '>' && appropriate_end_tag(self)) {
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        if (!at_eof && is_ascii_alpha(ch)) {
+            push(self, &self->tok.name, lower_ascii(ch));
+            push(self, &self->temp, ch);
+            CONSUME();
+            TH_DISPATCH();
+        }
+        rawtext_fallback(self, ST_RCDATA);
+        TH_DISPATCH();
+
+        TH_STATE(ST_RAWTEXT_LT)
+        if (!at_eof && ch == '/') {
+            CONSUME();
+            buf_reset(&self->temp);
+            self->state = ST_RAWTEXT_END_OPEN;
+            TH_DISPATCH();
+        }
+        text_begin_mark(self);
+        text_push(self, '<');
+        self->state = ST_RAWTEXT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_RAWTEXT_END_OPEN)
+        if (!at_eof && is_ascii_alpha(ch)) {
+            start_tag(self, 1, lower_ascii(ch));
+            self->eof_code = NULL; /* speculative until it proves to be the appropriate end tag */
+            push(self, &self->temp, ch);
+            CONSUME();
+            self->state = ST_RAWTEXT_END_NAME;
+            TH_DISPATCH();
+        }
+        text_begin_mark(self);
+        text_push(self, '<');
+        text_push(self, '/');
+        self->state = ST_RAWTEXT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_RAWTEXT_END_NAME)
+        if (!at_eof && is_space(ch) && appropriate_end_tag(self)) {
+            CONSUME();
+            self->eof_code = "eof-in-tag"; /* the end tag is the appropriate one, so it is now open */
+            self->state = ST_BEFORE_ATTR_NAME;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '/' && appropriate_end_tag(self)) {
+            CONSUME();
+            self->eof_code = "eof-in-tag";
+            self->state = ST_SELF_CLOSING_START_TAG;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '>' && appropriate_end_tag(self)) {
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        if (!at_eof && is_ascii_alpha(ch)) {
+            push(self, &self->tok.name, lower_ascii(ch));
+            push(self, &self->temp, ch);
+            CONSUME();
+            TH_DISPATCH();
+        }
+        rawtext_fallback(self, ST_RAWTEXT);
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_LT)
+        if (!at_eof && ch == '/') {
+            CONSUME();
+            buf_reset(&self->temp);
+            self->state = ST_SCRIPT_END_OPEN;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '!') {
+            CONSUME();
+            text_begin_mark(self);
+            text_push(self, '<');
+            text_push(self, '!');
+            self->state = ST_SCRIPT_ESC_START;
+            TH_DISPATCH();
+        }
+        text_begin_mark(self);
+        text_push(self, '<');
+        self->state = ST_SCRIPT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_END_OPEN)
+        if (!at_eof && is_ascii_alpha(ch)) {
+            start_tag(self, 1, lower_ascii(ch));
+            self->eof_code = NULL; /* speculative until it proves to be the appropriate end tag */
+            push(self, &self->temp, ch);
+            CONSUME();
+            self->state = ST_SCRIPT_END_NAME;
+            TH_DISPATCH();
+        }
+        text_begin_mark(self);
+        text_push(self, '<');
+        text_push(self, '/');
+        self->state = ST_SCRIPT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_END_NAME)
+        if (!at_eof && is_space(ch) && appropriate_end_tag(self)) {
+            CONSUME();
+            self->eof_code = "eof-in-tag"; /* the end tag is the appropriate one, so it is now open */
+            self->state = ST_BEFORE_ATTR_NAME;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '/' && appropriate_end_tag(self)) {
+            CONSUME();
+            self->eof_code = "eof-in-tag";
+            self->state = ST_SELF_CLOSING_START_TAG;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '>' && appropriate_end_tag(self)) {
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        if (!at_eof && is_ascii_alpha(ch)) {
+            push(self, &self->tok.name, lower_ascii(ch));
+            push(self, &self->temp, ch);
+            CONSUME();
+            TH_DISPATCH();
+        }
+        rawtext_fallback(self, ST_SCRIPT);
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_ESC_START)
+        if (!at_eof && ch == '-') {
+            CONSUME();
+            text_push(self, '-');
+            self->state = ST_SCRIPT_ESC_START_DASH;
+            TH_DISPATCH();
+        }
+        self->state = ST_SCRIPT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_ESC_START_DASH)
+        if (!at_eof && ch == '-') {
+            CONSUME();
+            text_push(self, '-');
+            self->state = ST_SCRIPT_ESCAPED_DASH_DASH;
+            TH_DISPATCH();
+        }
+        self->state = ST_SCRIPT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_ESCAPED)
+        if (at_eof) {
+            tok_error(self, "eof-in-script-html-comment-like-text");
+            EOF_FLUSH();
+        }
+        if (ch == '-') {
+            CONSUME();
+            text_push(self, '-');
+            self->state = ST_SCRIPT_ESCAPED_DASH;
+            TH_DISPATCH();
+        }
+        if (ch == '<') {
+            MARK();
+            CONSUME();
+            self->state = ST_SCRIPT_ESCAPED_LT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_ESCAPED_DASH)
+        if (at_eof) {
+            tok_error(self, "eof-in-script-html-comment-like-text");
+            EOF_FLUSH();
+        }
+        if (ch == '-') {
+            CONSUME();
+            text_push(self, '-');
+            self->state = ST_SCRIPT_ESCAPED_DASH_DASH;
+            TH_DISPATCH();
+        }
+        if (ch == '<') {
+            MARK();
+            CONSUME();
+            self->state = ST_SCRIPT_ESCAPED_LT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        self->state = ST_SCRIPT_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_ESCAPED_DASH_DASH)
+        if (at_eof) {
+            tok_error(self, "eof-in-script-html-comment-like-text");
+            EOF_FLUSH();
+        }
+        if (ch == '-') {
+            CONSUME();
+            text_push(self, '-');
+            TH_DISPATCH();
+        }
+        if (ch == '<') {
+            MARK();
+            CONSUME();
+            self->state = ST_SCRIPT_ESCAPED_LT;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            text_push(self, '>');
+            self->state = ST_SCRIPT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        self->state = ST_SCRIPT_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_ESCAPED_LT)
+        if (!at_eof && ch == '/') {
+            CONSUME();
+            buf_reset(&self->temp);
+            self->state = ST_SCRIPT_ESCAPED_END_OPEN;
+            TH_DISPATCH();
+        }
+        if (!at_eof && is_ascii_alpha(ch)) {
+            buf_reset(&self->temp);
+            text_begin_mark(self);
+            text_push(self, '<');
+            self->state = ST_SCRIPT_DOUBLE_ESC_START;
+            TH_DISPATCH();
+        }
+        text_begin_mark(self);
+        text_push(self, '<');
+        self->state = ST_SCRIPT_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_ESCAPED_END_OPEN)
+        if (!at_eof && is_ascii_alpha(ch)) {
+            start_tag(self, 1, lower_ascii(ch));
+            self->eof_code = NULL; /* speculative until it proves to be the appropriate end tag */
+            push(self, &self->temp, ch);
+            CONSUME();
+            self->state = ST_SCRIPT_ESCAPED_END_NAME;
+            TH_DISPATCH();
+        }
+        text_begin_mark(self);
+        text_push(self, '<');
+        text_push(self, '/');
+        self->state = ST_SCRIPT_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_ESCAPED_END_NAME)
+        if (!at_eof && is_space(ch) && appropriate_end_tag(self)) {
+            CONSUME();
+            self->eof_code = "eof-in-tag"; /* the end tag is the appropriate one, so it is now open */
+            self->state = ST_BEFORE_ATTR_NAME;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '/' && appropriate_end_tag(self)) {
+            CONSUME();
+            self->eof_code = "eof-in-tag";
+            self->state = ST_SELF_CLOSING_START_TAG;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '>' && appropriate_end_tag(self)) {
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        if (!at_eof && is_ascii_alpha(ch)) {
+            push(self, &self->tok.name, lower_ascii(ch));
+            push(self, &self->temp, ch);
+            CONSUME();
+            TH_DISPATCH();
+        }
+        rawtext_fallback(self, ST_SCRIPT_ESCAPED);
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_DOUBLE_ESC_START)
+        if (!at_eof && (is_space(ch) || ch == '/' || ch == '>')) {
+            CONSUME();
+            text_push(self, ch);
+            self->state = (self->temp.len == 6 && memcmp(self->temp.data, "script", 6) == 0) ? ST_SCRIPT_DOUBLE_ESCAPED
+                                                                                             : ST_SCRIPT_ESCAPED;
+            TH_DISPATCH();
+        }
+        if (!at_eof && is_ascii_alpha(ch)) {
+            push(self, &self->temp, lower_ascii(ch));
+            text_push(self, ch);
+            CONSUME();
+            TH_DISPATCH();
+        }
+        self->state = ST_SCRIPT_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_DOUBLE_ESCAPED)
+        if (at_eof) {
+            tok_error(self, "eof-in-script-html-comment-like-text");
+            EOF_FLUSH();
+        }
+        if (ch == '-') {
+            CONSUME();
+            text_push(self, '-');
+            self->state = ST_SCRIPT_DOUBLE_ESCAPED_DASH;
+            TH_DISPATCH();
+        }
+        if (ch == '<') {
+            CONSUME();
+            text_push(self, '<');
+            self->state = ST_SCRIPT_DOUBLE_ESCAPED_LT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_DOUBLE_ESCAPED_DASH)
+        if (at_eof) {
+            tok_error(self, "eof-in-script-html-comment-like-text");
+            EOF_FLUSH();
+        }
+        if (ch == '-') {
+            CONSUME();
+            text_push(self, '-');
+            self->state = ST_SCRIPT_DOUBLE_ESCAPED_DASH_DASH;
+            TH_DISPATCH();
+        }
+        if (ch == '<') {
+            CONSUME();
+            text_push(self, '<');
+            self->state = ST_SCRIPT_DOUBLE_ESCAPED_LT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        self->state = ST_SCRIPT_DOUBLE_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_DOUBLE_ESCAPED_DASH_DASH)
+        if (at_eof) {
+            tok_error(self, "eof-in-script-html-comment-like-text");
+            EOF_FLUSH();
+        }
+        if (ch == '-') {
+            CONSUME();
+            text_push(self, '-');
+            TH_DISPATCH();
+        }
+        if (ch == '<') {
+            CONSUME();
+            text_push(self, '<');
+            self->state = ST_SCRIPT_DOUBLE_ESCAPED_LT;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            text_push(self, '>');
+            self->state = ST_SCRIPT;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        text_push(self, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        self->state = ST_SCRIPT_DOUBLE_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_DOUBLE_ESCAPED_LT)
+        if (!at_eof && ch == '/') {
+            CONSUME();
+            buf_reset(&self->temp);
+            text_push(self, '/');
+            self->state = ST_SCRIPT_DOUBLE_ESC_END;
+            TH_DISPATCH();
+        }
+        self->state = ST_SCRIPT_DOUBLE_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SCRIPT_DOUBLE_ESC_END)
+        if (!at_eof && (is_space(ch) || ch == '/' || ch == '>')) {
+            CONSUME();
+            text_push(self, ch);
+            self->state = (self->temp.len == 6 && memcmp(self->temp.data, "script", 6) == 0) ? ST_SCRIPT_ESCAPED
+                                                                                             : ST_SCRIPT_DOUBLE_ESCAPED;
+            TH_DISPATCH();
+        }
+        if (!at_eof && is_ascii_alpha(ch)) {
+            push(self, &self->temp, lower_ascii(ch));
+            text_push(self, ch);
+            CONSUME();
+            TH_DISPATCH();
+        }
+        self->state = ST_SCRIPT_DOUBLE_ESCAPED;
+        TH_DISPATCH();
+
+        TH_STATE(ST_BEFORE_ATTR_NAME)
+        if (at_eof || ch == '/' || ch == '>') {
+            self->state = ST_AFTER_ATTR_NAME;
+            TH_DISPATCH();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            TH_DISPATCH();
+        }
+        new_attr(self);
+        if (ch == '=') {
+            tok_error(self, "unexpected-equals-sign-before-attribute-name");
+            if (self->capture_attributes) {
+                push(self, &self->attr->name, ch);
+            }
+            CONSUME();
+        }
+        self->state = ST_ATTR_NAME;
+        TH_DISPATCH();
+
+        TH_STATE(ST_ATTR_NAME)
+        if (at_eof || is_space(ch) || ch == '/' || ch == '>') {
+            finish_attr_name(self);
+            self->state = ST_AFTER_ATTR_NAME;
+            TH_DISPATCH();
+        }
+        if (ch == '=') {
+            finish_attr_name(self);
+            CONSUME();
+            self->state = ST_BEFORE_ATTR_VALUE;
+            TH_DISPATCH();
+        }
+        if (ch == '"' || ch == '\'' || ch == '<') {
+            tok_error(self, "unexpected-character-in-attribute-name");
+        } else if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        if (self->capture_attributes) {
+            push(self, &self->attr->name, ch == 0 ? REPLACEMENT : lower_ascii(ch));
+        }
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_AFTER_ATTR_NAME)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '/') {
+            CONSUME();
+            self->state = ST_SELF_CLOSING_START_TAG;
+            TH_DISPATCH();
+        }
+        if (ch == '=') {
+            CONSUME();
+            self->state = ST_BEFORE_ATTR_VALUE;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        new_attr(self);
+        self->state = ST_ATTR_NAME;
+        TH_DISPATCH();
+
+        TH_STATE(ST_BEFORE_ATTR_VALUE)
+        if (!at_eof && is_space(ch)) {
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (self->capture_attributes) {
+            self->attr->has_value = 1;
+        }
+        if (!at_eof && ch == '"') {
+            CONSUME();
+            self->state = ST_ATTR_VALUE_DQ;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '\'') {
+            CONSUME();
+            self->state = ST_ATTR_VALUE_SQ;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '>') {
+            tok_error(self, "missing-attribute-value");
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        self->state = ST_ATTR_VALUE_UNQ;
+        TH_DISPATCH();
+
+        TH_STATE(ST_ATTR_VALUE_DQ)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (ch != '"' && ch != '&' && ch != '\n' && ch != 0) {
+            /* bulk-copy the ordinary value run; '\n' is a stop so line/col
+               stay accurate, and &/" /NUL keep their dedicated handling */
+            Py_ssize_t stop = TH_SCAN(self, self->pos, '"', '&', '\n', 0);
+            if (self->capture_attributes) {
+                buf_append_input(self, &self->attr->value, self->pos, stop - self->pos);
+            }
+            self->col += stop - self->pos;
+            self->pos = stop;
+            TH_DISPATCH();
+        }
+        if (ch == '"') {
+            CONSUME();
+            attr_end_here(self); /* the closing quote is part of the attribute span */
+            self->state = ST_AFTER_ATTR_VALUE_QUOTED;
+            TH_DISPATCH();
+        }
+        if (ch == '&') {
+            Py_ssize_t consumed =
+                TH_NAME(consume_charref)(self, self->capture_attributes ? &self->attr->value : NULL, 1, NULL);
+            if (consumed == -1) {
+                return RUN_NEED_MORE;
+            }
+            self->pos += consumed;
+            self->col += consumed;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        if (self->capture_attributes) {
+            push(self, &self->attr->value, ch == 0 ? REPLACEMENT : ch);
+        }
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_ATTR_VALUE_SQ)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (ch != '\'' && ch != '&' && ch != '\n' && ch != 0) {
+            Py_ssize_t stop = TH_SCAN(self, self->pos, '\'', '&', '\n', 0);
+            if (self->capture_attributes) {
+                buf_append_input(self, &self->attr->value, self->pos, stop - self->pos);
+            }
+            self->col += stop - self->pos;
+            self->pos = stop;
+            TH_DISPATCH();
+        }
+        if (ch == '\'') {
+            CONSUME();
+            attr_end_here(self); /* the closing quote is part of the attribute span */
+            self->state = ST_AFTER_ATTR_VALUE_QUOTED;
+            TH_DISPATCH();
+        }
+        if (ch == '&') {
+            Py_ssize_t consumed =
+                TH_NAME(consume_charref)(self, self->capture_attributes ? &self->attr->value : NULL, 1, NULL);
+            if (consumed == -1) {
+                return RUN_NEED_MORE;
+            }
+            self->pos += consumed;
+            self->col += consumed;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        if (self->capture_attributes) {
+            push(self, &self->attr->value, ch == 0 ? REPLACEMENT : ch);
+        }
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_ATTR_VALUE_UNQ)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (is_space(ch)) {
+            attr_end_here(self); /* the value ends at the delimiting whitespace */
+            CONSUME();
+            self->state = ST_BEFORE_ATTR_NAME;
+            TH_DISPATCH();
+        }
+        if (ch == '&') {
+            Py_ssize_t consumed =
+                TH_NAME(consume_charref)(self, self->capture_attributes ? &self->attr->value : NULL, 1, NULL);
+            if (consumed == -1) {
+                return RUN_NEED_MORE;
+            }
+            self->pos += consumed;
+            self->col += consumed;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            attr_end_here(self); /* the value ends at the closing '>' */
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        if (ch == '"' || ch == '\'' || ch == '<' || ch == '=' || ch == '`') {
+            tok_error(self, "unexpected-character-in-unquoted-attribute-value");
+        } else if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        if (self->capture_attributes) {
+            push(self, &self->attr->value, ch == 0 ? REPLACEMENT : ch);
+        }
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_AFTER_ATTR_VALUE_QUOTED)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            self->state = ST_BEFORE_ATTR_NAME;
+            TH_DISPATCH();
+        }
+        if (ch == '/') {
+            CONSUME();
+            self->state = ST_SELF_CLOSING_START_TAG;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        tok_error(self, "missing-whitespace-between-attributes");
+        self->state = ST_BEFORE_ATTR_NAME;
+        TH_DISPATCH();
+
+        TH_STATE(ST_SELF_CLOSING_START_TAG)
+        if (at_eof) {
+            EOF_FLUSH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            self->tok.self_closing = 1;
+            finish_tag(self);
+            return RUN_EMITTED;
+        }
+        tok_error(self, "unexpected-solidus-in-tag");
+        self->state = ST_BEFORE_ATTR_NAME;
+        TH_DISPATCH();
+
+        TH_STATE(ST_BOGUS_COMMENT)
+        if (at_eof) {
+            EMIT_MARKUP();
+        }
+        if (ch == '>') {
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        push(self, &self->tok.text, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_MARKUP_DECL_OPEN) {
             int match = TH_NAME(match_kw)(self, "--", 2, 0);
             if (match == 2) {
                 self->pos += 2;
@@ -1299,7 +1405,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
                 init_markup(self, TH_COMMENT);
                 self->eof_code = "eof-in-comment"; /* the comment is now open */
                 self->state = ST_COMMENT_START;
-                continue;
+                TH_DISPATCH();
             }
             if (match == 1 && !self->eof) {
                 return RUN_NEED_MORE;
@@ -1310,7 +1416,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
                 self->col += 7;
                 self->eof_code = "eof-in-doctype"; /* the doctype is now open */
                 self->state = ST_DOCTYPE;
-                continue;
+                TH_DISPATCH();
             }
             if (match == 1 && !self->eof) {
                 return RUN_NEED_MORE;
@@ -1321,7 +1427,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
                 self->col += 7;
                 if (self->cdata_ok) {
                     self->state = ST_CDATA; /* CDATA content is a plain text run */
-                    continue;
+                    TH_DISPATCH();
                 }
                 tok_error_at(self, "cdata-in-html-content", self->col - 1);
                 init_markup(self, TH_COMMENT);
@@ -1329,7 +1435,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
                     push(self, &self->tok.text, (Py_UCS4)(unsigned char)*cdata_char);
                 }
                 self->state = ST_BOGUS_COMMENT;
-                continue;
+                TH_DISPATCH();
             }
             if (match == 1 && !self->eof) {
                 return RUN_NEED_MORE;
@@ -1337,233 +1443,233 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
             tok_error(self, "incorrectly-opened-comment");
             init_markup(self, TH_COMMENT);
             self->state = ST_BOGUS_COMMENT;
-            continue;
+            TH_DISPATCH();
         }
 
-        case ST_COMMENT_START:
-            if (!at_eof && ch == '-') {
-                CONSUME();
-                self->state = ST_COMMENT_START_DASH;
-                continue;
-            }
-            if (!at_eof && ch == '>') {
-                tok_error(self, "abrupt-closing-of-empty-comment");
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            self->state = ST_COMMENT;
-            continue;
-
-        case ST_COMMENT_START_DASH:
-            if (at_eof) {
-                EMIT_MARKUP();
-            }
-            if (ch == '-') {
-                CONSUME();
-                self->state = ST_COMMENT_END;
-                continue;
-            }
-            if (ch == '>') {
-                tok_error(self, "abrupt-closing-of-empty-comment");
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            push(self, &self->tok.text, '-');
-            self->state = ST_COMMENT;
-            continue;
-
-        case ST_COMMENT:
-            if (at_eof) {
-                EMIT_MARKUP();
-            }
-            if (ch == '<') {
-                push(self, &self->tok.text, '<');
-                CONSUME();
-                self->state = ST_COMMENT_LT;
-                continue;
-            }
-            if (ch == '-') {
-                CONSUME();
-                self->state = ST_COMMENT_END_DASH;
-                continue;
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            push(self, &self->tok.text, ch == 0 ? REPLACEMENT : ch);
+        TH_STATE(ST_COMMENT_START)
+        if (!at_eof && ch == '-') {
             CONSUME();
-            continue;
+            self->state = ST_COMMENT_START_DASH;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '>') {
+            tok_error(self, "abrupt-closing-of-empty-comment");
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        self->state = ST_COMMENT;
+        TH_DISPATCH();
 
-        case ST_COMMENT_LT:
-            if (!at_eof && ch == '!') {
-                push(self, &self->tok.text, '!');
-                CONSUME();
-                self->state = ST_COMMENT_LT_BANG;
-                continue;
-            }
-            if (!at_eof && ch == '<') {
-                push(self, &self->tok.text, '<');
-                CONSUME();
-                continue;
-            }
-            self->state = ST_COMMENT;
-            continue;
-
-        case ST_COMMENT_LT_BANG:
-            if (!at_eof && ch == '-') {
-                CONSUME();
-                self->state = ST_COMMENT_LT_BANG_DASH;
-                continue;
-            }
-            self->state = ST_COMMENT;
-            continue;
-
-        case ST_COMMENT_LT_BANG_DASH:
-            if (!at_eof && ch == '-') {
-                CONSUME();
-                self->state = ST_COMMENT_LT_BANG_DASH_DASH;
-                continue;
-            }
-            self->state = ST_COMMENT_END_DASH;
-            continue;
-
-        case ST_COMMENT_LT_BANG_DASH_DASH:
-            if (!at_eof && ch != '>') {
-                tok_error(self, "nested-comment");
-            }
+        TH_STATE(ST_COMMENT_START_DASH)
+        if (at_eof) {
+            EMIT_MARKUP();
+        }
+        if (ch == '-') {
+            CONSUME();
             self->state = ST_COMMENT_END;
-            continue;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            tok_error(self, "abrupt-closing-of-empty-comment");
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        push(self, &self->tok.text, '-');
+        self->state = ST_COMMENT;
+        TH_DISPATCH();
 
-        case ST_COMMENT_END_DASH:
-            if (at_eof) {
-                EMIT_MARKUP();
-            }
-            if (ch == '-') {
-                CONSUME();
-                self->state = ST_COMMENT_END;
-                continue;
-            }
-            push(self, &self->tok.text, '-');
-            self->state = ST_COMMENT;
-            continue;
+        TH_STATE(ST_COMMENT)
+        if (at_eof) {
+            EMIT_MARKUP();
+        }
+        if (ch == '<') {
+            push(self, &self->tok.text, '<');
+            CONSUME();
+            self->state = ST_COMMENT_LT;
+            TH_DISPATCH();
+        }
+        if (ch == '-') {
+            CONSUME();
+            self->state = ST_COMMENT_END_DASH;
+            TH_DISPATCH();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        push(self, &self->tok.text, ch == 0 ? REPLACEMENT : ch);
+        CONSUME();
+        TH_DISPATCH();
 
-        case ST_COMMENT_END:
-            if (at_eof) {
-                EMIT_MARKUP();
-            }
-            if (ch == '>') {
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            if (ch == '!') {
-                CONSUME();
-                self->state = ST_COMMENT_END_BANG;
-                continue;
-            }
-            if (ch == '-') {
-                push(self, &self->tok.text, '-');
-                CONSUME();
-                continue;
-            }
-            push(self, &self->tok.text, '-');
-            push(self, &self->tok.text, '-');
-            self->state = ST_COMMENT;
-            continue;
+        TH_STATE(ST_COMMENT_LT)
+        if (!at_eof && ch == '!') {
+            push(self, &self->tok.text, '!');
+            CONSUME();
+            self->state = ST_COMMENT_LT_BANG;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == '<') {
+            push(self, &self->tok.text, '<');
+            CONSUME();
+            TH_DISPATCH();
+        }
+        self->state = ST_COMMENT;
+        TH_DISPATCH();
 
-        case ST_COMMENT_END_BANG:
-            if (at_eof) {
-                EMIT_MARKUP();
-            }
-            if (ch == '-') {
-                push(self, &self->tok.text, '-');
-                push(self, &self->tok.text, '-');
-                push(self, &self->tok.text, '!');
-                CONSUME();
-                self->state = ST_COMMENT_END_DASH;
-                continue;
-            }
-            if (ch == '>') {
-                tok_error(self, "incorrectly-closed-comment");
-                CONSUME();
-                EMIT_MARKUP();
-            }
+        TH_STATE(ST_COMMENT_LT_BANG)
+        if (!at_eof && ch == '-') {
+            CONSUME();
+            self->state = ST_COMMENT_LT_BANG_DASH;
+            TH_DISPATCH();
+        }
+        self->state = ST_COMMENT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_COMMENT_LT_BANG_DASH)
+        if (!at_eof && ch == '-') {
+            CONSUME();
+            self->state = ST_COMMENT_LT_BANG_DASH_DASH;
+            TH_DISPATCH();
+        }
+        self->state = ST_COMMENT_END_DASH;
+        TH_DISPATCH();
+
+        TH_STATE(ST_COMMENT_LT_BANG_DASH_DASH)
+        if (!at_eof && ch != '>') {
+            tok_error(self, "nested-comment");
+        }
+        self->state = ST_COMMENT_END;
+        TH_DISPATCH();
+
+        TH_STATE(ST_COMMENT_END_DASH)
+        if (at_eof) {
+            EMIT_MARKUP();
+        }
+        if (ch == '-') {
+            CONSUME();
+            self->state = ST_COMMENT_END;
+            TH_DISPATCH();
+        }
+        push(self, &self->tok.text, '-');
+        self->state = ST_COMMENT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_COMMENT_END)
+        if (at_eof) {
+            EMIT_MARKUP();
+        }
+        if (ch == '>') {
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        if (ch == '!') {
+            CONSUME();
+            self->state = ST_COMMENT_END_BANG;
+            TH_DISPATCH();
+        }
+        if (ch == '-') {
+            push(self, &self->tok.text, '-');
+            CONSUME();
+            TH_DISPATCH();
+        }
+        push(self, &self->tok.text, '-');
+        push(self, &self->tok.text, '-');
+        self->state = ST_COMMENT;
+        TH_DISPATCH();
+
+        TH_STATE(ST_COMMENT_END_BANG)
+        if (at_eof) {
+            EMIT_MARKUP();
+        }
+        if (ch == '-') {
             push(self, &self->tok.text, '-');
             push(self, &self->tok.text, '-');
             push(self, &self->tok.text, '!');
-            self->state = ST_COMMENT;
-            continue;
+            CONSUME();
+            self->state = ST_COMMENT_END_DASH;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            tok_error(self, "incorrectly-closed-comment");
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        push(self, &self->tok.text, '-');
+        push(self, &self->tok.text, '-');
+        push(self, &self->tok.text, '!');
+        self->state = ST_COMMENT;
+        TH_DISPATCH();
 
-        case ST_DOCTYPE:
-            if (at_eof) {
-                init_markup(self, TH_DOCTYPE);
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                self->state = ST_BEFORE_DOCTYPE_NAME;
-                continue;
-            }
-            if (ch != '>') {
-                tok_error(self, "missing-whitespace-before-doctype-name");
-            }
-            self->state = ST_BEFORE_DOCTYPE_NAME;
-            continue;
-
-        case ST_BEFORE_DOCTYPE_NAME:
-            if (at_eof) {
-                init_markup(self, TH_DOCTYPE);
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                continue;
-            }
+        TH_STATE(ST_DOCTYPE)
+        if (at_eof) {
             init_markup(self, TH_DOCTYPE);
-            if (ch == '>') {
-                tok_error(self, "missing-doctype-name");
-                self->tok.force_quirks = 1;
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            push(self, &self->tok.name, ch == 0 ? REPLACEMENT : lower_ascii(ch));
+            self->tok.force_quirks = 1;
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
             CONSUME();
-            self->state = ST_DOCTYPE_NAME;
-            continue;
+            self->state = ST_BEFORE_DOCTYPE_NAME;
+            TH_DISPATCH();
+        }
+        if (ch != '>') {
+            tok_error(self, "missing-whitespace-before-doctype-name");
+        }
+        self->state = ST_BEFORE_DOCTYPE_NAME;
+        TH_DISPATCH();
 
-        case ST_DOCTYPE_NAME:
+        TH_STATE(ST_BEFORE_DOCTYPE_NAME)
+        if (at_eof) {
+            init_markup(self, TH_DOCTYPE);
+            self->tok.force_quirks = 1;
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            TH_DISPATCH();
+        }
+        init_markup(self, TH_DOCTYPE);
+        if (ch == '>') {
+            tok_error(self, "missing-doctype-name");
+            self->tok.force_quirks = 1;
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        push(self, &self->tok.name, ch == 0 ? REPLACEMENT : lower_ascii(ch));
+        CONSUME();
+        self->state = ST_DOCTYPE_NAME;
+        TH_DISPATCH();
+
+        TH_STATE(ST_DOCTYPE_NAME)
+        if (at_eof) {
+            self->tok.force_quirks = 1;
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            self->state = ST_AFTER_DOCTYPE_NAME;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        push(self, &self->tok.name, ch == 0 ? REPLACEMENT : lower_ascii(ch));
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_AFTER_DOCTYPE_NAME) {
             if (at_eof) {
                 self->tok.force_quirks = 1;
                 EMIT_MARKUP();
             }
             if (is_space(ch)) {
                 CONSUME();
-                self->state = ST_AFTER_DOCTYPE_NAME;
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            push(self, &self->tok.name, ch == 0 ? REPLACEMENT : lower_ascii(ch));
-            CONSUME();
-            continue;
-
-        case ST_AFTER_DOCTYPE_NAME: {
-            if (at_eof) {
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                continue;
+                TH_DISPATCH();
             }
             if (ch == '>') {
                 CONSUME();
@@ -1574,7 +1680,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
                 self->pos += 6;
                 self->col += 6;
                 self->state = ST_AFTER_DOCTYPE_PUBLIC_KW;
-                continue;
+                TH_DISPATCH();
             }
             if (match == 1 && !self->eof) {
                 return RUN_NEED_MORE;
@@ -1584,7 +1690,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
                 self->pos += 6;
                 self->col += 6;
                 self->state = ST_AFTER_DOCTYPE_SYSTEM_KW;
-                continue;
+                TH_DISPATCH();
             }
             if (match == 1 && !self->eof) {
                 return RUN_NEED_MORE;
@@ -1594,60 +1700,60 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
             BOGUS_DOCTYPE();
         }
 
-        case ST_AFTER_DOCTYPE_PUBLIC_KW:
-            if (at_eof) {
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                self->state = ST_BEFORE_DOCTYPE_PUBLIC_ID;
-                continue;
-            }
-            if (ch == '"' || ch == '\'') {
-                tok_error(self, "missing-whitespace-after-doctype-public-keyword");
-                self->tok.has_public_id = 1;
-                self->state = (ch == '"') ? ST_DOCTYPE_PUBLIC_ID_DQ : ST_DOCTYPE_PUBLIC_ID_SQ;
-                CONSUME();
-                continue;
-            }
-            if (ch == '>') {
-                tok_error(self, "missing-doctype-public-identifier");
-                self->tok.force_quirks = 1;
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            tok_error(self, "missing-quote-before-doctype-public-identifier");
+        TH_STATE(ST_AFTER_DOCTYPE_PUBLIC_KW)
+        if (at_eof) {
             self->tok.force_quirks = 1;
-            BOGUS_DOCTYPE();
-
-        case ST_BEFORE_DOCTYPE_PUBLIC_ID:
-            if (at_eof) {
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                continue;
-            }
-            if (ch == '"' || ch == '\'') {
-                self->tok.has_public_id = 1;
-                self->state = (ch == '"') ? ST_DOCTYPE_PUBLIC_ID_DQ : ST_DOCTYPE_PUBLIC_ID_SQ;
-                CONSUME();
-                continue;
-            }
-            if (ch == '>') {
-                tok_error(self, "missing-doctype-public-identifier");
-                self->tok.force_quirks = 1;
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            tok_error(self, "missing-quote-before-doctype-public-identifier");
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            self->state = ST_BEFORE_DOCTYPE_PUBLIC_ID;
+            TH_DISPATCH();
+        }
+        if (ch == '"' || ch == '\'') {
+            tok_error(self, "missing-whitespace-after-doctype-public-keyword");
+            self->tok.has_public_id = 1;
+            self->state = (ch == '"') ? ST_DOCTYPE_PUBLIC_ID_DQ : ST_DOCTYPE_PUBLIC_ID_SQ;
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            tok_error(self, "missing-doctype-public-identifier");
             self->tok.force_quirks = 1;
-            BOGUS_DOCTYPE();
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        tok_error(self, "missing-quote-before-doctype-public-identifier");
+        self->tok.force_quirks = 1;
+        BOGUS_DOCTYPE();
 
-        case ST_DOCTYPE_PUBLIC_ID_DQ:
-        case ST_DOCTYPE_PUBLIC_ID_SQ: {
+        TH_STATE(ST_BEFORE_DOCTYPE_PUBLIC_ID)
+        if (at_eof) {
+            self->tok.force_quirks = 1;
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '"' || ch == '\'') {
+            self->tok.has_public_id = 1;
+            self->state = (ch == '"') ? ST_DOCTYPE_PUBLIC_ID_DQ : ST_DOCTYPE_PUBLIC_ID_SQ;
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            tok_error(self, "missing-doctype-public-identifier");
+            self->tok.force_quirks = 1;
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        tok_error(self, "missing-quote-before-doctype-public-identifier");
+        self->tok.force_quirks = 1;
+        BOGUS_DOCTYPE();
+
+        TH_STATE(ST_DOCTYPE_PUBLIC_ID_DQ)
+        TH_STATE(ST_DOCTYPE_PUBLIC_ID_SQ) {
             Py_UCS4 quote = (self->state == ST_DOCTYPE_PUBLIC_ID_DQ) ? '"' : '\'';
             if (at_eof) {
                 self->tok.force_quirks = 1;
@@ -1656,7 +1762,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
             if (ch == quote) {
                 CONSUME();
                 self->state = ST_AFTER_DOCTYPE_PUBLIC_ID;
-                continue;
+                TH_DISPATCH();
             }
             if (ch == '>') {
                 tok_error(self, "abrupt-doctype-public-identifier");
@@ -1669,111 +1775,111 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
             }
             push(self, &self->tok.public_id, ch == 0 ? REPLACEMENT : ch);
             CONSUME();
-            continue;
+            TH_DISPATCH();
         }
 
-        case ST_AFTER_DOCTYPE_PUBLIC_ID:
-            if (at_eof) {
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                self->state = ST_BETWEEN_DOCTYPE_PUB_SYS;
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            if (ch == '"' || ch == '\'') {
-                tok_error(self, "missing-whitespace-between-doctype-public-and-system-identifiers");
-                self->tok.has_system_id = 1;
-                self->state = (ch == '"') ? ST_DOCTYPE_SYSTEM_ID_DQ : ST_DOCTYPE_SYSTEM_ID_SQ;
-                CONSUME();
-                continue;
-            }
-            tok_error(self, "missing-quote-before-doctype-system-identifier");
+        TH_STATE(ST_AFTER_DOCTYPE_PUBLIC_ID)
+        if (at_eof) {
             self->tok.force_quirks = 1;
-            BOGUS_DOCTYPE();
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            self->state = ST_BETWEEN_DOCTYPE_PUB_SYS;
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        if (ch == '"' || ch == '\'') {
+            tok_error(self, "missing-whitespace-between-doctype-public-and-system-identifiers");
+            self->tok.has_system_id = 1;
+            self->state = (ch == '"') ? ST_DOCTYPE_SYSTEM_ID_DQ : ST_DOCTYPE_SYSTEM_ID_SQ;
+            CONSUME();
+            TH_DISPATCH();
+        }
+        tok_error(self, "missing-quote-before-doctype-system-identifier");
+        self->tok.force_quirks = 1;
+        BOGUS_DOCTYPE();
 
-        case ST_BETWEEN_DOCTYPE_PUB_SYS:
-            if (at_eof) {
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            if (ch == '"' || ch == '\'') {
-                self->tok.has_system_id = 1;
-                self->state = (ch == '"') ? ST_DOCTYPE_SYSTEM_ID_DQ : ST_DOCTYPE_SYSTEM_ID_SQ;
-                CONSUME();
-                continue;
-            }
-            tok_error(self, "missing-quote-before-doctype-system-identifier");
+        TH_STATE(ST_BETWEEN_DOCTYPE_PUB_SYS)
+        if (at_eof) {
             self->tok.force_quirks = 1;
-            BOGUS_DOCTYPE();
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        if (ch == '"' || ch == '\'') {
+            self->tok.has_system_id = 1;
+            self->state = (ch == '"') ? ST_DOCTYPE_SYSTEM_ID_DQ : ST_DOCTYPE_SYSTEM_ID_SQ;
+            CONSUME();
+            TH_DISPATCH();
+        }
+        tok_error(self, "missing-quote-before-doctype-system-identifier");
+        self->tok.force_quirks = 1;
+        BOGUS_DOCTYPE();
 
-        case ST_AFTER_DOCTYPE_SYSTEM_KW:
-            if (at_eof) {
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                self->state = ST_BEFORE_DOCTYPE_SYSTEM_ID;
-                continue;
-            }
-            if (ch == '"' || ch == '\'') {
-                tok_error(self, "missing-whitespace-after-doctype-system-keyword");
-                self->tok.has_system_id = 1;
-                self->state = (ch == '"') ? ST_DOCTYPE_SYSTEM_ID_DQ : ST_DOCTYPE_SYSTEM_ID_SQ;
-                CONSUME();
-                continue;
-            }
-            if (ch == '>') {
-                tok_error(self, "missing-doctype-system-identifier");
-                self->tok.force_quirks = 1;
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            tok_error(self, "missing-quote-before-doctype-system-identifier");
+        TH_STATE(ST_AFTER_DOCTYPE_SYSTEM_KW)
+        if (at_eof) {
             self->tok.force_quirks = 1;
-            BOGUS_DOCTYPE();
-
-        case ST_BEFORE_DOCTYPE_SYSTEM_ID:
-            if (at_eof) {
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                continue;
-            }
-            if (ch == '"' || ch == '\'') {
-                self->tok.has_system_id = 1;
-                self->state = (ch == '"') ? ST_DOCTYPE_SYSTEM_ID_DQ : ST_DOCTYPE_SYSTEM_ID_SQ;
-                CONSUME();
-                continue;
-            }
-            if (ch == '>') {
-                tok_error(self, "missing-doctype-system-identifier");
-                self->tok.force_quirks = 1;
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            tok_error(self, "missing-quote-before-doctype-system-identifier");
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            self->state = ST_BEFORE_DOCTYPE_SYSTEM_ID;
+            TH_DISPATCH();
+        }
+        if (ch == '"' || ch == '\'') {
+            tok_error(self, "missing-whitespace-after-doctype-system-keyword");
+            self->tok.has_system_id = 1;
+            self->state = (ch == '"') ? ST_DOCTYPE_SYSTEM_ID_DQ : ST_DOCTYPE_SYSTEM_ID_SQ;
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            tok_error(self, "missing-doctype-system-identifier");
             self->tok.force_quirks = 1;
-            BOGUS_DOCTYPE();
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        tok_error(self, "missing-quote-before-doctype-system-identifier");
+        self->tok.force_quirks = 1;
+        BOGUS_DOCTYPE();
 
-        case ST_DOCTYPE_SYSTEM_ID_DQ:
-        case ST_DOCTYPE_SYSTEM_ID_SQ: {
+        TH_STATE(ST_BEFORE_DOCTYPE_SYSTEM_ID)
+        if (at_eof) {
+            self->tok.force_quirks = 1;
+            EMIT_MARKUP();
+        }
+        if (is_space(ch)) {
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '"' || ch == '\'') {
+            self->tok.has_system_id = 1;
+            self->state = (ch == '"') ? ST_DOCTYPE_SYSTEM_ID_DQ : ST_DOCTYPE_SYSTEM_ID_SQ;
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            tok_error(self, "missing-doctype-system-identifier");
+            self->tok.force_quirks = 1;
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        tok_error(self, "missing-quote-before-doctype-system-identifier");
+        self->tok.force_quirks = 1;
+        BOGUS_DOCTYPE();
+
+        TH_STATE(ST_DOCTYPE_SYSTEM_ID_DQ)
+        TH_STATE(ST_DOCTYPE_SYSTEM_ID_SQ) {
             Py_UCS4 quote = (self->state == ST_DOCTYPE_SYSTEM_ID_DQ) ? '"' : '\'';
             if (at_eof) {
                 self->tok.force_quirks = 1;
@@ -1782,7 +1888,7 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
             if (ch == quote) {
                 CONSUME();
                 self->state = ST_AFTER_DOCTYPE_SYSTEM_ID;
-                continue;
+                TH_DISPATCH();
             }
             if (ch == '>') {
                 tok_error(self, "abrupt-doctype-system-identifier");
@@ -1795,85 +1901,88 @@ static enum run_result TH_NAME(run)(th_tokenizer *self) {
             }
             push(self, &self->tok.system_id, ch == 0 ? REPLACEMENT : ch);
             CONSUME();
-            continue;
+            TH_DISPATCH();
         }
 
-        case ST_AFTER_DOCTYPE_SYSTEM_ID:
-            if (at_eof) {
-                self->tok.force_quirks = 1;
-                EMIT_MARKUP();
-            }
-            if (is_space(ch)) {
-                CONSUME();
-                continue;
-            }
-            if (ch == '>') {
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            tok_error(self, "unexpected-character-after-doctype-system-identifier");
-            BOGUS_DOCTYPE();
-
-        case ST_BOGUS_DOCTYPE:
-            if (at_eof) {
-                EMIT_MARKUP();
-            }
-            if (ch == '>') {
-                CONSUME();
-                EMIT_MARKUP();
-            }
-            if (ch == 0) {
-                tok_error(self, "unexpected-null-character");
-            }
-            CONSUME();
-            continue;
-
-        case ST_CDATA:
-            if (at_eof) {
-                tok_error(self, "eof-in-cdata");
-                EOF_FLUSH();
-            }
-            if (ch != ']' && ch != '\n') {
-                Py_ssize_t stop = TH_SCAN(self, self->pos + 1, ']', '\n', '\n', '\n');
-                text_append_run(self, stop);
-                continue;
-            }
-            if (ch == ']') {
-                CONSUME();
-                self->state = ST_CDATA_BRACKET;
-                continue;
-            }
-            text_push(self, ch);
-            CONSUME();
-            continue;
-
-        case ST_CDATA_BRACKET:
-            if (!at_eof && ch == ']') {
-                CONSUME();
-                self->state = ST_CDATA_END;
-                continue;
-            }
-            text_push(self, ']');
-            self->state = ST_CDATA;
-            continue;
-
-        case ST_CDATA_END:
-            if (!at_eof && ch == '>') {
-                CONSUME();
-                self->state = ST_DATA;
-                continue;
-            }
-            if (!at_eof && ch == ']') {
-                text_push(self, ']');
-                CONSUME();
-                continue;
-            }
-            text_push(self, ']');
-            text_push(self, ']');
-            self->state = ST_CDATA;
-            continue;
+        TH_STATE(ST_AFTER_DOCTYPE_SYSTEM_ID)
+        if (at_eof) {
+            self->tok.force_quirks = 1;
+            EMIT_MARKUP();
         }
+        if (is_space(ch)) {
+            CONSUME();
+            TH_DISPATCH();
+        }
+        if (ch == '>') {
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        tok_error(self, "unexpected-character-after-doctype-system-identifier");
+        BOGUS_DOCTYPE();
+
+        TH_STATE(ST_BOGUS_DOCTYPE)
+        if (at_eof) {
+            EMIT_MARKUP();
+        }
+        if (ch == '>') {
+            CONSUME();
+            EMIT_MARKUP();
+        }
+        if (ch == 0) {
+            tok_error(self, "unexpected-null-character");
+        }
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_CDATA)
+        if (at_eof) {
+            tok_error(self, "eof-in-cdata");
+            EOF_FLUSH();
+        }
+        if (ch != ']' && ch != '\n') {
+            Py_ssize_t stop = TH_SCAN(self, self->pos + 1, ']', '\n', '\n', '\n');
+            text_append_run(self, stop);
+            TH_DISPATCH();
+        }
+        if (ch == ']') {
+            CONSUME();
+            self->state = ST_CDATA_BRACKET;
+            TH_DISPATCH();
+        }
+        text_push(self, ch);
+        CONSUME();
+        TH_DISPATCH();
+
+        TH_STATE(ST_CDATA_BRACKET)
+        if (!at_eof && ch == ']') {
+            CONSUME();
+            self->state = ST_CDATA_END;
+            TH_DISPATCH();
+        }
+        text_push(self, ']');
+        self->state = ST_CDATA;
+        TH_DISPATCH();
+
+        TH_STATE(ST_CDATA_END)
+        if (!at_eof && ch == '>') {
+            CONSUME();
+            self->state = ST_DATA;
+            TH_DISPATCH();
+        }
+        if (!at_eof && ch == ']') {
+            text_push(self, ']');
+            CONSUME();
+            TH_DISPATCH();
+        }
+        text_push(self, ']');
+        text_push(self, ']');
+        self->state = ST_CDATA;
+        TH_DISPATCH();
     }
 }
 
+#undef TH_DISPATCH
+#undef TH_FETCH
+#undef TH_STATE
+#undef TH_THREADED
 #undef TH_READ

--- a/src/turbohtml/_c/tokenizer/statemachine_run.h
+++ b/src/turbohtml/_c/tokenizer/statemachine_run.h
@@ -1979,6 +1979,12 @@ th_dispatch:
         self->state = ST_CDATA;
         TH_DISPATCH();
     }
+#if !TH_THREADED
+    /* Every state ends in TH_DISPATCH, so control never falls out of the switch. MSVC does not
+       follow that and warns C4715; the threaded form ends every path in a computed goto, where
+       no marker is needed. */
+    Py_UNREACHABLE();
+#endif
 }
 
 #undef TH_DISPATCH


### PR DESCRIPTION
The tokenizer runs 71 states through one `switch`, which compiles to a single indirect branch: `run_ucs1` carries one `br` against a 71-entry jump table. Every state transition trains that one predictor entry, so each transition aliases every other, and the predictor cannot learn a pattern that holds for one state alone. Threading the dispatch gives each state its own fetch and jump, so each transition carries its own prediction history.

Each state now ends in `TH_DISPATCH()`, which re-reads the cursor and jumps through a table of label addresses instead of falling back to a shared loop head. In the binary, `run_ucs1` goes from 1 indirect branch to 472, and from 5,517 instructions to 12,240. The growth is the fetch replicated per state. This buys branch prediction with code size, and whether that trade pays is what the change has to prove.

MSVC has no computed goto, so both dispatch forms share one state block and one `TH_FETCH` macro, the way `ceval.c` carries CPython's two forms. The switch form still compiles to 5,452 instructions and 1 indirect branch, matching today's binary, so that toolchain sees no change.

Review this with `git diff -w`. Dropping the `for (;;)` level reindents the whole function body, which inflates the raw diff to about 1,500 lines; ignoring whitespace it is 679. I built both dispatch forms and ran the suite against each, and both pass 15,223 tests.

The wall-clock benefit is not established, and the instruction counts above do not establish it. I could not measure it here: the workstation sat at load average 18 with competing `rustc` and VM processes, and the alternating pyperf rounds did not reproduce. The baseline swung between 565 µs and 1.38 ms on identical code, several times wider than the effect I was chasing. That leaves the CodSpeed gate as the arbiter, and it runs in `simulation` mode, so it scores instruction and cache behaviour rather than timing this predictor effect on real silicon. If it shows no gain, close this rather than argue past the gate.
