### PR TITLE
👷 ci(codspeed): pin the malloc arena count

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -49,7 +49,11 @@ jobs:
           # GitHub hands each run a different physical CPU (Intel Xeon with AVX-512, or AMD EPYC without), and glibc
           # dispatches a different SIMD memcpy/memmove per CPU, so Callgrind counts different instructions for the same
           # code and untouched benchmarks drift a few percent run to run. Force one baseline path on every CPU.
-          GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW,-AVX512DQ,-AVX512CD,-AVX2,-AVX,-ERMS,-FSRM"
+          # arena_max pins the other half of that dispatch: glibc sizes the malloc arena count from the core count
+          # (8 * ncores), so a runner with a different core count takes different paths through malloc and Callgrind
+          # counts those too. Every op here allocates -- the tokenizer and DOM grow their buffers as they parse -- so
+          # the arena count reaches the measurement. One arena is the same arena on every runner.
+          GLIBC_TUNABLES: "glibc.cpu.hwcaps=-AVX512F,-AVX512VL,-AVX512BW,-AVX512DQ,-AVX512CD,-AVX2,-AVX,-ERMS,-FSRM:glibc.malloc.arena_max=1"
         with:
           mode: simulation
           run: .tox/codspeed/bin/python -m pytest tests/benchmarks --codspeed


### PR DESCRIPTION
The simulation gate pins one half of glibc's per-CPU dispatch and leaves the other half free. `glibc.cpu.hwcaps` already holds the SIMD `memcpy`/`memmove` to one baseline path, so Callgrind counts the same copy whichever CPU a runner hands out. The malloc arena count still floats: glibc sizes it from the core count at `8 * ncores`, so a runner with a different core count walks different paths through malloc, and the simulation counts those instructions the same as any other. Every op on this gate allocates, since the tokenizer and the DOM grow their buffers while they parse, so the arena count reaches the measurement rather than sitting off to one side.

Pinning `glibc.malloc.arena_max=1` makes it one arena on every runner. 🔬 [peryx](https://github.com/tox-dev/peryx/blob/main/.github/workflows/codspeed.yml) pins both halves this way in its own simulation gate, and its second tunable, `glibc.cpu.name=generic`, stays out of this diff on purpose: that one is aarch64-only, peryx runs `ubuntu-24.04-arm`, and on the `ubuntu-24.04` x86_64 runner here the equivalent knob is `glibc.cpu.hwcaps`, which this workflow already sets.

A live `Different runtime environments detected` warning on #676 prompted this, where CodSpeed compared a base and head that landed on different runner CPUs. This removes one real source of that variance. It does not follow that the warning goes quiet, and I have not shown that it does. The effect lands on measurement stability rather than on the library, so the gate's own numbers cannot confirm it; what the gate can show is that the benchmarks still run and that untouched ops stay untouched.
