### PR TITLE
⚡ perf(idna): reject non-mark composition pairs

### DIFF
--- a/src/turbohtml/_c/data/idna_table.h
+++ b/src/turbohtml/_c/data/idna_table.h
@@ -8282,6 +8282,10 @@ typedef struct {
 } th_idna_comp_row;
 
 static const int th_idna_comp_count = 961;
+/* The lowest `second` of any pair. Sorting by (first, second) leaves no row holding this bound the
+   way th_idna_ccc[0].code holds the combining table's, so table_compose reads it to reject a pair
+   below every composition without probing. */
+static const uint32_t th_idna_comp_second_min = 0x300;
 static const th_idna_comp_row th_idna_comp[] = {
     {0x3C, 0x338, 0x226E}, {0x3D, 0x338, 0x2260}, {0x3E, 0x338, 0x226F}, {0x41, 0x300, 0xC0}, {0x41, 0x301, 0xC1},
     {0x41, 0x302, 0xC2}, {0x41, 0x303, 0xC3}, {0x41, 0x304, 0x100}, {0x41, 0x306, 0x102}, {0x41, 0x307, 0x226},

--- a/src/turbohtml/_c/url/idna.c
+++ b/src/turbohtml/_c/url/idna.c
@@ -118,6 +118,12 @@ static const th_idna_decomp_row *decomp_row(Py_UCS4 cp) {
 /* The tabled canonical composition of the pair (first, second), or 0 when the sorted table pairs them into nothing; 0
    is a safe "no composition" sentinel because U+0000 is never a composition target. */
 static Py_UCS4 table_compose(Py_UCS4 first, Py_UCS4 second) {
+    /* Every canonical composition pairs a starter with a combining mark, so no row's `second` falls below the table's
+       lowest one. A run of unaccented text makes NFC probe adjacent starters, whose second is an ordinary letter; one
+       comparison rejects that pair instead of a search that cannot match. */
+    if (second < th_idna_comp_second_min) {
+        return 0;
+    }
     int lo = 0;
     int hi = th_idna_comp_count;
     while (lo < hi) {

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -733,6 +733,36 @@ _URL_SHAPES = (
 )
 _URL_BATCH = tuple(shape.format(index=index) for index in range(20) for shape in _URL_SHAPES)
 _IDNA_URLS: Final[tuple[str, ...]] = tuple(f"https://münchen-{index}.example/" for index in range(4100))
+# The münchen workload repeats one host, so every lookup walks the same rows. These labels spread the searches across
+# ranges a single Latin-1 vowel does not reach: Latin Extended, Greek (with the final sigma the mapping rewrites),
+# Cyrillic, Arabic, Hebrew, Devanagari, Thai, CJK, and Hangul, whose jamo compose arithmetically rather than through
+# the table. The last two labels are typed decomposed, so composition and canonical ordering run instead of falling
+# through.
+_IDNA_LABELS: Final[tuple[str, ...]] = (
+    "münchen",
+    "zürich",
+    "gdańsk",
+    "kraków",
+    "plzeň",
+    "tromsø",
+    "straße",
+    "ΟΔΥΣΣΕΥΣ",
+    "αθήνα",
+    "москва",
+    "київ",
+    "القاهرة",
+    "ירושלים",
+    "मुंबई",
+    "กรุงเทพ",
+    "東京",
+    "北京",
+    "서울",
+    "cafe\u0301",  # e + combining acute, which composition folds back to the precomposed é
+    "viet\u0301\u0323",  # an above mark typed before a below one, so canonical ordering has to swap them
+)
+_IDNA_VARIED_URLS: Final[tuple[str, ...]] = tuple(
+    f"https://{_IDNA_LABELS[index % len(_IDNA_LABELS)]}-{index}.example/" for index in range(4100)
+)
 _EXTERNAL_LINKS_HTML: Final = "".join(
     f'<a href="https://{host}/post/{index}">link</a>'
     for index in range(300)
@@ -961,7 +991,10 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "decode": _decode_cases,
     "normalize": _normalize_cases,
     "detect-language": _language_cases,
-    "idna": lambda: (("4,100 uncached Unicode hosts", _IDNA_URLS),),
+    "idna": lambda: (
+        ("4,100 uncached Unicode hosts", _IDNA_URLS),
+        ("4,100 varied-script hosts", _IDNA_VARIED_URLS),
+    ),
     "urls-clean": lambda: (
         ("clean 100 URLs", ("clean", _URL_BATCH)),
         ("normalize 100 URLs", ("normalize", _URL_BATCH)),

--- a/tools/generate_idna.py
+++ b/tools/generate_idna.py
@@ -309,6 +309,10 @@ def _emit(
         "    uint32_t composed;\n"
         "} th_idna_comp_row;\n\n"
         f"static const int th_idna_comp_count = {len(pairs)};\n"
+        "/* The lowest `second` of any pair. Sorting by (first, second) leaves no row holding this bound the\n"
+        "   way th_idna_ccc[0].code holds the combining table's, so table_compose reads it to reject a pair\n"
+        "   below every composition without probing. */\n"
+        f"static const uint32_t th_idna_comp_second_min = 0x{min(second for _, second, _ in pairs):X};\n"
         f"static const th_idna_comp_row th_idna_comp[] = {{\n{comp_rows}\n}};\n\n"
         "#endif /* TURBOHTML_IDNA_TABLE_H */\n"
     )


### PR DESCRIPTION
The IDNA ToASCII path searches four pinned Unicode tables, and three of them open with a cheap reject: `map_host` bypasses `map_row` for ASCII (tox-dev/turbohtml#650), `ccc_of` returns at `U+0300`, and `decomp_row` returns at `U+00C0`. `table_compose` had no such guard, so every call ran the full binary search over all 961 composition pairs. NFC composition probes each adjacent pair of starters, so a run of unaccented text pays that search once per character for a result the table cannot supply. ⚡

Every canonical composition pairs a starter with a combining mark, so no pair carries a `second` below `U+0300`. `table_compose` now compares against that bound and rejects an ordinary letter pair in one comparison rather than a ten-probe search. `tools/generate_idna.py` emits the bound as `th_idna_comp_second_min` instead of `idna.c` hardcoding it, so a Unicode upgrade that lowers the smallest `second` recomputes the constant next to the table it guards.

Counting binary-search probes over the 4,100-host `münchen` workload behind the registered `idna` operation isolates where the work went. This change leaves `map_row`, `ccc_of` and `decomp_row` alone, and their guards already hold them under two probes per call. `table_compose` made 28,700 calls and issued 287,000 probes, which drop to 41,000. Total table probes across the pipeline fall from 467,400 to 221,400.

| search | calls | probes before | probes after |
| --- | ---: | ---: | ---: |
| `map_row` | 4,100 | 53,300 | 53,300 |
| `ccc_of` | 65,600 | 82,000 | 82,000 |
| `decomp_row` | 28,700 | 45,100 | 45,100 |
| `table_compose` | 28,700 | 287,000 | 41,000 |
| **total** | | **467,400** | **221,400** |

The bench gains a varied-script host workload. The `münchen` workload repeats one label, so it walks a single path through the tables and leaves the Latin Extended, Greek (including the final sigma the mapping rewrites), Cyrillic, Arabic, Hebrew, Devanagari, Thai, CJK and Hangul ranges unmeasured, along with decomposed input that makes composition and canonical ordering do work. `_IDNA_VARIED_URLS` spreads 20 such labels over the same 4,100 hosts. 🌍

This workload reaches the pyperf bench table only. `tools/bench/ci.py` registers one CodSpeed benchmark per operation through `INPUTS[op]()[0][1]`, so the `idna` gate stays bound to the `münchen` workload and keeps scoring the common cache-miss path.

Read the CodSpeed comment with care. It reports `idna` at 89 ms against 84.1 ms, and it also reports `text-content` at +15.59% and `canonicalize` at +6.27%, neither of which this diff reaches. It flags `Different runtime environments detected`, and a rerun reproduced `text-content` to the same 15.59%, so the comparison carries a systematic offset from the runner rather than a fresh baseline. That offset is the size of the `idna` figure, so I am not claiming the end-to-end percentage. The probe counts above come from a counter compiled into `TH_IDNA_STANDALONE` and hold regardless of runner or load.
