### PR TITLE
👷 ci: pin PYTHONHASHSEED for coverage

### DIFF
--- a/tox.toml
+++ b/tox.toml
@@ -30,6 +30,12 @@ deps = [
 ]
 dependency_groups = [ "test" ]
 pass_env = [ "COV_GCOV", "PYTEST_*" ]
+# Pin the hash seed so set iteration order is fixed across runs. Without it every CI process draws a
+# fresh seed, and a test whose path through the C core depends on set ordering then exercises a
+# branch on some runs and not others. The C branch gate wants every branch every run, and llvm-cov
+# (the macOS cells) counts branches gcc does not, so such a branch flakes only on macOS -- one cell,
+# rotating by interpreter, green on rerun. A fixed seed makes the gate reproducible.
+set_env = { PYTHONHASHSEED = "0" }
 commands_pre = [
   [
     "python",


### PR DESCRIPTION
The C coverage gate requires every branch on every run, but nothing pinned `PYTHONHASHSEED`, so each CI process drew a fresh seed. Python randomizes `set` and `frozenset` iteration order per seed, so a test whose path through the C core depends on that order exercises a branch on some runs and skips it on others. The result is an intermittent `Failed minimum branch coverage (got 99.9%)`.

It shows up only on macOS because that is the one platform on `llvm-cov`, which counts branches `gcc` does not. A branch that only `llvm-cov` sees can flake there while Linux and Windows stay green. The signature matches: a single branch, one macOS cell at a time, rotating by interpreter version, green on rerun, and it has now hit three separate PRs (#676 on 3.14 and again on 3.13 after a rebase, #680 on 3.11). Details and the per-run evidence are in #681.

Pinning the seed to `0` fixes set iteration order across runs, so the branch gate measures the same paths every time. The value is the conventional reproducible choice, and the gate itself validates it: if `0` were a seed that left the flaky branch uncovered, this PR would fail the C coverage cells deterministically rather than pass, which is the immediate check on whether the mechanism is what I think it is.

This is a hypothesis-driven fix, not a confirmed one. I could not reproduce the flake locally: gcov collection on my macOS checkout writes data for only 7 of 65 translation units regardless of the run, so the local total is meaningless. If the flake recurs on a macOS cell after this lands, the cause is not hash-seed-dependent set order and the search moves to the next candidate. The determinism it buys is worth having either way.
