### PR TITLE
👷 ci(codspeed): keep base runs complete

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -6,8 +6,13 @@ on:
     tags-ignore: ["**"]
   pull_request:
 concurrency:
-  group: codspeed-${{ github.ref }}
-  cancel-in-progress: true
+  # Key push runs by commit, pull-request runs by ref. Every main commit is a base measurement some
+  # open PR compares against, so it must run to completion; keying pushes by ref meant the next main
+  # commit canceled the previous one's benchmark mid-run, leaving CodSpeed to diff against a partial
+  # or stale base and report drift on untouched benchmarks. Pull-request runs still supersede their
+  # own older commits.
+  group: codspeed-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
CodSpeed diffs a pull request's benchmark run against the base commit's run on main. Recent perf PRs (#676, #679, #680) reported `Different runtime environments detected` and posted large deltas on benchmarks the diff never touched, such as `text-content` gaining 15.59% from a change that only edits IDNA host tables. A gain that size on a benchmark the code cannot reach is a base-measurement artifact, not a real result.

The concurrency group is one cause. It keyed every run by `github.ref` with `cancel-in-progress: true`, so pushes to main all shared one group and the next main commit cancelled the previous commit's benchmark mid-run. When that cancelled commit was the base for an open PR, CodSpeed had only a partial or stale base to compare against, which surfaces as drift on untouched benchmarks.

Keying push runs by `github.sha` gives each main commit its own group, so a base measurement runs to completion instead of being cancelled by the commit behind it. Pull-request runs stay keyed by ref with cancel-in-progress, so a new commit on a PR still supersedes its own older run. The change is limited to the concurrency block.

This addresses base-run completeness, not the whole warning. Shared GitHub runners still hand out different physical CPUs between the base run and the PR run, and `GLIBC_TUNABLES` already pins the SIMD dispatch and malloc arena against that. Whether a stale-base contribution remains is visible in whether the untouched-benchmark drift shrinks on PRs that open after this lands; I cannot reproduce a cross-runner CodSpeed comparison locally to prove it ahead of time.
