### PR TITLE
⚡ perf(parser): inline tag-atom verify compare

### DIFF
--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -82,8 +82,17 @@ static uint16_t intern_atom(const th_buf *name, uint8_t *out_flags) {
         return TH_TAG_UNKNOWN;
     }
     const th_tag_entry *entry = &th_tag_table[index - 1];
-    if (entry->name_len != name->len || memcmp(entry->name, str, (size_t)name->len) != 0) {
+    if (entry->name_len != name->len) {
         return TH_TAG_UNKNOWN;
+    }
+    /* Verify with an inline byte loop, not memcmp: tag names are 1-10 bytes, so a
+       libc call's setup costs more than the compare it saves -- most of all for the
+       one-byte names (p, a, b, ...) a parse hits far more often than div or span. */
+    const unsigned char *en = (const unsigned char *)entry->name;
+    for (Py_ssize_t pos = 0; pos < name->len; pos++) {
+        if (str[pos] != en[pos]) {
+            return TH_TAG_UNKNOWN;
+        }
     }
     *out_flags = entry->flags;
     return entry->atom;


### PR DESCRIPTION
A same-machine A/B of main against the 1.4.0 release turned up a parse slowdown on documents dense with short tag names. On an 8 KB article (400 paragraphs, so ~800 one-byte `p` tags), main runs about 8% slower than 1.4.0 under the LTO-only build the CodSpeed gate uses, and about 2.3% slower under the shipped PGO+LTO wheels. The larger `socialcard-spec` corpus and the tiny cases do not regress, which is why the CodSpeed op (spec-sized) read clean and the step-down went unnoticed.

The cause is `perf(parser): index tag atoms` (#659). That change replaced the tag-name lookup's first-byte bucket and inline tail scan with a perfect-hash slot, then verified the hit with a libc `memcmp`. For the one-byte names a real document hits most often, the `memcmp` call's setup costs more than the single-byte compare it performs, so short tags regressed while `div`/`span` still won on the avoided bucket scan. The net looked positive on the commit's own benchmark and the short-tag loss did not surface until this A/B.

This verifies the hash hit with an inline byte loop instead of `memcmp`, keeping the perfect-hash slot that #659 added. The inline compare wins for both short and long names: on the shipped PGO build the socialcard article recovers from 22.5 µs to 21.8 µs (back to 1.4.0), and `div`/`span` — the case #659 set out to speed — improves further from 59.4 µs to 58.5 µs, so the original optimization is preserved rather than undone. The change is semantically identical to the `memcmp` it replaces; the full html5lib tree-builder and tokenizer conformance suites pass and parse output stays byte-for-byte identical on a mixed known/unknown-tag document and the 235 KB spec.

