### PR TITLE
⚡ perf(dom): restore text-walk inlining

### DIFF
--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -15,6 +15,24 @@
 #define ARENA_BLOCK ((Py_ssize_t)64 * 1024)
 #define ARENA_MAX_BLOCK ((Py_ssize_t)256 * 1024)
 
+/* Keep the one-time span realization out of line so need_text() stays small
+   enough to inline into the serialize/text walks (see the header comment). Its
+   arena_alloc grew a geometric-growth branch, and inlining that whole cold path
+   into need_text pushed the accessor past the caller's inline budget. */
+#if defined(_MSC_VER)
+#define TH_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__) || defined(__clang__)
+#define TH_NOINLINE __attribute__((noinline))
+#else
+#define TH_NOINLINE
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define TH_MAYBE_UNUSED __attribute__((unused))
+#else
+#define TH_MAYBE_UNUSED
+#endif
+
 typedef struct arena_block {
     struct arena_block *next;
     Py_ssize_t used;
@@ -142,7 +160,7 @@ static inline void *arena_alloc(th_tree *tree, Py_ssize_t size) {
 /* Copy the input span [off, off+length) into a freshly arena-allocated UCS4
    array, widening the borrowed input to code points. Shared by slice
    materialization and the lazy realization of zero-copy text spans. */
-static inline Py_UCS4 *copy_input_span(th_tree *tree, Py_ssize_t off, Py_ssize_t length) {
+static TH_NOINLINE TH_MAYBE_UNUSED Py_UCS4 *copy_input_span(th_tree *tree, Py_ssize_t off, Py_ssize_t length) {
     Py_UCS4 *out = arena_alloc(tree, length * (Py_ssize_t)sizeof(Py_UCS4));
     if (out == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */

--- a/src/turbohtml/_c/serialize/markdown.c
+++ b/src/turbohtml/_c/serialize/markdown.c
@@ -28,12 +28,6 @@
 /* Keep the depth-guard wrappers out of line: inlined into their many call sites,
    the compiler emits a separate branch counter per copy and the guard-taken edge
    reads as uncovered in all but the one copy a deep tree exercises. */
-#if defined(_MSC_VER)
-#define TH_NOINLINE __declspec(noinline)
-#else
-#define TH_NOINLINE __attribute__((noinline))
-#endif
-
 /* Whether an element's own Markdown markup is dropped under the strip/convert
    filter, leaving its children to render transparently in the surrounding flow.
    A strip set names the tags to drop; a convert set names the only tags to keep,


### PR DESCRIPTION
This restores an inlining the CodSpeed regression gate depends on. The gate builds LTO-only on purpose (PGO is not byte-reproducible across runners, so it would report false regressions), and on that build the `text-content` op stepped down about 5.5% versus 1.4.0. `perf(dom): grow arena blocks` (#667) grew `arena_alloc` from a one-line ternary into a geometric-growth block; that function inlines up through `copy_input_span` into `need_text`, and the larger body pushed `need_text` past the compiler's inline budget, so it stopped inlining into `collect_text`, the text walk's hot loop. Every text node then paid a real call plus lost loop-invariant hoisting.

Marking the cold one-time `copy_input_span` as `TH_NOINLINE` shrinks `need_text` back so it re-inlines, while the span realization — which runs once per node on first read and is cold thereafter — stays out of line. On the LTO gate `collect_text` returns to a fully inlined form and `text-content` recovers to the 1.4.0 level. The arena growth #667 added is untouched, and the parse path never calls the cold function, so that optimization is unaffected.

Scope this honestly: the shipped PGO+LTO wheels never had this regression. Under PGO the profile force-inlines `need_text` on its own, so main already runs `text-content` slightly faster than 1.4.0 and this change is measured-neutral there (76.0 vs 76.1 µs, inside the noise). The value is keeping the deterministic LTO gate — the config the project uses to catch exactly this class of codegen regression — tracking 1.4.0, and making `collect_text`'s layout deterministic rather than dependent on a per-build inlining decision. It is not a user-facing speedup and the changelog reflects that.

