### PR TITLE
fix(tests): cast attr id for sorted to satisfy ty

### DIFF
--- a/tests/dom/test_tree_freethread.py
+++ b/tests/dom/test_tree_freethread.py
@@ -14,6 +14,7 @@ runs each test in one thread per core at once, multiplying the contention.
 from __future__ import annotations
 
 import threading
+from typing import cast
 
 import turbohtml
 from turbohtml.query import Query
@@ -116,7 +117,7 @@ def test_concurrent_multi_root_query_is_one_tree_snapshot() -> None:
     def reader() -> None:
         start.wait()
         for _ in range(500):
-            assert sorted(element.attrs["id"] for element in query.find("p")) == ["x", "y"]
+            assert sorted(cast("str", element.attrs["id"]) for element in query.find("p")) == ["x", "y"]
 
     def mutator() -> None:
         start.wait()


### PR DESCRIPTION
The `type` env is red on `main` (and so on every open PR, e.g. #693): `ty` is pinned only as `ty>=0.0.57` and now resolves to 0.0.63, which narrows `Element.attrs` values to `str | list[str] | None`. `sorted()` rejects that union:

```
tests/dom/test_tree_freethread.py:119:27: error[invalid-argument-type]
  Argument to function `sorted` is incorrect: `str | list[str] | None` does not satisfy upper bound ...
```

The ids under test are strings, so cast the lookup — matching the existing `cast` usage elsewhere in the suite. `ty check src tests tools` passes again.

Once merged, #693 goes green on rebase.