### PR TITLE
🐛 fix(xml): case-sensitive tag and attr lookups

### DIFF
--- a/docs/changelog/695.bugfix.rst
+++ b/docs/changelog/695.bugfix.rst
@@ -1,0 +1,3 @@
+Match tag and attribute names case-sensitively on a :func:`turbohtml.parse_xml` document: an uppercase name like ``Y``
+reads through :attr:`~turbohtml.Element.attrs` instead of raising :exc:`KeyError`, and CSS selectors tell ``[Attr]``
+from ``[attr]`` and ``Child`` from ``child``.

--- a/docs/changelog/695.bugfix.rst
+++ b/docs/changelog/695.bugfix.rst
@@ -1,3 +1,4 @@
 Match tag and attribute names case-sensitively on a :func:`turbohtml.parse_xml` document: an uppercase name like ``Y``
-reads through :attr:`~turbohtml.Element.attrs` instead of raising :exc:`KeyError`, and CSS selectors tell ``[Attr]``
-from ``[attr]`` and ``Child`` from ``child``.
+reads through :attr:`~turbohtml.Element.attrs` instead of raising :exc:`KeyError`, CSS selectors tell ``[Attr]`` from
+``[attr]`` and ``Child`` from ``child``, and :func:`pickle.loads`/:func:`copy.deepcopy` round-trip the tree without
+folding its names to the HTML parser's lowercase.

--- a/docs/changelog/696.bugfix.rst
+++ b/docs/changelog/696.bugfix.rst
@@ -1,0 +1,3 @@
+Normalize line endings in a :func:`turbohtml.parse_xml` document per XML 1.0 §2.11 across attribute values, CDATA
+sections, comments, and processing instructions: a literal ``CRLF`` folds to a single ``LF`` (one space in an attribute
+value) rather than two, matching the text-content path and every other conformant XML parser.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,6 +254,8 @@ line-length = 120
 extend-exclude = [
   "tests/conformance/chardetng",
   "tests/conformance/encoding_rs",
+  "tests/conformance/libxml2",
+  "tests/conformance/libxslt",
   "tests/conformance/unicodetools",
   "tests/html5lib-tests",
   "tools/html5lib-python"
@@ -333,6 +335,8 @@ max_supported_python = "3.15"
 src.exclude = [
   "tests/conformance/chardetng",
   "tests/conformance/encoding_rs",
+  "tests/conformance/libxml2",
+  "tests/conformance/libxslt",
   "tests/conformance/unicodetools",
   "tests/html5lib-tests",
   "tools/html5lib-python"

--- a/src/turbohtml/_c/css/select/selector.c
+++ b/src/turbohtml/_c/css/select/selector.c
@@ -151,14 +151,17 @@ static void sel_string(sel_parser *parser, const Py_UCS4 **out, Py_ssize_t *out_
     *out_len = write - start;
 }
 
-/* UTF-8 encode a slice and resolve it to a tag atom. */
-static uint16_t sel_tag_atom(const Py_UCS4 *name, Py_ssize_t len) {
+/* UTF-8 encode a slice and resolve it to a tag atom. Folded for an HTML tree's
+   lowercased tags, kept verbatim for a case-sensitive XML tree; a NULL tree is the
+   CSS-to-XPath translator, which folds. */
+static uint16_t sel_tag_atom(th_tree *tree, const Py_UCS4 *name, Py_ssize_t len) {
     char bytes[64];
     Py_ssize_t at = 0;
+    int fold = tree == NULL || !th_tree_is_xml(tree);
     for (Py_ssize_t index = 0; index < len && at < (Py_ssize_t)sizeof(bytes) - 4; index++) {
         Py_UCS4 ch = name[index];
-        if (ch >= 'A' && ch <= 'Z') {
-            ch += 32; /* tag names match case-insensitively */
+        if (fold && ch >= 'A' && ch <= 'Z') {
+            ch += 32;
         }
         if (ch < 0x80) {
             bytes[at++] = (char)ch;
@@ -169,13 +172,16 @@ static uint16_t sel_tag_atom(const Py_UCS4 *name, Py_ssize_t len) {
     return th_tag_lookup(bytes, at);
 }
 
+/* HTML attribute names are lowercased in the tree, so the selector name folds to match;
+   XML keeps case. The caller only resolves an atom when the tree is non-NULL. */
 static uint32_t sel_attr_atom(th_tree *tree, const Py_UCS4 *name, Py_ssize_t len) {
     char bytes[128];
     Py_ssize_t at = 0;
+    int fold = !th_tree_is_xml(tree);
     for (Py_ssize_t index = 0; index < len && at < (Py_ssize_t)sizeof(bytes) - 4; index++) {
         Py_UCS4 ch = name[index];
-        if (ch >= 'A' && ch <= 'Z') {
-            ch += 32; /* attribute names are lowercased in the tree */
+        if (fold && ch >= 'A' && ch <= 'Z') {
+            ch += 32;
         }
         if (ch < 0x80) {
             bytes[at++] = (char)ch;
@@ -387,7 +393,7 @@ static void sel_type_local(sel_parser *parser, sel_simple *simple) {
                (sel_is_ident(parser->src[parser->pos]) || parser->src[parser->pos] == '\\')) {
         simple->kind = 'e';
         sel_ident(parser, &simple->name, &simple->name_len);
-        simple->tag_atom = sel_tag_atom(simple->name, simple->name_len);
+        simple->tag_atom = sel_tag_atom(parser->tree, simple->name, simple->name_len);
     } else {
         sel_fail(parser, "expected a type or '*' after the namespace prefix");
     }
@@ -760,7 +766,7 @@ static void sel_one(sel_parser *parser, sel_simple *simple) {
             sel_type_local(parser, simple);
         } else {
             simple->kind = 'e';
-            simple->tag_atom = sel_tag_atom(simple->name, simple->name_len);
+            simple->tag_atom = sel_tag_atom(parser->tree, simple->name, simple->name_len);
         }
     }
 }
@@ -1825,12 +1831,16 @@ int sel_match_simple(th_node *node, const sel_simple *simple, const sel_ctx *ctx
     case ':':
         return sel_match_pseudo(node, simple, ctx);
     case 'e':
-        if (simple->tag_atom != TH_TAG_UNKNOWN) {
-            return node->atom == simple->tag_atom;
+        if (simple->tag_atom != TH_TAG_UNKNOWN && node->atom == simple->tag_atom) {
+            return 1;
         }
-        /* a custom/unknown tag is stored lowercased; type selectors are ASCII case-insensitive
-           in HTML, so match it case-insensitively like the builtin-atom path above does */
-        return sel_eq(node->text, node->text_len, simple->name, simple->name_len, 1);
+        /* An XML element keeps its literal spelling under TH_TAG_UNKNOWN even when the name
+           looks like a builtin, so a builtin-atom selector falls back to a spelling compare;
+           an HTML element carrying a different builtin atom does not match. */
+        if (node->atom != TH_TAG_UNKNOWN) {
+            return 0;
+        }
+        return sel_eq(node->text, node->text_len, simple->name, simple->name_len, !th_tree_is_xml(ctx->tree));
     case '#': {
         /* class/ID selectors are case-sensitive in no-quirks mode, ASCII
            case-insensitive in quirks mode (Selectors-4 §6.1/§6.2) */

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -1522,6 +1522,20 @@ static PyObject *node_pickle_data(PyObject *self, th_node *node) {
     }
     case TH_NODE_DOCUMENT:
     case TH_NODE_CONTENT:
+        /* An XML tree serializes under XML rules so the round-trip reparses with
+           parse_xml and keeps case-sensitive names; th_node_html would lower them. */
+        if (th_tree_is_xml(tree_of(self))) {
+            th_serialize_opts opts = {0};
+            opts.xml = 1;
+            Py_ssize_t len;
+            Py_UCS4 *markup = th_node_serialize(tree_of(self), node, &opts, NULL, 0, &len);
+            if (markup == NULL) {        /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            PyObject *result = ucs4_to_str(markup, len);
+            PyMem_Free(markup);
+            return result;
+        }
         return str_from_accessor(th_node_html, tree_of(self), node);
     }
     Py_RETURN_NONE; /* GCOVR_EXCL_LINE: unreachable, the switch is exhaustive */
@@ -1541,7 +1555,9 @@ PyObject *node_reduce(PyObject *self, PyObject *Py_UNUSED(ignored)) {
         Py_DECREF(reconstruct);             /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;                        /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    PyObject *result = Py_BuildValue("(O(iNN))", reconstruct, (int)node->type, data, children);
+    /* the xml flag rebuilds a document/content payload with parse_xml; other kinds ignore it */
+    PyObject *result =
+        Py_BuildValue("(O(iNNi))", reconstruct, (int)node->type, data, children, th_tree_is_xml(tree_of(self)));
     Py_DECREF(reconstruct);
     return result;
 }
@@ -1590,7 +1606,8 @@ PyObject *turbohtml_reconstruct(PyObject *module, PyObject *args) {
     int kind;
     PyObject *data;
     PyObject *children;
-    if (!PyArg_ParseTuple(args, "iOO", &kind, &data, &children)) {
+    int xml = 0; /* set for a document/content payload serialized under XML rules */
+    if (!PyArg_ParseTuple(args, "iOO|i", &kind, &data, &children, &xml)) {
         return NULL;
     }
     module_state *state = PyModule_GetState(module);
@@ -1619,7 +1636,7 @@ PyObject *turbohtml_reconstruct(PyObject *module, PyObject *args) {
             PyErr_SetString(PyExc_ValueError, "namespace out of range");
             return NULL;
         }
-        node = make_element((PyTypeObject *)state->element_type, tag, element_attrs);
+        node = make_element((PyTypeObject *)state->element_type, tag, element_attrs, xml);
         if (node != NULL) {
             ((NodeObject *)node)->node->ns = (uint8_t)ns;
         }
@@ -1633,7 +1650,7 @@ PyObject *turbohtml_reconstruct(PyObject *module, PyObject *args) {
         if (call_args == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return NULL;         /* GCOVR_EXCL_LINE: allocation-failure path */
         }
-        node = turbohtml_parse(module, call_args, NULL);
+        node = xml ? turbohtml_parse_xml(module, call_args, NULL) : turbohtml_parse(module, call_args, NULL);
         Py_DECREF(call_args);
         break;
     }

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -11,10 +11,11 @@ static int validate_name(PyObject *name, int is_attr);
 
 static int element_attr_value(PyObject *value, Py_UCS4 **points, Py_ssize_t *len, int *has_value);
 
-/* ASCII-lowercase a str key into a freshly allocated UTF-8 buffer so a lookup
-   matches the parser's lowercased names; *out_len its length. NULL with TypeError
-   when the key is not a str. Caller frees with PyMem_Free. */
-char *attr_key_utf8(PyObject *key, Py_ssize_t *out_len) {
+/* Encode a str key into a freshly allocated UTF-8 buffer for an attribute lookup;
+   *out_len its length. Folded to match an HTML tree's lowercased names, kept verbatim
+   for a case-sensitive XML tree. NULL with TypeError when the key is not a str. Caller
+   frees with PyMem_Free. */
+char *attr_key_utf8(th_tree *tree, PyObject *key, Py_ssize_t *out_len) {
     if (!PyUnicode_Check(key)) {
         PyErr_SetString(PyExc_TypeError, "attribute name must be a str");
         return NULL;
@@ -24,16 +25,17 @@ char *attr_key_utf8(PyObject *key, Py_ssize_t *out_len) {
     if (utf8 == NULL) { /* GCOVR_EXCL_BR_LINE: a lone-surrogate name cannot encode, hard to force */
         return NULL;    /* GCOVR_EXCL_LINE: surrogate path */
     }
-    char *lower = PyMem_Malloc((size_t)(len ? len : 1));
-    if (lower == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    char *name = PyMem_Malloc((size_t)(len ? len : 1));
+    if (name == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
+    int fold = !th_tree_is_xml(tree);
     for (Py_ssize_t index = 0; index < len; index++) {
         char ch = utf8[index];
-        lower[index] = ch >= 'A' && ch <= 'Z' ? (char)(ch + 32) : ch;
+        name[index] = fold && ch >= 'A' && ch <= 'Z' ? (char)(ch + 32) : ch;
     }
     *out_len = len;
-    return lower;
+    return name;
 }
 
 /* The live mutable view of an element's attributes: a mapping name -> value over
@@ -66,7 +68,7 @@ static Py_ssize_t attrs_length(PyObject *self) {
 
 static PyObject *attrs_subscript(PyObject *self, PyObject *key) {
     Py_ssize_t len;
-    char *name = attr_key_utf8(key, &len);
+    char *name = attr_key_utf8(tree_of(self), key, &len);
     if (name == NULL) {
         return NULL;
     }
@@ -94,7 +96,7 @@ static int attrs_ass_subscript(PyObject *self, PyObject *key, PyObject *value) {
     th_tree *tree = tree_of(self);
     if (value == NULL) {
         Py_ssize_t len;
-        char *name = attr_key_utf8(key, &len);
+        char *name = attr_key_utf8(tree, key, &len);
         if (name == NULL) {
             return -1;
         }
@@ -117,7 +119,7 @@ static int attrs_ass_subscript(PyObject *self, PyObject *key, PyObject *value) {
         return -1;
     }
     Py_ssize_t len;
-    char *name = attr_key_utf8(key, &len);
+    char *name = attr_key_utf8(tree, key, &len);
     if (name == NULL) { /* GCOVR_EXCL_BR_LINE: a validated name is a str that encodes */
         return -1;      /* GCOVR_EXCL_LINE: unreachable after validate_name */
     }
@@ -143,7 +145,7 @@ static int attrs_contains(PyObject *self, PyObject *key) {
         return 0; /* a non-str key is never an attribute name */
     }
     Py_ssize_t len;
-    char *name = attr_key_utf8(key, &len);
+    char *name = attr_key_utf8(tree_of(self), key, &len);
     if (name == NULL) { /* GCOVR_EXCL_BR_LINE: key is a str here, so this cannot fail */
         return -1;      /* GCOVR_EXCL_LINE: unreachable */
     }
@@ -250,7 +252,7 @@ static PyObject *attrs_get(PyObject *self, PyObject *args) {
     }
     if (PyUnicode_Check(key)) {
         Py_ssize_t len;
-        char *name = attr_key_utf8(key, &len);
+        char *name = attr_key_utf8(tree_of(self), key, &len);
         if (name == NULL) { /* GCOVR_EXCL_BR_LINE: key is a str here */
             return NULL;    /* GCOVR_EXCL_LINE: unreachable */
         }
@@ -1035,7 +1037,7 @@ static PyObject *element_attr(PyObject *self, PyObject *args, PyObject *kwds) {
         return NULL;
     }
     Py_ssize_t name_len;
-    char *name = attr_key_utf8(name_obj, &name_len);
+    char *name = attr_key_utf8(tree_of(self), name_obj, &name_len);
     if (name == NULL) {
         return NULL;
     }

--- a/src/turbohtml/_c/dom/element.c
+++ b/src/turbohtml/_c/dom/element.c
@@ -1793,8 +1793,9 @@ static int element_attr_value(PyObject *value, Py_UCS4 **points, Py_ssize_t *len
     return 0;
 }
 
-/* Fill a constructed element's attribute slots from the keys of attrs. */
-static int fill_element_attrs(th_tree *tree, th_node *node, PyObject *attrs, PyObject *keys) {
+/* Fill a constructed element's attribute slots from the keys of attrs. fold lowercases
+   each name for an HTML tree; an XML tree keeps case, so its names are stored verbatim. */
+static int fill_element_attrs(th_tree *tree, th_node *node, PyObject *attrs, PyObject *keys, int fold) {
     Py_ssize_t count = PyList_GET_SIZE(keys);
     for (Py_ssize_t index = 0; index < count; index++) {
         PyObject *name = PyList_GET_ITEM(keys, index);
@@ -1810,13 +1811,13 @@ static int fill_element_attrs(th_tree *tree, th_node *node, PyObject *attrs, PyO
         if (name_utf8 == NULL) { /* GCOVR_EXCL_BR_LINE: a lone-surrogate name cannot encode, hard to force */
             return -1;           /* GCOVR_EXCL_LINE: surrogate path */
         }
-        char *lower = PyMem_Malloc((size_t)name_len);
-        if (lower == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-            return -1;       /* GCOVR_EXCL_LINE: allocation-failure path */
+        char *stored = PyMem_Malloc((size_t)name_len);
+        if (stored == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;        /* GCOVR_EXCL_LINE: allocation-failure path */
         }
         for (Py_ssize_t byte = 0; byte < name_len; byte++) {
             char ch = name_utf8[byte];
-            lower[byte] = ch >= 'A' && ch <= 'Z' ? (char)(ch + 32) : ch;
+            stored[byte] = fold && ch >= 'A' && ch <= 'Z' ? (char)(ch + 32) : ch;
         }
         PyObject *value = PyObject_GetItem(attrs, name);
         Py_UCS4 *points;
@@ -1825,11 +1826,11 @@ static int fill_element_attrs(th_tree *tree, th_node *node, PyObject *attrs, PyO
         int bad = value == NULL || element_attr_value(value, &points, &value_len, &has_value) < 0;
         Py_XDECREF(value);
         if (bad) {
-            PyMem_Free(lower);
+            PyMem_Free(stored);
             return -1;
         }
-        int rc = th_tree_set_attr(tree, node, index, lower, name_len, points, value_len, has_value);
-        PyMem_Free(lower);
+        int rc = th_tree_set_attr(tree, node, index, stored, name_len, points, value_len, has_value);
+        PyMem_Free(stored);
         PyMem_Free(points);
         if (rc < 0) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
             return -1; /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1845,8 +1846,10 @@ static int fill_element_attrs(th_tree *tree, th_node *node, PyObject *attrs, PyO
 /* Build an Element wrapper for tag with attrs, without the public constructor's
    name validation. The parser and pickle reconstruction produce tag names (e.g.
    "a<b" from malformed input) that Element() rejects but that must round-trip
-   unchanged, so the trusted callers reach the element through this helper. */
-PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs) {
+   unchanged, so the trusted callers reach the element through this helper. xml keeps
+   the tag and attribute names case-sensitive (no fold, no builtin atom), so an element
+   unpickled from an XML tree matches parse_xml's storage. */
+PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs, int xml) {
     Py_ssize_t tag_len = PyUnicode_GET_LENGTH(tag);
     PyObject *keys = NULL;
     Py_ssize_t attr_count = 0;
@@ -1866,17 +1869,20 @@ PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs) {
         Py_XDECREF(keys);        /* GCOVR_EXCL_LINE: allocation-failure path */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    Py_ssize_t utf8_len;
-    const char *utf8 = PyUnicode_AsUTF8AndSize(tag, &utf8_len);
+    th_tree_set_xml(tree, xml);
     uint16_t atom = TH_TAG_UNKNOWN;
-    char stack[ELEMENT_TAG_LOWER_STACK_BYTES];
-    if (utf8 != NULL && utf8_len <= (Py_ssize_t)sizeof(stack)) {
-        for (Py_ssize_t byte = 0; byte < utf8_len; byte++) {
-            stack[byte] = utf8[byte] >= 'A' && utf8[byte] <= 'Z' ? (char)(utf8[byte] + 32) : utf8[byte];
+    if (!xml) { /* an XML tree stores every element as an unknown atom, keeping its spelling */
+        Py_ssize_t utf8_len;
+        const char *utf8 = PyUnicode_AsUTF8AndSize(tag, &utf8_len);
+        char stack[ELEMENT_TAG_LOWER_STACK_BYTES];
+        if (utf8 != NULL && utf8_len <= (Py_ssize_t)sizeof(stack)) {
+            for (Py_ssize_t byte = 0; byte < utf8_len; byte++) {
+                stack[byte] = utf8[byte] >= 'A' && utf8[byte] <= 'Z' ? (char)(utf8[byte] + 32) : utf8[byte];
+            }
+            atom = th_tag_lookup(stack, utf8_len);
+        } else {
+            PyErr_Clear(); /* a surrogate or very long custom tag is not in the table */
         }
-        atom = th_tag_lookup(stack, utf8_len);
-    } else {
-        PyErr_Clear(); /* a surrogate or very long custom tag is not in the table */
     }
     Py_UCS4 *tag_points = atom == TH_TAG_UNKNOWN ? PyUnicode_AsUCS4Copy(tag) : NULL;
     if (atom == TH_TAG_UNKNOWN && tag_points == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure */
@@ -1884,9 +1890,9 @@ PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs) {
         Py_XDECREF(keys);                               /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;                                    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    /* Unknown tag names are ASCII-lowercased to match what the parser stores.
-       Known names already point at their lowercase generated entry. */
-    for (Py_ssize_t index = 0; index < tag_len && tag_points != NULL; index++) {
+    /* An HTML unknown tag is ASCII-lowercased to match what the parser stores; a known
+       name already points at its lowercase entry, and an XML name keeps its case. */
+    for (Py_ssize_t index = 0; !xml && index < tag_len && tag_points != NULL; index++) {
         if (tag_points[index] >= 'A' && tag_points[index] <= 'Z') {
             tag_points[index] += 32;
         }
@@ -1898,7 +1904,7 @@ PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs) {
         Py_XDECREF(keys);        /* GCOVR_EXCL_LINE: allocation-failure path */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    if (keys != NULL && fill_element_attrs(tree, node, attrs, keys) < 0) {
+    if (keys != NULL && fill_element_attrs(tree, node, attrs, keys, !xml) < 0) {
         th_tree_free(tree);
         Py_DECREF(keys);
         return NULL;
@@ -1922,7 +1928,7 @@ static PyObject *element_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (validate_name(tag, 0) < 0) {
         return NULL;
     }
-    PyObject *element = make_element(type, tag, attrs);
+    PyObject *element = make_element(type, tag, attrs, 0); /* the public constructor builds HTML elements */
     if (element == NULL) {
         return NULL;
     }

--- a/src/turbohtml/_c/dom/leaf.c
+++ b/src/turbohtml/_c/dom/leaf.c
@@ -55,6 +55,7 @@ static PyObject *node_copy_impl(PyObject *self) {
     if (tree == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
+    th_tree_set_xml(tree, th_tree_is_xml(tree_of(self)));
     NodeObject *source = (NodeObject *)self;
     th_node *copy;
     Py_BEGIN_CRITICAL_SECTION(source->handle);

--- a/src/turbohtml/_c/dom/mutate.c
+++ b/src/turbohtml/_c/dom/mutate.c
@@ -24,6 +24,10 @@ th_tree *th_tree_new(void) {
     return PyMem_Calloc(1, sizeof(th_tree));
 }
 
+int th_tree_is_xml(const th_tree *tree) {
+    return tree->xml;
+}
+
 /* Construct an empty document-fragment node in tree's arena: the container the
    Range content operations (dom/range.c) fill and hand back. */
 th_node *th_tree_make_fragment(th_tree *tree) {
@@ -289,8 +293,9 @@ Py_ssize_t th_node_attr_find(th_tree *tree, th_node *node, const char *name, Py_
     }
     /* A foreign element can store a case-adjusted attribute name (definitionURL)
        whose atom differs from the lowercased probe, so match case-insensitively
-       against the stored names; the probe is already lowercased by the caller. */
-    if (node->ns != TH_NS_HTML) {
+       against the stored names; the probe is already lowercased by the caller. XML
+       keeps names case-sensitive, so its exact-atom match above is the only pass. */
+    if (!tree->xml && node->ns != TH_NS_HTML) {
         for (Py_ssize_t index = 0; index < node->attr_count; index++) {
             Py_ssize_t stored_len;
             const char *stored = th_attr_name(tree, node->attrs[index].name_atom, &stored_len);

--- a/src/turbohtml/_c/dom/mutate.c
+++ b/src/turbohtml/_c/dom/mutate.c
@@ -28,6 +28,10 @@ int th_tree_is_xml(const th_tree *tree) {
     return tree->xml;
 }
 
+void th_tree_set_xml(th_tree *tree, int xml) {
+    tree->xml = xml;
+}
+
 /* Construct an empty document-fragment node in tree's arena: the container the
    Range content operations (dom/range.c) fill and hand back. */
 th_node *th_tree_make_fragment(th_tree *tree) {

--- a/src/turbohtml/_c/dom/nodes.h
+++ b/src/turbohtml/_c/dom/nodes.h
@@ -619,7 +619,7 @@ PyObject *wrap_fresh_tree_node(module_state *state, th_tree *tree, th_node *node
 PyObject *data_node_in_fresh_tree(module_state *state, int node_type, PyObject *data);
 PyObject *node_copy(PyObject *self, PyObject *Py_UNUSED(ignored));
 PyObject *node_deepcopy(PyObject *self, PyObject *Py_UNUSED(memo));
-PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs);
+PyObject *make_element(PyTypeObject *type, PyObject *tag, PyObject *attrs, int xml);
 PyObject *node_insert_before(PyObject *self, PyObject *nodes);
 PyObject *node_insert_after(PyObject *self, PyObject *nodes);
 PyObject *node_replace_with(PyObject *self, PyObject *nodes);

--- a/src/turbohtml/_c/dom/nodes.h
+++ b/src/turbohtml/_c/dom/nodes.h
@@ -593,9 +593,10 @@ void handle_clear_css_cache(HandleObject *handle);
    element.c beside the mutation bindings; query/methods.c calls it from prune/remove/strip. */
 void handle_drop_index(PyObject *handle_obj);
 
-/* Lower-case an attribute-name str into a freshly allocated (PyMem_Free) UTF-8 buffer, or
-   NULL with an exception set. Defined in element.c; query/methods.c reuses it for re(). */
-char *attr_key_utf8(PyObject *key, Py_ssize_t *out_len);
+/* Encode an attribute-name str into a freshly allocated (PyMem_Free) UTF-8 buffer for a
+   lookup on tree, folding case for HTML but not XML, or NULL with an exception set.
+   Defined in element.c; query/methods.c reuses it for re(). */
+char *attr_key_utf8(th_tree *tree, PyObject *key, Py_ssize_t *out_len);
 
 PyObject *node_get_text(PyObject *self, void *Py_UNUSED(closure));
 PyObject *element_get_tag(PyObject *self, void *Py_UNUSED(closure));

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -206,6 +206,10 @@ th_tree *th_tree_parse_xml(int kind, const void *data, Py_ssize_t length);
    allocation failure (no Python error is set). */
 th_tree *th_tree_new(void);
 
+/* Whether the tree was parsed under XML rules, so name lookups are case-sensitive
+   rather than folded to the HTML parser's lowercased names. */
+int th_tree_is_xml(const th_tree *tree);
+
 /* Construct a text/comment/doctype/cdata node (by enum th_node_type) owning a copy
    of the data code points in the tree's arena. NULL on allocation failure. */
 th_node *th_tree_make_data_node(th_tree *tree, int type, const Py_UCS4 *data, Py_ssize_t len);

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -210,6 +210,10 @@ th_tree *th_tree_new(void);
    rather than folded to the HTML parser's lowercased names. */
 int th_tree_is_xml(const th_tree *tree);
 
+/* Carry the XML mode onto a tree built by copying nodes out of an XML one, so the
+   copy keeps case-sensitive name lookups. */
+void th_tree_set_xml(th_tree *tree, int xml);
+
 /* Construct a text/comment/doctype/cdata node (by enum th_node_type) owning a copy
    of the data code points in the tree's arena. NULL on allocation failure. */
 th_node *th_tree_make_data_node(th_tree *tree, int type, const Py_UCS4 *data, Py_ssize_t len);

--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -86,6 +86,7 @@ struct th_tree {
     int scripting;          /* the WHATWG scripting flag: noscript is a rawtext element when set */
     int declarative_shadow; /* allow a <template shadowrootmode> to attach a shadow root to its parent */
     int has_nul;            /* the input contains a U+0000; otherwise text needs no NUL filtering */
+    int xml;                /* parsed under XML rules: tag and attribute names are case-sensitive */
     int can_span;           /* input is borrowed and outlives the tree: text nodes may be
                                zero-copy spans into it instead of materialized copies */
     int track_positions;    /* record each element's source line/col in trailing node slots */

--- a/src/turbohtml/_c/query/methods.c
+++ b/src/turbohtml/_c/query/methods.c
@@ -542,16 +542,16 @@ static PyObject *regex_find_first(PyObject *compiled, PyObject *source, PyObject
     return value;
 }
 
-/* Resolve the optional attr keyword into a lowercased UTF-8 name (the caller frees
-   it with PyMem_Free), leaving *name NULL when the regex should run over text. A
+/* Resolve the optional attr keyword into a UTF-8 name for a lookup on tree (the caller
+   frees it with PyMem_Free), leaving *name NULL when the regex should run over text. A
    non-str, non-None attr raises TypeError. Returns 0, or -1 with an exception. */
-static int regex_attr_name(PyObject *attr_obj, char **name, Py_ssize_t *name_len) {
+static int regex_attr_name(th_tree *tree, PyObject *attr_obj, char **name, Py_ssize_t *name_len) {
     *name = NULL;
     *name_len = 0;
     if (attr_obj == NULL || attr_obj == Py_None) {
         return 0;
     }
-    *name = attr_key_utf8(attr_obj, name_len);
+    *name = attr_key_utf8(tree, attr_obj, name_len);
     return *name == NULL ? -1 : 0;
 }
 
@@ -564,7 +564,7 @@ PyObject *node_re(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     char *attr_name;
     Py_ssize_t attr_len;
-    if (regex_attr_name(attr_obj, &attr_name, &attr_len) < 0) {
+    if (regex_attr_name(tree_of(self), attr_obj, &attr_name, &attr_len) < 0) {
         return NULL;
     }
     module_state *state = state_of(self);
@@ -601,7 +601,7 @@ PyObject *node_re_first(PyObject *self, PyObject *args, PyObject *kwds) {
     }
     char *attr_name;
     Py_ssize_t attr_len;
-    if (regex_attr_name(attr_obj, &attr_name, &attr_len) < 0) {
+    if (regex_attr_name(tree_of(self), attr_obj, &attr_name, &attr_len) < 0) {
         return NULL;
     }
     module_state *state = state_of(self);

--- a/src/turbohtml/_c/tokenizer/xml.c
+++ b/src/turbohtml/_c/tokenizer/xml.c
@@ -1202,6 +1202,7 @@ th_tree *th_tree_parse_xml(int kind, const void *data, Py_ssize_t length) {
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     tree->can_span = 1; /* text nodes may span into the borrowed input */
+    tree->xml = 1;      /* case-sensitive tag and attribute names */
     tree->kind = kind;
     tree->data = data;
     tree->length = length;

--- a/src/turbohtml/_c/tokenizer/xml.c
+++ b/src/turbohtml/_c/tokenizer/xml.c
@@ -189,6 +189,29 @@ static Py_UCS4 *widen(xml_parser *parser, Py_ssize_t start, Py_ssize_t len) {
     return parser->names;
 }
 
+/* Widen a span into the reusable buffer, folding CR and CRLF to a single LF for XML
+   line-ending normalization (2.11); *out_len receives the folded length. Comments,
+   CDATA, and PI data copy through here so their line endings match parsed text. */
+static Py_UCS4 *widen_lf(xml_parser *parser, Py_ssize_t start, Py_ssize_t len, Py_ssize_t *out_len) {
+    Py_UCS4 *buf = widen(parser, start, len);
+    if (buf == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    Py_ssize_t write = 0;
+    for (Py_ssize_t read = 0; read < len; read++) {
+        Py_UCS4 ch = buf[read];
+        if (ch == '\r') {
+            ch = '\n';
+            if (read + 1 < len && buf[read + 1] == '\n') {
+                read++;
+            }
+        }
+        buf[write++] = ch;
+    }
+    *out_len = write;
+    return buf;
+}
+
 /* Encode the input range [start, start+len) as UTF-8 into the reusable buffer;
  *out_len receives the byte count. NULL on allocation failure. */
 static const char *encode_utf8(xml_parser *parser, Py_ssize_t start, Py_ssize_t len, Py_ssize_t *out_len) {
@@ -564,11 +587,12 @@ static int consume_comment(xml_parser *parser) {
                 record(parser, "xml-double-hyphen-in-comment", parser->pos);
                 return -1;
             }
-            Py_UCS4 *data = widen(parser, start, parser->pos - start);
+            Py_ssize_t data_len;
+            Py_UCS4 *data = widen_lf(parser, start, parser->pos - start, &data_len);
             if (data == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
                 return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
             }
-            th_node *node = th_tree_make_data_node(parser->tree, TH_NODE_COMMENT, data, parser->pos - start);
+            th_node *node = th_tree_make_data_node(parser->tree, TH_NODE_COMMENT, data, data_len);
             if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
                 return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
             }
@@ -596,11 +620,12 @@ static int consume_cdata(xml_parser *parser) {
     Py_ssize_t start = parser->pos;
     while (parser->pos < parser->length) {
         if (starts_with(parser, parser->pos, "]]>")) {
-            Py_UCS4 *data = widen(parser, start, parser->pos - start);
+            Py_ssize_t data_len;
+            Py_UCS4 *data = widen_lf(parser, start, parser->pos - start, &data_len);
             if (data == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
                 return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
             }
-            th_node *node = th_tree_make_data_node(parser->tree, TH_NODE_CDATA, data, parser->pos - start);
+            th_node *node = th_tree_make_data_node(parser->tree, TH_NODE_CDATA, data, data_len);
             if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
                 return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
             }
@@ -812,11 +837,12 @@ static int consume_pi(xml_parser *parser) {
             return -1;                                 /* GCOVR_EXCL_LINE: allocation-failure path */
         }
     }
-    Py_UCS4 *data = widen(parser, data_start, data_end - data_start);
+    Py_ssize_t data_len;
+    Py_UCS4 *data = widen_lf(parser, data_start, data_end - data_start, &data_len);
     if (data == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    th_node *node = th_tree_make_pi(parser->tree, parser->scratch, parser->scratch_len, data, data_end - data_start);
+    th_node *node = th_tree_make_pi(parser->tree, parser->scratch, parser->scratch_len, data, data_len);
     if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }
@@ -995,8 +1021,15 @@ static int consume_attribute(xml_parser *parser, th_node *element, Py_ssize_t de
             record(parser, "xml-invalid-char", parser->pos);
             return -1;
         }
-        if (ch == '\t' || ch == '\n' || ch == '\r') {
-            ch = ' '; /* attribute-value normalization folds literal whitespace to space */
+        if (ch == '\r') {
+            /* line-ending normalization (XML 2.11) folds CR and CRLF to a single LF before
+               attribute-value normalization turns that LF into one space, not two */
+            if (parser->pos + 1 < parser->length && cp(parser, parser->pos + 1) == '\n') {
+                parser->pos++;
+            }
+            ch = ' ';
+        } else if (ch == '\t' || ch == '\n') {
+            ch = ' '; /* attribute-value normalization folds a literal tab or LF to space */
         }
         if (scratch_push(parser, ch) < 0) { /* GCOVR_EXCL_BR_LINE: allocation unreachable */
             return -1;                      /* GCOVR_EXCL_LINE: allocation-failure path */

--- a/tests/dom/test_parse_xml.py
+++ b/tests/dom/test_parse_xml.py
@@ -229,6 +229,59 @@ def test_non_ascii_attribute_names_encode() -> None:
     assert dict(root_of(doc).attrs) == {"é": "a", "中": "b", "\U0001d538": "c"}
 
 
+def test_attribute_name_lookup_is_case_sensitive() -> None:
+    root = root_of(parse_xml('<test x="a" Y="b">t</test>'))
+    assert root.attrs["Y"] == "b"
+    assert root.attrs["x"] == "a"
+    with pytest.raises(KeyError):
+        root.attrs["y"]
+    with pytest.raises(KeyError):
+        root.attrs["X"]
+
+
+def test_attribute_get_and_contains_are_case_sensitive() -> None:
+    root = root_of(parse_xml('<test Y="b">t</test>'))
+    assert root.attrs.get("Y") == "b"
+    assert root.attrs.get("y") is None
+    assert "Y" in root.attrs
+    assert "y" not in root.attrs
+
+
+def test_attr_method_is_case_sensitive() -> None:
+    root = root_of(parse_xml('<test Y="b">t</test>'))
+    assert root.attr("Y") == "b"
+    assert root.attr("y") is None
+    assert root.attr("y", "fallback") == "fallback"
+
+
+def test_attributes_differing_only_in_case_are_distinct() -> None:
+    root = root_of(parse_xml('<test a="lower" A="upper"/>'))
+    assert root.attrs["a"] == "lower"
+    assert root.attrs["A"] == "upper"
+
+
+def test_attribute_set_preserves_case_and_stays_distinct() -> None:
+    root = root_of(parse_xml('<test Y="b"/>'))
+    root.attrs["Z"] = "c"
+    root.attrs["z"] = "d"
+    assert dict(root.attrs) == {"Y": "b", "Z": "c", "z": "d"}
+
+
+def test_attribute_delete_is_case_sensitive() -> None:
+    root = root_of(parse_xml('<test Y="b"/>'))
+    with pytest.raises(KeyError):
+        del root.attrs["y"]
+    del root.attrs["Y"]
+    assert dict(root.attrs) == {}
+
+
+def test_re_over_attribute_is_case_sensitive() -> None:
+    root = root_of(parse_xml('<test Y="abc"/>'))
+    assert root.re(r"(\w)", attr="Y") == ["a", "b", "c"]
+    assert root.re(r"(\w)", attr="y") == []
+    assert root.re_first(r"(\w)", attr="y", default="none") == "none"
+
+
 def test_lowercase_hex_character_reference() -> None:
     assert data_of(root_of(parse_xml("<r>&#xe9;&#xff;</r>")).children[0]) == "éÿ"
 

--- a/tests/dom/test_parse_xml.py
+++ b/tests/dom/test_parse_xml.py
@@ -195,6 +195,36 @@ def test_attribute_value_whitespace_folds_to_space() -> None:
     assert dict(root_of(parse_xml('<r a="x\ty\nz\rw"/>')).attrs) == {"a": "x y z w"}
 
 
+def test_attribute_value_crlf_folds_to_one_space() -> None:
+    # XML 2.11 collapses CRLF to a single LF before 3.3.3 folds it to one space, not two
+    assert dict(root_of(parse_xml('<r a="x\r\ny\r\n\tz"/>')).attrs) == {"a": "x y  z"}
+
+
+def test_cdata_normalizes_line_endings() -> None:
+    assert data_of(root_of(parse_xml("<r><![CDATA[a\r\nb\rc]]></r>")).children[0]) == "a\nb\nc"
+
+
+def test_cdata_trailing_carriage_return_folds_to_lf() -> None:
+    # a lone CR as the last content character still folds, exercising the CRLF look-ahead's edge
+    assert data_of(root_of(parse_xml("<r><![CDATA[a\r]]></r>")).children[0]) == "a\n"
+
+
+def test_attribute_ending_in_carriage_return_is_unterminated() -> None:
+    with pytest.raises(HTMLParseError) as info:
+        parse_xml('<r a="x\r')
+    assert info.value.error.code == "xml-unterminated-attribute"
+
+
+def test_comment_normalizes_line_endings() -> None:
+    assert data_of(root_of(parse_xml("<r><!--a\r\nb\rc-->x</r>")).children[0]) == "a\nb\nc"
+
+
+def test_processing_instruction_normalizes_line_endings() -> None:
+    pi = root_of(parse_xml("<r><?t a\r\nb\rc?></r>")).children[0]
+    assert isinstance(pi, ProcessingInstruction)
+    assert pi.data == "a\nb\nc"
+
+
 def test_attribute_reference_is_resolved() -> None:
     assert dict(root_of(parse_xml('<r a="1 &lt; 2"/>')).attrs) == {"a": "1 < 2"}
 

--- a/tests/dom/test_tree_copy.py
+++ b/tests/dom/test_tree_copy.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import Doctype, Element, Text, parse
+from turbohtml import Doctype, Element, Text, parse, parse_xml
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -24,6 +24,22 @@ def test_duplicates_a_standalone_subtree(duplicate: Callable[[Element], Element]
     assert clone is not div
     assert clone.html == '<div id="a"><b>x</b>y</div>'
     assert clone.parent is None  # both shallow and deep yield a detached root, not a view
+
+
+@pytest.mark.parametrize(
+    "duplicate",
+    [pytest.param(copy.copy, id="shallow"), pytest.param(copy.deepcopy, id="deep")],
+)
+def test_xml_duplicate_keeps_names_case_sensitive(duplicate: Callable[[Element], Element]) -> None:
+    root = parse_xml('<Root Attr="v"><Child X="1"/></Root>').root
+    assert isinstance(root, Element)
+    clone = duplicate(root)
+    assert clone.tag == "Root"
+    assert clone.attrs["Attr"] == "v"
+    assert "attr" not in clone.attrs
+    child = clone.children[0]
+    assert isinstance(child, Element)
+    assert child.attrs["X"] == "1"
 
 
 def test_copy_is_independent_of_the_original() -> None:

--- a/tests/dom/test_tree_pickle.py
+++ b/tests/dom/test_tree_pickle.py
@@ -6,7 +6,7 @@ import pickle  # ruff:ignore[suspicious-pickle-import]  # round-tripping our own
 
 import pytest
 
-from turbohtml import CData, Comment, Doctype, Document, Element, Node, ProcessingInstruction, Text, parse
+from turbohtml import CData, Comment, Doctype, Document, Element, Node, ProcessingInstruction, Text, parse, parse_xml
 from turbohtml._html import _reconstruct  # the private pickle hook
 
 
@@ -75,6 +75,31 @@ def test_document_round_trips() -> None:
     clone = _roundtrip(doc)
     assert isinstance(clone, Document)
     assert clone.html == doc.html
+
+
+def test_xml_document_round_trips_case_sensitively() -> None:
+    doc = parse_xml('<Root Attr="v"><Child X="1"/><![CDATA[r]]><?pi d?></Root>')
+    clone = _roundtrip(doc)
+    assert isinstance(clone, Document)
+    root = clone.root
+    assert isinstance(root, Element)
+    assert root.attrs["Attr"] == "v"
+    assert "attr" not in root.attrs
+    assert root.html == '<Root Attr="v"><Child X="1"></Child><![CDATA[r]]><?pi d></Root>'
+
+
+def test_xml_element_subtree_round_trips_case_sensitively() -> None:
+    root = parse_xml('<Root><Child X="1"><Gc Y="2"/></Child></Root>').root
+    assert isinstance(root, Element)
+    clone = _roundtrip(root.children[0])
+    assert isinstance(clone, Element)
+    assert clone.tag == "Child"
+    assert clone.attrs["X"] == "1"
+    assert "x" not in clone.attrs
+    grandchild = clone.children[0]
+    assert isinstance(grandchild, Element)
+    assert grandchild.tag == "Gc"
+    assert grandchild.attrs["Y"] == "2"
 
 
 @pytest.mark.parametrize(

--- a/tests/query/css/test_tree_select_xml.py
+++ b/tests/query/css/test_tree_select_xml.py
@@ -1,0 +1,52 @@
+"""CSS selectors over a parse_xml() document: tag and attribute names are case-sensitive."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Element, parse_xml
+
+_DOC = '<Root><Child Attr="v" class="c"/><child/><div/><DIV/><Wide data-K="1"/></Root>'
+
+
+def _root(markup: str) -> Element:
+    root = parse_xml(markup).root
+    assert isinstance(root, Element)
+    return root
+
+
+def _sel(selector: str) -> list[str]:
+    return [element.tag for element in _root(_DOC).select(selector)]
+
+
+@pytest.mark.parametrize(
+    ("selector", "tags"),
+    [
+        pytest.param("Child", ["Child"], id="type-exact"),
+        pytest.param("child", ["child"], id="type-lower"),
+        pytest.param("div", ["div"], id="builtin-name-exact"),
+        pytest.param("DIV", ["DIV"], id="builtin-name-upper"),
+        pytest.param("Foo", [], id="type-absent"),
+        pytest.param("[Attr]", ["Child"], id="attr-exact"),
+        pytest.param("[attr]", [], id="attr-wrong-case"),
+        pytest.param("[Attr=v]", ["Child"], id="attr-value-exact"),
+        pytest.param("[attr=v]", [], id="attr-value-wrong-case"),
+        pytest.param("[data-K]", ["Wide"], id="attr-mixed-case"),
+        pytest.param("[data-k]", [], id="attr-mixed-case-wrong"),
+    ],
+)
+def test_xml_selectors_are_case_sensitive(selector: str, tags: list[str]) -> None:
+    assert _sel(selector) == tags
+
+
+def test_xml_matches_is_case_sensitive() -> None:
+    child = _root("<Root><child/></Root>").select_one("child")
+    assert child is not None
+    assert child.matches("child")
+    assert not child.matches("Child")
+
+
+def test_xml_builtin_named_element_matches_only_its_spelling() -> None:
+    root = _root("<Root><Table/></Root>")
+    assert [element.tag for element in root.select("Table")] == ["Table"]
+    assert root.select("table") == []


### PR DESCRIPTION
`parse_xml` documents its names as case-sensitive, yet `parse_xml('<test Y="b"/>').root.attrs["Y"]` raised `KeyError`: every name lookup lowercased its query key to match the HTML parser's lowercased storage, so an uppercase XML name was unreachable. The same fold left CSS selectors unable to target `[Attr]`, folded `Child` into `child`, and made a known-HTML-named XML element such as `<div>` match nothing. Fixes #695.

The tree now records whether it was parsed under XML rules (`th_tree_is_xml`) and each name lookup skips the case fold for such trees: the `attrs` mapping (read, `get`, `in`, set, delete), `attr()`, `re(attr=...)`, and the CSS type and attribute selectors behind `select`, `select_one`, and `matches`. The type-selector match falls back to a spelling compare for builtin-named XML elements, mirroring `find`/`find_all` and `xpath`, which already matched by exact atom or spelling.

Pickling or deep-copying an XML document used to rebuild it under HTML rules — the reduce path reparsed the serialized markup with `parse()`, and `copy` cloned into a fresh HTML tree — so a round-trip lowercased tags and attributes. Both paths now carry the XML flag, so `pickle` and `copy.deepcopy` preserve the tree.

Diffing `parse_xml` against lxml over the W3C XML Conformance Suite surfaced a second bug: line endings were normalized per character rather than per XML 1.0 §2.11, so a `CRLF` in an attribute value, CDATA section, comment, or processing instruction became two characters instead of one. 🔎 These now fold `CRLF` to a single `LF` (one space in an attribute value) like the text path, and the whole non-DTD suite matches lxml. HTML case folding and foreign-content matching (`definitionURL`, `viewBox`) are unchanged.
