### PR TITLE
👷 ci(coverage): pin ctrace core so test contexts record

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -370,6 +370,10 @@ ini_options.filterwarnings = [
 ]
 
 [tool.coverage]
+# coverage defaults to the sysmon core on 3.14+, which cannot record the per-test dynamic
+# contexts pytest-cov sets via --cov-context (7.15.2 dropped them silently, 7.15.3 warns,
+# and filterwarnings=error turns that into a failure); ctrace supports them
+run.core = "ctrace"
 # The differential suites diff against oracle libraries that are bench, not test, dependencies
 # (lxml additionally ships no wheels for 3.15, the free-threaded builds, or Windows), so each
 # module importorskips itself where its oracle is absent; measuring them would make the gate


### PR DESCRIPTION
Every 🧪 matrix job fails since coverage 7.15.3 reached PyPI: on Python 3.14+ coverage defaults to the `sysmon` core, which cannot record dynamic contexts, and [7.15.3 now warns](https://coverage.readthedocs.io/en/7.15.3/changes.html) when pytest-cov sets one through the context API where 7.15.2 dropped the data without a word. Our `filterwarnings = error` turns that `no-sysmon-context` warning into a teardown error for every test, which is why #702 and the latest scheduled run on `main` show 127k errors.

Pinning `run.core = "ctrace"` in the coverage config keeps the C tracer that supports dynamic contexts, matching what every job used before the `sysmon` default arrived. This also restores the per-test context data behind `--cov-context test` and `html.show_contexts`, which 7.15.2 had been discarding on 3.14+ without any signal.
