### PR TITLE
🧪 test(serialize): widen the node differential timeout

### DIFF
--- a/tests/serialize/js/test_fold.py
+++ b/tests/serialize/js/test_fold.py
@@ -760,7 +760,9 @@ def test_compresses(source: str, expected: str) -> None:
 
 def _run(code: str) -> str:
     assert _NODE is not None  # the callers are skipped when node is unavailable
-    result = subprocess.run([_NODE, "-e", code], capture_output=True, text=True, timeout=60, check=False)  # ruff:ignore[subprocess-without-shell-equals-true]
+    # the first node start on a cold Windows runner has taken over a minute on its own; the timeout
+    # is only here to bound a snippet that never returns, so it sits well clear of a slow launch
+    result = subprocess.run([_NODE, "-e", code], capture_output=True, text=True, timeout=300, check=False)  # ruff:ignore[subprocess-without-shell-equals-true]
     return result.stdout + result.stderr
 
 

--- a/tests/serialize/js/test_mangle.py
+++ b/tests/serialize/js/test_mangle.py
@@ -74,7 +74,9 @@ def test_renames(source: str, expected: str) -> None:
 
 def _run(code: str) -> str:
     assert _NODE is not None  # the callers are skipped when node is unavailable
-    result = subprocess.run([_NODE, "-e", code], capture_output=True, text=True, timeout=60, check=False)  # ruff:ignore[subprocess-without-shell-equals-true]
+    # the first node start on a cold Windows runner has taken over a minute on its own; the timeout
+    # is only here to bound a snippet that never returns, so it sits well clear of a slow launch
+    result = subprocess.run([_NODE, "-e", code], capture_output=True, text=True, timeout=300, check=False)  # ruff:ignore[subprocess-without-shell-equals-true]
     return result.stdout + result.stderr
 
 


### PR DESCRIPTION
The Windows 3.10 cell of [#704](https://github.com/tox-dev/turbohtml/pull/704) went red on `test_folding_preserves_behavior[literals]`. That case is the first in `tests/serialize/js/test_fold.py` to launch `node`, and `subprocess.run` raised `TimeoutExpired` at its 60s bound. The [job's slowest-durations table](https://github.com/tox-dev/turbohtml/actions/runs/30834452288/job/91756094119) puts the next case at 14.92s for its two launches and nothing else in the file above a second, which points at a one-time cost to start a cold `node.exe`. Which case pays that cost depends on collection order, so the failure moves around.

The bound exists to stop a snippet that never returns from wedging the run, so it goes to 300s, past a slow process start and still short enough to catch a hang. `tests/serialize/js/test_mangle.py` runs the same helper against the mangling differential and carried the same 60s bound, so both move together.

The `tests/conformance` suites that shell out to `node` keep their 120s bounds. That job runs only on `ubuntu-24.04`, where this cold-start cost has not shown up.
