### PR TITLE
🐛 fix(parser): keep keygen inside select

### DIFF
--- a/docs/changelog/717.bugfix.rst
+++ b/docs/changelog/717.bugfix.rst
@@ -1,0 +1,1 @@
+Apply the living-standard ``keygen`` rules inside ``select`` elements.

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -2903,9 +2903,7 @@ static enum th_drain drain_in_body(th_tree *tree, th_token *tok, th_insert *dc) 
             }
             return TH_DRAIN_NEXT;
         }
-        if (atom == TH_TAG_INPUT || atom == TH_TAG_KEYGEN) {
-            /* an input or keygen closes an open select entirely (and is
-               ignored outright in a select-context fragment) */
+        if (atom == TH_TAG_INPUT) {
             if (tree->fragment_root != NULL && tree->ctx_atom == TH_TAG_SELECT) {
                 return TH_DRAIN_NEXT;
             }

--- a/tests/dom/test_keygen_living_standard.py
+++ b/tests/dom/test_keygen_living_standard.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Element, parse, parse_fragment
+
+
+@pytest.mark.parametrize(
+    ("markup", "parent_tag", "expected"),
+    [
+        pytest.param("<select><keygen>", "select", ["keygen"], id="select"),
+        pytest.param("<keygen><span>", "body", ["keygen", "span"], id="body"),
+    ],
+)
+def test_keygen_document_children(markup: str, parent_tag: str, expected: list[str]) -> None:
+    parent = parse(markup).find(parent_tag)
+    assert parent is not None
+    assert [child.tag for child in parent.children if isinstance(child, Element)] == expected
+
+
+def test_keygen_and_option_are_siblings_in_select_fragment() -> None:
+    fragment = parse_fragment("<keygen><option>", "select")
+    assert [child.tag for child in fragment.children if isinstance(child, Element)] == ["keygen", "option"]

--- a/tests/dom/test_treebuilder_conformance.py
+++ b/tests/dom/test_treebuilder_conformance.py
@@ -90,12 +90,6 @@ _SPEC_OVERRIDES: dict[tuple[str, str, str | None], str] = {
     ),
     ("foreign-fragment.dat", "<svg></br><foo>", "div"): "| <svg svg>\n|   <br>\n|   <svg foo>",
     ("foreign-fragment.dat", "</br><foo>", "svg svg"): "| <svg foo>",
-    # The "in select" mode pops an open select for an input/keygen/textarea start tag (and ignores
-    # it in a select-context fragment). The pinned .dat predates the keygen rule and still nests it;
-    # html5lib's own library pops it (sibling) for a document and ignores it in a select fragment,
-    # matching the WHATWG algorithm. See https://github.com/tox-dev/turbohtml/issues/93
-    ("tests7.dat", "<select><keygen>", None): "| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <keygen>",
-    ("tests_innerHTML_1.dat", "<keygen><option>", "select"): "| <option>",
     # WHATWG added HTML processing instructions after the pinned html5lib-tests revision.
     (
         "html5test-com.dat",

--- a/tests/dom/test_treebuilder_differential.py
+++ b/tests/dom/test_treebuilder_differential.py
@@ -17,10 +17,10 @@ the tree the browser resolves.
 Two divergence classes are documented rather than silently skipped:
 
 - Spec-lag: a handful of pinned ``.dat`` cases encode pre-errata trees for ``</p>``/``</br>`` in
-  foreign content and ``<select><keygen>``. turbohtml follows the modern WHATWG algorithm (as do
-  lexbor and html5lib's own library); the pinned data does not. For these the public tree is
+  foreign content. turbohtml follows the modern WHATWG algorithm (as do lexbor and html5lib's own
+  library); the pinned data does not. For these the public tree is
   asserted against turbohtml's spec-validated parse, which the conformance suite pins to the
-  corrected tree. See issues #32, #63, #93.
+  corrected tree. See issues #32 and #63.
 - A ``.dat`` text-format limit: the html5lib ``#document`` dump wraps doctype identifiers in unescaped
   quotes, so it cannot represent a quote embedded in one (``taco"`` reads back as ``taco``). turbohtml
   keeps the quote, matching html5lib-python and the WHATWG tokenizer, so the public tree is asserted
@@ -142,7 +142,7 @@ _CASES = [(path.name, *case) for path in sorted(_TREE_DIR.glob("*.dat")) for cas
 
 # The pinned .dat predates modern-spec errata for these cases; turbohtml is spec-correct (lexbor and
 # html5lib's own library agree). The public tree is checked against turbohtml's conformance-validated
-# parse, which test_treebuilder_conformance pins to the corrected tree. See issues #32, #63, #93.
+# parse, which test_treebuilder_conformance pins to the corrected tree. See issues #32 and #63.
 _SPEC_LAG: frozenset[tuple[str, str, str | None]] = frozenset({
     ("tests26.dat", "<svg></p><foo>", None),
     ("tests26.dat", "<math></p><foo>", None),
@@ -152,8 +152,6 @@ _SPEC_LAG: frozenset[tuple[str, str, str | None]] = frozenset({
     ("foreign-fragment.dat", "</p><foo>", "svg svg"),
     ("foreign-fragment.dat", "<svg></br><foo>", "div"),
     ("foreign-fragment.dat", "</br><foo>", "svg svg"),
-    ("tests7.dat", "<select><keygen>", None),
-    ("tests_innerHTML_1.dat", "<keygen><option>", "select"),
     ("html5test-com.dat", '<?import namespace="foo" implementation="#bar">', None),
     ("tests1.dat", "<?", None),
     ("tests1.dat", "<?COMMENT?>", None),


### PR DESCRIPTION
📐 TurboHTML applied the obsolete input-specific `in select` rule to `keygen`: document parsing popped the open `select`, while select-fragment parsing discarded `keygen`. The [living HTML algorithm](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inselect) no longer lists that tag. This fixes [#717](https://github.com/tox-dev/turbohtml/issues/717).

`keygen` uses the generic start-tag path and keeps its void-element behavior. Document and fragment parsing follow the same rule without TurboHTML-specific exceptions.