### PR TITLE
🐛 fix(parser): close scoped nobr

### DIFF
--- a/docs/changelog/718.bugfix.rst
+++ b/docs/changelog/718.bugfix.rst
@@ -1,0 +1,1 @@
+Keep repeated ``nobr`` elements as siblings across table formatting scope.

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -2983,7 +2983,9 @@ static enum th_drain drain_in_body(th_tree *tree, th_token *tok, th_insert *dc) 
         if (atom == TH_TAG_NOBR) {
             reconstruct_afe(tree);
             if (has_in_scope(tree, TH_TAG_NOBR)) {
-                adoption_agency(tree, TH_TAG_NOBR);
+                if (!adoption_agency(tree, TH_TAG_NOBR)) {
+                    any_other_end_tag(tree, TH_TAG_NOBR, tok);
+                }
                 reconstruct_afe(tree);
             }
             th_node *node = insert_element(tree, tok);
@@ -3134,8 +3136,9 @@ static enum th_drain drain_in_body(th_tree *tree, th_token *tok, th_insert *dc) 
             return TH_DRAIN_NEXT;
         }
         if (flags & TH_TAG_FORMATTING) {
-            adoption_agency(tree, atom);
-            return TH_DRAIN_NEXT;
+            if (adoption_agency(tree, atom)) {
+                return TH_DRAIN_NEXT;
+            }
         }
         if (atom == TH_TAG_APPLET || atom == TH_TAG_MARQUEE || atom == TH_TAG_OBJECT) {
             if (has_in_scope(tree, atom)) {

--- a/tests/dom/test_nobr_adoption.py
+++ b/tests/dom/test_nobr_adoption.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import parse
+
+
+@pytest.mark.parametrize(
+    ("markup", "body_html"),
+    [
+        pytest.param(
+            "<nobr><table><marquee></table><nobr>",
+            "<body><nobr><marquee></marquee><table></table></nobr><nobr></nobr></body>",
+            id="table-and-open-marquee",
+        ),
+        pytest.param(
+            "<nobr><table></table><nobr>",
+            "<body><nobr><table></table></nobr><nobr></nobr></body>",
+            id="table",
+        ),
+        pytest.param(
+            "<nobr><marquee></marquee><nobr>",
+            "<body><nobr><marquee></marquee></nobr><nobr></nobr></body>",
+            id="marquee",
+        ),
+        pytest.param("<nobr>x<nobr>y", "<body><nobr>x</nobr><nobr>y</nobr></body>", id="repeated-nobr"),
+    ],
+)
+def test_nobr_adoption_builds_siblings(markup: str, body_html: str) -> None:
+    body = parse(markup).find("body")
+    assert body is not None
+    assert body.html == body_html


### PR DESCRIPTION
📐 Table recovery can leave an active `nobr` entry outside scope when a `marquee` remains open. The next `nobr` start tag nested under the first element, while the [adoption-agency algorithm](https://html.spec.whatwg.org/multipage/parsing.html#adoption-agency-algorithm) requires the any-other-end-tag fallback. This fixes [#718](https://github.com/tox-dev/turbohtml/issues/718).

The parser invokes that fallback when adoption cannot act on the formatting element. Successful adoption-agency calls keep their existing path.