### PR TITLE
🐛 fix(query): preserve XML tag case

### DIFF
--- a/docs/changelog/710.bugfix.rst
+++ b/docs/changelog/710.bugfix.rst
@@ -1,0 +1,1 @@
+Make XML tag-name queries case-sensitive, including names shared with known HTML tags.

--- a/src/turbohtml/_c/query/find.c
+++ b/src/turbohtml/_c/query/find.c
@@ -31,9 +31,10 @@ typedef struct {
     /* Fast path for a plain-string tag filter: resolve the name to an atom once
        so the per-node test is an integer compare instead of building a str for
        every element. tag_plain is set when tag is a single str; tag_atom is its
-       atom, or TH_TAG_UNKNOWN for a name outside the table (then the rare
-       unknown-atom elements are compared by name). */
+       atom, or TH_TAG_UNKNOWN for a name outside the table. XML names always
+       use the exact-name path, including names present in the HTML atom table. */
     int tag_plain;
+    int tag_exact;
     uint16_t tag_atom;
     /* Fast path for a plain-string class_ filter: its code points are copied
        once so each element's class tokens are compared without building a str
@@ -216,16 +217,10 @@ static int tag_plain_matches(const query_t *query, th_node *node) {
     if (query->tag_atom != TH_TAG_UNKNOWN) {
         return node->atom == query->tag_atom;
     }
-    if (node->atom != TH_TAG_UNKNOWN) {
+    if (!query->tag_exact && node->atom != TH_TAG_UNKNOWN) {
         return 0;
     }
-    PyObject *name = ucs4_to_str(node->text, node->text_len);
-    if (name == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
-    int equal = PyUnicode_Compare(name, query->tag) == 0;
-    Py_DECREF(name);
-    return equal;
+    return ucs4_equals_pystr(node->text, node->text_len, query->tag);
 }
 
 /* Whether an element matches the whole query. Returns 1/0, or -1 with an
@@ -431,6 +426,7 @@ static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_
     query->filter_plain = NULL;
     query->nattr = 0;
     query->tag_plain = 0;
+    query->tag_exact = 0;
     query->tag_atom = TH_TAG_UNKNOWN;
     query->class_ucs4 = NULL;
     query->class_len = 0;
@@ -441,17 +437,18 @@ static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_
     }
     if (tag != NULL && tag != Py_None) {
         query->tag = tag;
-        /* a plain str tag matches by interned atom; encode case-sensitively (a
-           find() name match is exact, unlike a case-insensitive CSS type) */
         if (PyUnicode_Check(tag)) {
-            Py_ssize_t blen;
-            const char *bytes = PyUnicode_AsUTF8AndSize(tag, &blen);
-            if (bytes == NULL) {
-                /* a lone surrogate cannot encode; fall back to the str-compare path */
-                PyErr_Clear();
-            } else {
-                query->tag_plain = 1;
-                query->tag_atom = blen > 0 ? th_tag_lookup(bytes, blen) : TH_TAG_UNKNOWN;
+            query->tag_plain = 1;
+            query->tag_exact = th_tree_is_xml(tree);
+            if (!query->tag_exact) {
+                Py_ssize_t blen;
+                const char *bytes = PyUnicode_AsUTF8AndSize(tag, &blen);
+                if (bytes == NULL) {
+                    /* A lone surrogate cannot encode, so the exact-name path handles it. */
+                    PyErr_Clear();
+                } else {
+                    query->tag_atom = blen > 0 ? th_tag_lookup(bytes, blen) : TH_TAG_UNKNOWN;
+                }
             }
         }
     }

--- a/tests/query/find/test_xml_find.py
+++ b/tests/query/find/test_xml_find.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Document, parse_xml
+
+
+@pytest.mark.parametrize("tag", ["div", "DIV", "custom", "Custom"])
+def test_xml_find_all_matches_exact_tag_name(tag: str, xml_case_document: Document) -> None:
+    assert [element.tag for element in xml_case_document.find_all(tag)] == [tag]
+
+
+@pytest.mark.parametrize("tag", ["div", "DIV", "custom", "Custom"])
+def test_xml_find_matches_exact_tag_name(tag: str, xml_case_document: Document) -> None:
+    assert (match := xml_case_document.find(tag)) is not None
+    assert match.tag == tag
+
+
+def test_xml_find_all_matches_known_tag_below_subtree() -> None:
+    root = parse_xml("<Root><section><div id='inside'/></section><div id='outside'/></Root>").root
+    assert root is not None
+    assert (section := root.find("section")) is not None
+    assert [element.attrs["id"] for element in section.find_all("div")] == ["inside"]
+
+
+@pytest.fixture
+def xml_case_document() -> Document:
+    return parse_xml("<Root><div/><DIV/><custom/><Custom/></Root>")


### PR DESCRIPTION
🔎 The find compiler routed known HTML tag names through atom lookup on XML trees. Exact comparison handled names outside the HTML atom table, so `find_all("div")` missed an XML `<div>`. This closes #710.

XML queries now use exact stored-Unicode comparison, including names present in the HTML atom table. HTML queries retain integer atom comparison and tag-index lookup.

🧩 The PR depends on #740 for the repository-wide `ty` cleanup. Its own diff remains limited to XML name matching and public query coverage.
