### PR TITLE
🐛 fix(core): complete deep tree walks

### DIFF
--- a/docs/changelog/710.bugfix.rst
+++ b/docs/changelog/710.bugfix.rst
@@ -1,0 +1,1 @@
+Make XML tag-name queries case-sensitive, including names shared with known HTML tags.

--- a/docs/changelog/722.bugfix.rst
+++ b/docs/changelog/722.bugfix.rst
@@ -1,0 +1,1 @@
+Complete deep XML and programmatic-tree operations without silent truncation or C stack exhaustion.

--- a/docs/explanation/main-content.rst
+++ b/docs/explanation/main-content.rst
@@ -35,7 +35,8 @@ bundles alongside, are out of scope; reach for a dedicated tool there.
 The whole scoring walk is pure C and allocates only a small candidate array (a linear find-or-insert map, since the
 candidate set is just the parents and grandparents of scored paragraphs). It touches no Python object until a winner is
 chosen, at which point the binding (holding the same per-tree critical section the other walks use) wraps that one node,
-or renders its text for :meth:`~turbohtml.Node.main_text`. Two threads extracting from two trees never interfere.
+or renders its text for :meth:`~turbohtml.Node.main_text`. Parent-linked iteration keeps scoring and metadata harvesting
+complete on deep XML and programmatic trees. Two threads extracting from separate trees do not interfere.
 
 :func:`turbohtml.extract.boilerplate` layers the paragraph-level view justext and boilerpy3 expose over the same walk:
 the winner picks the content body, then each paragraph unit is reported individually -- outside the winner is

--- a/docs/explanation/mutation.rst
+++ b/docs/explanation/mutation.rst
@@ -50,11 +50,12 @@ ASCII-lowercased so they resolve to the same interned atoms the parser assigns. 
 directly rather than a throwaway dict), and ``copy.copy``, ``copy.deepcopy``, and :mod:`python:pickle` all run through
 the same subtree copy, so a clone is always a standalone tree.
 
-:class:`~turbohtml.ProcessingInstruction` and :class:`~turbohtml.CData` round out the node model for building, but the
-parser never emits them: a WHATWG-conformant parse folds ``<? ... >`` into a comment and a foreign CDATA section into
-text, and turbohtml keeps that conformance rather than inventing nodes the algorithm does not produce. Pickling carries
-an element's children as an explicit list instead of re-serializing, so those two node types survive a round-trip that
-serialize-and-reparse would fold away.
+Subtree copy, cross-tree adoption, equality, and :meth:`~turbohtml.Element.normalize` use parent-linked loops. Their
+results remain complete until allocation fails. The HTML parser's construction limit does not constrain these mutations.
+
+:class:`~turbohtml.ProcessingInstruction` and :class:`~turbohtml.CData` round out the node model for building. The HTML
+parser emits processing instructions but folds foreign CDATA sections into text. Pickling carries an element's children
+as an explicit list instead of re-serializing, so both node types survive a round-trip without losing their fields.
 
 *************************
  Observing changes: sync

--- a/docs/explanation/ranges.rst
+++ b/docs/explanation/ranges.rst
@@ -30,6 +30,10 @@ an arena boundary -- and why a clone reuses the tested deep-copy primitive withi
 the per-tree critical section, so a content edit is atomic under the free-threaded build the same way the other
 structural mutations are.
 
+The straddling-end algorithm retains the DOM specification's recursive shape. Before allocating a fragment or changing
+the source tree, it raises :exc:`RecursionError` when a partial boundary path reaches 400 levels. The iterative copy
+walk handles contained subtrees without a nesting limit.
+
 Two scope choices bound this. First, a ``Range`` is only as live as its own operations: its content methods move its
 boundaries per the spec, but an edit made through another API -- appending a sibling, removing a subtree -- does not
 shift a range you happen to be holding, because the tree's mutators do not track live ranges. A range is a cursor you

--- a/docs/explanation/sanitizing.rst
+++ b/docs/explanation/sanitizing.rst
@@ -68,6 +68,9 @@ choice about which content languages an application accepts at all. Keeping the 
 statement about intent, not a relaxation of the mutation-XSS defense that still governs how a MathML node may be
 reached.
 
+The policy walk uses an explicit checked stack rather than C recursion. It reaches the final safety pass at all depths
+that fits in memory; nesting cannot truncate the sanitized result or skip a descendant's checks.
+
 The ``xml`` flag sits outside the subtractive stack entirely: it changes how the surviving tree is *serialized*, not
 what survives. The walk is identical, and the safety baseline is unchanged, so an XML-mode policy is exactly as safe as
 its HTML-mode twin -- serializing more strictly cannot make a safe tree unsafe. What the XML serializer adds is

--- a/docs/explanation/serialization.rst
+++ b/docs/explanation/serialization.rst
@@ -171,6 +171,11 @@ pointers. turbohtml already has the tree, so the exporter is a single pass over 
 each element as block (its own line, with collapsed blank-line margins) or inline (wrapped in a marker), the CSS
 normal-flow distinction.
 
+An iterative depth walk preflights that recursive formatter. At 1,024 levels, it raises :exc:`RecursionError` before
+calling a converter or allocating an output buffer. The structural HTML serializers and plain
+:attr:`~turbohtml.Node.text` use parent-linked walks and have no nesting limit. Copy, equality, normalization, selector
+subtree scans, and shadow-slot flattening use the same approach.
+
 The one subtle part is whitespace, and it is where the reference libraries differ. turbohtml never emits a space from
 text eagerly: a run of whitespace sets a pending flag, and the owed space is written only just before the next visible
 character, and dropped at a line or block start. Because a closing emphasis marker does not flush that pending space, a

--- a/docs/explanation/structured-data.rst
+++ b/docs/explanation/structured-data.rst
@@ -11,6 +11,9 @@ record with a stable six-field shape -- ``json_ld``, ``microdata``, ``opengraph`
 ``microformats`` reserved for a later phase -- so code that reads it does not break when that format lands. The records
 hold no reference back into the tree, so they outlive the document they came from.
 
+Nested Microdata and RDFa resources become nested Python records. At 400 levels, the preflight raises
+:exc:`RecursionError` before record construction. The flat metadata helpers remain iterative.
+
 *********************
  Where the work runs
 *********************

--- a/docs/explanation/validation.rst
+++ b/docs/explanation/validation.rst
@@ -44,6 +44,8 @@ Doing that in the extension -- over the code-point buffers the parser already pr
 matcher for the ``pattern`` facet -- keeps a schema check close to the cost of the parse it follows, rather than a
 second pass in Python. The recursion guards that protect the RELAX NG derivative from schemas whose refs recurse without
 an element in between live there too, so an adversarial schema fails cleanly instead of overflowing the stack.
+Compilation and validation start with an iterative tree-depth scan. A schema or instance nested 400 levels or deeper
+raises :class:`RecursionError` before a recursive grammar walk starts, including on small worker-thread stacks.
 
 ***********************
  What a result carries

--- a/docs/how-to/markdown.rst
+++ b/docs/how-to/markdown.rst
@@ -33,7 +33,8 @@ second dependency and the whole walk in C:
     > Rest 1 hour.
 
 Call it on any node to export just that subtree (``article.to_markdown()``). The output is opinionated GFM: ATX
-headings, ``-`` bullets, fenced code blocks, inline links, and ``*``/``**`` emphasis.
+headings, ``-`` bullets, fenced code blocks, inline links, and ``*``/``**`` emphasis. A tree nested 1,024 levels or
+deeper raises :exc:`RecursionError` before conversion starts instead of returning partial Markdown.
 
 A :class:`~turbohtml.Markdown` configuration object covers the markdownify and html2text surface, so a migration
 reproduces the old output: setext headings, underscore emphasis, reference links, padded tables, alternate escaping, and

--- a/docs/how-to/plain-text.rst
+++ b/docs/how-to/plain-text.rst
@@ -13,6 +13,10 @@ Extract rendered text with :meth:`~turbohtml.Node.to_text`, and get the same tex
 <https://github.com/weblyzard/inscriptis>`_ fills), keeping the visual structure rather than collapsing everything like
 :attr:`~turbohtml.Node.text` does. Its most visible feature is laying tables out as aligned columns:
 
+Layout-aware text carries entry and exit state while it renders structure and annotations. A tree nested 1,024 levels or
+deeper raises :exc:`RecursionError` before rendering; :attr:`~turbohtml.Node.text`, which only concatenates text
+descendants, has no nesting limit.
+
 .. testcode::
 
     import turbohtml

--- a/docs/reference/serialize.rst
+++ b/docs/reference/serialize.rst
@@ -17,6 +17,11 @@ string helpers; :func:`annotation_surface` and :func:`annotation_tags` post-proc
 :class:`~turbohtml.clean.JSMinify` passed to :class:`Minify` extends HTML minification into inline ``<script>`` content;
 the standalone :func:`~turbohtml.clean.minify_js` lives with the other minifiers in :mod:`turbohtml.clean`.
 
+Markup serialization and :attr:`Node.text` use parent-linked tree walks and do not impose a nesting limit. The stateful
+:meth:`Node.to_markdown`, :meth:`Node.to_text`, and :meth:`Node.to_annotated_text` formatters accept nesting below 1,024
+levels. At 1,024 levels they raise :exc:`RecursionError` before output allocation or converter invocation. Callers
+receive no partial prefix.
+
 .. autofunction:: escape
 
 .. autofunction:: unescape

--- a/docs/reference/structured-data.rst
+++ b/docs/reference/structured-data.rst
@@ -9,6 +9,9 @@ per-format helpers :meth:`Document.json_ld`, :meth:`Document.opengraph`, :meth:`
 :meth:`Document.rdfa`, and :meth:`Document.dublin_core` beside it. The walk runs in the C core; the typed, read-only
 result records below are handed back from it.
 
+The nested-record methods :meth:`Document.microdata`, :meth:`Document.rdfa`, and :meth:`Document.structured_data` raise
+:exc:`RecursionError` for documents nested 400 levels or deeper, before they build result records.
+
 .. autoclass:: StructuredData
     :members:
 

--- a/docs/reference/validate.rst
+++ b/docs/reference/validate.rst
@@ -9,6 +9,10 @@ or RELAX NG schema. A schema compiles once in the C core; each :meth:`~XMLSchema
 there and returns a :class:`ValidationResult` -- a ``valid`` flag plus a tuple of :class:`ValidationError` records, one
 per violation, each locating the offending node. The Python layer only shapes the input and wraps the C result.
 
+Schema compilation and instance validation raise :class:`RecursionError` before processing a tree nested 400 levels or
+deeper. This limit keeps the remaining recursive grammar walks within small worker-thread stacks; the validator does not
+return partial results.
+
 .. autoclass:: XMLSchema
     :members:
     :inherited-members:

--- a/src/turbohtml/_c/clean/sanitize.c
+++ b/src/turbohtml/_c/clean/sanitize.c
@@ -9,6 +9,7 @@
 
 #include "core/ascii.h"
 #include "core/common.h"
+#include "core/vec.h"
 #include "url/url.h"
 
 #include "dom/tree.h"
@@ -17,7 +18,6 @@
 
 enum on_disallowed { ON_ESCAPE = 0, ON_STRIP = 1, ON_REMOVE = 2 };
 
-/* The compiled policy and the tree being walked, threaded through the recursion. */
 typedef struct {
     th_tree *tree;
     PyObject *tags;             /* frozenset[str]: allowed element names */
@@ -1372,13 +1372,8 @@ static void hoist_children(th_node *element) {
     }
 }
 
-/* Replace a disallowed element with its escaped start tag, its sanitized children, and its escaped end tag. */
+/* Replace a disallowed element with its escaped start tag, its already-sanitized children, and its escaped end tag. */
 static int escape_element(sanitizer *s, th_node *element) {
-    /* the element is being escaped to text, so its children lose this element as a
-       kept ancestor (parent_kept = 0): a foreign child must not survive into HTML */
-    if (sanitize_children(s, element, 0) < 0) {
-        return -1;
-    }
     PyObject *opening = open_tag(s, element);
     if (opening == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;         /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1532,7 +1527,9 @@ static int apply_transform(sanitizer *s, th_node *element, PyObject **tag) {
    1 when the element's parent is itself being kept; an allowlisted foreign (SVG/MathML)
    element is kept only then, so it never outlives its namespace context (e.g. an svg
    <a> must not survive into HTML as a live anchor when its <svg> is escaped). */
-static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
+enum sanitize_action { SANITIZE_DONE, SANITIZE_KEEP_CHILDREN, SANITIZE_STRIP_CHILDREN, SANITIZE_ESCAPE_CHILDREN };
+
+static int sanitize_element(sanitizer *s, th_node *element, int parent_kept, enum sanitize_action *action) {
     int is_html = element->ns == TH_NS_HTML;
     PyObject *tag = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, element->text, element->text_len);
     if (tag == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
@@ -1590,24 +1587,26 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
         return -1;                                             /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     int status = 0;
+    *action = SANITIZE_DONE;
     if (allowed < 0 || remove_content < 0) { /* GCOVR_EXCL_BR_LINE: PySet_Contains never fails on a str key */
         status = -1;                         /* GCOVR_EXCL_LINE */
     } else if (allowed && style_element) {
         /* a kept <style> holds raw CSS, not child elements, so scrub its stylesheet body instead of walking children */
         status = sanitize_attributes(s, element, tag, custom) < 0 ? -1 : sanitize_style_body(s, element);
     } else if (allowed) {
-        status = sanitize_attributes(s, element, tag, custom) < 0 ? -1 : sanitize_children(s, element, 1);
+        if (sanitize_attributes(s, element, tag, custom) < 0) {
+            status = -1;
+        } else {
+            *action = SANITIZE_KEEP_CHILDREN;
+        }
     } else if (remove_content || s->on_disallowed == ON_REMOVE || (s->on_disallowed == ON_STRIP && !is_html)) {
         /* drop the whole subtree: a content-removal tag (e.g. script/style, so its text never leaks), REMOVE mode, or
            foreign content under STRIP (unwrapping it would invite namespace confusion) */
         th_node_remove(element);
     } else if (s->on_disallowed == ON_STRIP) {
-        if ((status = sanitize_children(s, element, 0)) == 0) {
-            hoist_children(element);
-            th_node_remove(element);
-        }
+        *action = SANITIZE_STRIP_CHILDREN;
     } else {
-        status = escape_element(s, element);
+        *action = SANITIZE_ESCAPE_CHILDREN;
     }
     Py_DECREF(tag);
     return status;
@@ -1637,14 +1636,70 @@ static int strip_text_templates(sanitizer *s, th_node *node) {
     return status;
 }
 
-/* Walk an element's children, applying the policy; capturing the next sibling keeps the loop safe across edits. */
+typedef struct {
+    th_node *element;
+    th_node *next;
+    enum sanitize_action action;
+    int parent_kept;
+} sanitize_frame;
+
+/* Walk descendants with an explicit stack. A frame keeps the post-order strip/escape action and the sibling that
+   follows the element, so mutations cannot invalidate traversal state. */
 static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
+    sanitize_frame *frames = NULL;
+    Py_ssize_t depth = 0;
+    Py_ssize_t capacity = 0;
     th_node *child = parent->first_child;
-    while (child != NULL) {
+    for (;;) {
+        if (child == NULL) {
+            if (depth == 0) {
+                PyMem_Free(frames);
+                return 0;
+            }
+            sanitize_frame frame = frames[--depth];
+            if (frame.action == SANITIZE_STRIP_CHILDREN) {
+                hoist_children(frame.element);
+                th_node_remove(frame.element);
+            } else if (frame.action == SANITIZE_ESCAPE_CHILDREN && /* GCOVR_EXCL_BR_LINE: escape only fails on alloc */
+                       escape_element(s, frame.element) < 0) {     /* GCOVR_EXCL_BR_LINE: only allocation can fail */
+                PyMem_Free(frames);                                /* GCOVR_EXCL_LINE: allocation-failure cleanup */
+                return -1;                                         /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            parent_kept = frame.parent_kept;
+            child = frame.next;
+            continue;
+        }
         th_node *next = child->next_sibling;
         if (child->type == TH_NODE_ELEMENT) {
-            if (sanitize_element(s, child, parent_kept) < 0) {
+            enum sanitize_action action;
+            if (sanitize_element(s, child, parent_kept, &action) < 0) {
+                PyMem_Free(frames);
                 return -1;
+            }
+            if (action != SANITIZE_DONE) {
+                if (depth == capacity) {
+                    size_t grown;
+                    size_t bytes;
+                    int fits =
+                        th_grow_cap((size_t)depth + 1, (size_t)capacity, 16, sizeof(sanitize_frame), &grown, &bytes);
+                    if (!fits) {            /* GCOVR_EXCL_BR_LINE: no representable tree can overflow size_t here */
+                        PyMem_Free(frames); /* GCOVR_EXCL_LINE: size-overflow path */
+                        PyErr_NoMemory();   /* GCOVR_EXCL_LINE: size-overflow path */
+                        return -1;          /* GCOVR_EXCL_LINE: size-overflow path */
+                    }
+                    sanitize_frame *resized = PyMem_Realloc(frames, bytes);
+                    if (resized == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                        PyMem_Free(frames); /* GCOVR_EXCL_LINE: allocation-failure path */
+                        PyErr_NoMemory();   /* GCOVR_EXCL_LINE: allocation-failure path */
+                        return -1;          /* GCOVR_EXCL_LINE: allocation-failure path */
+                    }
+                    frames = resized;
+                    capacity = (Py_ssize_t)grown;
+                }
+                frames[depth++] = (sanitize_frame){child, next, action, parent_kept};
+                parent_kept = action == SANITIZE_KEEP_CHILDREN;
+                child = child->first_child;
+                continue;
             }
         } else if (child->type == TH_NODE_COMMENT) {
             if (s->strip_comments) {
@@ -1653,6 +1708,7 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
         } else if (child->type == TH_NODE_TEXT) {
             /* strip_text_templates only fails on allocation, which no test can force */
             if (s->strip_templates && strip_text_templates(s, child) < 0) { /* GCOVR_EXCL_BR_LINE */
+                PyMem_Free(frames);                                         /* GCOVR_EXCL_LINE */
                 return -1;                                                  /* GCOVR_EXCL_LINE */
             }
         } else {
@@ -1660,7 +1716,6 @@ static int sanitize_children(sanitizer *s, th_node *parent, int parent_kept) {
         }
         child = next;
     }
-    return 0;
 }
 
 /* The set-typed policy fields reach a PySet_Contains in the walk, which raises a bare SystemError on a non-set. Reject

--- a/src/turbohtml/_c/css/select/selector.c
+++ b/src/turbohtml/_c/css/select/selector.c
@@ -2151,6 +2151,36 @@ static int sel_rel_uses_scope(const sel_complex *rel) {
    populated deeper node, bounding its work at O(depth) total. */
 #define SEL_HAS_MEMO_MIN_DESCENT 24
 
+static th_node *sel_first_element_child(th_node *node) {
+    th_node *child = node->first_child;
+    while (child != NULL && child->type != TH_NODE_ELEMENT) {
+        child = child->next_sibling;
+    }
+    return child;
+}
+
+static th_node *sel_next_element_sibling(th_node *node) {
+    th_node *sibling = node->next_sibling;
+    while (sibling != NULL && sibling->type != TH_NODE_ELEMENT) {
+        sibling = sibling->next_sibling;
+    }
+    return sibling;
+}
+
+static void sel_has_mark_ancestors(th_node *node, th_node *root, int descent, const sel_complex *rel,
+                                   const sel_ctx *ctx) {
+    th_node *ancestor = node->parent;
+    for (int depth = descent - 1;; depth--) {
+        if (depth >= SEL_HAS_MEMO_MIN_DESCENT) {
+            sel_has_memo_put(ctx->has_memo, rel, ancestor, 1);
+        }
+        if (ancestor == root) {
+            return;
+        }
+        ancestor = ancestor->parent;
+    }
+}
+
 /* Whether node's subtree (its strict descendants) holds an element matching comp, the
    lone compound of a descendant :has() argument such as :has(a). The result is a pure
    function of the subtree, so it is memoized per (rel, node): each node's children are
@@ -2161,38 +2191,72 @@ static int sel_rel_uses_scope(const sel_complex *rel) {
    is no memo, the memo can no longer grow, or the descent is still shallow). */
 static int sel_has_desc(th_node *node, const sel_complex *rel, const sel_compound *comp, const sel_ctx *ctx,
                         int descent) {
-    int deep = descent >= SEL_HAS_MEMO_MIN_DESCENT;
-    int cached;
-    if (deep && sel_has_memo_get(ctx->has_memo, rel, node, &cached)) {
-        return cached;
-    }
-    int result = 0;
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type != TH_NODE_ELEMENT) {
+    th_node *current = node;
+    int current_descent = descent;
+    for (;;) {
+        th_node *child = sel_first_element_child(current);
+        if (child != NULL) {
+            current = child;
+            current_descent++;
+        entered:
+            if (current_descent >= SEL_HAS_MEMO_MIN_DESCENT) {
+                int cached;
+                if (sel_has_memo_get(ctx->has_memo, rel, current, &cached)) {
+                    if (cached) {
+                        sel_has_mark_ancestors(current, node, current_descent, rel, ctx);
+                        return 1;
+                    }
+                    goto complete;
+                }
+            }
+            if (sel_match_compound(current, comp, ctx)) {
+                sel_has_mark_ancestors(current, node, current_descent, rel, ctx);
+                return 1;
+            }
             continue;
         }
-        if (sel_match_compound(child, comp, ctx) || sel_has_desc(child, rel, comp, ctx, descent + 1)) {
-            result = 1;
-            break;
+    complete:
+        if (current_descent >= SEL_HAS_MEMO_MIN_DESCENT) {
+            sel_has_memo_put(ctx->has_memo, rel, current, 0);
         }
+        while (current != node) {
+            th_node *sibling = sel_next_element_sibling(current);
+            if (sibling != NULL) {
+                current = sibling;
+                goto entered;
+            }
+            current = current->parent;
+            current_descent--;
+            if (current != node && current_descent >= SEL_HAS_MEMO_MIN_DESCENT) {
+                sel_has_memo_put(ctx->has_memo, rel, current, 0);
+            }
+        }
+        return 0;
     }
-    if (deep) {
-        sel_has_memo_put(ctx->has_memo, rel, node, result);
-    }
-    return result;
 }
 
-/* Whether any element in the subtree below node is the subject of rel anchored at
-   anchor (the element :has() is testing), checked recursively in document order. */
 static int sel_has_subtree(th_node *node, const sel_complex *rel, int subject, th_node *anchor, const sel_ctx *ctx) {
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type != TH_NODE_ELEMENT) {
+    th_node *current = sel_first_element_child(node);
+    while (current != NULL) {
+        if (sel_match_compound(current, &rel->compounds[subject], ctx) &&
+            sel_match_from(current, rel, subject, anchor, ctx)) {
+            return 1;
+        }
+        th_node *child = sel_first_element_child(current);
+        if (child != NULL) {
+            current = child;
             continue;
         }
-        if ((sel_match_compound(child, &rel->compounds[subject], ctx) &&
-             sel_match_from(child, rel, subject, anchor, ctx)) ||
-            sel_has_subtree(child, rel, subject, anchor, ctx)) {
-            return 1;
+        for (;;) {
+            th_node *sibling = sel_next_element_sibling(current);
+            if (sibling != NULL) {
+                current = sibling;
+                break;
+            }
+            current = current->parent;
+            if (current == node) {
+                return 0;
+            }
         }
     }
     return 0;

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -441,7 +441,8 @@ PyDoc_STRVAR(structured_data_doc,
              ":param base_url: when given, the URL each relative URL-valued microdata, opengraph, or\n"
              "    RDFa field is resolved against (a <base href> refines it, HTML spec 4.2.3); json_ld\n"
              "    and Dublin Core are left verbatim. None (the default) returns every value verbatim.\n"
-             ":raises ValueError: if base_url is not a valid absolute URL.");
+             ":raises ValueError: if base_url is not a valid absolute URL.\n"
+             ":raises RecursionError: if the document is nested 400 levels or deeper.");
 
 PyDoc_STRVAR(json_ld_doc, "json_ld()\n--\n\n"
                           "Parse every <script type=\"application/ld+json\"> block in the document with the\n"
@@ -467,7 +468,8 @@ PyDoc_STRVAR(microdata_doc,
              ":param base_url: when given, the URL each relative URL-valued property (an a/area/link\n"
              "    href, a media src, an object data) is resolved against; a <base href> refines it.\n"
              "    None (the default) returns every value verbatim.\n"
-             ":raises ValueError: if base_url is not a valid absolute URL.");
+             ":raises ValueError: if base_url is not a valid absolute URL.\n"
+             ":raises RecursionError: if the document is nested 400 levels or deeper.");
 
 PyDoc_STRVAR(rdfa_doc, "rdfa(base_url=None)\n--\n\n"
                        "Extract RDFa as a list of RdfaItem, one per top-level typeof resource. Each item has\n"
@@ -477,7 +479,8 @@ PyDoc_STRVAR(rdfa_doc, "rdfa(base_url=None)\n--\n\n"
                        "context seeds the common prefixes); an undeclared prefix stays verbatim.\n\n"
                        ":param base_url: when given, the URL each resource/href/src IRI is resolved against; a\n"
                        "    <base href> refines it. None (the default) returns every value verbatim.\n"
-                       ":raises ValueError: if base_url is not a valid absolute URL.");
+                       ":raises ValueError: if base_url is not a valid absolute URL.\n"
+                       ":raises RecursionError: if the document is nested 400 levels or deeper.");
 
 PyDoc_STRVAR(dublin_core_doc, "dublin_core()\n--\n\n"
                               "Return a dict mapping each <meta name=\"dc.*\"> or <meta name=\"dcterms.*\"> name\n"

--- a/src/turbohtml/_c/dom/mutate.c
+++ b/src/turbohtml/_c/dom/mutate.c
@@ -449,13 +449,7 @@ static int data_equal(th_tree *left_tree, th_node *left, th_tree *right_tree, th
     return left->text_len == 0 || memcmp(left_text, right_text, (size_t)left->text_len * sizeof(Py_UCS4)) == 0;
 }
 
-/* Whether two subtrees are structurally equal: the same node type, and for an
-   element the same namespace, tag name, and attribute set (order-independent) with
-   the same ordered children compared recursively; for a leaf the same character
-   data. The engine behind Node.equals, an explicit structural test distinct from
-   `==`, which stays node identity. Recurses on tree depth, the same bound the
-   deep-copy walk assumes. */
-int th_node_equals(th_tree *left_tree, th_node *left, th_tree *right_tree, th_node *right) {
+static int node_data_equals(th_tree *left_tree, th_node *left, th_tree *right_tree, th_node *right) {
     if (left->type != right->type) {
         return 0;
     }
@@ -501,22 +495,46 @@ int th_node_equals(th_tree *left_tree, th_node *left, th_tree *right_tree, th_no
     case TH_NODE_CONTENT:
         break; /* a document / template-content fragment compares purely by its children */
     }
-    th_node *left_child = left->first_child;
-    th_node *right_child = right->first_child;
-    while (left_child != NULL && right_child != NULL) {
-        if (!th_node_equals(left_tree, left_child, right_tree, right_child)) {
-            return 0;
-        }
-        left_child = left_child->next_sibling;
-        right_child = right_child->next_sibling;
-    }
-    return left_child == NULL && right_child == NULL; /* an unequal child count leaves one non-NULL */
+    return 1;
 }
 
-/* Deep-copy a node and its subtree from src into dest's arena, materializing
-   borrowed text and re-interning per-tree attribute atoms. Used to adopt a node
-   from another tree without retaining the source. NULL on allocation failure. */
-static th_node *copy_node_at(th_tree *dest, th_tree *src, th_node *src_node, int depth) {
+/* Node.equals compares the two shapes in lockstep, using parent links to return from a subtree instead of the C stack.
+ */
+int th_node_equals(th_tree *left_tree, th_node *left, th_tree *right_tree, th_node *right) {
+    th_node *left_root = left;
+    th_node *right_root = right;
+    for (;;) {
+        if (!node_data_equals(left_tree, left, right_tree, right)) {
+            return 0;
+        }
+        if ((left->first_child == NULL) != (right->first_child == NULL)) {
+            return 0;
+        }
+        if (left->first_child != NULL) {
+            left = left->first_child;
+            right = right->first_child;
+            continue;
+        }
+        while (left != left_root && left->next_sibling == NULL) {
+            if (right->next_sibling != NULL) {
+                return 0;
+            }
+            left = left->parent;
+            right = right->parent;
+        }
+        if (left == left_root) {
+            return right == right_root;
+        }
+        if (right->next_sibling == NULL) {
+            return 0;
+        }
+        left = left->next_sibling;
+        right = right->next_sibling;
+    }
+}
+
+/* Copy one node without its children, materializing borrowed text and re-interning per-tree attribute atoms. */
+static th_node *copy_node_shallow(th_tree *dest, th_tree *src, th_node *src_node) {
     th_node *node = node_new(dest, src_node->type);
     if (node == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -565,37 +583,48 @@ static th_node *copy_node_at(th_tree *dest, th_tree *src, th_node *src_node, int
             }
         }
     }
-    if (depth < TH_MAX_WALK_DEPTH) {
-        /* past the backstop the copy is left shallow rather than recursing into a tree
-           built deeper than the parser ever would; see TH_MAX_WALK_DEPTH */
-        for (th_node *child = src_node->first_child; child != NULL; child = child->next_sibling) {
-            th_node *copy = copy_node_at(dest, src, child, depth + 1);
-            if (copy == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-                return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
-            }
-            node_append(node, copy);
-        }
-    }
     return node;
 }
 
 th_node *th_tree_copy_node(th_tree *dest, th_tree *src, th_node *src_node) {
-    return copy_node_at(dest, src, src_node, 0);
+    th_node *root = copy_node_shallow(dest, src, src_node);
+    if (root == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    th_node *from = src_node;
+    th_node *copy = root;
+    for (;;) {
+        if (from->first_child != NULL) {
+            from = from->first_child;
+            th_node *child = copy_node_shallow(dest, src, from);
+            if (child == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            node_append(copy, child);
+            copy = child;
+            continue;
+        }
+        while (from != src_node && from->next_sibling == NULL) {
+            from = from->parent;
+            copy = copy->parent;
+        }
+        if (from == src_node) {
+            return root;
+        }
+        from = from->next_sibling;
+        th_node *sibling = copy_node_shallow(dest, src, from);
+        if (sibling == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        node_append(copy->parent, sibling);
+        copy = sibling;
+    }
 }
 
-/* DOM normalize: merge adjacent Text children into the first of each run and drop
-   empty Text nodes, recursing into every element. Merged runs get a fresh arena
-   buffer; on allocation failure the merge stops early, leaving a valid tree. */
-static void normalize_at(th_tree *tree, th_node *root, int depth) {
-    if (depth >= TH_MAX_WALK_DEPTH) {
-        /* backstop for a tree built past the parser's depth cap; see TH_MAX_WALK_DEPTH */
-        return;
-    }
+static void normalize_children(th_tree *tree, th_node *root) {
     for (th_node *child = root->first_child; child != NULL;) {
         th_node *next = child->next_sibling;
-        if (child->type == TH_NODE_ELEMENT) {
-            normalize_at(tree, child, depth + 1);
-        } else if (child->type == TH_NODE_TEXT) {
+        if (child->type == TH_NODE_TEXT) {
             if (child->text_len == 0) {
                 th_node_remove(child);
                 child = next;
@@ -623,7 +652,23 @@ static void normalize_at(th_tree *tree, th_node *root, int depth) {
 }
 
 void th_node_normalize(th_tree *tree, th_node *root) {
-    normalize_at(tree, root, 0);
+    th_node *node = root;
+    for (;;) {
+        if (node == root || node->type == TH_NODE_ELEMENT) {
+            normalize_children(tree, node);
+        }
+        if (node->first_child != NULL) {
+            node = node->first_child;
+            continue;
+        }
+        while (node != root && node->next_sibling == NULL) {
+            node = node->parent;
+        }
+        if (node == root) {
+            return;
+        }
+        node = node->next_sibling;
+    }
 }
 
 /* Construct one shell element (html/head/body/meta/title) from its ASCII tag name,

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -555,7 +555,8 @@ PyDoc_STRVAR(to_markdown_doc, "to_markdown(options=None)\n--\n\n"
                               ":param options: a Markdown configuration object, or None for the defaults. Its\n"
                               "    grouped knobs (headings, links, tables, ...) cover the markdownify and\n"
                               "    html2text configuration surface.\n"
-                              ":returns: the Markdown rendering of this node's subtree.");
+                              ":returns: the Markdown rendering of this node's subtree.\n"
+                              ":raises RecursionError: if the tree is nested 1,024 levels or deeper.");
 
 /* Resolve a string option against its allowed values, writing the matched index
    into *out (an enum), or leave *out untouched when the argument was omitted. */
@@ -871,7 +872,8 @@ PyDoc_STRVAR(to_text_doc, "to_text(options=None)\n--\n\n"
                           "separated by blank lines, lists indented under their bullets, and tables\n"
                           "laid out as a column-aligned grid. The inscriptis role, in C.\n\n"
                           ":param options: a PlainText configuration object, or None for the defaults.\n"
-                          ":returns: the plain-text rendering of this node's subtree.");
+                          ":returns: the plain-text rendering of this node's subtree.\n"
+                          ":raises RecursionError: if the tree is nested 1,024 levels or deeper.");
 
 /* Parse the PlainText keyword options out of spec into opt; spec is a borrowed dict
    of the config's non-default values, or NULL for every default. -1 with an exception
@@ -910,8 +912,8 @@ static PyObject *node_text_render(PyObject *self, PyObject *spec) {
     Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
     data = th_node_layout_text(tree_of(self), ((NodeObject *)self)->node, &opt, &out_len);
     Py_END_CRITICAL_SECTION();
-    if (data == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+    if (data == NULL) {
+        return PyErr_Occurred() ? NULL : PyErr_NoMemory(); /* GCOVR_EXCL_LINE: bare NULL is allocation failure */
     }
     PyObject *result = ucs4_to_str(data, out_len);
     PyMem_Free(data);
@@ -987,7 +989,8 @@ PyDoc_STRVAR(to_annotated_text_doc, "to_annotated_text(annotation_rules, options
                                     ":param annotation_rules: maps a selector ('tag', 'tag#attr', 'tag#attr=value',\n"
                                     "    or '#attr') to the list of labels to attach to each matching element.\n"
                                     ":param options: a PlainText configuration object, or None for the defaults.\n"
-                                    ":returns: a (text, spans) pair, where spans is a list of (start, end, label).");
+                                    ":returns: a (text, spans) pair, where spans is a list of (start, end, label).\n"
+                                    ":raises RecursionError: if the tree is nested 1,024 levels or deeper.");
 
 static PyObject *node_annotated_render(PyObject *self, PyObject *rules_dict, PyObject *spec) {
     if (!PyDict_Check(rules_dict)) {
@@ -1027,12 +1030,11 @@ static PyObject *node_annotated_render(PyObject *self, PyObject *rules_dict, PyO
         data = th_node_annotated_text(tree_of(self), ((NodeObject *)self)->node, &opt, rules, rule_count, &spans,
                                       &span_count, &out_len);
         Py_END_CRITICAL_SECTION();
-        if (data == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-            PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
-        } /* GCOVR_EXCL_LINE: merge of the unreachable alloc-failure block */
-        /* data is NULL only on an alloc failure, so the NULL arms are unreachable */
-        PyObject *text = data != NULL ? ucs4_to_str(data, out_len) : NULL;   /* GCOVR_EXCL_BR_LINE */
-        PyObject *label_list = data != NULL ? PyList_New(span_count) : NULL; /* GCOVR_EXCL_BR_LINE */
+        if (data == NULL && !PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: bare NULL is allocation failure */
+            PyErr_NoMemory();                    /* GCOVR_EXCL_LINE: allocation-failure path */
+        } /* GCOVR_EXCL_LINE: closes the allocation-failure-only branch */
+        PyObject *text = data != NULL ? ucs4_to_str(data, out_len) : NULL;
+        PyObject *label_list = data != NULL ? PyList_New(span_count) : NULL;
         if (text != NULL && label_list != NULL) { /* GCOVR_EXCL_BR_LINE: only an alloc failure makes either NULL */
             for (Py_ssize_t span_index = 0; span_index < span_count; span_index++) {
                 PyList_SET_ITEM(
@@ -1151,8 +1153,8 @@ static PyObject *node_main_text(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     if (empty) {
         return ucs4_to_str(NULL, 0);
     }
-    if (data == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+    if (data == NULL) {
+        return PyErr_Occurred() ? NULL : PyErr_NoMemory(); /* GCOVR_EXCL_LINE: bare NULL is allocation failure */
     }
     PyObject *result = ucs4_to_str(data, out_len);
     PyMem_Free(data);
@@ -1248,12 +1250,16 @@ static PyObject *node_article(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     if (winner != NULL) {
         text_data = th_node_layout_text(tree, winner, &opt, &text_len);
     }
-    th_article_metadata(tree, th_tree_document(tree), &meta);
+    if (winner == NULL || text_data != NULL) {
+        th_article_metadata(tree, th_tree_document(tree), &meta);
+    }
     Py_END_CRITICAL_SECTION();
+    if (winner != NULL && text_data == NULL) {
+        th_article_meta_clear(&meta);
+        return PyErr_Occurred() ? NULL : PyErr_NoMemory(); /* GCOVR_EXCL_LINE: bare NULL is allocation failure */
+    }
 
     PyObject *element = winner != NULL ? turbohtml_node_wrap_in(self, winner) : Py_NewRef(Py_None);
-    /* th_node_layout_text leaves text_data NULL with text_len 0 only on an
-       (unforceable) allocation failure, which ucs4_to_str renders as empty text. */
     PyObject *text = winner != NULL ? ucs4_to_str(text_data, text_len) : ucs4_to_str(NULL, 0);
     PyMem_Free(text_data);
     PyObject *title = article_field(meta.title, meta.title_len);

--- a/src/turbohtml/_c/dom/range.c
+++ b/src/turbohtml/_c/dom/range.c
@@ -19,6 +19,8 @@ typedef struct {
     Py_ssize_t end_offset;
 } RangeObject;
 
+#define RANGE_MAX_RECURSIVE_DEPTH ((Py_ssize_t)400)
+
 /* Character data whose offset indexes code points and which the content operations split in place. */
 static int is_char_data(const th_node *node) {
     switch (node->type) {
@@ -187,6 +189,29 @@ static th_node *common_ancestor(th_node *start_node, th_node *end_node) {
         container = container->parent;
     }
     return container;
+}
+
+/* clone/extract follow the two partially contained boundary paths recursively. Reject an unsafe path before allocating
+   a fragment or mutating the source; contained subtrees use the iterative DOM copy primitive. */
+static int range_check_recursive_depth(RangeObject *range, const char *operation) {
+    if (range->start_node == range->end_node) {
+        return 0;
+    }
+    th_node *common = common_ancestor(range->start_node, range->end_node);
+    Py_ssize_t start_depth = 0;
+    for (th_node *node = range->start_node; node != common; node = node->parent) {
+        start_depth++;
+    }
+    Py_ssize_t end_depth = 0;
+    for (th_node *node = range->end_node; node != common; node = node->parent) {
+        end_depth++;
+    }
+    if (start_depth < RANGE_MAX_RECURSIVE_DEPTH && end_depth < RANGE_MAX_RECURSIVE_DEPTH) {
+        return 0;
+    }
+    PyErr_Format(PyExc_RecursionError, "%s does not support boundary paths %zd levels or deeper", operation,
+                 RANGE_MAX_RECURSIVE_DEPTH);
+    return -1;
 }
 
 /* The first (walking forward) child of common the range partially contains. */
@@ -802,20 +827,23 @@ static PyObject *extract_or_delete(PyObject *self, int discard) {
     module_state *state = state_of(self);
     PyObject *result = NULL;
     Py_BEGIN_CRITICAL_SECTION(range->start_handle);
-    handle_drop_index(range->start_handle);
-    th_node *new_node;
-    Py_ssize_t new_offset;
-    int collapsed = range_is_collapsed(range);
-    if (!collapsed) {
-        collapse_point(range->start_node, range->start_offset, range->end_node, &new_node, &new_offset);
-    }
-    th_node *fragment = do_extract(tree, range->start_node, range->start_offset, range->end_node, range->end_offset);
-    if (fragment != NULL) {
+    if (range_check_recursive_depth(range, discard ? "delete_contents()" : "extract_contents()") == 0) {
+        handle_drop_index(range->start_handle);
+        th_node *new_node;
+        Py_ssize_t new_offset;
+        int collapsed = range_is_collapsed(range);
         if (!collapsed) {
-            store_start(range, range->start_handle, new_node, new_offset);
-            store_end(range, range->start_handle, new_node, new_offset);
+            collapse_point(range->start_node, range->start_offset, range->end_node, &new_node, &new_offset);
         }
-        result = discard ? Py_NewRef(Py_None) : node_wrap(state, range->start_handle, fragment);
+        th_node *fragment =
+            do_extract(tree, range->start_node, range->start_offset, range->end_node, range->end_offset);
+        if (fragment != NULL) {
+            if (!collapsed) {
+                store_start(range, range->start_handle, new_node, new_offset);
+                store_end(range, range->start_handle, new_node, new_offset);
+            }
+            result = discard ? Py_NewRef(Py_None) : node_wrap(state, range->start_handle, fragment);
+        }
     }
     Py_END_CRITICAL_SECTION();
     return result;
@@ -835,9 +863,11 @@ static PyObject *range_clone_contents(PyObject *self, PyObject *Py_UNUSED(ignore
     module_state *state = state_of(self);
     PyObject *result = NULL;
     Py_BEGIN_CRITICAL_SECTION(range->start_handle);
-    th_node *fragment = do_clone(tree, range->start_node, range->start_offset, range->end_node, range->end_offset);
-    if (fragment != NULL) {
-        result = node_wrap(state, range->start_handle, fragment);
+    if (range_check_recursive_depth(range, "clone_contents()") == 0) {
+        th_node *fragment = do_clone(tree, range->start_node, range->start_offset, range->end_node, range->end_offset);
+        if (fragment != NULL) {
+            result = node_wrap(state, range->start_handle, fragment);
+        }
     }
     Py_END_CRITICAL_SECTION();
     return result;
@@ -1120,9 +1150,17 @@ PyDoc_STRVAR(compare_point_doc,
 PyDoc_STRVAR(is_point_in_range_doc,
              "is_point_in_range(node, offset, /)\n--\n\nWhether (node, offset) is within the range.");
 PyDoc_STRVAR(intersects_node_doc, "intersects_node(node, /)\n--\n\nWhether node overlaps the range.");
-PyDoc_STRVAR(clone_contents_doc, "clone_contents()\n--\n\nCopy the range's content into a new fragment.");
-PyDoc_STRVAR(extract_contents_doc, "extract_contents()\n--\n\nMove the range's content into a new fragment.");
-PyDoc_STRVAR(delete_contents_doc, "delete_contents()\n--\n\nRemove the range's content from the tree.");
+PyDoc_STRVAR(clone_contents_doc, "clone_contents()\n--\n\n"
+                                 "Copy the range's content into a new fragment.\n\n"
+                                 ":raises RecursionError: if a partial boundary path is 400 levels or deeper.");
+PyDoc_STRVAR(extract_contents_doc,
+             "extract_contents()\n--\n\n"
+             "Move the range's content into a new fragment.\n\n"
+             ":raises RecursionError: if a partial boundary path is 400 levels or deeper; the tree is unchanged.");
+PyDoc_STRVAR(delete_contents_doc,
+             "delete_contents()\n--\n\n"
+             "Remove the range's content from the tree.\n\n"
+             ":raises RecursionError: if a partial boundary path is 400 levels or deeper; the tree is unchanged.");
 PyDoc_STRVAR(insert_node_doc, "insert_node(node, /)\n--\n\nInsert node at the start of the range.");
 PyDoc_STRVAR(surround_contents_doc, "surround_contents(new_parent, /)\n--\n\nWrap the range's content in new_parent.");
 PyDoc_STRVAR(clone_range_doc, "clone_range()\n--\n\nReturn a new Range with the same boundary points.");

--- a/src/turbohtml/_c/dom/shadow.c
+++ b/src/turbohtml/_c/dom/shadow.c
@@ -28,7 +28,7 @@ typedef struct {
 static void nodevec_push(nodevec *vec, th_node *node) {
     if (vec->failed) { /* GCOVR_EXCL_BR_LINE: only set on an unforceable allocation failure */
         return;        /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
+    } /* GCOVR_EXCL_LINE: closes the allocation-failure-only branch */
     if (vec->len == vec->cap) {
         size_t cap, bytes;
         /* the requested length cannot overflow size_t, so the grow guard never trips */
@@ -133,37 +133,61 @@ static void collect_slotables(th_tree *tree, th_node *slot, nodevec *vec) {
     }
 }
 
-/* Collect the flattened slotables of slot: its assigned slotables, or -- when it has
-   none -- its own slotable children as fallback, with any nested shadow slot expanded
-   recursively. (DOM: find flattened slotables.) */
-static void collect_flattened(th_tree *tree, th_node *slot, nodevec *vec) {
+/* Collect the assigned slotables or fallback children that one slot contributes. */
+static void collect_flattened_candidates(th_tree *tree, th_node *slot, nodevec *assigned) {
     th_node *root = node_root(slot);
     if (!th_node_is_shadow_root(root)) {
         return;
     }
-    nodevec assigned = {0};
-    collect_slotables(tree, slot, &assigned);
-    if (assigned.failed) {          /* GCOVR_EXCL_BR_LINE: only set on an unforceable allocation failure */
-        vec->failed = 1;            /* GCOVR_EXCL_LINE: allocation-failure path */
-        PyMem_Free(assigned.items); /* GCOVR_EXCL_LINE: allocation-failure path */
-        return;                     /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
-    if (assigned.len == 0) {
+    collect_slotables(tree, slot, assigned);
+    if (assigned->failed) { /* GCOVR_EXCL_BR_LINE: nodevec fails only on allocation failure */
+        return;             /* GCOVR_EXCL_LINE: allocation-failure path */
+    } /* GCOVR_EXCL_LINE: closes the allocation-failure-only branch */
+    if (assigned->len == 0) {
         for (th_node *child = slot->first_child; child != NULL; child = child->next_sibling) {
             if (is_slottable(child)) {
-                nodevec_push(&assigned, child);
+                nodevec_push(assigned, child);
             }
         }
     }
-    for (Py_ssize_t index = 0; index < assigned.len; index++) {
-        th_node *node = assigned.items[index];
+}
+
+/* Collect flattened slotables depth first. pending is an explicit checked stack, so nested fallback slots do not
+   consume the C stack. (DOM: find flattened slotables.) */
+static void collect_flattened(th_tree *tree, th_node *slot, nodevec *vec) {
+    nodevec pending = {0};
+    nodevec assigned = {0};
+    collect_flattened_candidates(tree, slot, &assigned);
+    for (Py_ssize_t index = assigned.len; index > 0; index--) {
+        nodevec_push(&pending, assigned.items[index - 1]);
+    }
+    if (assigned.failed) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        pending.failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
+    } /* GCOVR_EXCL_LINE: closes the allocation-failure-only branch */
+    PyMem_Free(assigned.items);
+    while (pending.len > 0) {
+        if (pending.failed || vec->failed) { /* GCOVR_EXCL_BR_LINE: nodevec fails only on allocation failure */
+            break;                           /* GCOVR_EXCL_LINE: allocation-failure path */
+        } /* GCOVR_EXCL_LINE: closes the allocation-failure-only branch */
+        th_node *node = pending.items[--pending.len];
         if (is_slot(node) && th_node_is_shadow_root(node_root(node))) {
-            collect_flattened(tree, node, vec);
+            assigned = (nodevec){0};
+            collect_flattened_candidates(tree, node, &assigned);
+            for (Py_ssize_t index = assigned.len; index > 0; index--) {
+                nodevec_push(&pending, assigned.items[index - 1]);
+            }
+            if (assigned.failed) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                pending.failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
+            } /* GCOVR_EXCL_LINE: closes the allocation-failure-only branch */
+            PyMem_Free(assigned.items);
         } else {
             nodevec_push(vec, node);
         }
     }
-    PyMem_Free(assigned.items);
+    if (pending.failed) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        vec->failed = 1;  /* GCOVR_EXCL_LINE: allocation-failure path */
+    } /* GCOVR_EXCL_LINE: closes the allocation-failure-only branch */
+    PyMem_Free(pending.items);
 }
 
 /* Collect node's flattened-tree children: a shadow host descends into its shadow tree,

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -1267,47 +1267,79 @@ static int node_has_attr(const th_node *node, uint32_t atom) {
 /* The first HTML element with this atom in a depth-first walk of parent's
    subtree, not descending into nested selects. */
 static th_node *first_descendant_atom(th_node *parent, uint16_t atom) {
-    for (th_node *child = parent->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type == TH_NODE_ELEMENT && child->ns == TH_NS_HTML) {
-            if (child->atom == atom) {
-                return child;
+    th_node *node = parent->first_child;
+    while (node != NULL) {
+        int skip_children = 0;
+        if (node->type == TH_NODE_ELEMENT && node->ns == TH_NS_HTML) {
+            if (node->atom == atom) {
+                return node;
             }
             /* GCOVR_EXCL_START: a nested <select> start closes the open select, so a select never contains one */
-            if (child->atom == TH_TAG_SELECT) {
-                continue;
-            }
+            skip_children = node->atom == TH_TAG_SELECT;
             /* GCOVR_EXCL_STOP */
         }
-        th_node *found = first_descendant_atom(child, atom);
-        if (found != NULL) {
-            return found;
+        if (!skip_children && /* GCOVR_EXCL_BR_LINE: tree construction closes nested selects */
+            node->first_child != NULL) {
+            node = node->first_child;
+            continue;
         }
+        while (node != parent && node->next_sibling == NULL) {
+            node = node->parent;
+        }
+        node = node == parent ? NULL : node->next_sibling;
     }
     return NULL;
 }
 
-/* Deep-copy src's children, appending the copies to dst. */
+static th_node *copy_node_in_tree(th_tree *tree, th_node *source) {
+    if (source->type == TH_NODE_ELEMENT) {
+        th_node *copy = node_clone(tree, source);
+        if (copy != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+            copy->ns = source->ns;
+        }
+        return copy;
+    }
+    th_node *copy = node_new(tree, source->type);
+    if (copy != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
+        copy->text = need_text(tree, source);
+        copy->text_len = source->text_len;
+        if (source->type == TH_NODE_PI ||      /* GCOVR_EXCL_BR_LINE: HTML currently emits PI syntax as comments */
+            source->type == TH_NODE_DOCTYPE) { /* GCOVR_EXCL_BR_LINE: HTML cannot nest a doctype in selected content */
+            copy->attr_count = source->attr_count; /* GCOVR_EXCL_LINE: neither node can occur below an HTML option */
+        } /* GCOVR_EXCL_LINE: closes the selected-option node-type arm */
+    }
+    return copy;
+}
+
+/* Deep-copy src's children into dst without consuming one C stack frame per level. */
 static void deep_copy_children(th_tree *tree, const th_node *src, th_node *dst) {
-    for (th_node *child = src->first_child; child != NULL; child = child->next_sibling) {
-        th_node *copy;
-        if (child->type == TH_NODE_ELEMENT) {
-            copy = node_clone(tree, child);
-            if (copy != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                copy->ns = child->ns;
+    const th_node *from = src;
+    th_node *copy = dst;
+    for (;;) {
+        if (from->first_child != NULL) {
+            from = from->first_child;
+            th_node *child = copy_node_in_tree(tree, (th_node *)from);
+            if (child == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                return;          /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
             }
-        } else {
-            copy = node_new(tree, child->type);
-            if (copy != NULL) { /* GCOVR_EXCL_BR_LINE: NULL only on alloc failure */
-                /* Realize a zero-copy span before sharing the payload pointer. */
-                copy->text = need_text(tree, (th_node *)child);
-                copy->text_len = child->text_len;
-            }
+            node_append(copy, child);
+            copy = child;
+            continue;
         }
-        if (copy == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-            return;         /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
+        while (from != src && from->next_sibling == NULL) {
+            from = from->parent;
+            copy = copy->parent;
         }
-        node_append(dst, copy);
-        deep_copy_children(tree, child, copy);
+        if (from == src) {
+            return;
+        }
+        from = from->next_sibling;
+        th_node *sibling = copy_node_in_tree(tree, (th_node *)from);
+        if (sibling == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return;            /* GCOVR_EXCL_LINE: allocation-failure path, unreachable from a test */
+        }
+        node_append(copy->parent, sibling);
+        copy = sibling;
     }
 }
 

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -26,18 +26,12 @@
    the stack of open elements, so further start tags become its siblings rather than
    descending further -- the same runaway-nesting bound browsers apply (Blink and
    WebKit cap the parser's open-element depth at 512). Capping at construction keeps
-   every parsed tree shallow enough that the recursive sanitize/text/markdown walks
-   cannot exhaust the C stack, and bounds the O(depth^2) cost a linear run of start
-   tags would otherwise pay. */
+   parser bookkeeping bounded, and caps the O(depth^2) cost a linear run of start tags would otherwise pay. */
 #define TH_MAX_TREE_DEPTH 512
 
-/* The recursive tree walks (sanitize, text collection, markdown, clone, normalize)
-   stop descending past this depth. The mutation API can build a tree deeper than the
-   parser ever would -- the parse-time cap above does not gate it -- so the walks need
-   their own backstop against C-stack exhaustion. The 2x headroom over TH_MAX_TREE_DEPTH
-   guarantees a parsed tree never reaches it, so parsed input walks byte-for-byte
-   identically; only a directly-constructed, pathologically deep tree is truncated. */
-#define TH_MAX_WALK_DEPTH (TH_MAX_TREE_DEPTH * 2)
+/* Markdown and layout-text formatting still use recursive state machines whose entry/exit actions depend on the C call
+   stack. They preflight this limit with a parent-linked walk and raise before producing output. */
+#define TH_MAX_RECURSIVE_RENDER_DEPTH ((Py_ssize_t)(TH_MAX_TREE_DEPTH * 2))
 
 enum th_node_type {
     TH_NODE_DOCUMENT,
@@ -126,6 +120,32 @@ struct th_node {
     th_node_attr *attrs;
     Py_ssize_t attr_count;
 };
+
+/* Reject an unsafe recursive consumer before it allocates output, invokes callbacks, or mutates the tree. */
+static inline int th_node_check_max_depth(th_node *root, Py_ssize_t limit, const char *operation) {
+    th_node *node = root;
+    Py_ssize_t depth = 0;
+    for (;;) {
+        if (depth >= limit) {
+            PyErr_Format(PyExc_RecursionError, "%s does not support trees nested %zd levels or deeper", operation,
+                         limit);
+            return -1;
+        }
+        if (node->first_child != NULL) {
+            node = node->first_child;
+            depth++;
+            continue;
+        }
+        while (node != root && node->next_sibling == NULL) {
+            node = node->parent;
+            depth--;
+        }
+        if (node == root) {
+            return 0;
+        }
+        node = node->next_sibling;
+    }
+}
 
 typedef struct th_tree th_tree;
 
@@ -311,13 +331,12 @@ th_node *th_tree_copy_node(th_tree *dest, th_tree *src, th_node *src_node);
 
 /* Whether two subtrees are structurally equal: same node type, and for an element the
    same namespace, tag name, and attribute set (names + values, order-independent) with
-   the same ordered children compared recursively; for a leaf the same character data.
+   the same ordered children; for a leaf the same character data.
    The two nodes may live in different trees. Pure structure -- it never touches node
    identity (the `==` operator's domain). */
 int th_node_equals(th_tree *left_tree, th_node *left, th_tree *right_tree, th_node *right);
 
-/* DOM normalize over a subtree: merge each run of adjacent Text children into one
-   node and drop empty Text nodes, recursing into every element. */
+/* DOM normalize over a subtree: merge each run of adjacent Text children into one node and drop empty Text nodes. */
 void th_node_normalize(th_tree *tree, th_node *root);
 
 /* Parse an HTML fragment as if set as the innerHTML of the given context element

--- a/src/turbohtml/_c/extract/readability.c
+++ b/src/turbohtml/_c/extract/readability.c
@@ -216,30 +216,62 @@ static int read_should_skip(th_tree *tree, th_node *node, int strip_landmarks) {
     return 0;
 }
 
+static th_node *read_preorder_next(th_node *node, th_node *root) {
+    if (node->type == TH_NODE_ELEMENT && node->first_child != NULL) {
+        return node->first_child;
+    }
+    while (node != root && node->next_sibling == NULL) {
+        node = node->parent;
+    }
+    return node == root ? NULL : node->next_sibling;
+}
+
+/* Advance after visiting node, pruning the subtrees the readability scoring walk ignores. */
+static th_node *read_visible_next(th_tree *tree, th_node *node, th_node *root, int strip_landmarks) {
+    if (node->type == TH_NODE_ELEMENT && !read_should_skip(tree, node, strip_landmarks) && node->first_child != NULL) {
+        return node->first_child;
+    }
+    while (node != root && node->next_sibling == NULL) {
+        node = node->parent;
+    }
+    return node == root ? NULL : node->next_sibling;
+}
+
 /* Accumulate the text statistics over node's subtree, excluding boilerplate
    subtrees; text inside an <a> also counts toward link_chars. `strip_landmarks`
    mirrors the walk so a retry that keeps landmarks also counts their text. */
 static void read_text_stats(th_tree *tree, th_node *node, int in_anchor, int strip_landmarks, read_stats *stats) {
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type == TH_NODE_TEXT) {
-            stats->chars += child->text_len;
-            if (in_anchor) {
-                stats->link_chars += child->text_len;
+    th_node *current = node->first_child;
+    while (current != NULL) {
+        if (current->type == TH_NODE_TEXT) {
+            stats->chars += current->text_len;
+            if (in_anchor > 0) {
+                stats->link_chars += current->text_len;
             }
-            if (child->text_len > 0) {
-                const Py_UCS4 *text = need_text(tree, child);
-                for (Py_ssize_t index = 0; index < child->text_len; index++) {
+            if (current->text_len > 0) {
+                const Py_UCS4 *text = need_text(tree, current);
+                for (Py_ssize_t index = 0; index < current->text_len; index++) {
                     if (text[index] == ',') {
                         stats->commas++;
                     }
                 }
             }
-        } else if (child->type == TH_NODE_ELEMENT) {
-            if (child->ns != TH_NS_HTML || read_is_skip_tag(child->atom, strip_landmarks)) {
-                continue;
-            }
-            read_text_stats(tree, child, in_anchor || child->atom == TH_TAG_A, strip_landmarks, stats);
         }
+        if (current->type == TH_NODE_ELEMENT && current->ns == TH_NS_HTML &&
+            !read_is_skip_tag(current->atom, strip_landmarks) && current->first_child != NULL) {
+            if (current->atom == TH_TAG_A) {
+                in_anchor++;
+            }
+            current = current->first_child;
+            continue;
+        }
+        while (current != node && current->next_sibling == NULL) {
+            current = current->parent;
+            if (current != node && current->atom == TH_TAG_A) {
+                in_anchor--;
+            }
+        }
+        current = current == node ? NULL : current->next_sibling;
     }
 }
 
@@ -302,19 +334,21 @@ static void read_score_paragraph(read_scorer *scorer, th_node *paragraph, th_nod
     }
 }
 
-/* Walk node's element children, scoring paragraphs against their parent (node, when
-   it is an element) and grandparent (the nearest enclosing element above node). */
-static void read_walk(read_scorer *scorer, th_node *node, th_node *grandparent) {
-    int node_is_element = node->type == TH_NODE_ELEMENT;
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type != TH_NODE_ELEMENT || read_should_skip(scorer->tree, child, scorer->strip_landmarks)) {
+static void read_walk(read_scorer *scorer, th_node *root) {
+    for (th_node *node = root->first_child; node != NULL;
+         node = read_visible_next(scorer->tree, node, root, scorer->strip_landmarks)) {
+        if (node->type != TH_NODE_ELEMENT || read_should_skip(scorer->tree, node, scorer->strip_landmarks)) {
             continue;
         }
-        if (node_is_element &&
-            read_atom_in(child->atom, read_paragraph_tags, sizeof(read_paragraph_tags) / sizeof(uint16_t))) {
-            read_score_paragraph(scorer, child, node, grandparent);
+        th_node *parent = node->parent;
+        if (parent->type == TH_NODE_ELEMENT &&
+            read_atom_in(node->atom, read_paragraph_tags, sizeof(read_paragraph_tags) / sizeof(uint16_t))) {
+            th_node *grandparent = parent->parent;
+            while (grandparent != NULL && grandparent->type != TH_NODE_ELEMENT) {
+                grandparent = grandparent->parent;
+            }
+            read_score_paragraph(scorer, node, parent, grandparent);
         }
-        read_walk(scorer, child, node_is_element ? node : grandparent);
     }
 }
 
@@ -343,23 +377,22 @@ typedef struct {
     double effective;
 } read_pick;
 
-static void read_scan_containers(read_scorer *scorer, th_node *node, uint16_t wanted, read_pick *pick) {
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type != TH_NODE_ELEMENT || read_should_skip(scorer->tree, child, 1)) {
+static void read_scan_containers(read_scorer *scorer, th_node *root, uint16_t wanted, read_pick *pick) {
+    for (th_node *node = root->first_child; node != NULL; node = read_visible_next(scorer->tree, node, root, 1)) {
+        if (node->type != TH_NODE_ELEMENT || read_should_skip(scorer->tree, node, 1)) {
             continue;
         }
-        if (child->atom == wanted) {
+        if (node->atom == wanted) {
             read_stats stats = {0, 0, 0};
-            read_text_stats(scorer->tree, child, 0, 1, &stats);
+            read_text_stats(scorer->tree, node, 0, 1, &stats);
             if (stats.chars >= READ_FALLBACK_MIN_CHARS) {
                 double effective = (double)stats.chars - (double)stats.link_chars;
                 if (effective > pick->effective) {
                     pick->effective = effective;
-                    pick->node = child;
+                    pick->node = node;
                 }
             }
         }
-        read_scan_containers(scorer, child, wanted, pick);
     }
 }
 
@@ -386,12 +419,12 @@ static th_node *read_semantic_fallback(read_scorer *scorer, th_node *root) {
    surface an explicit <article>/<main> body that carries no scoring paragraph. */
 th_node *th_node_main_content(th_tree *tree, th_node *root) {
     read_scorer scorer = {tree, NULL, 0, 0, 1};
-    read_walk(&scorer, root, NULL);
+    read_walk(&scorer, root);
     th_node *best = read_best(&scorer);
     if (best == NULL) {
         scorer.count = 0;
         scorer.strip_landmarks = 0;
-        read_walk(&scorer, root, NULL);
+        read_walk(&scorer, root);
         best = read_best(&scorer);
     }
     if (best == NULL) {
@@ -452,16 +485,12 @@ typedef int (*read_match_fn)(th_tree *tree, th_node *node, const void *ctx);
 /* The first HTML element under root (document order, depth first) the predicate
    accepts, or NULL when none matches. */
 static th_node *read_find(th_tree *tree, th_node *root, read_match_fn match, const void *ctx) {
-    for (th_node *child = root->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type != TH_NODE_ELEMENT) {
+    for (th_node *node = root->first_child; node != NULL; node = read_preorder_next(node, root)) {
+        if (node->type != TH_NODE_ELEMENT) {
             continue;
         }
-        if (match(tree, child, ctx)) {
-            return child;
-        }
-        th_node *found = read_find(tree, child, match, ctx);
-        if (found != NULL) {
-            return found;
+        if (match(tree, node, ctx)) {
+            return node;
         }
     }
     return NULL;
@@ -756,22 +785,19 @@ static int read_social_visit_meta(th_tree *tree, th_node *meta, read_social *out
    here keeps it independent of body size. Returns -1 only on the excluded
    allocation-failure path. */
 static int read_walk_social(th_tree *tree, th_node *root, read_social *out) {
-    for (th_node *child = root->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type != TH_NODE_ELEMENT) {
+    for (th_node *node = root->first_child; node != NULL; node = read_preorder_next(node, root)) {
+        if (node->type != TH_NODE_ELEMENT) {
             continue;
         }
-        if (child->atom == TH_TAG_META) {
-            if (read_social_visit_meta(tree, child, out) < 0) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
-                return -1;                                      /* GCOVR_EXCL_LINE: allocation-failure path */
+        if (node->atom == TH_TAG_META) {
+            if (read_social_visit_meta(tree, node, out) < 0) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
+                return -1;                                     /* GCOVR_EXCL_LINE: allocation-failure path */
             }
-        } else if (child->atom == TH_TAG_LINK && out->canonical == NULL) {
-            Py_ssize_t rel = th_node_attr_find(tree, child, "rel", 3);
-            if (rel >= 0 && read_rel_has_token(child->attrs[rel].value, child->attrs[rel].value_len, "canonical")) {
-                out->canonical = read_attr_value(tree, child, "href", 4, &out->canonical_len);
+        } else if (node->atom == TH_TAG_LINK && out->canonical == NULL) {
+            Py_ssize_t rel = th_node_attr_find(tree, node, "rel", 3);
+            if (rel >= 0 && read_rel_has_token(node->attrs[rel].value, node->attrs[rel].value_len, "canonical")) {
+                out->canonical = read_attr_value(tree, node, "href", 4, &out->canonical_len);
             }
-        }
-        if (read_walk_social(tree, child, out) < 0) { /* GCOVR_EXCL_BR_LINE: allocation-failure path */
-            return -1;                                /* GCOVR_EXCL_LINE: allocation-failure path */
         }
     }
     return 0;

--- a/src/turbohtml/_c/extract/structured_data.c
+++ b/src/turbohtml/_c/extract/structured_data.c
@@ -23,6 +23,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define STRUCTURED_DATA_MAX_RECURSIVE_DEPTH ((Py_ssize_t)400)
+
 /* The HTML script type that flags a JSON-LD block, matched case-insensitively after trimming. */
 static const char JSON_LD_TYPE[] = "application/ld+json";
 
@@ -555,11 +557,10 @@ done:
     return status;
 }
 
-/* Steal `value` into slot `index` of `tuple`, returning -1 only on the excluded allocation-failure path (a NULL value
-   the section builder could not allocate). */
+/* Steal `value` into slot `index` of `tuple`, returning -1 when its section builder failed. */
 static int tuple_set_or_fail(PyObject *tuple, Py_ssize_t index, PyObject *value) {
-    if (value == NULL) { /* GCOVR_EXCL_BR_LINE: the section is built only from unforceable allocations */
-        return -1;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    if (value == NULL) { /* GCOVR_EXCL_BR_LINE: only allocation failure or a mutation timed between locked passes */
+        return -1;       /* GCOVR_EXCL_LINE: unforceable failure timing */
     }
     PyTuple_SET_ITEM(tuple, index, value);
     return 0;
@@ -712,7 +713,7 @@ static PyObject *gather_opengraph(PyObject *self, PyObject *base) {
 /* Build one MicrodataItem for every top-level Microdata item (an element with itemscope and no itemprop, so it is not a
    property of another item). URL-valued properties are absolutized against `base` when the caller passed one (base is
    NULL otherwise, leaving values verbatim). NULL only on the excluded allocation-failure path. */
-static PyObject *gather_microdata(PyObject *self, PyObject *base) {
+static PyObject *gather_microdata(PyObject *self, PyObject *base, int check_depth) {
     PyObject *items = PyList_New(0);
     if (items == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -722,21 +723,24 @@ static PyObject *gather_microdata(PyObject *self, PyObject *base) {
     micro_ctx ctx = {state_of(self), tree, base, {NULL, 0, 0}};
     int failed = 0;
     Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
-    for (th_node *node = root->first_child; node != NULL; node = preorder_next(node, root)) {
-        if (node->type != TH_NODE_ELEMENT || find_node_attr(node, TH_ATTR_ITEMSCOPE) == NULL ||
-            find_node_attr(node, TH_ATTR_ITEMPROP) != NULL) {
-            continue;
-        }
-        PyObject *item = build_item(&ctx, node);
-        if (item == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-            failed = 1;     /* GCOVR_EXCL_LINE: allocation-failure path */
-            break;          /* GCOVR_EXCL_LINE */
-        }
-        int append_failed = PyList_Append(items, item) < 0;
-        Py_DECREF(item);
-        if (append_failed) { /* GCOVR_EXCL_BR_LINE: append fails only on unforceable allocation */
-            failed = 1;      /* GCOVR_EXCL_LINE: allocation-failure path */
-            break;           /* GCOVR_EXCL_LINE */
+    failed = check_depth && th_node_check_max_depth(root, STRUCTURED_DATA_MAX_RECURSIVE_DEPTH, "microdata()") < 0;
+    if (!failed) {
+        for (th_node *node = root->first_child; node != NULL; node = preorder_next(node, root)) {
+            if (node->type != TH_NODE_ELEMENT || find_node_attr(node, TH_ATTR_ITEMSCOPE) == NULL ||
+                find_node_attr(node, TH_ATTR_ITEMPROP) != NULL) {
+                continue;
+            }
+            PyObject *item = build_item(&ctx, node);
+            if (item == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                failed = 1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+                break;          /* GCOVR_EXCL_LINE */
+            }
+            int append_failed = PyList_Append(items, item) < 0;
+            Py_DECREF(item);
+            if (append_failed) { /* GCOVR_EXCL_BR_LINE: append fails only on unforceable allocation */
+                failed = 1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+                break;           /* GCOVR_EXCL_LINE */
+            }
         }
     }
     Py_END_CRITICAL_SECTION();
@@ -1265,7 +1269,7 @@ static int walk_rdfa(th_tree *tree, module_state *state, th_node *element, rdfa_
 
 /* Build one RdfaItem for every top-level RDFa resource, absolutizing IRIs against `base` when the caller passed one.
    NULL only on the excluded allocation-failure path. */
-static PyObject *gather_rdfa(PyObject *self, PyObject *base) {
+static PyObject *gather_rdfa(PyObject *self, PyObject *base, int check_depth) {
     PyObject *items = PyList_New(0);
     if (items == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
@@ -1277,7 +1281,10 @@ static PyObject *gather_rdfa(PyObject *self, PyObject *base) {
     Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
     /* A document that never interns a typeof attribute carries no RDFa resource, so skip the walk and the prefix map it
        would need -- this is the whole cost of the RDFa pass on the pages (most of them) that use no RDFa. */
-    if (th_attr_lookup(tree, "typeof", 6) != UINT32_MAX) {
+    int has_rdfa = th_attr_lookup(tree, "typeof", 6) != UINT32_MAX;
+    failed =
+        has_rdfa && check_depth && th_node_check_max_depth(root, STRUCTURED_DATA_MAX_RECURSIVE_DEPTH, "rdfa()") < 0;
+    if (has_rdfa && !failed) {
         PyObject *prefixes = build_default_prefixes();
         failed = prefixes == NULL; /* the build fails only on unforceable allocation */
         if (prefixes != NULL) {    /* GCOVR_EXCL_BR_LINE: the build fails only on unforceable allocation */
@@ -1508,7 +1515,7 @@ PyObject *turbohtml_document_microdata(PyObject *self, PyObject *args, PyObject 
     if (parse_base_url(self, args, kwargs, "|O:microdata", &base) < 0) {
         return NULL;
     }
-    PyObject *result = gather_microdata(self, base);
+    PyObject *result = gather_microdata(self, base, 1);
     Py_XDECREF(base);
     return result;
 }
@@ -1519,7 +1526,7 @@ PyObject *turbohtml_document_rdfa(PyObject *self, PyObject *args, PyObject *kwar
     if (parse_base_url(self, args, kwargs, "|O:rdfa", &base) < 0) {
         return NULL;
     }
-    PyObject *result = gather_rdfa(self, base);
+    PyObject *result = gather_rdfa(self, base, 1);
     Py_XDECREF(base);
     return result;
 }
@@ -1539,21 +1546,30 @@ PyObject *turbohtml_document_structured_data(PyObject *self, PyObject *args, PyO
     if (parse_base_url(self, args, kwargs, "|O:structured_data", &base) < 0) {
         return NULL;
     }
+    int safe;
+    Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
+    safe =
+        th_node_check_max_depth(((NodeObject *)self)->node, STRUCTURED_DATA_MAX_RECURSIVE_DEPTH, "structured_data()");
+    Py_END_CRITICAL_SECTION();
+    if (safe < 0) {
+        Py_XDECREF(base);
+        return NULL;
+    }
     PyObject *sections = PyTuple_New(6);
     if (sections == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         Py_XDECREF(base);   /* GCOVR_EXCL_LINE: allocation-failure path */
         return NULL;        /* GCOVR_EXCL_LINE */
     }
-    int failed = 0;
-    failed |= tuple_set_or_fail(sections, 0, turbohtml_document_json_ld(self, NULL));
-    failed |= tuple_set_or_fail(sections, 1, gather_microdata(self, base));
-    failed |= tuple_set_or_fail(sections, 2, gather_opengraph(self, base));
-    failed |= tuple_set_or_fail(sections, 3, PyList_New(0));
-    failed |= tuple_set_or_fail(sections, 4, gather_rdfa(self, base));
-    failed |= tuple_set_or_fail(sections, 5, gather_dublin_core(self));
+    /* A section fails only after an allocation failure or a mutation between separately locked passes. */
+    int failed = tuple_set_or_fail(sections, 0, turbohtml_document_json_ld(self, NULL)) < 0 || /* GCOVR_EXCL_BR_LINE */
+                 tuple_set_or_fail(sections, 1, gather_microdata(self, base, 0)) < 0 ||        /* GCOVR_EXCL_BR_LINE */
+                 tuple_set_or_fail(sections, 2, gather_opengraph(self, base)) < 0 ||           /* GCOVR_EXCL_BR_LINE */
+                 tuple_set_or_fail(sections, 3, PyList_New(0)) < 0 ||                          /* GCOVR_EXCL_BR_LINE */
+                 tuple_set_or_fail(sections, 4, gather_rdfa(self, base, 0)) < 0 ||             /* GCOVR_EXCL_BR_LINE */
+                 tuple_set_or_fail(sections, 5, gather_dublin_core(self)) < 0;
     Py_XDECREF(base);
-    if (failed != 0) {       /* GCOVR_EXCL_BR_LINE: a section build fails only on unforceable allocation */
-        Py_DECREF(sections); /* GCOVR_EXCL_LINE: allocation-failure path */
+    if (failed) {            /* GCOVR_EXCL_BR_LINE: only allocation failure or concurrent mutation between passes */
+        Py_DECREF(sections); /* GCOVR_EXCL_LINE: unforceable failure timing */
         return NULL;         /* GCOVR_EXCL_LINE */
     }
     PyObject *result = PyObject_Call(state_of(self)->structured_data_type, sections, NULL);

--- a/src/turbohtml/_c/query/find.c
+++ b/src/turbohtml/_c/query/find.c
@@ -31,9 +31,10 @@ typedef struct {
     /* Fast path for a plain-string tag filter: resolve the name to an atom once
        so the per-node test is an integer compare instead of building a str for
        every element. tag_plain is set when tag is a single str; tag_atom is its
-       atom, or TH_TAG_UNKNOWN for a name outside the table (then the rare
-       unknown-atom elements are compared by name). */
+       atom, or TH_TAG_UNKNOWN for a name outside the table. XML names always
+       use the exact-name path, including names present in the HTML atom table. */
     int tag_plain;
+    int tag_exact;
     uint16_t tag_atom;
     /* Fast path for a plain-string class_ filter: its code points are copied
        once so each element's class tokens are compared without building a str
@@ -216,16 +217,10 @@ static int tag_plain_matches(const query_t *query, th_node *node) {
     if (query->tag_atom != TH_TAG_UNKNOWN) {
         return node->atom == query->tag_atom;
     }
-    if (node->atom != TH_TAG_UNKNOWN) {
+    if (!query->tag_exact && node->atom != TH_TAG_UNKNOWN) {
         return 0;
     }
-    PyObject *name = ucs4_to_str(node->text, node->text_len);
-    if (name == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
-    int equal = PyUnicode_Compare(name, query->tag) == 0;
-    Py_DECREF(name);
-    return equal;
+    return ucs4_equals_pystr(node->text, node->text_len, query->tag);
 }
 
 /* Whether an element matches the whole query. Returns 1/0, or -1 with an
@@ -431,6 +426,7 @@ static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_
     query->filter_plain = NULL;
     query->nattr = 0;
     query->tag_plain = 0;
+    query->tag_exact = 0;
     query->tag_atom = TH_TAG_UNKNOWN;
     query->class_ucs4 = NULL;
     query->class_len = 0;
@@ -441,17 +437,18 @@ static int build_query(PyObject *self, PyObject *args, PyObject *kwargs, int is_
     }
     if (tag != NULL && tag != Py_None) {
         query->tag = tag;
-        /* a plain str tag matches by interned atom; encode case-sensitively (a
-           find() name match is exact, unlike a case-insensitive CSS type) */
         if (PyUnicode_Check(tag)) {
-            Py_ssize_t blen;
-            const char *bytes = PyUnicode_AsUTF8AndSize(tag, &blen);
-            if (bytes == NULL) {
-                /* a lone surrogate cannot encode; fall back to the str-compare path */
-                PyErr_Clear();
-            } else {
-                query->tag_plain = 1;
-                query->tag_atom = blen > 0 ? th_tag_lookup(bytes, blen) : TH_TAG_UNKNOWN;
+            query->tag_plain = 1;
+            query->tag_exact = th_tree_is_xml(tree);
+            if (!query->tag_exact) {
+                Py_ssize_t blen;
+                const char *bytes = PyUnicode_AsUTF8AndSize(tag, &blen);
+                if (bytes == NULL) {
+                    /* A lone surrogate cannot encode, so the exact-name path handles it. */
+                    PyErr_Clear();
+                } else {
+                    query->tag_atom = blen > 0 ? th_tag_lookup(bytes, blen) : TH_TAG_UNKNOWN;
+                }
             }
         }
     }

--- a/src/turbohtml/_c/query/find.c
+++ b/src/turbohtml/_c/query/find.c
@@ -636,11 +636,9 @@ static int snapshot_text_candidates(PyObject *self, const query_t *query, th_nod
    span, so a candidate's collected text is sized before it is gathered. */
 static Py_ssize_t subtree_text_len(th_node *node) {
     Py_ssize_t total = 0;
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type == TH_NODE_TEXT) {
-            total += child->text_len;
-        } else if (child->type == TH_NODE_ELEMENT || child->type == TH_NODE_CONTENT) {
-            total += subtree_text_len(child);
+    for (th_node *descendant = node->first_child; descendant != NULL; descendant = preorder_next(descendant, node)) {
+        if (descendant->type == TH_NODE_TEXT) {
+            total += descendant->text_len;
         }
     }
     return total;

--- a/src/turbohtml/_c/query/xslt.c
+++ b/src/turbohtml/_c/query/xslt.c
@@ -44,7 +44,7 @@ static int xb_reserve(xb *buf, Py_ssize_t extra) {
     size_t cap;
     size_t bytes;
     /* Size overflow needs a length no allocation could hold. */
-    int fits = th_grow_cap((size_t)(buf->len + extra), (size_t)buf->cap, 16, sizeof(Py_UCS4), &cap, &bytes);
+    int fits = th_grow_cap((size_t)buf->len + (size_t)extra, (size_t)buf->cap, 16, sizeof(Py_UCS4), &cap, &bytes);
     if (!fits) {   /* GCOVR_EXCL_BR_LINE */
         return -1; /* GCOVR_EXCL_LINE */
     }
@@ -3943,24 +3943,30 @@ static int rule_order(const void *left_ptr, const void *right_ptr) {
 
 /* ---- output serialization ------------------------------------------------- */
 
+static th_node *xslt_preorder_next(th_node *root, th_node *node) {
+    if (node->first_child != NULL) {
+        return node->first_child;
+    }
+    while (node != root && node->next_sibling == NULL) {
+        node = node->parent;
+    }
+    return node == root ? NULL : node->next_sibling;
+}
+
 /* Append the text of every Text descendant of node, in document order. */
 static int collect_output_text(th_node *node, xb *buffer) {
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type == TH_NODE_TEXT) {
-            if (xb_add(buffer, child->text, child->text_len) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                return -1;                                          /* GCOVR_EXCL_LINE */
-            }
-        } else if (collect_output_text(child, buffer) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-            return -1;                                       /* GCOVR_EXCL_LINE */
+    for (th_node *child = node->first_child; child != NULL; child = xslt_preorder_next(node, child)) {
+        if (child->type == TH_NODE_TEXT && /* GCOVR_EXCL_BR_LINE: the second condition fails only on allocation */
+            xb_add(buffer, child->text, child->text_len) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+            return -1;                                          /* GCOVR_EXCL_LINE */
         }
     }
     return 0;
 }
 
-/* Retype every direct text-node child of a cdata-section-elements element to a CDATA node so
-   the serializer wraps it in <![CDATA[...]]> (section 16.1). Recurses the output tree. */
+/* Retype direct text children of cdata-section-elements so the serializer wraps them in CDATA. */
 static void apply_cdata_sections(engine *eng, th_node *node) {
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+    for (th_node *child = node->first_child; child != NULL; child = xslt_preorder_next(node, child)) {
         if (child->type != TH_NODE_ELEMENT) {
             continue;
         }
@@ -3971,7 +3977,6 @@ static void apply_cdata_sections(engine *eng, th_node *node) {
                 }
             }
         }
-        apply_cdata_sections(eng, child);
     }
 }
 
@@ -4291,31 +4296,75 @@ static int strip_record(engine *eng, th_node *node, th_node *parent, th_node *ne
     return 0;
 }
 
-/* Detach every strippable whitespace-only text node under element in document order, honoring
-   an inherited xml:space="preserve" (nearest xml:space ancestor wins). Recurses into children. */
-static int strip_walk(engine *eng, th_node *element, int inherited_preserve) {
+typedef struct {
+    th_node *element;
+    th_node *child;
+    int preserve;
+    int strips;
+} strip_frame;
+
+static int strip_push(engine *eng, strip_frame **frames, size_t *length, size_t *capacity, th_node *element,
+                      int inherited_preserve) {
+    if (*length == *capacity) {
+        size_t grown_capacity;
+        size_t bytes;
+        /* Source depth cannot exhaust size_t. */
+        /* GCOVR_EXCL_BR_START */
+        if (!th_grow_cap(*length + 1, *capacity, 16, sizeof(strip_frame), &grown_capacity, &bytes)) {
+            return fail(eng, "out of memory"); /* GCOVR_EXCL_LINE */
+        }
+        /* GCOVR_EXCL_BR_STOP */
+        strip_frame *grown = PyMem_Realloc(*frames, bytes);
+        if (grown == NULL) {                   /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+            return fail(eng, "out of memory"); /* GCOVR_EXCL_LINE */
+        }
+        *frames = grown;
+        *capacity = grown_capacity;
+    }
     int preserve = inherited_preserve;
     Py_ssize_t xmlspace_len = 0;
     const Py_UCS4 *xmlspace = attr_lookup(eng->src_tree, element, "xml:space", &xmlspace_len);
     if (xmlspace != NULL) {
         preserve = ucs4_ascii_eq(xmlspace, xmlspace_len, "preserve");
     }
-    int strips = !preserve && element_strips_space(eng, element);
-    th_node *child = element->first_child;
-    while (child != NULL) {
-        th_node *next = child->next_sibling;
+    (*frames)[(*length)++] =
+        (strip_frame){element, element->first_child, preserve, !preserve && element_strips_space(eng, element)};
+    return 0;
+}
+
+/* Detach strippable whitespace text in document order while tracking inherited xml:space on a heap stack. */
+static int strip_walk(engine *eng, th_node *element, int inherited_preserve) {
+    strip_frame *frames = NULL;
+    size_t length = 0;
+    size_t capacity = 0;
+    int push_failed = strip_push(eng, &frames, &length, &capacity, element, inherited_preserve);
+    if (push_failed < 0) {  /* GCOVR_EXCL_BR_LINE: failure requires allocation exhaustion */
+        PyMem_Free(frames); /* GCOVR_EXCL_LINE */
+        return -1;          /* GCOVR_EXCL_LINE */
+    }
+    while (length > 0) {
+        strip_frame *frame = &frames[length - 1];
+        if (frame->child == NULL) {
+            length--;
+            continue;
+        }
+        th_node *child = frame->child;
+        frame->child = child->next_sibling;
         if (child->type == TH_NODE_TEXT) {
-            if (strips && th_node_text_is_blank(eng->src_tree, child)) {
-                if (strip_record(eng, child, element, next) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
-                    return -1;                                     /* GCOVR_EXCL_LINE */
+            if (frame->strips && th_node_text_is_blank(eng->src_tree, child)) {
+                if (strip_record(eng, child, frame->element, frame->child) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+                    PyMem_Free(frames);                                           /* GCOVR_EXCL_LINE */
+                    return -1;                                                    /* GCOVR_EXCL_LINE */
                 }
                 th_node_remove(child);
             }
-        } else if (child->type == TH_NODE_ELEMENT && strip_walk(eng, child, preserve) < 0) { /* GCOVR_EXCL_BR_LINE */
-            return -1;                                                                       /* GCOVR_EXCL_LINE */
+        } else if (child->type == TH_NODE_ELEMENT && /* GCOVR_EXCL_BR_LINE: failure requires allocation exhaustion */
+                   strip_push(eng, &frames, &length, &capacity, child, frame->preserve) < 0) {
+            PyMem_Free(frames); /* GCOVR_EXCL_LINE */
+            return -1;          /* GCOVR_EXCL_LINE */
         }
-        child = next;
     }
+    PyMem_Free(frames);
     return 0;
 }
 

--- a/src/turbohtml/_c/serialize/document.c
+++ b/src/turbohtml/_c/serialize/document.c
@@ -492,18 +492,20 @@ int th_node_doctype_ids(th_node *node, const Py_UCS4 **public_id, Py_ssize_t *pu
     return 1;
 }
 
-static void collect_text(sbuf *out, th_tree *tree, th_node *node, int depth) {
-    if (depth >= TH_MAX_WALK_DEPTH) {
-        /* Backstop against a tree built past the parser's depth cap through the
-           mutation API: stop collecting rather than overflow the C stack. A parsed
-           tree never reaches this depth. */
-        return;
+static th_node *text_preorder_next(th_node *node, th_node *root) {
+    if (node->first_child != NULL) {
+        return node->first_child;
     }
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type == TH_NODE_TEXT) {
-            sbuf_put_ucs4(out, need_text(tree, child), child->text_len);
-        } else if (child->type == TH_NODE_ELEMENT || child->type == TH_NODE_CONTENT) {
-            collect_text(out, tree, child, depth + 1);
+    while (node != root && node->next_sibling == NULL) {
+        node = node->parent;
+    }
+    return node == root ? NULL : node->next_sibling;
+}
+
+static void collect_text(sbuf *out, th_tree *tree, th_node *root) {
+    for (th_node *node = root->first_child; node != NULL; node = text_preorder_next(node, root)) {
+        if (node->type == TH_NODE_TEXT) {
+            sbuf_put_ucs4(out, need_text(tree, node), node->text_len);
         }
     }
 }
@@ -513,7 +515,7 @@ Py_UCS4 *th_node_text(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
     if (node->type == TH_NODE_TEXT) {
         sbuf_put_ucs4(&out, need_text(tree, node), node->text_len);
     } else {
-        collect_text(&out, tree, node, 0);
+        collect_text(&out, tree, node);
     }
     return sbuf_finish(&out, out_len);
 }
@@ -522,20 +524,18 @@ Py_UCS4 *th_node_text(th_tree *tree, th_node *node, Py_ssize_t *out_len) {
    zero-copy spans on the way; the caller sizes buf to the subtree's text length.
    The find(text=) C scan reuses one buffer across candidates so no per-node str is
    built; a Text or Content child of a content fragment is descended like an element. */
-static Py_ssize_t collect_text_into(th_tree *tree, th_node *node, Py_UCS4 *buf, Py_ssize_t pos) {
-    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
-        if (child->type == TH_NODE_TEXT) {
-            memcpy(buf + pos, need_text(tree, child), (size_t)child->text_len * sizeof(Py_UCS4));
-            pos += child->text_len;
-        } else if (child->type == TH_NODE_ELEMENT || child->type == TH_NODE_CONTENT) {
-            pos = collect_text_into(tree, child, buf, pos);
+static void collect_text_into(th_tree *tree, th_node *root, Py_UCS4 *buf) {
+    Py_ssize_t pos = 0;
+    for (th_node *node = root->first_child; node != NULL; node = text_preorder_next(node, root)) {
+        if (node->type == TH_NODE_TEXT) {
+            memcpy(buf + pos, need_text(tree, node), (size_t)node->text_len * sizeof(Py_UCS4));
+            pos += node->text_len;
         }
     }
-    return pos;
 }
 
 void th_node_collect_text(th_tree *tree, th_node *node, Py_UCS4 *buf) {
-    collect_text_into(tree, node, buf, 0);
+    collect_text_into(tree, node, buf);
 }
 
 /* The WHATWG-conformant defaults the html/inner_html accessors serialize under:

--- a/src/turbohtml/_c/serialize/internal.h
+++ b/src/turbohtml/_c/serialize/internal.h
@@ -27,6 +27,12 @@
 #define MAX_SORTED_ATTRS 64
 #define MAX_ATTR_NAME 128
 
+/* The Markdown and layout-text renderers have paired entry/exit state spread across their recursive dispatch. Reject a
+   tree that cannot enter that renderer safely before converters run or an output buffer is allocated. */
+static inline int ser_check_recursive_depth(th_node *root, const char *operation) {
+    return th_node_check_max_depth(root, TH_MAX_RECURSIVE_RENDER_DEPTH, operation);
+}
+
 /* The escape policy serialize()/encode() expose through the Formatter enum. */
 enum th_formatter {
     TH_FMT_WHATWG,  /* conformant minimal escaping: & < > nbsp in text, & " nbsp in attrs */

--- a/src/turbohtml/_c/serialize/markdown.c
+++ b/src/turbohtml/_c/serialize/markdown.c
@@ -25,9 +25,6 @@
 
 #include <string.h>
 
-/* Keep the depth-guard wrappers out of line: inlined into their many call sites,
-   the compiler emits a separate branch counter per copy and the guard-taken edge
-   reads as uncovered in all but the one copy a deep tree exercises. */
 /* Whether an element's own Markdown markup is dropped under the strip/convert
    filter, leaving its children to render transparently in the surrounding flow.
    A strip set names the tags to drop; a convert set names the only tags to keep,
@@ -124,7 +121,6 @@ typedef struct {
     int list_depth;       /* nesting depth of the current list, for bullet cycling */
     int g_bold;           /* google_doc: a CSS font-weight bold is in force from an ancestor */
     int g_italic;         /* google_doc: a CSS font-style italic is in force from an ancestor */
-    int depth;            /* block/inline recursion depth, bounded by TH_MAX_WALK_DEPTH */
     int failed;           /* a reference buffer allocation failed */
 } md_ctx;
 
@@ -944,13 +940,7 @@ static void md_render_google(md_ctx *ctx, th_node *node) {
    flow (rare, e.g. a <div> inside a <span>) is laid out as its own block. */
 static void md_render_inline_body(md_ctx *ctx, th_node *node);
 static TH_NOINLINE void md_render_inline(md_ctx *ctx, th_node *node) {
-    if (ctx->depth >= TH_MAX_WALK_DEPTH) {
-        /* backstop for a tree built past the parser's depth cap; see TH_MAX_WALK_DEPTH */
-        return;
-    }
-    ctx->depth++;
     md_render_inline_body(ctx, node);
-    ctx->depth--;
 }
 static void md_render_inline_body(md_ctx *ctx, th_node *node) {
     if (node->type == TH_NODE_TEXT) {
@@ -1716,13 +1706,7 @@ static void md_render_pre(md_ctx *ctx, th_node *node) {
 
 static void md_render_block_body(md_ctx *ctx, th_node *node);
 static TH_NOINLINE void md_render_block(md_ctx *ctx, th_node *node) {
-    if (ctx->depth >= TH_MAX_WALK_DEPTH) {
-        /* backstop for a tree built past the parser's depth cap; see TH_MAX_WALK_DEPTH */
-        return;
-    }
-    ctx->depth++;
     md_render_block_body(ctx, node);
-    ctx->depth--;
 }
 static void md_render_block_body(md_ctx *ctx, th_node *node) {
     if (md_apply_converter(ctx, node)) {
@@ -1856,6 +1840,9 @@ static void md_flush_references(md_ctx *ctx) {
 }
 
 Py_UCS4 *th_node_markdown(th_tree *tree, th_node *node, const md_opts *opt, Py_ssize_t *out_len) {
+    if (ser_check_recursive_depth(node, "to_markdown()") < 0) {
+        return NULL;
+    }
     md_ctx ctx = {0};
     ctx.tree = tree;
     ctx.opt = opt;

--- a/src/turbohtml/_c/serialize/text.c
+++ b/src/turbohtml/_c/serialize/text.c
@@ -782,6 +782,9 @@ static void text_render_root(text_ctx *ctx, th_node *node) {
 }
 
 Py_UCS4 *th_node_layout_text(th_tree *tree, th_node *node, const text_opts *opt, Py_ssize_t *out_len) {
+    if (ser_check_recursive_depth(node, "to_text()") < 0) {
+        return NULL;
+    }
     text_ctx ctx = {0};
     ctx.tree = tree;
     ctx.opt = opt;
@@ -795,6 +798,9 @@ Py_UCS4 *th_node_layout_text(th_tree *tree, th_node *node, const text_opts *opt,
 Py_UCS4 *th_node_annotated_text(th_tree *tree, th_node *node, const text_opts *opt, const text_rule *rules,
                                 Py_ssize_t n_rules, text_span **out_spans, Py_ssize_t *out_span_count,
                                 Py_ssize_t *out_len) {
+    if (ser_check_recursive_depth(node, "to_annotated_text()") < 0) {
+        return NULL;
+    }
     text_ctx ctx = {0};
     ctx.tree = tree;
     ctx.opt = opt;

--- a/src/turbohtml/_c/validate/relaxng.h
+++ b/src/turbohtml/_c/validate/relaxng.h
@@ -852,7 +852,6 @@ static pattern *rng_end_tag_deriv(th_schema *schema, pattern *p) {
 }
 
 static pattern *rng_child_element(valctx *ctx, pattern *p, th_node *element);
-static pattern *rng_child_element_inner(valctx *ctx, pattern *p, th_node *element);
 
 /* Derive over an element's child list, ignoring whitespace-only text between elements
    and allowing insignificant whitespace when the content is a single text run. */
@@ -892,20 +891,7 @@ static pattern *rng_children_deriv(valctx *ctx, pattern *p, th_node *element) {
 }
 
 /* Derive the pattern over one child element, localizing any failure to it. */
-/* Bound the per-element recursion so a pathologically deep document cannot overflow the
-   thread stack; report once and stop descending past the cap. */
 static pattern *rng_child_element(valctx *ctx, pattern *p, th_node *element) {
-    if (ctx->depth >= TH_VALIDATE_MAX_DEPTH) {
-        report(ctx, element, "structure", "maximum element nesting depth exceeded");
-        return ctx->schema->p_notallowed;
-    }
-    ctx->depth++;
-    pattern *result = rng_child_element_inner(ctx, p, element);
-    ctx->depth--;
-    return result;
-}
-
-static pattern *rng_child_element_inner(valctx *ctx, pattern *p, th_node *element) {
     th_schema *schema = ctx->schema;
     th_tree *tree = ctx->tree;
     qname name = node_qname(tree, element, element->text, element->text_len, 0);

--- a/src/turbohtml/_c/validate/schema.c
+++ b/src/turbohtml/_c/validate/schema.c
@@ -35,11 +35,9 @@ static const char XSD_DT_NS[] = "http://www.w3.org/2001/XMLSchema-datatypes";
 static const char RNG_NS[] = "http://relaxng.org/ns/structure/1.0";
 static const char XML_URI[] = "http://www.w3.org/XML/1998/namespace";
 
-/* Instance element nesting the validator recurses into per level. A document can nest
-   arbitrarily deep (the XML parser has no depth cap), and each level costs a C call
-   chain, so the recursion is bounded to keep a pathological document from overflowing
-   the ~1 MB thread stack of a Windows free-threaded worker. */
-#define TH_VALIDATE_MAX_DEPTH 1000
+/* Schema compilation and instance validation still have recursive grammar walks. Preflight the tree far enough below
+   the smallest supported thread stack that those walks cannot exhaust it. */
+#define TH_VALIDATE_MAX_DEPTH 400
 
 /* ======================= bump arena ======================= */
 
@@ -320,7 +318,6 @@ typedef struct {
     struct th_schema *schema;
     pathbuf path;
     int failed;
-    int depth; /* current instance element nesting depth, capped at TH_VALIDATE_MAX_DEPTH */
 } valctx;
 
 static void report(valctx *ctx, th_node *node, const char *type, const char *fmt, ...) {
@@ -804,6 +801,10 @@ PyObject *turbohtml_schema_compile(PyObject *module, PyObject *args) {
     if (tree == NULL) {
         return NULL;
     }
+    if (th_node_check_max_depth(th_tree_document(tree), TH_VALIDATE_MAX_DEPTH, "schema compilation") < 0) {
+        th_tree_free(tree);
+        return NULL;
+    }
     th_schema *schema = PyMem_Calloc(1, sizeof(th_schema));
     if (schema == NULL) {        /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         th_tree_free(tree);      /* GCOVR_EXCL_LINE */
@@ -851,11 +852,13 @@ PyObject *turbohtml_schema_validate(PyObject *module, PyObject *args) {
     if (errors == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return NULL;      /* GCOVR_EXCL_LINE */
     }
-    valctx ctx = {errors, tree, schema, {NULL, 0, 0}, 0, 0};
+    valctx ctx = {errors, tree, schema, {NULL, 0, 0}, 0};
     th_node *root = node->type == TH_NODE_DOCUMENT ? document_root(tree) : node;
     Py_BEGIN_CRITICAL_SECTION(turbohtml_node_handle(node_obj));
     if (root == NULL) { /* GCOVR_EXCL_BR_LINE: parse_xml rejects a rootless document, so the shim never passes one */
         report(&ctx, node, "structure", "document has no root element"); /* GCOVR_EXCL_LINE */
+    } else if (th_node_check_max_depth(root, TH_VALIDATE_MAX_DEPTH, "schema validation") < 0) {
+        ctx.failed = 1;
     } else if (schema->kind == 0) {
         xsd_validate_root(&ctx, root);
     } else {
@@ -863,9 +866,9 @@ PyObject *turbohtml_schema_validate(PyObject *module, PyObject *args) {
     }
     Py_END_CRITICAL_SECTION();
     PyMem_Free(ctx.path.data);
-    if (ctx.failed) {      /* GCOVR_EXCL_BR_LINE: only set on an unforceable allocation failure */
-        Py_DECREF(errors); /* GCOVR_EXCL_LINE */
-        return NULL;       /* GCOVR_EXCL_LINE */
+    if (ctx.failed) {
+        Py_DECREF(errors);
+        return NULL;
     }
     int valid = PyList_GET_SIZE(errors) == 0;
     return Py_BuildValue("(ON)", valid ? Py_True : Py_False, errors);

--- a/src/turbohtml/_c/validate/xsd.h
+++ b/src/turbohtml/_c/validate/xsd.h
@@ -327,7 +327,6 @@ static void xsd_match_once(th_schema *schema, th_tree *inst, th_node *particle, 
 }
 
 static void xsd_validate_element(valctx *ctx, th_node *instance, th_node *decl);
-static void xsd_validate_element_inner(valctx *ctx, th_node *instance, th_node *decl);
 
 /* Validate an `all` group: each child element matches a distinct particle by name,
    with its per-particle occurs honored and order ignored. */
@@ -806,19 +805,7 @@ static void xsd_validate_complex(valctx *ctx, th_node *instance, th_node *ctype)
 
 /* ---- element ---- */
 
-/* Bound the per-element recursion so a pathologically deep document cannot overflow the
-   thread stack; report once and stop descending past the cap. */
 static void xsd_validate_element(valctx *ctx, th_node *instance, th_node *decl) {
-    if (ctx->depth >= TH_VALIDATE_MAX_DEPTH) {
-        report(ctx, instance, "structure", "maximum element nesting depth exceeded");
-        return;
-    }
-    ctx->depth++;
-    xsd_validate_element_inner(ctx, instance, decl);
-    ctx->depth--;
-}
-
-static void xsd_validate_element_inner(valctx *ctx, th_node *instance, th_node *decl) {
     th_schema *schema = ctx->schema;
     th_tree *tree = schema->tree;
     qname name = node_qname(ctx->tree, instance, instance->text, instance->text_len, 0);

--- a/src/turbohtml/query/_match.py
+++ b/src/turbohtml/query/_match.py
@@ -167,7 +167,7 @@ class Matcher:
         :returns: the members that match.
         """
         if isinstance(iterable, list):
-            return _matches_many(cast("list[Element]", iterable), self._selector)
+            return _matches_many(iterable, self._selector)
         if isinstance(iterable, (Element, Document)):
             iterable = (child for child in iterable.children if isinstance(child, Element))
         return [node for node in iterable if node.matches(self._selector)]

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -68,6 +68,25 @@ def test_default_keeps_allowlisted() -> None:
     assert sanitize('<a href="http://x.com" title="t">hi</a>') == '<a href="http://x.com" title="t">hi</a>'
 
 
+def test_deep_input_is_sanitized_without_using_the_c_stack() -> None:
+    markup = "<div>" * 1_200 + "bottom" + "</div>" * 1_200
+    output = sanitize(markup, Policy(tags=frozenset({"div"})))
+    assert (output.count("<div>"), "bottom" in output) == (1_200, True)
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_open_count"),
+    [
+        pytest.param(OnDisallowed.STRIP, 0, id="strip"),
+        pytest.param(OnDisallowed.ESCAPE, 1_200, id="escape"),
+    ],
+)
+def test_deep_disallowed_input_completes_postorder_actions(mode: OnDisallowed, expected_open_count: int) -> None:
+    markup = "<x>" * 1_200 + "bottom" + "</x>" * 1_200
+    output = sanitize(markup, Policy(on_disallowed_tag=mode))
+    assert (output.count("&lt;x&gt;"), "bottom" in output) == (expected_open_count, True)
+
+
 def test_disallowed_attribute_dropped() -> None:
     assert sanitize('<a href="http://x" class="c" id="i">x</a>') == '<a href="http://x">x</a>'
 

--- a/tests/convert/test_transform_depth.py
+++ b/tests/convert/test_transform_depth.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Final
+
+from turbohtml import parse_xml
+from turbohtml.transform import Transform
+
+_LEVELS: Final = 1_200
+_XSLT: Final = "http://www.w3.org/1999/XSL/Transform"
+
+
+def _nested_xml(inner: str) -> str:
+    return "<x>" * _LEVELS + inner + "</x>" * _LEVELS
+
+
+def test_transform_text_output_collects_deep_descendants() -> None:
+    source = parse_xml(_nested_xml("bottom"))
+    stylesheet = parse_xml(
+        f'<xsl:stylesheet version="1.0" xmlns:xsl="{_XSLT}"><xsl:output method="text"/>'
+        '<xsl:template match="/"><xsl:copy-of select="."/></xsl:template></xsl:stylesheet>'
+    )
+
+    assert Transform(stylesheet)(source) == "bottom"
+
+
+def test_transform_cdata_conversion_reaches_deep_descendants() -> None:
+    source = parse_xml(_nested_xml("<leaf>bottom</leaf>"))
+    stylesheet = parse_xml(
+        f'<xsl:stylesheet version="1.0" xmlns:xsl="{_XSLT}">'
+        '<xsl:output method="xml" omit-xml-declaration="yes" cdata-section-elements="leaf"/>'
+        '<xsl:template match="/"><xsl:copy-of select="."/></xsl:template></xsl:stylesheet>'
+    )
+
+    assert "<leaf><![CDATA[bottom]]></leaf>" in Transform(stylesheet)(source)
+
+
+def test_transform_strip_space_reaches_deep_descendants_and_restores_source() -> None:
+    source = parse_xml(_nested_xml("  <leaf>bottom</leaf>  "))
+    before = source.html
+    stylesheet = parse_xml(
+        f'<xsl:stylesheet version="1.0" xmlns:xsl="{_XSLT}"><xsl:output method="text"/>'
+        '<xsl:strip-space elements="*"/><xsl:template match="/">'
+        '<xsl:value-of select="."/></xsl:template></xsl:stylesheet>'
+    )
+
+    assert Transform(stylesheet)(source) == "bottom"
+    assert source.html == before

--- a/tests/dom/test_shadow.py
+++ b/tests/dom/test_shadow.py
@@ -261,6 +261,20 @@ def test_flatten_expands_nested_fallback_slot() -> None:
     assert [type(node).__name__ for node in outer.assigned_nodes(flatten=True)] == ["Text"]
 
 
+def test_flatten_expands_deep_fallback_slots_iteratively() -> None:
+    root = Element("div").attach_shadow("open")
+    outer = Element("slot")
+    root.append(outer)
+    deepest = outer
+    for _ in range(1_200):
+        child = Element("slot")
+        deepest.append(child)
+        deepest = child
+    fallback = Text("deep")
+    deepest.append(fallback)
+    assert outer.assigned_nodes(flatten=True) == [fallback]
+
+
 def test_flatten_fallback_skips_non_slottable_content() -> None:
     host = Element("div")
     root = host.attach_shadow("open")

--- a/tests/dom/test_tree_api.py
+++ b/tests/dom/test_tree_api.py
@@ -196,6 +196,7 @@ def test_equals_rejects_non_node() -> None:
         pytest.param(Element("a", {"href": "/x"}), Element("a", {"href": "/xyz"}), id="attr-value-length"),
         pytest.param(Element("a", {"href": "/x"}), Element("a"), id="attr-presence"),
         pytest.param(Element("a", {"href": "/x"}), Element("a", {"rel": "/x"}), id="attr-name"),
+        pytest.param(Element("div", None, [Element("a")]), Element("div"), id="child-presence"),
         pytest.param(
             Element("div", None, [Element("a")]),
             Element("div", None, [Element("a"), Element("b")]),

--- a/tests/dom/test_tree_depth_cap.py
+++ b/tests/dom/test_tree_depth_cap.py
@@ -1,19 +1,22 @@
-"""The tree builder caps element nesting so pathologically deep input cannot overflow
-the C stack or cost O(depth^2), and the recursive tree walks carry their own backstop
-for a tree built past that cap through the mutation API."""
+"""Depth limits for HTML construction and recursive output formatters."""
 
 from __future__ import annotations
 
 import copy
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
 
 import pytest
 
-from turbohtml import Document, Element, Text, parse
+from turbohtml import Document, Element, Html, Indent, Range, Text, parse, parse_xml
 from turbohtml.clean import sanitize
 
-# Well above the 512 parse cap and the 1024 walk-cap, small enough that an unguarded
-# recursive walk would already overflow an ASan stack: the fuzzer aborted at 20000.
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 _PATHOLOGICAL = 20000
+_DEEP = 1_200
 
 
 def _max_element_depth(node: Element | Document) -> int:
@@ -27,15 +30,20 @@ def _max_element_depth(node: Element | Document) -> int:
     return deepest
 
 
-def _nested(tag: str, levels: int) -> Element:
+def _nested(tag: str, levels: int, text: str | None = "X") -> Element:
+    return _nested_with_deepest(tag, levels, text)[0]
+
+
+def _nested_with_deepest(tag: str, levels: int, text: str | None = "X") -> tuple[Element, Element]:
     root = Element(tag)
     node = root
     for _ in range(levels):
         child = Element(tag)
         node.append(child)
         node = child
-    node.append(Text("X"))
-    return root
+    if text is not None:
+        node.append(Text(text))
+    return root, node
 
 
 def test_deeply_nested_parse_caps_element_depth() -> None:
@@ -65,37 +73,72 @@ def test_nesting_below_the_cap_is_left_untouched(levels: int) -> None:
     assert _max_element_depth(doc) == levels + 2  # html + body + every div, fully nested
 
 
-def test_text_walk_backstops_a_tree_past_the_cap() -> None:
-    assert not _nested("div", 3000).text  # walk stops before the deepest text, no overflow
+@pytest.mark.parametrize("source", [pytest.param("xml", id="parsed-xml"), pytest.param("mutation", id="mutation")])
+def test_deep_text_and_serialization_are_complete(source: str) -> None:
+    root = (
+        parse_xml("<x>" * _DEEP + "bottom" + "</x>" * _DEEP).root if source == "xml" else _nested("x", _DEEP, "bottom")
+    )
+    assert isinstance(root, Element)
+    expected_open_count = _DEEP if source == "xml" else _DEEP + 1
+    assert (root.text, root.html.count("<x>"), "bottom" in root.serialize(Html(layout=Indent(1)))) == (
+        "bottom",
+        expected_open_count,
+        True,
+    )
 
 
-def test_text_walk_reads_a_tree_within_the_cap() -> None:
-    assert _nested("div", 400).text == "X"  # the backstop never fires below the cap
+def test_find_text_reads_a_deep_programmatic_tree() -> None:
+    root = _nested("x", _DEEP, "bottom")
+    assert root.find("x", text="bottom") is not None
+
+
+def test_css_has_reads_a_deep_programmatic_tree() -> None:
+    root, deepest = _nested_with_deepest("x", _DEEP, None)
+    deepest.attrs["class"] = "target"
+    assert root.matches(":has(.target)")
+    assert root.select_one("x:has(.target)") is not None
 
 
 @pytest.mark.parametrize("tag", [pytest.param("div", id="block"), pytest.param("b", id="inline")])
-def test_markdown_walk_backstops_a_tree_past_the_cap(tag: str) -> None:
-    assert not _nested(tag, 3000).to_markdown()  # both block and inline recursion are bounded
+def test_recursive_renderers_reject_a_deep_tree_before_output(tag: str) -> None:
+    root = _nested(tag, _DEEP)
+    with pytest.raises(RecursionError, match=r"to_markdown\(\).*1024"):
+        root.to_markdown()
+    with pytest.raises(RecursionError, match=r"to_text\(\).*1024"):
+        root.to_text()
+    with pytest.raises(RecursionError, match=r"to_annotated_text\(\).*1024"):
+        root.to_annotated_text({tag: ["deep"]})
 
 
-def test_markdown_walk_renders_a_tree_within_the_cap() -> None:
-    assert "X" in _nested("b", 400).to_markdown()  # the backstop never fires below the cap
+def test_recursive_renderers_accept_the_last_supported_depth() -> None:
+    root = _nested("b", 1_022)
+    assert "X" in root.to_markdown()
+    assert root.to_text() == "X"
 
 
-def test_clone_walk_backstops_a_tree_past_the_cap() -> None:
-    clone = copy.deepcopy(_nested("div", 3000))
-    assert not clone.text  # the copy is truncated rather than recursing into the deep source
+@pytest.mark.parametrize("duplicate", [pytest.param(copy.copy, id="copy"), pytest.param(copy.deepcopy, id="deepcopy")])
+def test_clone_walk_copies_a_deep_tree(duplicate: Callable[[Element], Element]) -> None:
+    root = _nested("x", _DEEP, "bottom")
+    clone = duplicate(root)
+    assert clone.text == "bottom"
+    assert clone.equals(root)
 
 
-def test_clone_walk_copies_a_tree_within_the_cap() -> None:
-    clone = copy.deepcopy(_nested("div", 400))
-    assert clone.text == "X"
+def test_append_copies_a_deep_foreign_tree() -> None:
+    root = Element("root")
+    child = _nested("x", _DEEP, "bottom")
+    root.append(child)
+    assert root.text == "bottom"
+    assert child.text == "bottom"
 
 
-def test_normalize_walk_backstops_a_tree_past_the_cap() -> None:
-    root = _nested("div", 3000)
-    root.normalize()  # must not overflow walking the deep tree
-    assert isinstance(root, Element)
+def test_normalize_walk_reaches_deep_text() -> None:
+    root, deepest = _nested_with_deepest("x", _DEEP, None)
+    deepest.append(Text("a"))
+    deepest.append(Text(""))
+    deepest.append(Text("b"))
+    root.normalize()
+    assert root.text == "ab"
 
 
 def test_normalize_walk_merges_text_within_the_cap() -> None:
@@ -104,3 +147,70 @@ def test_normalize_walk_merges_text_within_the_cap() -> None:
     element.append(Text("b"))
     element.normalize()
     assert element.text == "ab"
+
+
+def test_readability_reaches_a_deep_programmatic_tree_before_render_preflight() -> None:
+    root = _nested("x", _DEEP, None)
+    root.append(Element("p", None, [Text("A long article sentence, " * 20)]))
+    assert root.main_content() == root
+    with pytest.raises(RecursionError, match=r"to_text\(\).*1024"):
+        root.main_text()
+    with pytest.raises(RecursionError, match=r"to_text\(\).*1024"):
+        root.article()
+
+
+@pytest.mark.parametrize("method", ["clone_contents", "extract_contents", "delete_contents"])
+@pytest.mark.parametrize("deep_boundary", [pytest.param("start", id="deep-start"), pytest.param("end", id="deep-end")])
+def test_range_rejects_a_deep_partial_boundary_before_mutation(method: str, deep_boundary: str) -> None:
+    root, deepest = _nested_with_deepest("x", _DEEP, None)
+    text_node = Text("bottom")
+    deepest.append(text_node)
+    if deep_boundary == "start":
+        selection = Range(text_node, 0)
+        selection.set_end(root, 1)
+    else:
+        selection = Range(root, 0)
+        selection.set_end(text_node, 0)
+    before = root.html
+    with pytest.raises(RecursionError, match=rf"{method}\(\).*400"):
+        getattr(selection, method)()
+    assert (root.html, selection.start_container, selection.end_container) == (
+        before,
+        text_node if deep_boundary == "start" else root,
+        root if deep_boundary == "start" else text_node,
+    )
+
+
+@pytest.mark.parametrize("method", ["microdata", "rdfa", "structured_data"])
+def test_structured_data_rejects_deep_xml_before_building_results(method: str) -> None:
+    document = parse_xml("<x>" * _DEEP + "<item itemscope='' typeof='Thing'/>" + "</x>" * _DEEP)
+    with pytest.raises(RecursionError, match=rf"{method}\(\).*400"):
+        getattr(document, method)()
+
+
+def test_deep_operations_fit_a_small_thread_stack() -> None:
+    roots = [
+        parse_xml("<x>" * _DEEP + "bottom" + "</x>" * _DEEP).root,
+        _nested("x", _DEEP, "bottom"),
+    ]
+
+    def run() -> list[tuple[str, str, str]]:
+        captured: list[tuple[str, str, str]] = []
+        for root in roots:
+            assert isinstance(root, Element)
+            clone = copy.deepcopy(root)
+            clone.normalize()
+            with pytest.raises(RecursionError):
+                root.to_markdown()
+            assert root.matches(":has(x)")
+            captured.append((root.text, clone.text, root.serialize(Html(layout=Indent(1)))))
+        return captured
+
+    previous = threading.stack_size(256 * 1024)
+    try:
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            captured = pool.submit(run).result()
+    finally:
+        threading.stack_size(previous)
+    assert [(text, clone_text) for text, clone_text, _ in captured] == [("bottom", "bottom")] * 2
+    assert all("bottom" in markup for _, _, markup in captured)

--- a/tests/extract/test_tree_main_content.py
+++ b/tests/extract/test_tree_main_content.py
@@ -249,6 +249,14 @@ def test_methods_exist_on_document_and_element() -> None:
     assert body.main_content() is not None
 
 
+def test_shadow_paragraph_scores_its_element_parent() -> None:
+    root = Element("div").attach_shadow()
+    root.set_inner_html(f"<section><p>{PROSE}</p></section>")
+    found = root.main_content()
+    assert isinstance(found, Element)
+    assert found.tag == "section"
+
+
 def test_div_list_body_without_paragraphs_falls_back_to_article() -> None:
     # #385: an <article> whose text lives in div/ul/li with no scoring <p> must not
     # extract to empty; the semantic-container fallback surfaces the <article>.

--- a/tests/query/css/test_tree_select.py
+++ b/tests/query/css/test_tree_select.py
@@ -722,6 +722,11 @@ def test_has_memo_deep_chain(depth: int, selector: str, expected: str) -> None:
     assert len(parse(_nested_divs(depth)).select(selector)) == counts[expected]
 
 
+def test_has_memo_walks_next_sibling_after_leaf() -> None:
+    leaf = "<i></i><!-- gap --><a>x</a>"
+    assert len(parse(_nested_divs(30, leaf)).select("div:has(a)")) == 30
+
+
 def test_has_memo_deep_sibling_chains() -> None:
     # two sibling deep chains: the first populates the memo, so the second's anchors
     # probe a non-empty table for keys it does not hold (the get-miss + linear-probe

--- a/tests/query/find/test_tree_find.py
+++ b/tests/query/find/test_tree_find.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Final
 
 import pytest
 
-from turbohtml import Axis, Element, parse
+from turbohtml import Axis, Element, Text, parse
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -565,6 +565,17 @@ def test_text_empty_string_matches_textless_element() -> None:
 def test_text_equal_length_different_content_does_not_match() -> None:
     # both are three code points, so the length gate passes and the content compare decides
     assert parse("<p>abc</p>").find_all(text="xyz") == []
+
+
+def test_text_scan_handles_programmatic_tree_beyond_parser_depth_cap() -> None:
+    root = Element("div")
+    parent = root
+    for _ in range(1_200):
+        child = Element("div")
+        parent.append(child)
+        parent = child
+    parent.append(Text("needle"))
+    assert root.find(text="needle") is not None
 
 
 # A non-literal regex keeps the Python path that snapshots candidates under the lock, where the

--- a/tests/query/find/test_xml_find.py
+++ b/tests/query/find/test_xml_find.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Document, parse_xml
+
+
+@pytest.fixture
+def xml_case_document() -> Document:
+    return parse_xml("<Root><div/><DIV/><custom/><Custom/></Root>")
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        pytest.param("div", ["div"], id="known-lowercase"),
+        pytest.param("DIV", ["DIV"], id="known-uppercase"),
+        pytest.param("custom", ["custom"], id="unknown-lowercase"),
+        pytest.param("Custom", ["Custom"], id="unknown-uppercase"),
+    ],
+)
+def test_xml_find_all_matches_exact_tag_name(tag: str, expected: list[str], xml_case_document: Document) -> None:
+    assert [element.tag for element in xml_case_document.find_all(tag)] == expected
+
+
+@pytest.mark.parametrize("tag", ["div", "DIV", "custom", "Custom"])
+def test_xml_find_matches_exact_tag_name(tag: str, xml_case_document: Document) -> None:
+    assert (match := xml_case_document.find(tag)) is not None
+    assert match.tag == tag
+
+
+def test_xml_find_all_matches_known_tag_below_subtree() -> None:
+    root = parse_xml("<Root><section><div id='inside'/></section><div id='outside'/></Root>").root
+    assert root is not None
+    assert (section := root.find("section")) is not None
+    assert [element.attrs["id"] for element in section.find_all("div")] == ["inside"]

--- a/tests/validate/test_edge_cases.py
+++ b/tests/validate/test_edge_cases.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import sys
-
 import pytest
 
 from turbohtml import parse_xml
@@ -1009,31 +1007,52 @@ def test_rng_data_param_without_name() -> None:
     assert rng_ok(schema, "<e>hello</e>")
 
 
-@pytest.mark.skipif(
-    sys.implementation.name == "pypy",
-    reason="RPython's own stack check trips on the C validator's recursion before its depth cap can "
-    "report, raising SystemError instead; the recursion stays bounded either way",
-)
-def test_xsd_deep_nesting_is_bounded() -> None:
+def test_xsd_deep_nesting_is_rejected_before_validation() -> None:
     schema = XMLSchema(
         f'<xs:schema {XS}><xs:element name="a"><xs:complexType><xs:sequence>'
         '<xs:element ref="a" minOccurs="0"/></xs:sequence></xs:complexType></xs:element></xs:schema>'
     )
     assert schema.validate(parse_xml("<a>" * 20 + "</a>" * 20)).valid
-    result = schema.validate(parse_xml("<a>" * 1100 + "</a>" * 1100))
-    assert not result.valid
-    assert "nesting depth" in result.errors[0].message
+    with pytest.raises(RecursionError, match="schema validation"):
+        schema.validate(parse_xml("<a>" * 1200 + "</a>" * 1200))
 
 
-def test_rng_deep_nesting_is_bounded() -> None:
+def test_rng_deep_nesting_is_rejected_before_validation() -> None:
     schema = RelaxNG(
         f'<grammar xmlns="{R}"><start><ref name="a"/></start>'
         '<define name="a"><element name="a"><optional><ref name="a"/></optional></element></define></grammar>'
     )
     assert schema.validate(parse_xml("<a>" * 20 + "</a>" * 20)).valid
-    result = schema.validate(parse_xml("<a>" * 1100 + "</a>" * 1100))
-    assert not result.valid
-    assert "nesting depth" in result.errors[0].message
+    with pytest.raises(RecursionError, match="schema validation"):
+        schema.validate(parse_xml("<a>" * 1200 + "</a>" * 1200))
+
+
+@pytest.mark.parametrize(
+    ("schema_type", "source"),
+    [
+        pytest.param(
+            XMLSchema,
+            f'<xs:schema {XS}><xs:element name="a"><xs:complexType>'
+            + "<xs:sequence>" * 1200
+            + '<xs:element name="b"/>'
+            + "</xs:sequence>" * 1200
+            + "</xs:complexType></xs:element></xs:schema>",
+            id="xsd",
+        ),
+        pytest.param(
+            RelaxNG,
+            f'<grammar xmlns="{R}"><start>'
+            + "<optional>" * 1200
+            + "<empty/>"
+            + "</optional>" * 1200
+            + "</start></grammar>",
+            id="relax-ng",
+        ),
+    ],
+)
+def test_deep_schema_is_rejected_before_compilation(schema_type: type[XMLSchema | RelaxNG], source: str) -> None:
+    with pytest.raises(RecursionError, match="schema compilation"):
+        schema_type(source)
 
 
 def test_long_names_and_values_hit_buffer_bounds() -> None:


### PR DESCRIPTION
Some subtree consumers omitted descendants on deep XML and programmatic trees. Recursive helpers also risked exhausting a small thread stack.

The C code uses loops or checked heap stacks to complete these walks. State machines that retain recursion preflight a documented limit before output or mutation, then raise `RecursionError` before producing a partial result, closing #722.

The merge order applies #727 first to keep its XML query correction in one PR.
