### PR TITLE
🐛 fix(clean): decode CSS safety tokens

### DIFF
--- a/docs/changelog/721.bugfix.rst
+++ b/docs/changelog/721.bugfix.rst
@@ -1,0 +1,1 @@
+Decode CSS escapes when checking sanitizer function names and URL schemes.

--- a/docs/explanation/sanitizing.rst
+++ b/docs/explanation/sanitizing.rst
@@ -6,11 +6,11 @@ Sanitizing is subtractive and layered: each configurable allowlist can only *rem
 under all of them sits a baseline no policy can reach. The order matters, so read a kept ``style`` attribute as the
 worked example.
 
-A style declaration passes through three gates in turn. First the non-configurable safety baseline: ``expression()``
-runs script in old IE, and ``url(javascript:...)`` carries a disallowed scheme, so either drops the whole declaration no
-matter what the policy says. Then ``css_properties``, the property-*name* allowlist: a property outside the set is gone
-even if its value is harmless. Only a declaration that clears both reaches ``allowed_styles``, the property-*value*
-allowlist, which keeps it only when its value matches one of the patterns listed for the element's tag (or ``"*"``).
+A style declaration passes through three gates in turn. The non-configurable safety baseline drops ``expression()``,
+``url(javascript:...)``, ``behavior``, and ``-moz-binding``. It decodes CSS escapes before matching tokens, while text
+inside strings and comments stays inert. Then ``css_properties`` drops names outside the property allowlist. A
+declaration that clears both reaches ``allowed_styles``, which checks its value against the patterns for the element's
+tag or ``"*"``.
 
 The layering is deliberately one-directional. ``allowed_styles`` *narrows* -- it can reject a value the earlier layers
 would have kept, but it can never re-admit one they dropped. A caller who writes ``{"color": [r".*"]}`` has not opened a

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -30,8 +30,10 @@ element or stripped attribute, the way DOMPurify populates ``DOMPurify.removed``
 way sanitize-html's ``allowedStyles`` does. Key it ``{tag: {property: [pattern, ...]}}`` (``"*"`` matches every tag); a
 ``style`` declaration survives only when its property is listed for the element's tag or ``"*"`` and its value matches
 one of the patterns via an unanchored :func:`re.search`. It runs on top of ``css_properties`` and the dangerous-value
-baseline -- the property must still be in ``css_properties``, and ``expression()`` or a disallowed-scheme ``url()`` is
-dropped even when a pattern would admit it:
+baseline. The property must still be in ``css_properties``. The baseline drops ``expression()`` and disallowed-scheme
+``url()`` values even when a pattern admits them, including function names and URL schemes written with CSS escapes. It
+also rejects ``behavior`` and ``-moz-binding`` even if ``css_properties`` lists them. The scanner treats strings and
+comments as inert content instead of executable functions.
 
 .. testcode::
 

--- a/src/turbohtml/_c/clean/sanitize.c
+++ b/src/turbohtml/_c/clean/sanitize.c
@@ -519,6 +519,8 @@ static int apply_set_attributes(sanitizer *s, th_node *element, PyObject *tag) {
     return mutated;
 }
 
+static int css_decode_escape(const Py_UCS4 *value, Py_ssize_t *pos, Py_ssize_t end, Py_UCS4 *decoded);
+
 /* A CSS property name is ASCII letters, digits, and '-', so an ASCII lowercase key is enough to look it up. Callers
    guarantee 0 < len < 64 (a real property name), so the fixed buffer never overflows. Returns a new str, or NULL on
    allocation failure. */
@@ -530,9 +532,32 @@ static PyObject *css_property_key(const Py_UCS4 *name, Py_ssize_t len) {
     return PyUnicode_FromStringAndSize(lowered, len);
 }
 
+/* Legacy engines execute these properties independently of their values. Decode escapes before comparing so an
+   allowlist cannot admit an obfuscated spelling. */
+static int css_property_blocked(const Py_UCS4 *name, Py_ssize_t len) {
+    char decoded[64];
+    Py_ssize_t decoded_len = 0;
+    for (Py_ssize_t pos = 0; pos < len;) {
+        Py_UCS4 codepoint = name[pos];
+        if (codepoint == '\\') {
+            if (!css_decode_escape(name, &pos, len, &codepoint)) {
+                return 1;
+            }
+        } else {
+            pos++;
+        }
+        if (codepoint > 0x7F) {
+            return 1;
+        }
+        decoded[decoded_len++] = (char)lower_ascii(codepoint);
+    }
+    return (decoded_len == 8 && memcmp(decoded, "behavior", 8) == 0) ||
+           (decoded_len == 12 && memcmp(decoded, "-moz-binding", 12) == 0);
+}
+
 /* Is the CSS property `name[0:len]` in the name allowlist? Returns 1 allow, 0 drop, -1 error. */
 static int css_property_allowed(sanitizer *s, const Py_UCS4 *name, Py_ssize_t len) {
-    if (len == 0 || len >= 64) {
+    if (len == 0 || len >= 64 || css_property_blocked(name, len)) {
         return 0; /* empty, or longer than any real property name */
     }
     PyObject *key = css_property_key(name, len);
@@ -603,19 +628,58 @@ static int css_style_declaration_allowed(sanitizer *s, const style_allowlist *st
    (`background:curl(x)` is not a `url()`). */
 static int is_css_ident_char(Py_UCS4 c) {
     Py_UCS4 lower = c | 0x20;
-    return (lower >= 'a' && lower <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_';
+    return (lower >= 'a' && lower <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c >= 0x80;
 }
 
-/* Does the lowercase ASCII `keyword` sit at value[pos:]? Returns the index just past it, or -1. */
-static Py_ssize_t css_match_keyword(const Py_UCS4 *value, Py_ssize_t pos, Py_ssize_t end, const char *keyword) {
-    Py_ssize_t index = 0;
-    while (keyword[index] != '\0') {
-        if (pos + index >= end || (value[pos + index] | 0x20) != (Py_UCS4)keyword[index]) {
-            return -1;
-        }
-        index++;
+static int is_css_hex(Py_UCS4 codepoint) {
+    Py_UCS4 lower = codepoint | 0x20;
+    return (codepoint >= '0' && codepoint <= '9') || (lower >= 'a' && lower <= 'f');
+}
+
+static int is_css_newline(Py_UCS4 codepoint) {
+    switch (codepoint) {
+    case '\n':
+    case '\r':
+    case '\f':
+        return 1;
+    default:
+        return 0;
     }
-    return pos + index;
+}
+
+/* Decode one CSS escape at `*pos`, which points at its backslash. CSS consumes one to six hexadecimal digits and one
+   optional whitespace terminator, or one escaped code point. Returns 1 and advances `*pos`, or 0 for a trailing
+   backslash or escaped newline. */
+static int css_decode_escape(const Py_UCS4 *value, Py_ssize_t *pos, Py_ssize_t end, Py_UCS4 *decoded) {
+    Py_ssize_t index = *pos + 1;
+    if (index >= end || is_css_newline(value[index])) {
+        return 0;
+    }
+    if (!is_css_hex(value[index])) {
+        *decoded = value[index];
+        *pos = index + 1;
+        return 1;
+    }
+    Py_UCS4 point = 0;
+    int digits = 0;
+    while (index < end && digits < 6 && is_css_hex(value[index])) {
+        Py_UCS4 digit = value[index++] | 0x20;
+        point = (point << 4) + (digit <= '9' ? digit - '0' : digit - 'a' + 10);
+        digits++;
+    }
+    if (index < end && is_space(value[index])) {
+        if (value[index] == '\r') {
+            index++;
+            if (index < end && value[index] == '\n') {
+                index++;
+            }
+        } else {
+            index++;
+        }
+    }
+    *decoded = point == 0 || point > 0x10FFFF || (point >= 0xD800 && point <= 0xDFFF) ? 0xFFFD : point;
+    *pos = index;
+    return 1;
 }
 
 /* Skip the whitespace and CSS comments a browser ignores between a function name and its opening paren, so a comment
@@ -641,41 +705,186 @@ static Py_ssize_t css_skip_ws_comments(const Py_UCS4 *value, Py_ssize_t pos, Py_
    the same scan the URL-attribute path uses, after stripping an optional surrounding quote so `url("javascript:...")`
    cannot smuggle a scheme past the check. Returns 1 allow, 0 drop, -1 error. */
 static int css_url_scheme_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t pos, Py_ssize_t end) {
+    enum { SCHEME_UNDECIDED = -2 };
     pos = css_skip_ws_comments(value, pos, end);
     Py_UCS4 quote = 0;
     if (pos < end && (value[pos] == '"' || value[pos] == '\'')) {
         quote = value[pos++];
     }
-    Py_ssize_t url_start = pos;
+    char inline_scheme[40];
+    char *scheme = inline_scheme;
+    size_t scheme_len = 0;
+    size_t scheme_capacity = sizeof(inline_scheme);
+    int scheme_started = 0;
+    int allowed = SCHEME_UNDECIDED;
+    int result = 0;
     while (pos < end && value[pos] != ')' && (quote ? value[pos] != quote : !is_space(value[pos]))) {
+        Py_UCS4 codepoint = value[pos];
+        if (codepoint == '\\') {
+            if (!css_decode_escape(value, &pos, end, &codepoint)) {
+                goto done;
+            }
+        } else {
+            if (!quote &&
+                (codepoint == '"' || codepoint == '\'' || codepoint == '(' || codepoint < 0x20 || codepoint == 0x7F)) {
+                goto done;
+            }
+            if (quote && is_css_newline(codepoint)) {
+                goto done;
+            }
+            pos++;
+        }
+        if (allowed != SCHEME_UNDECIDED || is_url_ignorable(codepoint)) {
+            continue;
+        }
+        if (codepoint == ':' && scheme_started) {
+            PyObject *name = PyUnicode_FromStringAndSize(scheme, (Py_ssize_t)scheme_len);
+            if (name == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                result = -1;    /* GCOVR_EXCL_LINE: allocation-failure path */
+                goto done;      /* GCOVR_EXCL_LINE */
+            }
+            allowed = PySet_Contains(s->url_schemes, name);
+            Py_DECREF(name);
+            continue;
+        }
+        int is_scheme_letter = th_scheme_start(codepoint);
+        if (scheme_started ? !th_scheme_char(codepoint) : !is_scheme_letter) {
+            allowed = s->allow_relative;
+            continue;
+        }
+        if (scheme_len == scheme_capacity) {
+            size_t grown_capacity;
+            size_t bytes;
+            int fits = th_grow_cap(scheme_len + 1, scheme_capacity, sizeof(inline_scheme), sizeof(*scheme),
+                                   &grown_capacity, &bytes);
+            if (!fits) {          /* GCOVR_EXCL_BR_LINE: a CSS token cannot exhaust size_t */
+                PyErr_NoMemory(); /* GCOVR_EXCL_LINE: size-overflow path */
+                result = -1;      /* GCOVR_EXCL_LINE */
+                goto done;        /* GCOVR_EXCL_LINE */
+            }
+            char *grown = PyMem_Malloc(bytes);
+            if (grown == NULL) {  /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+                result = -1;      /* GCOVR_EXCL_LINE */
+                goto done;        /* GCOVR_EXCL_LINE */
+            }
+            memcpy(grown, scheme, scheme_len);
+            if (scheme != inline_scheme) {
+                PyMem_Free(scheme);
+            }
+            scheme = grown;
+            scheme_capacity = grown_capacity;
+        }
+        scheme[scheme_len++] = (char)(is_scheme_letter ? (codepoint | 0x20) : codepoint);
+        scheme_started = 1;
+    }
+    if (quote) {
+        if (pos >= end) { /* GCOVR_EXCL_BR_LINE: the declaration splitter rejects an unterminated quoted URL */
+            goto done;    /* GCOVR_EXCL_LINE: rejected-declaration path */
+        }
+        if (value[pos] != quote) {
+            goto done;
+        }
         pos++;
     }
-    return scheme_allowed(s, value + url_start, pos - url_start);
+    pos = css_skip_ws_comments(value, pos, end);
+    if (pos < end && value[pos] == ')') {
+        result = allowed == SCHEME_UNDECIDED ? s->allow_relative : allowed;
+    }
+done:
+    if (scheme != inline_scheme) {
+        PyMem_Free(scheme);
+    }
+    return result;
+}
+
+/* Consume one identifier token, decoding escapes and classifying the exact token as url, expression, or neither.
+   Matching the whole token avoids treating an escaped space inside `safe\\ url(...)` as a token boundary. */
+static int css_identifier_kind(const Py_UCS4 *value, Py_ssize_t *pos, Py_ssize_t end) {
+    char token[11];
+    Py_ssize_t length = 0;
+    int overflow = 0;
+    while (*pos < end && (is_css_ident_char(value[*pos]) || value[*pos] == '\\')) {
+        Py_UCS4 codepoint = value[*pos];
+        if (codepoint == '\\') {
+            if (!css_decode_escape(value, pos, end, &codepoint)) {
+                return -1;
+            }
+        } else {
+            (*pos)++;
+        }
+        if (length < (Py_ssize_t)sizeof(token)) {
+            token[length++] = codepoint <= 0x7F ? (char)lower_ascii(codepoint) : '\0';
+        } else {
+            overflow = 1;
+        }
+    }
+    if (overflow) {
+        return 0;
+    }
+    if (length == 3 && memcmp(token, "url", 3) == 0) {
+        return 1;
+    }
+    return length == 10 && memcmp(token, "expression", 10) == 0 ? 2 : 0;
+}
+
+/* Skip a quoted CSS string. Function-like text inside it is data, not a token. */
+static Py_ssize_t css_skip_string(const Py_UCS4 *value, Py_ssize_t pos, Py_ssize_t end) {
+    Py_UCS4 quote = value[pos++];
+    while (pos < end) {
+        if (value[pos] == quote) {
+            return pos + 1;
+        }
+        if (value[pos] != '\\') {
+            pos++;
+            continue;
+        }
+        pos++;
+        if (pos >= end) { /* GCOVR_EXCL_BR_LINE: the declaration splitter rejects a terminal string escape */
+            continue;     /* GCOVR_EXCL_LINE: rejected-declaration path */
+        }
+        if (value[pos] == '\r') {
+            pos++;
+            if (pos < end && value[pos] == '\n') { /* GCOVR_EXCL_BR_LINE: a terminal CR is rejected upstream */
+                pos++;
+            }
+        } else {
+            pos++;
+        }
+    }
+    return end;
 }
 
 /* A declaration whose property name is allowlisted can still carry a dangerous value: IE's `expression(...)` runs
-   script, and `url(javascript:...)` a disallowed scheme. Reject the whole declaration in either case. Returns 1 allow,
-   0 drop, -1 error. */
+   script, and `url(javascript:...)` a disallowed scheme. Scan CSS tokens so inert strings, comments, and longer
+   identifiers do not trigger the executable-function checks. Returns 1 allow, 0 drop, -1 error. */
 static int css_value_allowed(sanitizer *s, const Py_UCS4 *value, Py_ssize_t start, Py_ssize_t end) {
-    for (Py_ssize_t pos = start; pos < end; pos++) {
-        if (pos > start && is_css_ident_char(value[pos - 1])) {
-            continue; /* mid-identifier: not a function-name boundary */
+    Py_ssize_t pos = start;
+    while (pos < end) {
+        if (value[pos] == '/' && pos + 1 < end && value[pos + 1] == '*') {
+            pos = css_skip_ws_comments(value, pos, end);
+            continue;
         }
-        Py_ssize_t after_expr = css_match_keyword(value, pos, end, "expression");
-        if (after_expr >= 0) {
-            Py_ssize_t paren = css_skip_ws_comments(value, after_expr, end);
-            if (paren < end && value[paren] == '(') {
-                return 0;
-            }
+        if (value[pos] == '\'' || value[pos] == '"') {
+            pos = css_skip_string(value, pos, end);
+            continue;
         }
-        Py_ssize_t after_url = css_match_keyword(value, pos, end, "url");
-        if (after_url >= 0) {
-            Py_ssize_t paren = css_skip_ws_comments(value, after_url, end);
-            if (paren < end && value[paren] == '(') {
-                int ok = css_url_scheme_allowed(s, value, paren + 1, end);
-                if (ok <= 0) {
-                    return ok;
-                }
+        if (!is_css_ident_char(value[pos]) && value[pos] != '\\') {
+            pos++;
+            continue;
+        }
+        int identifier_kind = css_identifier_kind(value, &pos, end);
+        if (identifier_kind < 0) {
+            return 0;
+        }
+        Py_ssize_t paren = css_skip_ws_comments(value, pos, end);
+        if (identifier_kind == 2 && paren < end && value[paren] == '(') {
+            return 0;
+        }
+        if (identifier_kind == 1 && paren < end && value[paren] == '(') {
+            int url_allowed = css_url_scheme_allowed(s, value, paren + 1, end);
+            if (url_allowed <= 0) {
+                return url_allowed;
             }
         }
     }

--- a/src/turbohtml/clean/_sanitizer.py
+++ b/src/turbohtml/clean/_sanitizer.py
@@ -150,8 +150,10 @@ class Policy:
         escaped or stripped, so their text never leaks into the output.
     :param css_properties: the CSS property allowlist. A kept ``style`` attribute and, when ``style`` is in ``tags``,
         the ``<style>`` element's stylesheet body are both scrubbed against it: any declaration whose property name is
-        not in the set (or whose value smuggles ``expression()`` or a ``url()`` with a disallowed scheme) is dropped,
-        while selectors and block nesting are kept, so dangerous CSS cannot ride in on a kept ``style``.
+        not in the set (or whose value smuggles ``expression()`` or a ``url()`` with a disallowed scheme) is dropped.
+        The non-configurable baseline also drops ``behavior`` and ``-moz-binding``. CSS escapes are decoded before
+        these checks, while function-like text inside strings and comments remains inert. Selectors and block nesting
+        remain.
     :param attribute_prefixes: allow any attribute whose name starts with one of these prefixes (e.g. ``"data-"`` for
         every ``data-*``), on top of the exact-name and ``"*"`` matches in ``attributes``.
     :param attribute_values: restrict a kept attribute to literal values, keyed ``{tag: {attribute: allowed_values}}``;

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -389,6 +389,7 @@ def test_style_dropped_when_not_allowed() -> None:
         pytest.param(";;; color: red ;;;", 'style="color: red"', id="extra-semicolons"),
         pytest.param("position: fixed; z-index: 9", None, id="all-dropped-removes-attribute"),
         pytest.param(("a" * 70) + ": red; color: blue", 'style="color: blue"', id="property-name-too-long"),
+        pytest.param("é: red", None, id="non-ascii-property-name"),
     ],
 )
 def test_style_scrubbing(style: str, expected: str | None) -> None:
@@ -461,7 +462,7 @@ def test_style_double_quoted_css_string() -> None:
         pytest.param("color: url( javascript:x )", False, id="url-javascript-spaced"),
         pytest.param("color: url/* c */(javascript:x)", False, id="url-comment-before-paren"),
         pytest.param("color: url(http://x/a.png)", True, id="url-http-allowed"),
-        pytest.param("color: url(http://x y)", True, id="url-allowed-then-space"),
+        pytest.param("color: url(http://x y)", False, id="url-unquoted-whitespace"),
         pytest.param("color: url/* c */(http://x)", True, id="url-comment-then-allowed"),
         pytest.param("color: url(/rel.png)", True, id="url-relative-allowed"),
         pytest.param("color: url()", True, id="url-empty"),
@@ -473,18 +474,134 @@ def test_style_double_quoted_css_string() -> None:
         pytest.param("cursor: curl(x)", True, id="url-mid-identifier"),
         pytest.param("color: url/x", True, id="url-slash-not-comment"),
         pytest.param("color: url/", True, id="url-trailing-slash"),
-        pytest.param("color: url(", True, id="url-open-paren-at-end"),
-        pytest.param("color: url(http://x", True, id="url-unterminated-allowed"),
+        pytest.param("color: url(", False, id="url-open-paren-at-end"),
+        pytest.param("color: url(http://x", False, id="url-unterminated"),
         pytest.param("color: url/* unterminated", True, id="url-unterminated-comment"),
         pytest.param("color: url/* x*", True, id="url-comment-trailing-asterisk"),
         pytest.param("color: url/* a*b */(http://x)", True, id="url-comment-lone-asterisk-then-allowed"),
         pytest.param("color: a-b_1c", True, id="value-identifier-punctuation"),
+        pytest.param("cursor: identifierlong(javascript:alert(1))", True, id="long-identifier"),
+        pytest.param("cursor: url(#fragment)", True, id="fragment-url"),
+        pytest.param("cursor: url(java\u200bscript:alert(1))", False, id="ignorable-format-character"),
+        pytest.param("cursor: url(:relative)", True, id="colon-before-scheme"),
+        pytest.param("cursor: url(h1:opaque)", False, id="scheme-with-digit"),
+        pytest.param(f"cursor: url({'h' * 41}:opaque)", False, id="overlong-scheme"),
+        pytest.param("cursor: url(https://example.com/(x)", False, id="open-paren-in-unquoted-url"),
+        pytest.param("cursor: url(https://example.com/'x)", False, id="single-quote-in-unquoted-url"),
+        pytest.param("cursor: url(https://example.com/\x7fx)", False, id="delete-in-unquoted-url"),
+        pytest.param("cursor: url(https://example.com/\x01x)", False, id="control-in-unquoted-url"),
+        pytest.param('cursor: url("https://example.com/\fpath")', False, id="form-feed-in-quoted-url"),
     ],
 )
 def test_style_value_rejects_expression_and_bad_url_scheme(style: str, kept: bool) -> None:  # ruff:ignore[boolean-type-hint-positional-argument]
     # a kept property still has its value scrubbed: expression() and url(disallowed-scheme) drop the whole declaration
     out = sanitize(f'<p style="{style}">x</p>', _style_policy())
     assert ("style=" in out) is kept
+
+
+@pytest.mark.parametrize(
+    ("style", "kept"),
+    [
+        pytest.param(r"cursor: u\72l(javascript:alert(1))", False, id="escaped-function-hex"),
+        pytest.param(r"cursor: u\72 l(javascript:alert(1))", False, id="escaped-function-hex-terminator"),
+        pytest.param(r"cursor: u\rl(javascript:alert(1))", False, id="escaped-function-simple"),
+        pytest.param(r"cursor: U\000052L(JaVaScRiPt:alert(1))", False, id="escaped-function-mixed-case"),
+        pytest.param(r"cursor: url(jav\61script:alert(1))", False, id="escaped-scheme"),
+        pytest.param(r'cursor: u\72l("jav\61script:alert(1)")', False, id="escaped-quoted-url"),
+        pytest.param("cursor: u\\\nrl(javascript:alert(1))", False, id="escaped-newline"),
+        pytest.param("cursor: \\", False, id="trailing-escape"),
+        pytest.param(r"width: expr\65ssion(alert(1))", False, id="escaped-expression"),
+        pytest.param(r"cursor: url(https://example.com/a), u\72l(jav\61script:alert(1))", False, id="multiple-urls"),
+        pytest.param(r"cursor: url(jav\110000-script:x)", True, id="invalid-code-point-is-not-script"),
+        pytest.param(r"cursor: url(jav\0 -script:x)", True, id="null-escape-is-not-script"),
+        pytest.param(r"cursor: url(jav\d800 -script:x)", True, id="surrogate-escape-is-not-script"),
+        pytest.param(r"cursor: url(jav\1f642 -script:x)", True, id="non-bmp-code-point-is-not-script"),
+        pytest.param(r"cursor: abcdefghijk\0000612", True, id="six-digit-escape-before-hex"),
+        pytest.param("cursor: url(jav\\\nascript:alert(1))", False, id="escaped-newline-in-url"),
+        pytest.param(r'cursor: url("https://example.com" trailing)', False, id="garbage-after-quoted-url"),
+        pytest.param(r'cursor: url("https://example.com)', False, id="unterminated-quoted-url"),
+        pytest.param('cursor: url("https://example.com\npath")', False, id="newline-in-quoted-url"),
+        pytest.param(r'cursor: url(https://example.com/"x)', False, id="quote-in-unquoted-url"),
+    ],
+)
+def test_style_value_decodes_css_escapes(style: str, *, kept: bool) -> None:
+    assert ("style=" in sanitize(f'<p style="{style}">x</p>', _style_policy())) is kept
+
+
+@pytest.mark.parametrize(
+    "prefix_length",
+    [pytest.param(40, id="inline-buffer"), pytest.param(96, id="grown-buffer")],
+)
+def test_style_url_scheme_lookup_does_not_truncate_long_names(prefix_length: int) -> None:
+    allowed_prefix = "h" * prefix_length
+    policy = Policy(
+        tags=frozenset({"p"}),
+        attributes={"p": frozenset({"style"})},
+        css_properties=frozenset({"cursor"}),
+        url_schemes=frozenset({allowed_prefix}),
+    )
+    assert "style=" not in sanitize(f'<p style="cursor: url({allowed_prefix}h:opaque)">x</p>', policy)
+
+
+@pytest.mark.parametrize(
+    ("style", "kept"),
+    [
+        pytest.param("content: 'a\\\rb'", True, id="carriage-return"),
+        pytest.param("content: 'a\\\r\nb'", True, id="crlf"),
+        pytest.param("content: 'a\\", False, id="trailing-string-escape"),
+        pytest.param("content: 'a\\zb'", True, id="simple-string-escape"),
+        pytest.param("content: \\61", True, id="hex-escape-at-end"),
+        pytest.param("content: \\61\r", True, id="hex-escape-carriage-return-at-end"),
+        pytest.param("content: \\61\rblue", True, id="hex-escape-carriage-return-terminator"),
+        pytest.param("content: \\61\r\nblue", True, id="hex-escape-crlf-terminator"),
+    ],
+)
+def test_set_style_scanner_handles_escape_boundaries(style: str, *, kept: bool) -> None:
+    policy = Policy(
+        tags=frozenset({"p"}),
+        css_properties=frozenset({"content", "cursor"}),
+        set_attributes={"p": {"style": style}},
+    )
+    assert ("style=" in sanitize("<p>x</p>", policy)) is kept
+
+
+@pytest.mark.parametrize(
+    "style",
+    [
+        pytest.param("behavior: url(#x)", id="behavior"),
+        pytest.param("BEHAVIOR: url(#x)", id="behavior-case"),
+        pytest.param(r"beha\76ior: url(#x)", id="behavior-escape"),
+        pytest.param("beha\\\nvior: url(#x)", id="invalid-property-escape"),
+        pytest.param("-moz-binding: url(#x)", id="moz-binding"),
+        pytest.param(r"-moz-b\69nding: url(#x)", id="moz-binding-escape"),
+    ],
+)
+def test_legacy_executable_css_properties_cannot_be_allowlisted(style: str) -> None:
+    policy = _style_policy(
+        css_properties=frozenset({"behavior", "BEHAVIOR", r"beha\76ior", "-moz-binding", r"-moz-b\69nding"})
+    )
+    assert "style=" not in sanitize(f'<p style="{style}">x</p>', policy)
+
+
+@pytest.mark.parametrize(
+    "style",
+    [
+        pytest.param("content: 'url(javascript:alert(1))'", id="string"),
+        pytest.param("color: /* url(javascript:alert(1)) */ red", id="comment"),
+        pytest.param(r"cursor: safe\ url(javascript:alert(1))", id="escaped-identifier-space"),
+        pytest.param("cursor: urlish(javascript:alert(1))", id="longer-identifier"),
+    ],
+)
+def test_css_safety_scanner_ignores_inert_tokens(style: str) -> None:
+    policy = _style_policy(css_properties=frozenset({"color", "content", "cursor"}))
+    assert "style=" in sanitize(f'<p style="{style}">x</p>', policy)
+
+
+def test_css_safety_scanner_keeps_url_text_inside_non_ascii_identifier() -> None:
+    policy = _style_policy(css_properties=frozenset({"cursor"}))
+    assert 'style="cursor: \u00e9url(javascript:alert(1))"' in sanitize(
+        '<p style="cursor: \u00e9url(javascript:alert(1))">x</p>', policy
+    )
 
 
 def test_style_double_quoted_url_scheme_is_stripped() -> None:
@@ -631,6 +748,19 @@ def _style_element_policy(*, css_properties: frozenset[str] = DEFAULT_CSS_PROPER
 def test_style_element_body_scrubbed(css: str, expected_body: str) -> None:
     # an allowlisted <style> keeps its element and structure; each declaration is vetted like a style attribute
     assert sanitize(f"<style>{css}</style>", _style_element_policy()) == f"<style>{expected_body}</style>"
+
+
+@pytest.mark.parametrize(
+    "style",
+    [
+        pytest.param(r"cursor:u\72l(javascript:alert(1))", id="escaped-function"),
+        pytest.param(r"cursor:url(jav\61script:alert(1))", id="escaped-scheme"),
+    ],
+)
+def test_style_element_body_decodes_css_escapes(style: str) -> None:
+    policy = _style_element_policy(css_properties=frozenset({"cursor"}))
+    once = sanitize(f"<style>p{{{style}}}</style>", policy)
+    assert (once, sanitize(once, policy)) == ("<style>p{}</style>", once)
 
 
 def test_allowed_styles_does_not_narrow_style_element_body() -> None:
@@ -870,6 +1000,17 @@ def test_attribute_filter_rewrites_value() -> None:
                 attribute_filter=lambda _tag, _name, _value: "color: url(javascript:alert(1))",
             ),
             id="style",
+        ),
+        pytest.param(
+            "p",
+            '<p style="cursor: auto">x</p>',
+            Policy(
+                tags=frozenset({"p"}),
+                attributes={"p": frozenset({"style"})},
+                css_properties=frozenset({"cursor"}),
+                attribute_filter=lambda _tag, _name, _value: "cursor: u\\72\r\nl(javascript:alert(1))",
+            ),
+            id="style-escaped-crlf-terminator",
         ),
         pytest.param(
             "a",

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -490,7 +490,7 @@ def test_style_double_quoted_css_string() -> None:
         pytest.param("cursor: url(https://example.com/'x)", False, id="single-quote-in-unquoted-url"),
         pytest.param("cursor: url(https://example.com/\x7fx)", False, id="delete-in-unquoted-url"),
         pytest.param("cursor: url(https://example.com/\x01x)", False, id="control-in-unquoted-url"),
-        pytest.param('cursor: url("https://example.com/\fpath")', False, id="form-feed-in-quoted-url"),
+        pytest.param("cursor: url('https://example.com/\fpath')", False, id="form-feed-in-quoted-url"),
     ],
 )
 def test_style_value_rejects_expression_and_bad_url_scheme(style: str, kept: bool) -> None:  # ruff:ignore[boolean-type-hint-positional-argument]
@@ -525,7 +525,7 @@ def test_style_value_rejects_expression_and_bad_url_scheme(style: str, kept: boo
     ],
 )
 def test_style_value_decodes_css_escapes(style: str, *, kept: bool) -> None:
-    assert ("style=" in sanitize(f'<p style="{style}">x</p>', _style_policy())) is kept
+    assert ("style=" in sanitize(f"<p style='{style}'>x</p>", _style_policy())) is kept
 
 
 @pytest.mark.parametrize(

--- a/tox.toml
+++ b/tox.toml
@@ -112,6 +112,8 @@ commands = [
     { replace = "if", condition = "factor['3.10']", then = "97", else = "100" },
     "--html-details",
     "{env_tmp_dir}{/}c_htmlcov.html",
+    "--txt-metric",
+    "branch",
     "--txt",
     "-",
   ] },


### PR DESCRIPTION
CSS escapes let active syntax survive raw-character sanitizer checks. Those checks also rejected function-like text inside inert strings and comments. 🔒

The native CSS scanner decodes escaped identifiers and URL values before comparison. It rejects malformed URL tokens and the legacy executable properties `behavior` and `-moz-binding`, respects token boundaries, and grows scheme buffers without truncation.

This branch follows [#728](https://github.com/tox-dev/turbohtml/pull/728) because rewritten style values need its final safety pass. The decoded checks close #721.
