### PR TITLE
⚡ perf(find): defer tag index builds

### DIFF
--- a/docs/changelog/712.bugfix.rst
+++ b/docs/changelog/712.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid building a whole-tree tag index for first-result and small-limit queries.

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -298,6 +298,10 @@ string built and no matcher dispatch. It stays ahead of resiliparse's lexbor pas
 widening to 22 times on the spec, leads lxml's C XPath engine by 14 to 24 times, and runs 12 to over 1,400 times ahead
 of pyquery, selectolax, parsel, BeautifulSoup, and soupsieve.
 
+A first-result query walks until its match when the document has no tag index. An uncapped ``find_all`` builds the
+whole-document index for later queries; ``find`` and ``find_all(..., limit=1)`` reuse it after that point. The cold-tree
+benchmark records hit positions and misses. It measures uncapped and limited collection, plus peak resident memory.
+
 .. bench-table::
     :file: bench/querying.json
 

--- a/src/turbohtml/_c/query/find.c
+++ b/src/turbohtml/_c/query/find.c
@@ -901,7 +901,7 @@ PyObject *node_find(PyObject *self, PyObject *args, PyObject *kwargs) {
        the child/sibling pointers mid-read (a no-op on the GIL build) */
     Py_BEGIN_CRITICAL_SECTION(handle);
     HandleObject *handle_obj = (HandleObject *)handle;
-    if (handle_use_index(handle_obj, origin, query_is_indexed_tag(&query))) {
+    if (handle_obj->index_built && handle_index_usable(handle_obj, origin) && query_is_indexed_tag(&query)) {
         Py_ssize_t pos = handle_obj->index_offsets[query.tag_atom];
         Py_ssize_t end = handle_obj->index_offsets[query.tag_atom + 1];
         if (query_is_simple_tag(&query)) {
@@ -976,7 +976,11 @@ PyObject *node_find_all(PyObject *self, PyObject *args, PyObject *kwargs) {
        the child/sibling pointers mid-read (a no-op on the GIL build) */
     Py_BEGIN_CRITICAL_SECTION(handle);
     HandleObject *handle_obj = (HandleObject *)handle;
-    if (handle_use_index(handle_obj, origin, query_is_indexed_tag(&query))) {
+    int use_index =
+        query.limit >= 0 && query.limit <= 8
+            ? handle_obj->index_built && handle_index_usable(handle_obj, origin) && query_is_indexed_tag(&query)
+            : handle_use_index(handle_obj, origin, query_is_indexed_tag(&query));
+    if (use_index) {
         int simple = query_is_simple_tag(&query);
         Py_ssize_t end = handle_obj->index_offsets[query.tag_atom + 1];
         for (Py_ssize_t pos = handle_obj->index_offsets[query.tag_atom]; pos < end; pos++) {

--- a/tests/query/find/test_tree_find.py
+++ b/tests/query/find/test_tree_find.py
@@ -232,6 +232,7 @@ def test_axis_preceding_excludes_ancestors() -> None:
     ("limit", "count"),
     [
         pytest.param(None, 2, id="none"),
+        pytest.param(9, 2, id="larger-than-walk-threshold"),
         pytest.param(1, 1, id="one"),
         pytest.param(0, 0, id="zero"),
     ],
@@ -277,12 +278,70 @@ def test_callable_error_propagates(id_filter: Filter) -> None:
         parse("<p>").find(id=id_filter)
 
 
-# a known-tag + attribute query rooted at the document reaches the matcher through the
-# atom-index bucket, so its error path is distinct from the general descendant walk's
 @pytest.mark.parametrize("query", [lambda doc: doc.find("p", id=_raise), lambda doc: doc.find_all("p", id=_raise)])
 def test_indexed_tag_filter_error_propagates(query: Callable[[Document], object]) -> None:
+    document = parse("<p>x</p>")
+    document.find_all("p")
     with pytest.raises(ZeroDivisionError):
-        query(parse("<p>x</p>"))
+        query(document)
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [pytest.param("target", "target", id="match"), pytest.param("missing", None, id="miss")],
+)
+def test_find_filtered_on_warm_tree(target: str, expected: str | None) -> None:
+    document = parse("<p id='first'/><p id='target'/>")
+    document.find_all("p")
+    match = document.find("p", id=target)
+    assert (match.attrs["id"] if match is not None else None) == expected
+
+
+@pytest.mark.parametrize(
+    ("markup", "tag", "expected"),
+    [
+        pytest.param("<custom id='target'/>", "custom", "target", id="unknown-tag"),
+        pytest.param("<div/>", "p", None, id="empty-known-tag-bucket"),
+    ],
+)
+def test_find_without_warm_index_bucket(markup: str, tag: str, expected: str | None) -> None:
+    document = parse(markup)
+    document.find_all("div")
+    match = document.find(tag)
+    assert (match.attrs["id"] if match is not None else None) == expected
+
+
+def test_find_on_warm_subtree() -> None:
+    document = parse("<section><p id='inside'/></section><p id='outside'/>")
+    document.find_all("p")
+    assert (section := document.find("section")) is not None
+    assert (match := section.find("p")) is not None
+    assert match.attrs["id"] == "inside"
+
+
+@pytest.mark.parametrize(
+    ("markup", "prime_tag", "tag"),
+    [
+        pytest.param("<p id='first'/><p id='second'/>", "p", "p", id="known-tag"),
+        pytest.param("<custom id='first'/><custom id='second'/>", "div", "custom", id="unknown-tag"),
+    ],
+)
+def test_find_all_limit_on_warm_tree(markup: str, prime_tag: str, tag: str) -> None:
+    document = parse(markup)
+    document.find_all(prime_tag)
+    assert [element.attrs["id"] for element in document.find_all(tag, limit=1)] == ["first"]
+
+
+def test_find_all_limit_on_warm_subtree() -> None:
+    document = parse("<section><p id='inside'/></section><p id='outside'/>")
+    document.find_all("p")
+    assert (section := document.find("section")) is not None
+    assert [element.attrs["id"] for element in section.find_all("p", limit=1)] == ["inside"]
+
+
+def test_limited_tag_filter_error_propagates_on_cold_tree() -> None:
+    with pytest.raises(ZeroDivisionError):
+        parse("<p>x</p>").find_all("p", id=_raise, limit=1)
 
 
 @pytest.mark.parametrize(

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -270,6 +270,21 @@ def find(text: str) -> None:
     _parsed(text).find_all("a")
 
 
+def _find_cold(case: tuple[str, turbohtml.Document]) -> None:
+    query_kind, document = case
+    if query_kind == "find":
+        document.find("a")
+    elif query_kind == "all":
+        document.find_all("a")
+    else:
+        document.find_all("a", limit=1)
+
+
+def _find_cold_setup(case: tuple[str, str]) -> tuple[str, turbohtml.Document]:
+    query_kind, source = case
+    return query_kind, turbohtml.parse(source)
+
+
 def select(text: str) -> None:
     """Run the CSS selector with turbohtml's select."""
     _parsed(text).select(_CSS)
@@ -951,6 +966,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "unescape": (unescape, "turbohtml"),
     "tokenize": (tokenize, "turbohtml"),
     "find": (find, "turbohtml"),
+    "find-cold": (Mutating(_find_cold_setup, _find_cold), "turbohtml"),
     "select": (select, "turbohtml"),
     "select-has": (select_has, "turbohtml"),
     "computed-style": (computed_style, "turbohtml"),

--- a/tools/bench/migration.py
+++ b/tools/bench/migration.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 _SIZE_OPS: Final = frozenset({"minify", "minify-css", "minify-js"})
 # a memory op leads with peak resident bytes, so its rows are two cells wide like a size op's
-_MEMORY_OPS: Final = frozenset({"parse-dense", "rewrite"})
+_MEMORY_OPS: Final = frozenset({"find-cold", "parse-dense", "rewrite"})
 _WIDE_OPS: Final = _SIZE_OPS | _MEMORY_OPS
 
 # Why a variant repeats the sibling's figure when the library is measured in more than one configuration: the

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -263,7 +263,7 @@ class Operation:
 SIZE_OPS: Final[frozenset[str]] = frozenset({"minify", "minify-css", "minify-js"})
 
 # Peak RSS runs in a fresh process so allocator reuse from pyperf's timed loops cannot hide the retained tree or buffer.
-MEMORY_OPS: Final[frozenset[str]] = frozenset({"parse-dense", "rewrite"})
+MEMORY_OPS: Final[frozenset[str]] = frozenset({"find-cold", "parse-dense", "rewrite"})
 
 
 OPERATIONS: dict[str, Operation] = {
@@ -287,6 +287,7 @@ OPERATIONS: dict[str, Operation] = {
     "unescape": Operation("unescape", "us"),
     "tokenize": Operation("tokenize", "us"),
     "find": Operation("find every anchor", "us"),
+    "find-cold": Operation("query a cold 10,000-element tree", "us"),
     "select": Operation("select div a[href]", "us"),
     "select-has": Operation("select div:has(a)", "us"),
     "computed-style": Operation("computed style for every element", "us"),
@@ -460,6 +461,15 @@ _LINKIFY_TRAVERSAL_CASES: Final[tuple[tuple[str, tuple[str, str]], ...]] = (
         ("callbacks", '<a href="https://kept.example">kept</a> https://example.com ' * 200),
     ),
     ("2,000 nodes without text", ("default", "<div></div>" * 2_000)),
+)
+
+_FIND_COLD_BODY: Final[str] = "<span>x</span>" * 10_000
+_FIND_COLD_CASES: Final[tuple[tuple[str, tuple[str, str]], ...]] = (
+    ("find early hit", ("find", "<a>x</a>" + _FIND_COLD_BODY)),
+    ("find late hit", ("find", _FIND_COLD_BODY + "<a>x</a>")),
+    ("find miss", ("find", _FIND_COLD_BODY)),
+    ("find_all", ("all", "<a>x</a>" + _FIND_COLD_BODY)),
+    ("find_all limit=1", ("limit", "<a>x</a>" + _FIND_COLD_BODY)),
 )
 
 _MARKDOWN_ARTICLE = "<h2>Heading</h2><p>A <b>bold</b> <a href='/x'>link</a> and <code>code</code>.</p>" * 18
@@ -922,6 +932,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "links-absolutize": _readpath_cases,
     "links-rewrite": _readpath_cases,
     "find": _readpath_cases,
+    "find-cold": lambda: _FIND_COLD_CASES,
     "select": _readpath_cases,
     "select-has": _readpath_cases,
     "computed-style": lambda: (("styled page (3 kB)", _styled_page(8)), ("styled page (11 kB)", _styled_page(40))),


### PR DESCRIPTION
⚡ On a cold 10,000-element tree, `find()` built a whole-document tag index before returning a match near the root. The [reproducer in #712](https://github.com/tox-dev/turbohtml/issues/712) incurred index setup and allocated one pointer per indexed element.

First-result queries and `find_all(..., limit=N)` for `N <= 8` walk until they have enough results, leaving the index unbuilt on cold trees. Uncapped and larger queries build it; warm queries reuse it.

🧩 Replacement #742 must land first so XML and HTML queries retain separate index rules. Query results and cache invalidation remain unchanged. This closes #712.
