### PR TITLE
🧪 test(parser): track living WPT corpus

### DIFF
--- a/docs/changelog/719.misc.rst
+++ b/docs/changelog/719.misc.rst
@@ -1,0 +1,1 @@
+Track the pinned living WPT tree-construction corpus with raw and spec-adjusted results.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -94,6 +94,29 @@ parse5). The convention is deliberate:
 The vendored ``html5lib-tests`` conformance data is separate: it lives under ``tests/dom``, ``tests/tokenizer``, and
 ``tests/encoding`` (not ``tests/conformance``) and runs in the ordinary matrix, so it is unaffected by the above.
 
+The committed ``tests/conformance/data/wpt_html_tree.json`` tracks the living WPT tree-construction corpus as a source
+apart from the frozen ``html5lib-tests`` data. Refresh it every three months and before releases or after WHATWG parsing
+changes. Check out the desired WPT revision before running the one command that updates the pin and prints four views:
+raw and spec-adjusted totals plus per-fixture and parse-error results:
+
+::
+
+    python tools/generate_wpt_tree_corpus.py /path/to/wpt tests/conformance/data/wpt_html_tree.json
+
+The pin at ``4830edb`` contains 1920 cases. Four fixtures require the `script processing model
+<https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model>`_ and therefore a JavaScript runtime;
+the parser denominator is 1916. TurboHTML matches 1908 raw fixture trees and all 1916 spec-correct trees. The eight raw
+differences are the ``</p>`` and ``</br>`` expectations in `foreign-fragment.dat
+<https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612>`_
+and `tests26.dat
+<https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453>`_.
+The fixtures conflict with the living `foreign-content end-tag rule
+<https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign>`_. The report keeps them visible in its raw
+count and records the normative result in a separate spec-adjusted count. Each JavaScript exclusion and each error
+adjustment for a processing instruction carries its specification and fixture links in the committed JSON. The exact
+comparison covers the 283 document cases that publish ``#new-errors`` data because the public fragment API does not
+expose parse errors.
+
 *********
  Fuzzing
 *********

--- a/tests/conformance/data/wpt_html_tree.json
+++ b/tests/conformance/data/wpt_html_tree.json
@@ -1,0 +1,24575 @@
+{
+ "source": "https://github.com/web-platform-tests/wpt/tree/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources",
+ "revision": "4830edb033cb486fd0cd6f85b5e937cfc718704d",
+ "files": [
+  "adoption01.dat",
+  "adoption02.dat",
+  "blocks.dat",
+  "comments01.dat",
+  "doctype01.dat",
+  "domjs-unsafe.dat",
+  "entities01.dat",
+  "entities02.dat",
+  "foreign-fragment.dat",
+  "html5test-com.dat",
+  "inbody01.dat",
+  "isindex.dat",
+  "main-element.dat",
+  "math.dat",
+  "menuitem-element.dat",
+  "namespace-sensitivity.dat",
+  "noscript01.dat",
+  "pending-spec-changes-plain-text-unsafe.dat",
+  "pending-spec-changes.dat",
+  "plain-text-unsafe.dat",
+  "processing-instructions.dat",
+  "quirks01.dat",
+  "ruby.dat",
+  "scriptdata01.dat",
+  "scripted_adoption01.dat",
+  "scripted_ark.dat",
+  "scripted_webkit01.dat",
+  "search-element.dat",
+  "svg.dat",
+  "tables01.dat",
+  "template.dat",
+  "tests1.dat",
+  "tests10.dat",
+  "tests11.dat",
+  "tests12.dat",
+  "tests14.dat",
+  "tests15.dat",
+  "tests16.dat",
+  "tests17.dat",
+  "tests18.dat",
+  "tests19.dat",
+  "tests2.dat",
+  "tests20.dat",
+  "tests21.dat",
+  "tests22.dat",
+  "tests23.dat",
+  "tests24.dat",
+  "tests25.dat",
+  "tests26.dat",
+  "tests3.dat",
+  "tests4.dat",
+  "tests5.dat",
+  "tests6.dat",
+  "tests7.dat",
+  "tests8.dat",
+  "tests9.dat",
+  "tests_innerHTML_1.dat",
+  "tricky01.dat",
+  "void-in-phrasing.dat",
+  "webkit01.dat",
+  "webkit02.dat"
+ ],
+ "fixture_counts": {
+  "adoption01.dat": 18,
+  "adoption02.dat": 3,
+  "blocks.dat": 48,
+  "comments01.dat": 16,
+  "doctype01.dat": 37,
+  "domjs-unsafe.dat": 49,
+  "entities01.dat": 75,
+  "entities02.dat": 26,
+  "foreign-fragment.dat": 66,
+  "html5test-com.dat": 24,
+  "inbody01.dat": 4,
+  "isindex.dat": 4,
+  "main-element.dat": 3,
+  "math.dat": 8,
+  "menuitem-element.dat": 20,
+  "namespace-sensitivity.dat": 1,
+  "noscript01.dat": 18,
+  "pending-spec-changes-plain-text-unsafe.dat": 1,
+  "pending-spec-changes.dat": 3,
+  "plain-text-unsafe.dat": 33,
+  "processing-instructions.dat": 124,
+  "quirks01.dat": 4,
+  "ruby.dat": 21,
+  "scriptdata01.dat": 26,
+  "scripted_adoption01.dat": 1,
+  "scripted_ark.dat": 1,
+  "scripted_webkit01.dat": 2,
+  "search-element.dat": 3,
+  "svg.dat": 8,
+  "tables01.dat": 19,
+  "template.dat": 112,
+  "tests1.dat": 112,
+  "tests10.dat": 54,
+  "tests11.dat": 13,
+  "tests12.dat": 2,
+  "tests14.dat": 7,
+  "tests15.dat": 14,
+  "tests16.dat": 197,
+  "tests17.dat": 13,
+  "tests18.dat": 36,
+  "tests19.dat": 103,
+  "tests2.dat": 63,
+  "tests20.dat": 64,
+  "tests21.dat": 23,
+  "tests22.dat": 5,
+  "tests23.dat": 5,
+  "tests24.dat": 8,
+  "tests25.dat": 26,
+  "tests26.dat": 20,
+  "tests3.dat": 24,
+  "tests4.dat": 9,
+  "tests5.dat": 17,
+  "tests6.dat": 52,
+  "tests7.dat": 34,
+  "tests8.dat": 10,
+  "tests9.dat": 27,
+  "tests_innerHTML_1.dat": 81,
+  "tricky01.dat": 9,
+  "void-in-phrasing.dat": 13,
+  "webkit01.dat": 52,
+  "webkit02.dat": 49
+ },
+ "applicable_fixture_counts": {
+  "adoption01.dat": 18,
+  "adoption02.dat": 3,
+  "blocks.dat": 48,
+  "comments01.dat": 16,
+  "doctype01.dat": 37,
+  "domjs-unsafe.dat": 49,
+  "entities01.dat": 75,
+  "entities02.dat": 26,
+  "foreign-fragment.dat": 66,
+  "html5test-com.dat": 24,
+  "inbody01.dat": 4,
+  "isindex.dat": 4,
+  "main-element.dat": 3,
+  "math.dat": 8,
+  "menuitem-element.dat": 20,
+  "namespace-sensitivity.dat": 1,
+  "noscript01.dat": 18,
+  "pending-spec-changes-plain-text-unsafe.dat": 1,
+  "pending-spec-changes.dat": 3,
+  "plain-text-unsafe.dat": 33,
+  "processing-instructions.dat": 124,
+  "quirks01.dat": 4,
+  "ruby.dat": 21,
+  "scriptdata01.dat": 26,
+  "scripted_adoption01.dat": 0,
+  "scripted_ark.dat": 0,
+  "scripted_webkit01.dat": 0,
+  "search-element.dat": 3,
+  "svg.dat": 8,
+  "tables01.dat": 19,
+  "template.dat": 112,
+  "tests1.dat": 112,
+  "tests10.dat": 54,
+  "tests11.dat": 13,
+  "tests12.dat": 2,
+  "tests14.dat": 7,
+  "tests15.dat": 14,
+  "tests16.dat": 197,
+  "tests17.dat": 13,
+  "tests18.dat": 36,
+  "tests19.dat": 103,
+  "tests2.dat": 63,
+  "tests20.dat": 64,
+  "tests21.dat": 23,
+  "tests22.dat": 5,
+  "tests23.dat": 5,
+  "tests24.dat": 8,
+  "tests25.dat": 26,
+  "tests26.dat": 20,
+  "tests3.dat": 24,
+  "tests4.dat": 9,
+  "tests5.dat": 17,
+  "tests6.dat": 52,
+  "tests7.dat": 34,
+  "tests8.dat": 10,
+  "tests9.dat": 27,
+  "tests_innerHTML_1.dat": 81,
+  "tricky01.dat": 9,
+  "void-in-phrasing.dat": 13,
+  "webkit01.dat": 52,
+  "webkit02.dat": 49
+ },
+ "normative_adjustments": [
+  {
+   "file": "tests26.dat",
+   "data": "<svg></p><foo>",
+   "context": null,
+   "scripting": null,
+   "reason": "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<math></p><foo>",
+   "context": null,
+   "scripting": null,
+   "reason": "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<svg></p><foo>",
+   "context": "div",
+   "scripting": null,
+   "reason": "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</p><foo>",
+   "context": "svg svg",
+   "scripting": null,
+   "reason": "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<svg></br><foo>",
+   "context": null,
+   "scripting": null,
+   "reason": "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<math></br><foo>",
+   "context": null,
+   "scripting": null,
+   "reason": "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<svg></br><foo>",
+   "context": "div",
+   "scripting": null,
+   "reason": "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</br><foo>",
+   "context": "svg svg",
+   "scripting": null,
+   "reason": "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612"
+  }
+ ],
+ "error_adjustments": [
+  {
+   "file": "comments01.dat",
+   "data": "<?xml version=\"1.0\">Hi",
+   "context": null,
+   "scripting": null,
+   "reason": "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/comments01.dat#L155-L195"
+  },
+  {
+   "file": "comments01.dat",
+   "data": "<?xml version=\"1.0\">",
+   "context": null,
+   "scripting": null,
+   "reason": "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/comments01.dat#L155-L195"
+  },
+  {
+   "file": "comments01.dat",
+   "data": "<?xml version",
+   "context": null,
+   "scripting": null,
+   "reason": "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/comments01.dat#L155-L195"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<?import namespace=\"foo\" implementation=\"#bar\">",
+   "context": null,
+   "scripting": null,
+   "reason": "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/html5test-com.dat#L129-L139"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<?",
+   "context": null,
+   "scripting": null,
+   "reason": "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests1.dat#L551-L570"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<?#",
+   "context": null,
+   "scripting": null,
+   "reason": "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests1.dat#L551-L570"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<?COMMENT?>",
+   "context": null,
+   "scripting": null,
+   "reason": "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests1.dat#L602-L614"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<?COM--MENT?>",
+   "context": null,
+   "scripting": null,
+   "reason": "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions.",
+   "spec": "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests1.dat#L641-L653"
+  }
+ ],
+ "exclusions": [
+  {
+   "file": "scripted_adoption01.dat",
+   "data": "<p><b id=\"A\"><script>document.getElementById(\"A\").id = \"B\"</script></p>TEXT</b>",
+   "context": null,
+   "scripting": true,
+   "reason": "The expected tree requires JavaScript execution; turbohtml has no JavaScript runtime.",
+   "spec": "https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/scripted_adoption01.dat#L1-L16",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         id=\"A\"\n|         <script>\n|           \"document.getElementById(\"A\").id = \"B\"\"\n|     <b>\n|       id=\"A\"\n|       \"TEXT\""
+  },
+  {
+   "file": "scripted_ark.dat",
+   "data": "<p><font size=4><font size=4><font size=4><script>document.getElementsByTagName(\"font\")[2].setAttribute(\"size\", \"5\");</script><font size=4><p>X",
+   "context": null,
+   "scripting": true,
+   "reason": "The expected tree requires JavaScript execution; turbohtml has no JavaScript runtime.",
+   "spec": "https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/scripted_ark.dat#L1-L27",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <script>\n|               \"document.getElementsByTagName(\"font\")[2].setAttribute(\"size\", \"5\");\"\n|             <font>\n|               size=\"4\"\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             \"X\""
+  },
+  {
+   "file": "scripted_webkit01.dat",
+   "data": "1<script>document.write(\"2\")</script>3",
+   "context": null,
+   "scripting": true,
+   "reason": "The expected tree requires JavaScript execution; turbohtml has no JavaScript runtime.",
+   "spec": "https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/scripted_webkit01.dat#L1-L12",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"1\"\n|     <script>\n|       \"document.write(\"2\")\"\n|     \"3\""
+  },
+  {
+   "file": "scripted_webkit01.dat",
+   "data": "1<script>document.write(\"<script>document.write('2')</scr\"+ \"ipt><script>document.write('3')</scr\" + \"ipt>\")</script>4",
+   "context": null,
+   "scripting": true,
+   "reason": "The expected tree requires JavaScript execution; turbohtml has no JavaScript runtime.",
+   "spec": "https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model",
+   "fixture": "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/scripted_webkit01.dat#L14-L30",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"1\"\n|     <script>\n|       \"document.write(\"<script>document.write('2')</scr\"+ \"ipt><script>document.write('3')</scr\" + \"ipt>\")\"\n|     \"4\""
+  }
+ ],
+ "cases": [
+  {
+   "file": "adoption01.dat",
+   "data": "<a><p></a></p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <p>\n|       <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <p>\n|       <a>"
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<a>1<p>2</a>3</p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <p>\n|       <a>\n|         \"2\"\n|       \"3\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <p>\n|       <a>\n|         \"2\"\n|       \"3\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<a>1<button>2</a>3</button>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <button>\n|       <a>\n|         \"2\"\n|       \"3\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <button>\n|       <a>\n|         \"2\"\n|       \"3\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<a>1<b>2</a>3</b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|       <b>\n|         \"2\"\n|     <b>\n|       \"3\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|       <b>\n|         \"2\"\n|     <b>\n|       \"3\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<a>1<div>2<div>3</a>4</div>5</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <div>\n|       <a>\n|         \"2\"\n|       <div>\n|         <a>\n|           \"3\"\n|         \"4\"\n|       \"5\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <div>\n|       <a>\n|         \"2\"\n|       <div>\n|         <a>\n|           \"3\"\n|         \"4\"\n|       \"5\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<table><a>1<p>2</a>3</p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <p>\n|       <a>\n|         \"2\"\n|       \"3\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <p>\n|       <a>\n|         \"2\"\n|       \"3\"\n|     <table>"
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<b><b><a><p></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <b>\n|         <a>\n|         <p>\n|           <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <b>\n|         <a>\n|         <p>\n|           <a>"
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<b><a><b><p></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <a>\n|         <b>\n|       <b>\n|         <p>\n|           <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <a>\n|         <b>\n|       <b>\n|         <p>\n|           <a>"
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<a><b><b><p></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|         <b>\n|     <b>\n|       <b>\n|         <p>\n|           <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|         <b>\n|     <b>\n|       <b>\n|         <p>\n|           <a>"
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<p>1<s id=\"A\">2<b id=\"B\">3</p>4</s>5</b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"1\"\n|       <s>\n|         id=\"A\"\n|         \"2\"\n|         <b>\n|           id=\"B\"\n|           \"3\"\n|     <s>\n|       id=\"A\"\n|       <b>\n|         id=\"B\"\n|         \"4\"\n|     <b>\n|       id=\"B\"\n|       \"5\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"1\"\n|       <s>\n|         id=\"A\"\n|         \"2\"\n|         <b>\n|           id=\"B\"\n|           \"3\"\n|     <s>\n|       id=\"A\"\n|       <b>\n|         id=\"B\"\n|         \"4\"\n|     <b>\n|       id=\"B\"\n|       \"5\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<table><a>1<td>2</td>3</table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <a>\n|       \"3\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"2\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"1\"\n|     <a>\n|       \"3\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"2\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<table>A<td>B</td>C</table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"AC\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"B\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"AC\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"B\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<a><svg><tr><input></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <svg svg>\n|         <svg tr>\n|           <svg input>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <svg svg>\n|         <svg tr>\n|           <svg input>"
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<div><a><b><div><div><div><div><div><div><div><div><div><div></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <a>\n|         <b>\n|       <b>\n|         <div>\n|           <a>\n|           <div>\n|             <a>\n|             <div>\n|               <a>\n|               <div>\n|                 <a>\n|                 <div>\n|                   <a>\n|                   <div>\n|                     <a>\n|                     <div>\n|                       <a>\n|                       <div>\n|                         <a>\n|                           <div>\n|                             <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <a>\n|         <b>\n|       <b>\n|         <div>\n|           <a>\n|           <div>\n|             <a>\n|             <div>\n|               <a>\n|               <div>\n|                 <a>\n|                 <div>\n|                   <a>\n|                   <div>\n|                     <a>\n|                     <div>\n|                       <a>\n|                       <div>\n|                         <a>\n|                           <div>\n|                             <div>"
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<div><a><b><u><i><code><div></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <a>\n|         <b>\n|           <u>\n|             <i>\n|               <code>\n|       <u>\n|         <i>\n|           <code>\n|             <div>\n|               <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <a>\n|         <b>\n|           <u>\n|             <i>\n|               <code>\n|       <u>\n|         <i>\n|           <code>\n|             <div>\n|               <a>"
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<b><b><b><b>x</b></b></b></b>y",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <b>\n|         <b>\n|           <b>\n|             \"x\"\n|     \"y\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <b>\n|         <b>\n|           <b>\n|             \"x\"\n|     \"y\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<p><b><b><b><b><p>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         <b>\n|           <b>\n|             <b>\n|     <p>\n|       <b>\n|         <b>\n|           <b>\n|             \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         <b>\n|           <b>\n|             <b>\n|     <p>\n|       <b>\n|         <b>\n|           <b>\n|             \"x\""
+  },
+  {
+   "file": "adoption01.dat",
+   "data": "<b><em><foo><foob><fooc><aside></b></em>",
+   "document": "| <b>\n|   <em>\n|     <foo>\n|       <foob>\n|         <fooc>\n| <aside>\n|   <b>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <b>\n|   <em>\n|     <foo>\n|       <foob>\n|         <fooc>\n| <aside>\n|   <b>"
+  },
+  {
+   "file": "adoption02.dat",
+   "data": "<b>1<i>2<p>3</b>4",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"1\"\n|       <i>\n|         \"2\"\n|     <i>\n|       <p>\n|         <b>\n|           \"3\"\n|         \"4\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"1\"\n|       <i>\n|         \"2\"\n|     <i>\n|       <p>\n|         <b>\n|           \"3\"\n|         \"4\""
+  },
+  {
+   "file": "adoption02.dat",
+   "data": "<a><div><style></style><address><a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <div>\n|       <a>\n|         <style>\n|       <address>\n|         <a>\n|         <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <div>\n|       <a>\n|         <style>\n|       <address>\n|         <a>\n|         <a>"
+  },
+  {
+   "file": "adoption02.dat",
+   "data": "<nobr><table><marquee></table><nobr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <nobr>\n|       <marquee>\n|       <table>\n|     <nobr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <nobr>\n|       <marquee>\n|       <table>\n|     <nobr>"
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<address>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <address>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <address>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><address><p>foo</address>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <address>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <address>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<article>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <article>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <article>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><article><p>foo</article>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <article>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <article>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<aside>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <aside>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <aside>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><aside><p>foo</aside>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <aside>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <aside>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<blockquote>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <blockquote>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <blockquote>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><blockquote><p>foo</blockquote>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <blockquote>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <blockquote>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<center>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <center>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <center>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><center><p>foo</center>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <center>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <center>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<details>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <details>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <details>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><details><p>foo</details>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <details>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <details>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<dialog>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <dialog>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <dialog>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><dialog><p>foo</dialog>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dialog>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dialog>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<dir>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <dir>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <dir>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><dir><p>foo</dir>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dir>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dir>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<div>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <div>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <div>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><div><p>foo</div>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<dl>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <dl>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <dl>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><dl><p>foo</dl>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dl>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dl>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<fieldset>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <fieldset>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <fieldset>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><fieldset><p>foo</fieldset>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <fieldset>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <fieldset>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<figcaption>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <figcaption>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <figcaption>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><figcaption><p>foo</figcaption>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <figcaption>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <figcaption>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<figure>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <figure>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <figure>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><figure><p>foo</figure>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <figure>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <figure>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<footer>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <footer>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <footer>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><footer><p>foo</footer>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <footer>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <footer>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<header>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <header>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <header>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><header><p>foo</header>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <header>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <header>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<hgroup>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <hgroup>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <hgroup>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><hgroup><p>foo</hgroup>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <hgroup>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <hgroup>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<listing>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <listing>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <listing>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><listing><p>foo</listing>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <listing>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <listing>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<menu>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <menu>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <menu>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><menu><p>foo</menu>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menu>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menu>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<nav>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <nav>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <nav>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><nav><p>foo</nav>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <nav>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <nav>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<ol>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <ol>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <ol>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><ol><p>foo</ol>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ol>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ol>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<pre>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <pre>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <pre>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><pre><p>foo</pre>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<section>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <section>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <section>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><section><p>foo</section>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <section>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <section>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<summary>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <summary>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <summary>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><summary><p>foo</summary>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <summary>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <summary>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><p>foo<ul>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <ul>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <ul>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "blocks.dat",
+   "data": "<!doctype html><ul><p>foo</ul>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-- BAR -->BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR  -->\n|     \"BAZ\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR  -->\n|     \"BAZ\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-- BAR --!>BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR  -->\n|     \"BAZ\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-closed-comment",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-closed-comment",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR  -->\n|     \"BAZ\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-- BAR --! >BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR --! >BAZ -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR --! >BAZ -->"
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-- BAR --!\n>BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR --!\n>BAZ -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 2,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 2,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR --!\n>BAZ -->"
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-- BAR --   >BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR --   >BAZ -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR --   >BAZ -->"
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-- BAR -- <QUX> -- MUX -->BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR -- <QUX> -- MUX  -->\n|     \"BAZ\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR -- <QUX> -- MUX  -->\n|     \"BAZ\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-- BAR -- <QUX> -- MUX --!>BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR -- <QUX> -- MUX  -->\n|     \"BAZ\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-closed-comment",
+     "line": 1,
+     "col": 32,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-closed-comment",
+     "line": 1,
+     "col": 32,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR -- <QUX> -- MUX  -->\n|     \"BAZ\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-- BAR -- <QUX> -- MUX -- >BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR -- <QUX> -- MUX -- >BAZ -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 36,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 36,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  BAR -- <QUX> -- MUX -- >BAZ -->"
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!---->BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  -->\n|     \"BAZ\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  -->\n|     \"BAZ\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!--->BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  -->\n|     \"BAZ\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "abrupt-closing-of-empty-comment",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "abrupt-closing-of-empty-comment",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  -->\n|     \"BAZ\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!-->BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  -->\n|     \"BAZ\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "abrupt-closing-of-empty-comment",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "abrupt-closing-of-empty-comment",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!--  -->\n|     \"BAZ\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "<?xml version=\"1.0\">Hi",
+   "document": "| <!-- ?xml version=\"1.0\" -->\n| <html>\n|   <head>\n|   <body>\n|     \"Hi\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-question-mark-instead-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "disallowed-processing-instruction-target",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- ?xml version=\"1.0\" -->\n| <html>\n|   <head>\n|   <body>\n|     \"Hi\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "<?xml version=\"1.0\">",
+   "document": "| <!-- ?xml version=\"1.0\" -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-question-mark-instead-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "disallowed-processing-instruction-target",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- ?xml version=\"1.0\" -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "comments01.dat",
+   "data": "<?xml version",
+   "document": "| <!-- ?xml version -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-question-mark-instead-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "disallowed-processing-instruction-target",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- ?xml version -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "comments01.dat",
+   "data": "FOO<!----->BAZ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!-- - -->\n|     \"BAZ\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <!-- - -->\n|     \"BAZ\""
+  },
+  {
+   "file": "comments01.dat",
+   "data": "<html><!-- comment --><title>Comment before head</title>",
+   "document": "| <html>\n|   <!--  comment  -->\n|   <head>\n|     <title>\n|       \"Comment before head\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <!--  comment  -->\n|   <head>\n|     <title>\n|       \"Comment before head\"\n|   <body>"
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE html>Hello",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!dOctYpE HtMl>Hello",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPEhtml>Hello",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE>Hello",
+   "document": "| <!DOCTYPE >\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE >\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE >Hello",
+   "document": "| <!DOCTYPE >\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-doctype-name",
+     "line": 1,
+     "col": 11,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-doctype-name",
+     "line": 1,
+     "col": 11,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE >\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato >Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato taco>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato taco \"ddd>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato sYstEM>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-doctype-system-identifier",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-doctype-system-identifier",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato sYstEM    >Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-doctype-system-identifier",
+     "line": 1,
+     "col": 28,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-doctype-system-identifier",
+     "line": 1,
+     "col": 28,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE   potato       sYstEM  ggg>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 34,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 34,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato SYSTEM taco  >Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 25,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 25,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato SYSTEM 'taco\"'>Hello",
+   "document": "| <!DOCTYPE potato \"\" \"taco\"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE potato \"\" \"taco\"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato SYSTEM \"taco\">Hello",
+   "document": "| <!DOCTYPE potato \"\" \"taco\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE potato \"\" \"taco\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato SYSTEM \"tai'co\">Hello",
+   "document": "| <!DOCTYPE potato \"\" \"tai'co\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE potato \"\" \"tai'co\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato SYSTEMtaco \"ddd\">Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato grass SYSTEM taco>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato pUbLIc>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-doctype-public-identifier",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-doctype-public-identifier",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato pUbLIc >Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-doctype-public-identifier",
+     "line": 1,
+     "col": 25,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-doctype-public-identifier",
+     "line": 1,
+     "col": 25,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato pUbLIcgoof>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-quote-before-doctype-public-identifier",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-quote-before-doctype-public-identifier",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato PUBLIC goof>Hello",
+   "document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-quote-before-doctype-public-identifier",
+     "line": 1,
+     "col": 25,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-quote-before-doctype-public-identifier",
+     "line": 1,
+     "col": 25,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato PUBLIC \"go'of\">Hello",
+   "document": "| <!DOCTYPE potato \"go'of\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE potato \"go'of\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato PUBLIC 'go'of'>Hello",
+   "document": "| <!DOCTYPE potato \"go\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato \"go\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato PUBLIC 'go:hh   of' >Hello",
+   "document": "| <!DOCTYPE potato \"go:hh   of\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE potato \"go:hh   of\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE potato PUBLIC \"W3C-//dfdf\" SYSTEM ggg>Hello",
+   "document": "| <!DOCTYPE potato \"W3C-//dfdf\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-quote-before-doctype-system-identifier",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE potato \"W3C-//dfdf\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\n   \"http://www.w3.org/TR/html4/strict.dtd\">Hello",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE ...>Hello",
+   "document": "| <!DOCTYPE ...>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE ...>\n| <html>\n|   <head>\n|   <body>\n|     \"Hello\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\"\n\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE root-element [SYSTEM OR PUBLIC FPI] \"uri\" [ \n<!-- internal declarations -->\n]>",
+   "document": "| <!DOCTYPE root-element>\n| <html>\n|   <head>\n|   <body>\n|     \"]>\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE root-element>\n| <html>\n|   <head>\n|   <body>\n|     \"]>\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE html PUBLIC\n  \"-//WAPFORUM//DTD XHTML Mobile 1.0//EN\"\n    \"http://www.wapforum.org/DTD/xhtml-mobile10.dtd\">",
+   "document": "| <!DOCTYPE html \"-//WAPFORUM//DTD XHTML Mobile 1.0//EN\" \"http://www.wapforum.org/DTD/xhtml-mobile10.dtd\">\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"-//WAPFORUM//DTD XHTML Mobile 1.0//EN\" \"http://www.wapforum.org/DTD/xhtml-mobile10.dtd\">\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE HTML SYSTEM \"http://www.w3.org/DTD/HTML4-strict.dtd\"><body><b>Mine!</b></body>",
+   "document": "| <!DOCTYPE html \"\" \"http://www.w3.org/DTD/HTML4-strict.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"Mine!\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"\" \"http://www.w3.org/DTD/HTML4-strict.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"Mine!\""
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\"http://www.w3.org/TR/html4/strict.dtd\">",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+     "line": 1,
+     "col": 50,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+     "line": 1,
+     "col": 50,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"'http://www.w3.org/TR/html4/strict.dtd'>",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+     "line": 1,
+     "col": 50,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+     "line": 1,
+     "col": 50,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE HTML PUBLIC\"-//W3C//DTD HTML 4.01//EN\"'http://www.w3.org/TR/html4/strict.dtd'>",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-after-doctype-public-keyword",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+     "line": 1,
+     "col": 49,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-after-doctype-public-keyword",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+     "line": 1,
+     "col": 49,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "doctype01.dat",
+   "data": "<!DOCTYPE HTML PUBLIC'-//W3C//DTD HTML 4.01//EN''http://www.w3.org/TR/html4/strict.dtd'>",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-after-doctype-public-keyword",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+     "line": 1,
+     "col": 49,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-after-doctype-public-keyword",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "missing-whitespace-between-doctype-public-and-system-identifiers",
+     "line": 1,
+     "col": 49,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><![CDATA[foo\nbar]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\nbar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\nbar\""
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><![CDATA[foo\rbar]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\nbar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\nbar\""
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><![CDATA[foo\r\nbar]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\nbar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\nbar\""
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script>a='\u0000'</script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"a='�'\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"a='�'\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--\u0000</script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--�\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 25,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 25,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--�\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--foo\u0000</script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--foo�\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 28,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 28,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--foo�\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!-- foo-\u0000</script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-�\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-�\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!-- foo--\u0000</script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo--�\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 31,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 31,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo--�\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!-- foo-",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!-- foo-<</script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-<\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-<\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!-- foo-<S",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-<S\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 32,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 32,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-<S\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!-- foo-</SCRIPT>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!-- foo-\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<p></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<p>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<p>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<script></script></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script></script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script></script>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<script>\u0000</script></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script>�</script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script>�</script>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<script>-\u0000</script></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script>-�</script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 34,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 34,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script>-�</script>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<script>--\u0000</script></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script>--�</script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script>--�</script>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<script>---</script></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script>---</script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script>---</script>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<script></scrip></SCRIPT></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script></scrip></SCRIPT>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script></scrip></SCRIPT>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<script></scrip </SCRIPT></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script></scrip </SCRIPT>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script></scrip </SCRIPT>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--<script></scrip/</SCRIPT></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script></scrip/</SCRIPT>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--<script></scrip/</SCRIPT>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"></scrip/></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"</scrip/>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"</scrip/>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"></scrip ></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"</scrip >\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"</scrip >\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--</scrip></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--</scrip>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--</scrip>\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--</scrip </script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--</scrip \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--</scrip \"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<script type=\"data\"><!--</scrip/</script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--</scrip/\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       type=\"data\"\n|       \"<!--</scrip/\"\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<!DOCTYPE html><!DOCTYPE html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<html><!DOCTYPE html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<html><head><!DOCTYPE html></head>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<html><head></head><!DOCTYPE html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<body></body><!DOCTYPE html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<table><!DOCTYPE html></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<select><!DOCTYPE html></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<table><colgroup><!DOCTYPE html></colgroup></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<table><colgroup><!--test--></colgroup></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <!-- test -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <!-- test -->"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<table><colgroup><html></colgroup></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<table><colgroup> foo</colgroup></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"foo\"\n|     <table>\n|       <colgroup>\n|         \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"foo\"\n|     <table>\n|       <colgroup>\n|         \" \""
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<select><!--test--></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <!-- test -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <!-- test -->"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<select><html></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<frameset><html></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<frameset></frameset><html>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<frameset></frameset><!DOCTYPE html>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<html><body></body></html><!DOCTYPE html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><!DOCTYPE html></svg>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><font></font></svg>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg font>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg font>"
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><font id=foo></font></svg>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg font>\n|         id=\"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg font>\n|         id=\"foo\""
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><font size=4></font></svg>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <font>\n|       size=\"4\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <font>\n|       size=\"4\""
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><font color=red></font></svg>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <font>\n|       color=\"red\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <font>\n|       color=\"red\""
+  },
+  {
+   "file": "domjs-unsafe.dat",
+   "data": "<svg><font font=sans></font></svg>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg font>\n|         font=\"sans\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg font>\n|         font=\"sans\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&gt;BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO>BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&gtBAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO>BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&gt BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO> BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO> BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&gt;;;BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO>;;BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO>;;BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "I'm &notit; I tell you",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"I'm ¬it; I tell you\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"I'm ¬it; I tell you\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "I'm &notin; I tell you",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"I'm ∉ I tell you\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"I'm ∉ I tell you\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "&ammmp;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&ammmp;\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unknown-named-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unknown-named-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&ammmp;\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "&ammmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmp;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&ammmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmp;\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unknown-named-character-reference",
+     "line": 1,
+     "col": 950,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unknown-named-character-reference",
+     "line": 1,
+     "col": 950,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&ammmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmp;\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO& BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO& BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO& BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&<BAR>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&\"\n|     <bar>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&\"\n|     <bar>"
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&&&&gt;BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&&&>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&&&>BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#41;BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO)BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO)BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x41;BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOABAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOABAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#X41;BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOABAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOABAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&#BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&#BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&#ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&#ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xBAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOºR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOºR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&#xZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&#xZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#XZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&#XZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO&#XZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#41BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO)BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO)BAR\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x41BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO䆺R\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 11,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 11,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO䆺R\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x41ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOAZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOAZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0000;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "null-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "null-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0078;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOxZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOxZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0079;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOyZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOyZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0080;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO€ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO€ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0081;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0082;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‚ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‚ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0083;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOƒZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOƒZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0084;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO„ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO„ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0085;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO…ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO…ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0086;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO†ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO†ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0087;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‡ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‡ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0088;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOˆZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOˆZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0089;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‰ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‰ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x008A;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOŠZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOŠZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x008B;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‹ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‹ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x008C;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOŒZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOŒZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x008D;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x008E;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOŽZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOŽZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x008F;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0090;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0091;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‘ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO‘ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0092;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO’ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO’ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0093;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO“ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO“ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0094;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO”ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO”ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0095;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO•ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO•ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0096;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO–ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO–ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0097;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO—ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO—ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0098;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO˜ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO˜ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x0099;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO™ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO™ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x009A;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOšZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOšZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x009B;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO›ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO›ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x009C;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOœZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOœZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x009D;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x009E;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOžZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOžZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x009F;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOŸZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOŸZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x00A0;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xD7FF;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO퟿ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO퟿ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xD800;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "surrogate-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "surrogate-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xD801;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "surrogate-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "surrogate-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xDFFE;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "surrogate-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "surrogate-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xDFFF;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "surrogate-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "surrogate-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xE000;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOOZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x10FFFE;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO􏿾ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "noncharacter-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "noncharacter-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO􏿾ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x1087D4;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO􈟔ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO􈟔ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x10FFFF;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO􏿿ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "noncharacter-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "noncharacter-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO􏿿ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#x110000;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#xFFFFFF;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#11111111111",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#1111111111",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#111111111111",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#11111111111ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#1111111111ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities01.dat",
+   "data": "FOO&#111111111111ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "character-reference-outside-unicode-range",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO�ZOO\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&gt;YY\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ>YY\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ>YY\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar='ZZ&'></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=ZZ&></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&gt=YY\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gt=YY\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gt=YY\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&gt0YY\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gt0YY\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gt0YY\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&gt9YY\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gt9YY\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gt9YY\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&gtaYY\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gtaYY\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gtaYY\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&gtZYY\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gtZYY\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&gtZYY\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&gt YY\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ> YY\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ> YY\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&gt\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ>\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ>\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar='ZZ&gt'></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ>\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ>\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=ZZ&gt></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ>\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ>\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&pound_id=23\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ£_id=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 19,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 19,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ£_id=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&prod_id=23\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&prod_id=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&prod_id=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&pound;_id=23\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ£_id=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ£_id=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&prod;_id=23\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ∏_id=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ∏_id=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&pound=23\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&pound=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&pound=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div bar=\"ZZ&prod=23\"></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&prod=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       bar=\"ZZ&prod=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div>ZZ&pound_id=23</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ£_id=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ£_id=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div>ZZ&prod_id=23</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ&prod_id=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ&prod_id=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div>ZZ&pound;_id=23</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ£_id=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ£_id=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div>ZZ&prod;_id=23</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ∏_id=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ∏_id=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div>ZZ&pound=23</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ£=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ£=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div>ZZ&prod=23</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ&prod=23\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZ&prod=23\""
+  },
+  {
+   "file": "entities02.dat",
+   "data": "<div>ZZ&AElig=</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZÆ=\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"ZZÆ=\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<nobr>X",
+   "document": "| <nobr>\n|   \"X\"",
+   "context": "svg path",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <nobr>\n|   \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<font color></font>X",
+   "document": "| <font>\n|   color=\"\"\n| \"X\"",
+   "context": "svg path",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <font>\n|   color=\"\"\n| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<font></font>X",
+   "document": "| <svg font>\n| \"X\"",
+   "context": "svg path",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg font>\n| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<g></path>X",
+   "document": "| <svg g>\n|   \"X\"",
+   "context": "svg path",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg g>\n|   \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</path>X",
+   "document": "| \"X\"",
+   "context": "svg path",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</foreignObject>X",
+   "document": "| \"X\"",
+   "context": "svg foreignObject",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</desc>X",
+   "document": "| \"X\"",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</title>X",
+   "document": "| \"X\"",
+   "context": "svg title",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</svg>X",
+   "document": "| \"X\"",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</mfenced>X",
+   "document": "| \"X\"",
+   "context": "math mfenced",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</malignmark>X",
+   "document": "| \"X\"",
+   "context": "math malignmark",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</math>X",
+   "document": "| \"X\"",
+   "context": "math math",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</annotation-xml>X",
+   "document": "| \"X\"",
+   "context": "math annotation-xml",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</mtext>X",
+   "document": "| \"X\"",
+   "context": "math mtext",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</mi>X",
+   "document": "| \"X\"",
+   "context": "math mi",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</mo>X",
+   "document": "| \"X\"",
+   "context": "math mo",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</mn>X",
+   "document": "| \"X\"",
+   "context": "math mn",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</ms>X",
+   "document": "| \"X\"",
+   "context": "math ms",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<b></b><mglyph/><i></i><malignmark/><u></u><ms/>X",
+   "document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <ms>\n|   \"X\"",
+   "context": "math ms",
+   "scripting": null,
+   "errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 49
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 49
+    }
+   ],
+   "spec_document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <ms>\n|   \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<malignmark></malignmark>",
+   "document": "| <math malignmark>",
+   "context": "math ms",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math malignmark>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "math ms",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <figure>",
+   "context": "math ms",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<b></b><mglyph/><i></i><malignmark/><u></u><mn/>X",
+   "document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <mn>\n|   \"X\"",
+   "context": "math mn",
+   "scripting": null,
+   "errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 49
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 49
+    }
+   ],
+   "spec_document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <mn>\n|   \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<malignmark></malignmark>",
+   "document": "| <math malignmark>",
+   "context": "math mn",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math malignmark>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "math mn",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <figure>",
+   "context": "math mn",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<b></b><mglyph/><i></i><malignmark/><u></u><mo/>X",
+   "document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <mo>\n|   \"X\"",
+   "context": "math mo",
+   "scripting": null,
+   "errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 49
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 49
+    }
+   ],
+   "spec_document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <mo>\n|   \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<malignmark></malignmark>",
+   "document": "| <math malignmark>",
+   "context": "math mo",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math malignmark>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "math mo",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <figure>",
+   "context": "math mo",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<b></b><mglyph/><i></i><malignmark/><u></u><mi/>X",
+   "document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <mi>\n|   \"X\"",
+   "context": "math mi",
+   "scripting": null,
+   "errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 49
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 49
+    }
+   ],
+   "spec_document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <mi>\n|   \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<malignmark></malignmark>",
+   "document": "| <math malignmark>",
+   "context": "math mi",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math malignmark>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "math mi",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <figure>",
+   "context": "math mi",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<b></b><mglyph/><i></i><malignmark/><u></u><mtext/>X",
+   "document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <mtext>\n|   \"X\"",
+   "context": "math mtext",
+   "scripting": null,
+   "errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 52
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 44,
+     "end_line": 1,
+     "end_col": 52
+    }
+   ],
+   "spec_document": "| <b>\n| <math mglyph>\n| <i>\n| <math malignmark>\n| <u>\n| <mtext>\n|   \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<malignmark></malignmark>",
+   "document": "| <math malignmark>",
+   "context": "math mtext",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math malignmark>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "math mtext",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <figure>",
+   "context": "math mtext",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "math annotation-xml",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <math figure>",
+   "context": "math annotation-xml",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "math math",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <math figure>",
+   "context": "math math",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "svg foreignObject",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <figure>",
+   "context": "svg foreignObject",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "svg title",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <figure>",
+   "context": "svg title",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<figure></figure>",
+   "document": "| <figure>",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <figure>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div><h1>X</h1></div>",
+   "document": "| <div>\n|   <h1>\n|     \"X\"",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>\n|   <h1>\n|     \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<div></div>",
+   "document": "| <div>",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<plaintext><foo>",
+   "document": "| <plaintext>\n|   \"<foo>\"",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <plaintext>\n|   \"<foo>\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<frameset>X",
+   "document": "| \"X\"",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<head>X",
+   "document": "| \"X\"",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<body>X",
+   "document": "| \"X\"",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<html>X",
+   "document": "| \"X\"",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<html class=\"foo\">X",
+   "document": "| \"X\"",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<body class=\"foo\">X",
+   "document": "| \"X\"",
+   "context": "svg desc",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"X\""
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<svg><p>",
+   "document": "| <svg svg>\n| <p>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n| <p>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<p>",
+   "document": "| <p>",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <p>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<svg></p><foo>",
+   "document": "| <svg svg>\n| <p>\n| <foo>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <p>\n|   <svg foo>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<svg></br><foo>",
+   "document": "| <svg svg>\n| <br>\n| <foo>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <br>\n|   <svg foo>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</p><foo>",
+   "document": "| <p>\n| <svg foo>",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg foo>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "</br><foo>",
+   "document": "| <br>\n| <svg foo>",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg foo>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<body><foo>",
+   "document": "| <svg foo>",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg foo>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<p><foo>",
+   "document": "| <p>\n|   <foo>",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <p>\n|   <foo>"
+  },
+  {
+   "file": "foreign-fragment.dat",
+   "data": "<p></p><foo>",
+   "document": "| <p>\n| <svg foo>",
+   "context": "svg svg",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <p>\n| <svg foo>"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<div<div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div<div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div<div>"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<div foo<bar=''>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       foo<bar=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       foo<bar=\"\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<div foo=`bar`>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       foo=\"`bar`\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-character-in-unquoted-attribute-value",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-character-in-unquoted-attribute-value",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-character-in-unquoted-attribute-value",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-character-in-unquoted-attribute-value",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       foo=\"`bar`\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<div \\\"foo=''>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \\\"foo=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \\\"foo=\"\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<a href='\\nbar'></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"\\nbar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"\\nbar\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<!DOCTYPE html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "&lang;&rang;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"⟨⟩\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"⟨⟩\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "&apos;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"'\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"'\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "&ImaginaryI;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"ⅈ\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"ⅈ\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "&Kopf;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"𝕂\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"𝕂\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "&notinva;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"∉\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"∉\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<?import namespace=\"foo\" implementation=\"#bar\">",
+   "document": "| <?import namespace=\"foo\" implementation=\"#bar\"?>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-question-mark-instead-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [],
+   "spec_document": "| <?import namespace=\"foo\" implementation=\"#bar\"?>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<!--foo--bar-->",
+   "document": "| <!-- foo--bar -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!-- foo--bar -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<![CDATA[x]]>",
+   "document": "| <!-- [CDATA[x]] -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "cdata-in-html-content",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "cdata-in-html-content",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- [CDATA[x]] -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<textarea><!--</textarea>--></textarea>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<!--\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<!--\"\n|     \"-->\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<textarea><!--</textarea>-->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<!--\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<!--\"\n|     \"-->\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<style><!--</style>--></style>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<style><!--</style>-->",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<ul><li>A </li> <li>B</li></ul>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|         \"A \"\n|       \" \"\n|       <li>\n|         \"B\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|         \"A \"\n|       \" \"\n|       <li>\n|         \"B\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<table><form><input type=hidden><input></form><div></div></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <input>\n|     <div>\n|     <table>\n|       <form>\n|       <input>\n|         type=\"hidden\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <input>\n|     <div>\n|     <table>\n|       <form>\n|       <input>\n|         type=\"hidden\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<i>A<b>B<p></i>C</b>D",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"A\"\n|       <b>\n|         \"B\"\n|     <b>\n|     <p>\n|       <b>\n|         <i>\n|         \"C\"\n|       \"D\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"A\"\n|       <b>\n|         \"B\"\n|     <b>\n|     <p>\n|       <b>\n|         <i>\n|         \"C\"\n|       \"D\""
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<div></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<svg></svg>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>"
+  },
+  {
+   "file": "html5test-com.dat",
+   "data": "<math></math>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>"
+  },
+  {
+   "file": "inbody01.dat",
+   "data": "<button>1</foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <button>\n|       \"1\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <button>\n|       \"1\""
+  },
+  {
+   "file": "inbody01.dat",
+   "data": "<foo>1<p>2</foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       \"1\"\n|       <p>\n|         \"2\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       \"1\"\n|       <p>\n|         \"2\""
+  },
+  {
+   "file": "inbody01.dat",
+   "data": "<dd>1</foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <dd>\n|       \"1\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <dd>\n|       \"1\""
+  },
+  {
+   "file": "inbody01.dat",
+   "data": "<foo>1<dd>2</foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       \"1\"\n|       <dd>\n|         \"2\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       \"1\"\n|       <dd>\n|         \"2\""
+  },
+  {
+   "file": "isindex.dat",
+   "data": "<isindex>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <isindex>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <isindex>"
+  },
+  {
+   "file": "isindex.dat",
+   "data": "<isindex name=\"A\" action=\"B\" prompt=\"C\" foo=\"D\">",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <isindex>\n|       action=\"B\"\n|       foo=\"D\"\n|       name=\"A\"\n|       prompt=\"C\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <isindex>\n|       action=\"B\"\n|       foo=\"D\"\n|       name=\"A\"\n|       prompt=\"C\""
+  },
+  {
+   "file": "isindex.dat",
+   "data": "<form><isindex>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <form>\n|       <isindex>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <form>\n|       <isindex>"
+  },
+  {
+   "file": "isindex.dat",
+   "data": "<!doctype html><isindex>x</isindex>x",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <isindex>\n|       \"x\"\n|     \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <isindex>\n|       \"x\"\n|     \"x\""
+  },
+  {
+   "file": "main-element.dat",
+   "data": "<!doctype html><p>foo<main>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <main>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <main>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "main-element.dat",
+   "data": "<!doctype html><main><p>foo</main>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <main>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <main>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "main-element.dat",
+   "data": "<!DOCTYPE html>xxx<svg><x><g><a><main><b>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"xxx\"\n|     <svg svg>\n|       <svg x>\n|         <svg g>\n|           <svg a>\n|             <svg main>\n|     <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"xxx\"\n|     <svg svg>\n|       <svg x>\n|         <svg g>\n|           <svg a>\n|             <svg main>\n|     <b>"
+  },
+  {
+   "file": "math.dat",
+   "data": "<math><tr><td><mo><tr>",
+   "document": "| <math math>\n|   <math tr>\n|     <math td>\n|       <math mo>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math math>\n|   <math tr>\n|     <math td>\n|       <math mo>"
+  },
+  {
+   "file": "math.dat",
+   "data": "<math><tr><td><mo><tr>",
+   "document": "| <math math>\n|   <math tr>\n|     <math td>\n|       <math mo>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math math>\n|   <math tr>\n|     <math td>\n|       <math mo>"
+  },
+  {
+   "file": "math.dat",
+   "data": "<math><thead><mo><tbody>",
+   "document": "| <math math>\n|   <math thead>\n|     <math mo>",
+   "context": "thead",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math math>\n|   <math thead>\n|     <math mo>"
+  },
+  {
+   "file": "math.dat",
+   "data": "<math><tfoot><mo><tbody>",
+   "document": "| <math math>\n|   <math tfoot>\n|     <math mo>",
+   "context": "tfoot",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math math>\n|   <math tfoot>\n|     <math mo>"
+  },
+  {
+   "file": "math.dat",
+   "data": "<math><tbody><mo><tfoot>",
+   "document": "| <math math>\n|   <math tbody>\n|     <math mo>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math math>\n|   <math tbody>\n|     <math mo>"
+  },
+  {
+   "file": "math.dat",
+   "data": "<math><tbody><mo></table>",
+   "document": "| <math math>\n|   <math tbody>\n|     <math mo>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math math>\n|   <math tbody>\n|     <math mo>"
+  },
+  {
+   "file": "math.dat",
+   "data": "<math><thead><mo></table>",
+   "document": "| <math math>\n|   <math thead>\n|     <math mo>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math math>\n|   <math thead>\n|     <math mo>"
+  },
+  {
+   "file": "math.dat",
+   "data": "<math><tfoot><mo></table>",
+   "document": "| <math math>\n|   <math tfoot>\n|     <math mo>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <math math>\n|   <math tfoot>\n|     <math mo>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<menuitem>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <menuitem>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <menuitem>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "</menuitem>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><body><menuitem>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       \"A\""
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><body><menuitem>A<menuitem>B",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       \"A\"\n|       <menuitem>\n|         \"B\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       \"A\"\n|       <menuitem>\n|         \"B\""
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><body><menuitem>A<menu>B</menu>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       \"A\"\n|       <menu>\n|         \"B\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       \"A\"\n|       <menu>\n|         \"B\""
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><body><menuitem>A<hr>B",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       \"A\"\n|       <hr>\n|       \"B\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       \"A\"\n|       <hr>\n|       \"B\""
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><li><menuitem><li>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <li>\n|       <menuitem>\n|     <li>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <li>\n|       <menuitem>\n|     <li>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><menuitem><p></menuitem>x",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <p>\n|         \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <p>\n|         \"x\""
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><p><b></p><menuitem>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|     <b>\n|       <menuitem>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|     <b>\n|       <menuitem>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><menuitem><asdf></menuitem>x",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <asdf>\n|     \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <asdf>\n|     \"x\""
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html></menuitem>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><html></menuitem>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><head></menuitem>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><select><menuitem></select>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <menuitem>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <menuitem>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><option><menuitem>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <option>\n|       <menuitem>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <option>\n|       <menuitem>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><menuitem><option>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <option>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><menuitem></body>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><menuitem></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><menuitem><p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <p>"
+  },
+  {
+   "file": "menuitem-element.dat",
+   "data": "<!DOCTYPE html><menuitem><li>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <li>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <menuitem>\n|       <li>"
+  },
+  {
+   "file": "namespace-sensitivity.dat",
+   "data": "<body><table><tr><td><svg><td><foreignObject><span></td>Foo",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"Foo\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg td>\n|                 <svg foreignObject>\n|                   <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"Foo\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg td>\n|                 <svg foreignObject>\n|                   <span>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><!doctype html><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><html class=\"foo\"><!--foo--></noscript>",
+   "document": "| <html>\n|   class=\"foo\"\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   class=\"foo\"\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript>   </noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       \"   \"\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       \"   \"\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><basefont><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <basefont>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <basefont>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><bgsound><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <bgsound>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <bgsound>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><link><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <link>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <link>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><meta><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <meta>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <meta>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><noframes>XXX</noscript></noframes></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <noframes>\n|         \"XXX</noscript>\"\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <noframes>\n|         \"XXX</noscript>\"\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><style>XXX</style></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <style>\n|         \"XXX\"\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <style>\n|         \"XXX\"\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript></br><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <br>\n|     <!-- foo -->",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <br>\n|     <!-- foo -->"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><head class=\"foo\"><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><noscript class=\"foo\"><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript></p><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript><p><!--foo--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <p>\n|       <!-- foo -->",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <p>\n|       <!-- foo -->"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript>XXX<!--foo--></noscript></head>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     \"XXX\"\n|     <!-- foo -->",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     \"XXX\"\n|     <!-- foo -->"
+  },
+  {
+   "file": "noscript01.dat",
+   "data": "<head><noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>"
+  },
+  {
+   "file": "pending-spec-changes-plain-text-unsafe.dat",
+   "data": "<body><table>\u0000filler\u0000text\u0000",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"fillertext\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 26,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 26,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"fillertext\"\n|     <table>"
+  },
+  {
+   "file": "pending-spec-changes.dat",
+   "data": "<input type=\"hidden\"><frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "pending-spec-changes.dat",
+   "data": "<!DOCTYPE html><table><caption><svg>foo</table>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <svg svg>\n|           \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <svg svg>\n|           \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "pending-spec-changes.dat",
+   "data": "<table><tr><td><svg><desc><td></desc><circle>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg desc>\n|           <td>\n|             <circle>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg desc>\n|           <td>\n|             <circle>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "FOO&#x000D;ZOO",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\rZOO\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "control-character-reference",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\rZOO\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<html>\u0000<frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<html> \u0000 <frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<html>a\u0000a<frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"aa\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"aa\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<html>\u0000\u0000<frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<html>\u0000\n<frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<html><select>\u0000",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "\u0000",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 1,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 1,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<body>\u0000",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<plaintext>\u0000filler\u0000text\u0000",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"�filler�text�\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 19,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 12,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 19,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"�filler�text�\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg><![CDATA[\u0000filler\u0000text\u0000]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�filler�text�\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�filler�text�\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<body><!\u0000>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- � -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- � -->"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<body><!\u0000filler\u0000text>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- �filler�text -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- �filler�text -->"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<body><svg><foreignObject>\u0000filler\u0000text",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         \"fillertext\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 34,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 34,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         \"fillertext\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg>\u0000filler\u0000text",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�filler�text\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 13,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 13,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�filler�text\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg>\u0000<frameset>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�\"\n|       <svg frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�\"\n|       <svg frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg>\u0000 <frameset>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"� \"\n|       <svg frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"� \"\n|       <svg frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg>\u0000a<frameset>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�a\"\n|       <svg frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�a\"\n|       <svg frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg>\u0000</svg><frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg>\u0000 </svg><frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg>\u0000a</svg><frameset>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�a\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"�a\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg><path></path></svg><frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<svg><p><frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><pre>\r\n\r\nA</pre>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"\nA\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"\nA\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><pre>\r\rA</pre>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"\nA\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"\nA\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><pre>\rA</pre>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"A\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><table><tr><td><math><mtext>\u0000a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <math math>\n|               <math mtext>\n|                 \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 44,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 44,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <math math>\n|               <math mtext>\n|                 \"a\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><table><tr><td><svg><foreignObject>\u0000a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg foreignObject>\n|                 \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 51,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 51,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg foreignObject>\n|                 \"a\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><math><mi>a\u0000b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"ab\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"ab\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><math><mo>a\u0000b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mo>\n|         \"ab\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mo>\n|         \"ab\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><math><mn>a\u0000b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mn>\n|         \"ab\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mn>\n|         \"ab\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><math><ms>a\u0000b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math ms>\n|         \"ab\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 27,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math ms>\n|         \"ab\""
+  },
+  {
+   "file": "plain-text-unsafe.dat",
+   "data": "<!DOCTYPE html><math><mtext>a\u0000b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mtext>\n|         \"ab\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-null-character",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mtext>\n|         \"ab\""
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?something>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?something ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?something ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?something><span>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?something ?>\n|     <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?something ?>\n|     <span>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?something good>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?something good?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?something good?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?something else is good>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?something else is good?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?something else is good?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?one><?two>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?one ?>\n|     <?two ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?one ?>\n|     <?two ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?a$><?b$><?good?>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?a$ -->\n|     <!-- ?b$ -->\n|     <?good ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?a$ -->\n|     <!-- ?b$ -->\n|     <?good ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?hey there?>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?hey   there?>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?hey?there>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?hey ?there?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?hey ?there?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?hey\tthere=1?>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there=1?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there=1?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?hey\nthere=1?>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there=1?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there=1?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?hey\rthere=1?>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there=1?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there=1?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?hey\fthere=1?>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there=1?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?hey there=1?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?something ? >",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?something ? ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?something ? ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?something x >",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?something x ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?something x ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?something ?\\t   ??>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?something ?\\t   ??>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?something ?\\t   ??>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?t d > ?>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?t d ?>\n|     \" ?>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?t d ?>\n|     \" ?>\""
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?module-handler>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?module-handler ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?module-handler ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?module-handler data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?module-handler data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?module-handler data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?view-port>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?view-port ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?view-port ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?view-port data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?view-port data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?view-port data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?config-v2>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?config-v2 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?config-v2 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?config-v2 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?config-v2 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?config-v2 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?x>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?x ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?x ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?x data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?x data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?x data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?zz2op>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?zz2op ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?zz2op ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?zz2op data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?zz2op data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?zz2op data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?xla->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?xla- ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?xla- ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?xla- data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?xla- data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?xla- data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?a-b-c>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?a-b-c ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?a-b-c ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?a-b-c data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?a-b-c data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?a-b-c data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?v-123>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?v-123 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?v-123 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?v-123 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?v-123 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?v-123 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?a0-b1-c2>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?a0-b1-c2 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?a0-b1-c2 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?a0-b1-c2 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?a0-b1-c2 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?a0-b1-c2 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?page-404>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?page-404 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?page-404 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?page-404 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?page-404 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?page-404 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?r2-d2>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?r2-d2 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?r2-d2 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?r2-d2 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?r2-d2 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?r2-d2 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?level-99>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?level-99 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?level-99 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?level-99 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?level-99 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?level-99 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?UPPERCASE>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?UPPERCASE ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?UPPERCASE ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?UPPERCASE data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?UPPERCASE data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?UPPERCASE data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?all-KINDS-of-CaSeS>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?all-KINDS-of-CaSeS ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?all-KINDS-of-CaSeS ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?all-KINDS-of-CaSeS data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?all-KINDS-of-CaSeS data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?all-KINDS-of-CaSeS data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?user_name>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?user_name ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?user_name ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?user_name data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?user_name data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?user_name data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?S_S-S_S>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?S_S-S_S ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?S_S-S_S ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?S_S-S_S data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?S_S-S_S data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?S_S-S_S data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?b_>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?b_ ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?b_ ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?b_ data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?b_ data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?b_ data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?_prefix>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?_prefix ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?_prefix ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?_prefix data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?_prefix data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?_prefix data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?_x132>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?_x132 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?_x132 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?_x132 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?_x132 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?_x132 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?_-_>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?_-_ ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?_-_ ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?_-_ data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?_-_ data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?_-_ data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?_>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?_ ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?_ ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?_ data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?_ data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?_ data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?A---------------->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?A---------------- ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?A---------------- ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?A---------------- data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?A---------------- data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?A---------------- data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?z0123456789>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?z0123456789 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?z0123456789 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?z0123456789 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?z0123456789 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?z0123456789 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?m-0>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?m-0 ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?m-0 ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?m-0 data>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <?m-0 data?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <?m-0 data?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?xml>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?xml -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?xml -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?xml-stylesheet>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?xml-stylesheet -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?xml-stylesheet -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?XML>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?XML -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?XML -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?XML-stylesheet>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?XML-stylesheet -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?XML-stylesheet -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?xML>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?xML -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?xML -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?xml-STYLesheet>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?xml-STYLesheet -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?xml-STYLesheet -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?1st-place>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?1st-place -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?1st-place -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?2-factor>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?2-factor -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?2-factor -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?99-problems>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?99-problems -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?99-problems -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?٥-star>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?٥-star -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?٥-star -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?-prefix>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?-prefix -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?-prefix -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?--internal>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?--internal -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?--internal -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?-data->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?-data- -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?-data- -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?-100>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?-100 -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?-100 -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?·middle-dot>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?·middle-dot -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?·middle-dot -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?͵greek-numeral>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?͵greek-numeral -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?͵greek-numeral -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?́accent-start>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?́accent-start -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?́accent-start -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?price$value>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?price$value -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?price$value -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?user@domain>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?user@domain -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?user@domain -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?tag#id>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?tag#id -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?tag#id -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?a+b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?a+b -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?a+b -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?100%>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?100% -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?100% -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?data.v1>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?data.v1 -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?data.v1 -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?namespace:tag>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?namespace:tag -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?namespace:tag -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?error!code>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?error!code -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?error!code -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?x=y>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?x=y -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?x=y -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?a<b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?a<b -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?a<b -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?true&false>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?true&false -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?true&false -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?not|or>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?not|or -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?not|or -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?lit$123456789>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?lit$123456789 -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?lit$123456789 -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?lit$$4x>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?lit$$4x -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?lit$$4x -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?🚀-launch>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?🚀-launch -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?🚀-launch -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?error-⚠️>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?error-⚠️ -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?error-⚠️ -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?fire-🔥>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?fire-🔥 -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?fire-🔥 -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?v1-✅>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?v1-✅ -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?v1-✅ -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?start",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?start?",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?start ",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?start data",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?start ? ?",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><?",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><? ",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <!-- ?  -->"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<div><?something></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <?something ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <?something ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<div><?something good></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <?something good?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <?something good?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<table><?something></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <?something ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <?something ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<table><tr><?something></tr></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <?something ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <?something ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<script><?something></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<?something>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<?something>\"\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<style><?something></style>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<?something>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<?something>\"\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<?something>",
+   "document": "| <?something ?>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <?something ?>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<head><?something>",
+   "document": "| <html>\n|   <head>\n|     <?something ?>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <?something ?>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<html><?something><head>",
+   "document": "| <html>\n|   <?something ?>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <?something ?>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<html><head></head><?something><body>",
+   "document": "| <html>\n|   <head>\n|   <?something ?>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <?something ?>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<html><body></body><?something>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|   <?something ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|   <?something ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<html><body></body></html><?something>",
+   "document": "| <html>\n|   <head>\n|   <body>\n| <?something ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n| <?something ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><template><?something></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <?something ?>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <?something ?>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><textarea><?something></textarea>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<?something>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<?something>\""
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<body><title><?something></title>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"<?something>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"<?something>\""
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<noscript><?pi>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <?pi ?>\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <?pi ?>\n|   <body>"
+  },
+  {
+   "file": "processing-instructions.dat",
+   "data": "<template><?pi>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <?pi ?>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <?pi ?>\n|   <body>"
+  },
+  {
+   "file": "quirks01.dat",
+   "data": "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\"\n\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\"><p><table>",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD XHTML 1.0 Frameset//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <table>"
+  },
+  {
+   "file": "quirks01.dat",
+   "data": "<!DOCTYPE html SYSTEM \"http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd\"><p><table>",
+   "document": "| <!DOCTYPE html \"\" \"http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"\" \"http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <table>"
+  },
+  {
+   "file": "quirks01.dat",
+   "data": "<!DOCTYPE html PUBLIC \"html\"><p><table>",
+   "document": "| <!DOCTYPE html \"html\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"html\" \"\">\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <table>"
+  },
+  {
+   "file": "quirks01.dat",
+   "data": "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2//EN\"\n   \"http://www.w3.org/TR/html4/strict.dtd\"><p><table>",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD HTML 3.2//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD HTML 3.2//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <table>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rb>b<rb></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rb>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rb>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rb>b<rt></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rt>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rb>b<rtc></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rtc>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rtc>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rb>b<rp></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rp>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rb>b<span></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|         <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|         <span>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rt>b<rb></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rb>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rb>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rt>b<rt></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rt>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rt>b<rtc></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rtc>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rtc>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rt>b<rp></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rp>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rt>b<span></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|         <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|         <span>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rtc>b<rb></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|       <rb>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|       <rb>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rtc>b<rt>c<rt>d</ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|         <rt>\n|           \"c\"\n|         <rt>\n|           \"d\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|         <rt>\n|           \"c\"\n|         <rt>\n|           \"d\""
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rtc>b<rtc></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|       <rtc>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|       <rtc>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rtc>b<rp></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|         <rp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|         <rp>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rtc>b<span></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|         <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|         <span>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rp>b<rb></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rb>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rb>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rp>b<rt></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rt>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rp>b<rtc></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rtc>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rtc>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rp>b<rp></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rp>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby>a<rp>b<span></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|         <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|         <span>"
+  },
+  {
+   "file": "ruby.dat",
+   "data": "<html><ruby><rtc><ruby>a<rb>b<rt></ruby></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <rtc>\n|         <ruby>\n|           \"a\"\n|           <rb>\n|             \"b\"\n|           <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <rtc>\n|         <ruby>\n|           \"a\"\n|           <rb>\n|             \"b\"\n|           <rt>"
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'Hello'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'Hello'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'Hello'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script></script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script></script >BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script></script/>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "end-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "end-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script></script/ >BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\"></scriptx>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"</scriptx>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"</scriptx>BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script></script foo=\">\" dd>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 31,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 31,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<!'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<!-'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<!--'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!--'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!--'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<!---'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!---'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!---'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<!-->'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-->'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-->'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<!-- potato'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-- potato'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-- potato'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<!-- <sCrIpt'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-- <sCrIpt'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-- <sCrIpt'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt>'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt>'</script>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 57,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 57,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt>'</script>BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> -'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt> -'</script>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 59,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 59,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt> -'</script>BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> --'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt> --'</script>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 60,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 60,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt> --'</script>BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script>'<!-- <sCrIpt> -->'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-- <sCrIpt> -->'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"'<!-- <sCrIpt> -->'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> --!>'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt> --!>'</script>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 62,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 62,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt> --!>'</script>BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt> -- >'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt> -- >'</script>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 62,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 62,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt> -- >'</script>BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt '</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt '</script>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 57,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 57,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt '</script>BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt/'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt/'</script>BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 57,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 57,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt/'</script>BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt\\'</script>BAR",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt\\'\"\n|     \"BAR\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt\\'\"\n|     \"BAR\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script type=\"text/plain\">'<!-- <sCrIpt/'</script>BAR</script>QUX",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt/'</script>BAR\"\n|     \"QUX\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       type=\"text/plain\"\n|       \"'<!-- <sCrIpt/'</script>BAR\"\n|     \"QUX\""
+  },
+  {
+   "file": "scriptdata01.dat",
+   "data": "FOO<script><!--<script>-></script>--></script>QUX",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"<!--<script>-></script>-->\"\n|     \"QUX\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"FOO\"\n|     <script>\n|       \"<!--<script>-></script>-->\"\n|     \"QUX\""
+  },
+  {
+   "file": "scripted_adoption01.dat",
+   "data": "<p><b id=\"A\"><script>document.getElementById(\"A\").id = \"B\"</script></p>TEXT</b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         id=\"B\"\n|         <script>\n|           \"document.getElementById(\"A\").id = \"B\"\"\n|     <b>\n|       id=\"A\"\n|       \"TEXT\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         id=\"B\"\n|         <script>\n|           \"document.getElementById(\"A\").id = \"B\"\"\n|     <b>\n|       id=\"A\"\n|       \"TEXT\""
+  },
+  {
+   "file": "scripted_ark.dat",
+   "data": "<p><font size=4><font size=4><font size=4><script>document.getElementsByTagName(\"font\")[2].setAttribute(\"size\", \"5\");</script><font size=4><p>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"5\"\n|             <script>\n|               \"document.getElementsByTagName(\"font\")[2].setAttribute(\"size\", \"5\");\"\n|             <font>\n|               size=\"4\"\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             \"X\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"5\"\n|             <script>\n|               \"document.getElementsByTagName(\"font\")[2].setAttribute(\"size\", \"5\");\"\n|             <font>\n|               size=\"4\"\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             \"X\""
+  },
+  {
+   "file": "scripted_webkit01.dat",
+   "data": "1<script>document.write(\"2\")</script>3",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"1\"\n|     <script>\n|       \"document.write(\"2\")\"\n|     \"23\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"1\"\n|     <script>\n|       \"document.write(\"2\")\"\n|     \"23\""
+  },
+  {
+   "file": "scripted_webkit01.dat",
+   "data": "1<script>document.write(\"<script>document.write('2')</scr\"+ \"ipt><script>document.write('3')</scr\" + \"ipt>\")</script>4",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"1\"\n|     <script>\n|       \"document.write(\"<script>document.write('2')</scr\"+ \"ipt><script>document.write('3')</scr\" + \"ipt>\")\"\n|     <script>\n|       \"document.write('2')\"\n|     \"2\"\n|     <script>\n|       \"document.write('3')\"\n|     \"34\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"1\"\n|     <script>\n|       \"document.write(\"<script>document.write('2')</scr\"+ \"ipt><script>document.write('3')</scr\" + \"ipt>\")\"\n|     <script>\n|       \"document.write('2')\"\n|     \"2\"\n|     <script>\n|       \"document.write('3')\"\n|     \"34\""
+  },
+  {
+   "file": "search-element.dat",
+   "data": "<!doctype html><p>foo<search>bar<p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <search>\n|       \"bar\"\n|       <p>\n|         \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|     <search>\n|       \"bar\"\n|       <p>\n|         \"baz\""
+  },
+  {
+   "file": "search-element.dat",
+   "data": "<!doctype html><search><p>foo</search>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <search>\n|       <p>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <search>\n|       <p>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "search-element.dat",
+   "data": "<!DOCTYPE html>xxx<svg><x><g><a><search><b>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"xxx\"\n|     <svg svg>\n|       <svg x>\n|         <svg g>\n|           <svg a>\n|             <svg search>\n|     <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"xxx\"\n|     <svg svg>\n|       <svg x>\n|         <svg g>\n|           <svg a>\n|             <svg search>\n|     <b>"
+  },
+  {
+   "file": "svg.dat",
+   "data": "<svg><tr><td><title><tr>",
+   "document": "| <svg svg>\n|   <svg tr>\n|     <svg td>\n|       <svg title>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <svg tr>\n|     <svg td>\n|       <svg title>"
+  },
+  {
+   "file": "svg.dat",
+   "data": "<svg><tr><td><title><tr>",
+   "document": "| <svg svg>\n|   <svg tr>\n|     <svg td>\n|       <svg title>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <svg tr>\n|     <svg td>\n|       <svg title>"
+  },
+  {
+   "file": "svg.dat",
+   "data": "<svg><thead><title><tbody>",
+   "document": "| <svg svg>\n|   <svg thead>\n|     <svg title>",
+   "context": "thead",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <svg thead>\n|     <svg title>"
+  },
+  {
+   "file": "svg.dat",
+   "data": "<svg><tfoot><title><tbody>",
+   "document": "| <svg svg>\n|   <svg tfoot>\n|     <svg title>",
+   "context": "tfoot",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <svg tfoot>\n|     <svg title>"
+  },
+  {
+   "file": "svg.dat",
+   "data": "<svg><tbody><title><tfoot>",
+   "document": "| <svg svg>\n|   <svg tbody>\n|     <svg title>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <svg tbody>\n|     <svg title>"
+  },
+  {
+   "file": "svg.dat",
+   "data": "<svg><tbody><title></table>",
+   "document": "| <svg svg>\n|   <svg tbody>\n|     <svg title>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <svg tbody>\n|     <svg title>"
+  },
+  {
+   "file": "svg.dat",
+   "data": "<svg><thead><title></table>",
+   "document": "| <svg svg>\n|   <svg thead>\n|     <svg title>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <svg thead>\n|     <svg title>"
+  },
+  {
+   "file": "svg.dat",
+   "data": "<svg><tfoot><title></table>",
+   "document": "| <svg svg>\n|   <svg tfoot>\n|     <svg title>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <svg svg>\n|   <svg tfoot>\n|     <svg title>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><th>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <th>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <th>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><col foo='bar'>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <col>\n|           foo=\"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <col>\n|           foo=\"bar\""
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><colgroup></html>foo",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"foo\"\n|     <table>\n|       <colgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"foo\"\n|     <table>\n|       <colgroup>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table></table><p>foo",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|     <p>\n|       \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|     <p>\n|       \"foo\""
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table></body></caption></col></colgroup></html></tbody></td></tfoot></th></thead></tr><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><select><option>3</select></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         \"3\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         \"3\"\n|     <table>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><select><table></table></select></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <table>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <table>\n|     <table>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><select></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <table>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><select><option>A<tr><td>B</td></tr></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         \"A\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"B\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         \"A\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"B\""
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><td></body></caption></col></colgroup></html>foo",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"foo\""
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><td>A</table>B",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"A\"\n|     \"B\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"A\"\n|     \"B\""
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><tr><caption>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|       <caption>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|       <caption>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><tr></body></caption></col></colgroup></html></td></th><td>foo",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"foo\""
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><td><tr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|         <tr>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><td><button><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <button>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <button>\n|           <td>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table><tr><td><svg><desc><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg desc>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg desc>\n|           <td>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<div><table><svg><foreignObject><select><table><s>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg foreignObject>\n|           <select>\n|       <table>\n|       <s>\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg foreignObject>\n|           <select>\n|       <table>\n|       <s>\n|       <table>"
+  },
+  {
+   "file": "tables01.dat",
+   "data": "<table>a<!doctype html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"a\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"a\"\n|     <table>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template>Hello</template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         \"Hello\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<template>Hello</template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Hello\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Hello\"\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template></template><div></div>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|   <body>\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|   <body>\n|     <div>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<html><template>Hello</template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Hello\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Hello\"\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<head><template><div></div></template></head>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <div>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <div>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<div><template><div><span></template><b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|           <div>\n|             <span>\n|       <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|           <div>\n|             <span>\n|       <b>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<div><template></div>Hello",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|           \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|           \"Hello\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<div></template></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template></template></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><div><template></template></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|     <table>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template></template><div></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|     <table>\n|       <template>\n|         content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|     <table>\n|       <template>\n|         content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table>   <template></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"   \"\n|       <template>\n|         content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"   \"\n|       <template>\n|         content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><tbody><template></template></tbody>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <template>\n|           content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <template>\n|           content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><tbody><template></tbody></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <template>\n|           content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <template>\n|           content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><tbody><template></template></tbody></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <template>\n|           content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <template>\n|           content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><thead><template></template></thead>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <thead>\n|         <template>\n|           content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <thead>\n|         <template>\n|           content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><tfoot><template></template></tfoot>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tfoot>\n|         <template>\n|           content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tfoot>\n|         <template>\n|           content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<select><template></template></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <template>\n|         content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <template>\n|         content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<select><template><option></option></template></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <template>\n|         content\n|           <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <template>\n|         content\n|           <option>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><option></option></select><option></option></template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <option>\n|         <option>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <option>\n|         <option>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<select><template></template><option></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <template>\n|         content\n|       <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <template>\n|         content\n|       <option>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<select><option><template></template></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         <template>\n|           content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         <template>\n|           content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<select><template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <template>\n|         content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <template>\n|         content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<select><option></option><template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <template>\n|         content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <template>\n|         content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<select><option></option><template><option>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <template>\n|         content\n|           <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <template>\n|         content\n|           <option>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><thead><template><td></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <thead>\n|         <template>\n|           content\n|             <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <thead>\n|         <template>\n|           content\n|             <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template><thead></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <thead>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <thead>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><table><template><td></tr><div></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <td>\n|             <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <td>\n|             <div>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template><thead></template></thead></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <thead>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <thead>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><thead><template><tr></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <thead>\n|         <template>\n|           content\n|             <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <thead>\n|         <template>\n|           content\n|             <tr>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template><tr></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <tr>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><tr><template><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <template>\n|             content\n|               <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <template>\n|             content\n|               <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template><tr><template><td></template></tr></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <tr>\n|             <template>\n|               content\n|                 <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <tr>\n|             <template>\n|               content\n|                 <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template><tr><template><td></td></template></tr></template></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <tr>\n|             <template>\n|               content\n|                 <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <tr>\n|             <template>\n|               content\n|                 <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><template><td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <template>\n|         content\n|           <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><template><tr></tr></template><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <tr>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <tr>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<table><colgroup><template><col>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <template>\n|           content\n|             <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <template>\n|           content\n|             <col>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<frameset><template><frame></frame></template></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|     <frame>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|     <frame>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><frame></frame></frameset><frame></frame></template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><div><frameset><span></span></div><span></span></template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <div>\n|           <span>\n|         <span>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <div>\n|           <span>\n|         <span>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><div><frameset><span></span></div><span></span></template></body>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <div>\n|           <span>\n|         <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <div>\n|           <span>\n|         <span>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><script>var i = 1;</script><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <script>\n|           \"var i = 1;\"\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <script>\n|           \"var i = 1;\"\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><tr><div></div></tr></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <div>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><tr></tr><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><td></td></tr><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><td></td><tbody><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><td></td><caption></caption><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><td></td><colgroup></caption><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><td></td></table><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <td>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><tr></tr><tbody><tr></tr></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <tr>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><tr></tr><caption><tr></tr></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <tr>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><tr></tr></table><tr></tr></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <tr>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><thead></thead><caption></caption><tbody></tbody></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <thead>\n|         <caption>\n|         <tbody>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <thead>\n|         <caption>\n|         <tbody>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><thead></thead></table><tbody></tbody></template></body>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <thead>\n|         <tbody>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <thead>\n|         <tbody>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><div><tr></tr></div></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <div>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><em>Hello</em></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <em>\n|           \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <em>\n|           \"Hello\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><!--comment--></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <!-- comment -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <!-- comment -->"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><style></style><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <style>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <style>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><meta><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <meta>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <meta>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><link><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <link>\n|         <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <link>\n|         <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><table><colgroup><template><col></col></template></colgroup></table></body>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <template>\n|           content\n|             <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <template>\n|           content\n|             <col>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body a=b><template><div></div><body c=d><div></div></body></template></body>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     a=\"b\"\n|     <template>\n|       content\n|         <div>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     a=\"b\"\n|     <template>\n|       content\n|         <div>\n|         <div>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<html a=b><template><div><html b=c><span></template>",
+   "document": "| <html>\n|   a=\"b\"\n|   <head>\n|     <template>\n|       content\n|         <div>\n|           <span>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   a=\"b\"\n|   <head>\n|     <template>\n|       content\n|         <div>\n|           <span>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<html a=b><template><col></col><html b=c><col></col></template>",
+   "document": "| <html>\n|   a=\"b\"\n|   <head>\n|     <template>\n|       content\n|         <col>\n|         <col>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   a=\"b\"\n|   <head>\n|     <template>\n|       content\n|         <col>\n|         <col>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<html a=b><template><frame></frame><html b=c><frame></frame></template>",
+   "document": "| <html>\n|   a=\"b\"\n|   <head>\n|     <template>\n|       content\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   a=\"b\"\n|   <head>\n|     <template>\n|       content\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><tr></tr><template></template><td></td></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <template>\n|           content\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <tr>\n|         <template>\n|           content\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><thead></thead><template><tr></tr></template><tr></tr><tfoot></tfoot></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <thead>\n|         <template>\n|           content\n|             <tr>\n|         <tbody>\n|           <tr>\n|         <tfoot>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <thead>\n|         <template>\n|           content\n|             <tr>\n|         <tbody>\n|           <tr>\n|         <tfoot>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><template><b><template></template></template>text</template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <b>\n|               <template>\n|                 content\n|         \"text\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <b>\n|               <template>\n|                 content\n|         \"text\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><col><colgroup>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><col></colgroup>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><col><colgroup></template></body>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><col><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><col></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><col>Hello",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <col>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template><i><menu>Foo</i>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <i>\n|         <menu>\n|           <i>\n|             \"Foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <i>\n|         <menu>\n|           <i>\n|             \"Foo\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><template></div><div>Foo</div><template></template><tr></tr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <div>\n|           \"Foo\"\n|         <template>\n|           content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <div>\n|           \"Foo\"\n|         <template>\n|           content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><div><template></div><tr><td>Foo</td></tr></template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|           <tr>\n|             <td>\n|               \"Foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|           <tr>\n|             <td>\n|               \"Foo\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<template></figcaption><sub><table></table>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <sub>\n|           <table>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <sub>\n|           <table>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><div>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <div>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <div>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><div>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <div>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <div>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><table>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <table>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <table>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><tbody>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <tbody>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <tbody>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><tr>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <tr>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <tr>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><td>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <td>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <td>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><caption>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <caption>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <caption>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><colgroup>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <colgroup>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <colgroup>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><col>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <col>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <col>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><tbody><select>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <tbody>\n|             <select>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <tbody>\n|             <select>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><table>Foo",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             \"Foo\"\n|             <table>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             \"Foo\"\n|             <table>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><frame>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><script>var i",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <script>\n|               \"var i\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <script>\n|               \"var i\"\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><template><style>var i",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <style>\n|               \"var i\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <style>\n|               \"var i\"\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><table></template><body><span>Foo",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <table>\n|   <body>\n|     <span>\n|       \"Foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <table>\n|   <body>\n|     <span>\n|       \"Foo\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><td></template><body><span>Foo",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <td>\n|   <body>\n|     <span>\n|       \"Foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <td>\n|   <body>\n|     <span>\n|       \"Foo\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><object></template><body><span>Foo",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <object>\n|   <body>\n|     <span>\n|       \"Foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <object>\n|   <body>\n|     <span>\n|       \"Foo\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><svg><template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <svg svg>\n|           <svg template>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <svg svg>\n|           <svg template>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><svg><foo><template><foreignObject><div></template><div>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <svg svg>\n|           <svg foo>\n|             <svg template>\n|               <svg foreignObject>\n|                 <div>\n|   <body>\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <svg svg>\n|           <svg foo>\n|             <svg template>\n|               <svg foreignObject>\n|                 <div>\n|   <body>\n|     <div>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<dummy><template><span></dummy>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <dummy>\n|       <template>\n|         content\n|           <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <dummy>\n|       <template>\n|         content\n|           <span>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<body><table><tr><td><select><template>Foo</template><caption>A</table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <template>\n|                 content\n|                   \"Foo\"\n|       <caption>\n|         \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <template>\n|                 content\n|                   \"Foo\"\n|       <caption>\n|         \"A\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<body></body><template>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content"
+  },
+  {
+   "file": "template.dat",
+   "data": "<head></head><template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<head></head><template>Foo</template>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Foo\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Foo\"\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<html><head></head><template></template><head>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<!DOCTYPE HTML><dummy><table><template><table><template><table><script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dummy>\n|       <table>\n|         <template>\n|           content\n|             <table>\n|               <template>\n|                 content\n|                   <table>\n|                     <script>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dummy>\n|       <table>\n|         <template>\n|           content\n|             <table>\n|               <template>\n|                 content\n|                   <table>\n|                     <script>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><a><table><a>",
+   "document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <a>\n|           <a>\n|           <table>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <template>\n|       content\n|         <a>\n|           <a>\n|           <table>\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<template><form><input name=\"q\"></form><div>second</div></template>",
+   "document": "| <template>\n|   content\n|     <form>\n|       <input>\n|         name=\"q\"\n|     <div>\n|       \"second\"",
+   "context": "template",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <template>\n|   content\n|     <form>\n|       <input>\n|         name=\"q\"\n|     <div>\n|       \"second\""
+  },
+  {
+   "file": "template.dat",
+   "data": "<!DOCTYPE HTML><template><tr><td>cell</td></tr></template>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <template>\n|       content\n|         <tr>\n|           <td>\n|             \"cell\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <template>\n|       content\n|         <tr>\n|           <td>\n|             \"cell\"\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<!DOCTYPE HTML><template> <tr> <td>cell</td> </tr> </template>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <template>\n|       content\n|         \" \"\n|         <tr>\n|           \" \"\n|           <td>\n|             \"cell\"\n|           \" \"\n|         \" \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <template>\n|       content\n|         \" \"\n|         <tr>\n|           \" \"\n|           <td>\n|             \"cell\"\n|           \" \"\n|         \" \"\n|   <body>"
+  },
+  {
+   "file": "template.dat",
+   "data": "<!DOCTYPE HTML><template><tr><td>cell</td></tr>a</template>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <template>\n|       content\n|         <tr>\n|           <td>\n|             \"cell\"\n|         \"a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <template>\n|       content\n|         <tr>\n|           <td>\n|             \"cell\"\n|         \"a\"\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "Test",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"Test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"Test\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<p>One<p>Two",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"One\"\n|     <p>\n|       \"Two\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"One\"\n|     <p>\n|       \"Two\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "Line1<br>Line2<br>Line3<br>Line4",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"Line1\"\n|     <br>\n|     \"Line2\"\n|     <br>\n|     \"Line3\"\n|     <br>\n|     \"Line4\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"Line1\"\n|     <br>\n|     \"Line2\"\n|     <br>\n|     \"Line3\"\n|     <br>\n|     \"Line4\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<head>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<body>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><head>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><head></head>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><head></head><body>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><head></head><body></body>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><head><body></body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><head></body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><head><body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<head></html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "</head>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "</body>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "</html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b><table><td><i></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <i>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <i>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b><table><td></b><i></table>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <i>\n|       \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <i>\n|       \"X\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<h1>Hello<h2>World",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <h1>\n|       \"Hello\"\n|     <h2>\n|       \"World\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <h1>\n|       \"Hello\"\n|     <h2>\n|       \"World\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a><p>X<a>Y</a>Z</p></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <p>\n|       <a>\n|         \"X\"\n|       <a>\n|         \"Y\"\n|       \"Z\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <p>\n|       <a>\n|         \"X\"\n|       <a>\n|         \"Y\"\n|       \"Z\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b><button>foo</b>bar",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <button>\n|       <b>\n|         \"foo\"\n|       \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <button>\n|       <b>\n|         \"foo\"\n|       \"bar\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!DOCTYPE html><span><button>foo</span>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <span>\n|       <button>\n|         \"foobar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <span>\n|       <button>\n|         \"foobar\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<p><b><div><marquee></p></b></div>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|     <div>\n|       <b>\n|         <marquee>\n|           <p>\n|           \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|     <div>\n|       <b>\n|         <marquee>\n|           <p>\n|           \"X\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<script><div></script></div><title><p></title><p><p>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<div>\"\n|     <title>\n|       \"<p>\"\n|   <body>\n|     <p>\n|     <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<div>\"\n|     <title>\n|       \"<p>\"\n|   <body>\n|     <p>\n|     <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!--><div>--<!-->",
+   "document": "| <!--  -->\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"--\"\n|       <!--  -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "abrupt-closing-of-empty-comment",
+     "line": 1,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "abrupt-closing-of-empty-comment",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "abrupt-closing-of-empty-comment",
+     "line": 1,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "abrupt-closing-of-empty-comment",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!--  -->\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"--\"\n|       <!--  -->"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<p><hr></p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <hr>\n|     <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <hr>\n|     <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<select><b><option><select><option></b></select>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <b>\n|         <option>\n|     <b>\n|       <option>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <b>\n|         <option>\n|     <b>\n|       <option>\n|     \"X\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a><table><td><a><table></table><a></tr><a></table><b>X</b>C<a>Y",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <a>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <a>\n|                 <table>\n|               <a>\n|     <a>\n|       <b>\n|         \"X\"\n|       \"C\"\n|     <a>\n|       \"Y\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <a>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <a>\n|                 <table>\n|               <a>\n|     <a>\n|       <b>\n|         \"X\"\n|       \"C\"\n|     <a>\n|       \"Y\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a X>0<b>1<a Y>2",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       x=\"\"\n|       \"0\"\n|       <b>\n|         \"1\"\n|     <b>\n|       <a>\n|         y=\"\"\n|         \"2\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       x=\"\"\n|       \"0\"\n|       <b>\n|         \"1\"\n|     <b>\n|       <a>\n|         y=\"\"\n|         \"2\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!-----><font><div>hello<table>excite!<b>me!<th><i>please!</tr><!--X-->",
+   "document": "| <!-- - -->\n| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <div>\n|         \"helloexcite!\"\n|         <b>\n|           \"me!\"\n|         <table>\n|           <tbody>\n|             <tr>\n|               <th>\n|                 <i>\n|                   \"please!\"\n|             <!-- X -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!-- - -->\n| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <div>\n|         \"helloexcite!\"\n|         <b>\n|           \"me!\"\n|         <table>\n|           <tbody>\n|             <tr>\n|               <th>\n|                 <i>\n|                   \"please!\"\n|             <!-- X -->"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!DOCTYPE html><li>hello<li>world<ul>how<li>do</ul>you</body><!--do-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <li>\n|       \"hello\"\n|     <li>\n|       \"world\"\n|       <ul>\n|         \"how\"\n|         <li>\n|           \"do\"\n|       \"you\"\n|   <!-- do -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <li>\n|       \"hello\"\n|     <li>\n|       \"world\"\n|       <ul>\n|         \"how\"\n|         <li>\n|           \"do\"\n|       \"you\"\n|   <!-- do -->"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!DOCTYPE html>A<option>B<optgroup>C<select>D</option>E",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\"\n|     <option>\n|       \"B\"\n|     <optgroup>\n|       \"C\"\n|       <select>\n|         \"DE\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\"\n|     <option>\n|       \"B\"\n|     <optgroup>\n|       \"C\"\n|       <select>\n|         \"DE\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"<\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-before-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-before-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"<\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<#",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"<#\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"<#\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "</",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"</\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-before-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-before-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"</\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "</#",
+   "document": "| <!-- # -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- # -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<?",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-question-mark-instead-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-processing-instruction",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<?#",
+   "document": "| <!-- ?# -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-question-mark-instead-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-first-character-of-processing-instruction-target",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- ?# -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!",
+   "document": "| <!--  -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!--  -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!#",
+   "document": "| <!-- # -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- # -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<?COMMENT?>",
+   "document": "| <?COMMENT ?>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-question-mark-instead-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [],
+   "spec_document": "| <?COMMENT ?>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!COMMENT>",
+   "document": "| <!-- COMMENT -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- COMMENT -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "</ COMMENT >",
+   "document": "| <!--  COMMENT  -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!--  COMMENT  -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<?COM--MENT?>",
+   "document": "| <?COM--MENT ?>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-question-mark-instead-of-tag-name",
+     "line": 1,
+     "col": 2,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [],
+   "spec_document": "| <?COM--MENT ?>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!COM--MENT>",
+   "document": "| <!-- COM--MENT -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- COM--MENT -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "</ COM--MENT >",
+   "document": "| <!--  COM--MENT  -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!--  COM--MENT  -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!DOCTYPE html><style> EOF",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \" EOF\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \" EOF\"\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!DOCTYPE html><script> <!-- </script> --> </script> EOF",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \" <!-- \"\n|     \" \"\n|   <body>\n|     \"-->  EOF\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \" <!-- \"\n|     \" \"\n|   <body>\n|     \"-->  EOF\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b><p></b>TEST",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <p>\n|       <b>\n|       \"TEST\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <p>\n|       <b>\n|       \"TEST\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<p id=a><b><p id=b></b>TEST",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       id=\"a\"\n|       <b>\n|     <p>\n|       id=\"b\"\n|       \"TEST\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       id=\"a\"\n|       <b>\n|     <p>\n|       id=\"b\"\n|       \"TEST\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b id=a><p><b id=b></p></b>TEST",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       id=\"a\"\n|       <p>\n|         <b>\n|           id=\"b\"\n|       \"TEST\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       id=\"a\"\n|       <p>\n|         <b>\n|           id=\"b\"\n|       \"TEST\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!DOCTYPE html><title>U-test</title><body><div><p>Test<u></p></div></body>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"U-test\"\n|   <body>\n|     <div>\n|       <p>\n|         \"Test\"\n|         <u>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"U-test\"\n|   <body>\n|     <div>\n|       <p>\n|         \"Test\"\n|         <u>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!DOCTYPE html><font><table></font></table></font>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <table>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<font><p>hello<b>cruel</font>world",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <font>\n|     <p>\n|       <font>\n|         \"hello\"\n|         <b>\n|           \"cruel\"\n|       <b>\n|         \"world\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <font>\n|     <p>\n|       <font>\n|         \"hello\"\n|         <b>\n|           \"cruel\"\n|       <b>\n|         \"world\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b>Test</i>Test",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"TestTest\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"TestTest\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b>A<cite>B<div>C",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"A\"\n|       <cite>\n|         \"B\"\n|         <div>\n|           \"C\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"A\"\n|       <cite>\n|         \"B\"\n|         <div>\n|           \"C\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b>A<cite>B<div>C</cite>D",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"A\"\n|       <cite>\n|         \"B\"\n|         <div>\n|           \"CD\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"A\"\n|       <cite>\n|         \"B\"\n|         <div>\n|           \"CD\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b>A<cite>B<div>C</b>D",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"A\"\n|       <cite>\n|         \"B\"\n|     <div>\n|       <b>\n|         \"C\"\n|       \"D\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"A\"\n|       <cite>\n|         \"B\"\n|     <div>\n|       <b>\n|         \"C\"\n|       \"D\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi <P>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|           <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|           <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi <P> jkl",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|           <p>\n|             \" jkl\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|           <p>\n|             \" jkl\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi <P> jkl </B>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|         <p>\n|           <b>\n|             \" jkl \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|         <p>\n|           <b>\n|             \" jkl \""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi <P> jkl </B> mno",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|         <p>\n|           <b>\n|             \" jkl \"\n|           \" mno\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|         <p>\n|           <b>\n|             \" jkl \"\n|           \" mno\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi <P> jkl </B> mno </I>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|       <p>\n|         <i>\n|           <b>\n|             \" jkl \"\n|           \" mno \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|       <p>\n|         <i>\n|           <b>\n|             \" jkl \"\n|           \" mno \""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi <P> jkl </B> mno </I> pqr",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|       <p>\n|         <i>\n|           <b>\n|             \" jkl \"\n|           \" mno \"\n|         \" pqr\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|       <p>\n|         <i>\n|           <b>\n|             \" jkl \"\n|           \" mno \"\n|         \" pqr\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi <P> jkl </B> mno </I> pqr </P>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|       <p>\n|         <i>\n|           <b>\n|             \" jkl \"\n|           \" mno \"\n|         \" pqr \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|       <p>\n|         <i>\n|           <b>\n|             \" jkl \"\n|           \" mno \"\n|         \" pqr \""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<DIV> abc <B> def <I> ghi <P> jkl </B> mno </I> pqr </P> stu",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|       <p>\n|         <i>\n|           <b>\n|             \" jkl \"\n|           \" mno \"\n|         \" pqr \"\n|       \" stu\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \" abc \"\n|       <b>\n|         \" def \"\n|         <i>\n|           \" ghi \"\n|       <i>\n|       <p>\n|         <i>\n|           <b>\n|             \" jkl \"\n|           \" mno \"\n|         \" pqr \"\n|       \" stu\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<test attribute---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <test>\n|       attribute----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <test>\n|       attribute----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------=\"\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a href=\"blah\">aba<table><a href=\"foo\">br<tr><td></td></tr>x</table>aoe",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"blah\"\n|       \"aba\"\n|       <a>\n|         href=\"foo\"\n|         \"br\"\n|       <a>\n|         href=\"foo\"\n|         \"x\"\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|     <a>\n|       href=\"foo\"\n|       \"aoe\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"blah\"\n|       \"aba\"\n|       <a>\n|         href=\"foo\"\n|         \"br\"\n|       <a>\n|         href=\"foo\"\n|         \"x\"\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|     <a>\n|       href=\"foo\"\n|       \"aoe\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a href=\"blah\">aba<table><tr><td><a href=\"foo\">br</td></tr>x</table>aoe",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"blah\"\n|       \"abax\"\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <a>\n|                 href=\"foo\"\n|                 \"br\"\n|       \"aoe\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"blah\"\n|       \"abax\"\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <a>\n|                 href=\"foo\"\n|                 \"br\"\n|       \"aoe\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<table><a href=\"blah\">aba<tr><td><a href=\"foo\">br</td></tr>x</table>aoe",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"blah\"\n|       \"aba\"\n|     <a>\n|       href=\"blah\"\n|       \"x\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <a>\n|               href=\"foo\"\n|               \"br\"\n|     <a>\n|       href=\"blah\"\n|       \"aoe\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"blah\"\n|       \"aba\"\n|     <a>\n|       href=\"blah\"\n|       \"x\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <a>\n|               href=\"foo\"\n|               \"br\"\n|     <a>\n|       href=\"blah\"\n|       \"aoe\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a href=a>aa<marquee>aa<a href=b>bb</marquee>aa",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"a\"\n|       \"aa\"\n|       <marquee>\n|         \"aa\"\n|         <a>\n|           href=\"b\"\n|           \"bb\"\n|       \"aa\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"a\"\n|       \"aa\"\n|       <marquee>\n|         \"aa\"\n|         <a>\n|           href=\"b\"\n|           \"bb\"\n|       \"aa\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<wbr><strike><code></strike><code><strike></code>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <wbr>\n|     <strike>\n|       <code>\n|     <code>\n|       <code>\n|         <strike>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <wbr>\n|     <strike>\n|       <code>\n|     <code>\n|       <code>\n|         <strike>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<!DOCTYPE html><spacer>foo",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <spacer>\n|       \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <spacer>\n|       \"foo\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<title><meta></title><link><title><meta></title>",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \"<meta>\"\n|     <link>\n|     <title>\n|       \"<meta>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \"<meta>\"\n|     <link>\n|     <title>\n|       \"<meta>\"\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<style><!--</style><meta><script>--><link></script>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|     <meta>\n|     <script>\n|       \"--><link>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|     <meta>\n|     <script>\n|       \"--><link>\"\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<head><meta></head><link>",
+   "document": "| <html>\n|   <head>\n|     <meta>\n|     <link>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <meta>\n|     <link>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<table><tr><tr><td><td><span><th><span>X</table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|         <tr>\n|           <td>\n|           <td>\n|             <span>\n|           <th>\n|             <span>\n|               \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|         <tr>\n|           <td>\n|           <td>\n|             <span>\n|           <th>\n|             <span>\n|               \"X\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<body><body><base><link><meta><title><p></title><body><p></body>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <base>\n|     <link>\n|     <meta>\n|     <title>\n|       \"<p>\"\n|     <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <base>\n|     <link>\n|     <meta>\n|     <title>\n|       \"<p>\"\n|     <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<textarea><p></textarea>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<p>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<p>\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<p><image></p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <img>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <img>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a><table><a></table><p><a><div><a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <a>\n|       <table>\n|     <p>\n|       <a>\n|     <div>\n|       <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <a>\n|       <table>\n|     <p>\n|       <a>\n|     <div>\n|       <a>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<head></p><meta><p>",
+   "document": "| <html>\n|   <head>\n|     <meta>\n|   <body>\n|     <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <meta>\n|   <body>\n|     <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<head></html><meta><p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <meta>\n|     <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <meta>\n|     <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b><table><td></b><i></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <i>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <i>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<h1><h2>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <h1>\n|     <h2>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <h1>\n|     <h2>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a><p><a></a></p></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <p>\n|       <a>\n|       <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <p>\n|       <a>\n|       <a>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<b><button></b></button></b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <button>\n|       <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <button>\n|       <b>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<p><b><div><marquee></p></b></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|     <div>\n|       <b>\n|         <marquee>\n|           <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|     <div>\n|       <b>\n|         <marquee>\n|           <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<script></script></div><title></title><p><p>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|     <title>\n|   <body>\n|     <p>\n|     <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|     <title>\n|   <body>\n|     <p>\n|     <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<select><b><option><select><option></b></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <b>\n|         <option>\n|     <b>\n|       <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <b>\n|         <option>\n|     <b>\n|       <option>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<html><head><title></title><body></body></html>",
+   "document": "| <html>\n|   <head>\n|     <title>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|   <body>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<a><table><td><a><table></table><a></tr><a></table><a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <a>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <a>\n|                 <table>\n|               <a>\n|     <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <a>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <a>\n|                 <table>\n|               <a>\n|     <a>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<ul><li></li><div><li></div><li><li><div><li><address><li><b><em></b><li></ul>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|       <div>\n|         <li>\n|       <li>\n|       <li>\n|         <div>\n|       <li>\n|         <address>\n|       <li>\n|         <b>\n|           <em>\n|       <li>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|       <div>\n|         <li>\n|       <li>\n|       <li>\n|         <div>\n|       <li>\n|         <address>\n|       <li>\n|         <b>\n|           <em>\n|       <li>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<ul><li><ul></li><li>a</li></ul></li></ul>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|         <ul>\n|           <li>\n|             \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|         <ul>\n|           <li>\n|             \"a\""
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<frameset><frame><frameset><frame></frameset><noframes></noframes></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|     <frame>\n|     <frameset>\n|       <frame>\n|     <noframes>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|     <frame>\n|     <frameset>\n|       <frame>\n|     <noframes>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<h1><table><td><h3></table><h3></h1>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <h1>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <h3>\n|     <h3>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <h1>\n|       <table>\n|         <tbody>\n|           <tr>\n|             <td>\n|               <h3>\n|     <h3>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<table><colgroup><col><colgroup><col><col><col><colgroup><col><col><thead><tr><td></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <col>\n|       <colgroup>\n|         <col>\n|         <col>\n|         <col>\n|       <colgroup>\n|         <col>\n|         <col>\n|       <thead>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <col>\n|       <colgroup>\n|         <col>\n|         <col>\n|         <col>\n|       <colgroup>\n|         <col>\n|         <col>\n|       <thead>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<table><col><tbody><col><tr><col><td><col></table><col>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <col>\n|       <tbody>\n|       <colgroup>\n|         <col>\n|       <tbody>\n|         <tr>\n|       <colgroup>\n|         <col>\n|       <tbody>\n|         <tr>\n|           <td>\n|       <colgroup>\n|         <col>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|         <col>\n|       <tbody>\n|       <colgroup>\n|         <col>\n|       <tbody>\n|         <tr>\n|       <colgroup>\n|         <col>\n|       <tbody>\n|         <tr>\n|           <td>\n|       <colgroup>\n|         <col>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<table><colgroup><tbody><colgroup><tr><colgroup><td><colgroup></table><colgroup>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|       <tbody>\n|       <colgroup>\n|       <tbody>\n|         <tr>\n|       <colgroup>\n|       <tbody>\n|         <tr>\n|           <td>\n|       <colgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>\n|       <tbody>\n|       <colgroup>\n|       <tbody>\n|         <tr>\n|       <colgroup>\n|       <tbody>\n|         <tr>\n|           <td>\n|       <colgroup>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "</strong></b></em></i></u></strike></s></blink></tt></pre></big></small></font></select></h1></h2></h3></h4></h5></h6></body></br></a></img></title></span></style></script></table></th></td></tr></frame></area></link></param></hr></input></col></base></meta></basefont></bgsound></embed></spacer></p></dd></dt></caption></colgroup></tbody></tfoot></thead></address></blockquote></center></dir></div></dl></fieldset></listing></menu></ol></ul></li></nobr></wbr></form></button></marquee></object></html></frameset></head></iframe></image></isindex></noembed></noframes></noscript></optgroup></option></plaintext></textarea>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <br>\n|     <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <br>\n|     <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<table><tr></strong></b></em></i></u></strike></s></blink></tt></pre></big></small></font></select></h1></h2></h3></h4></h5></h6></body></br></a></img></title></span></style></script></table></th></td></tr></frame></area></link></param></hr></input></col></base></meta></basefont></bgsound></embed></spacer></p></dd></dt></caption></colgroup></tbody></tfoot></thead></address></blockquote></center></dir></div></dl></fieldset></listing></menu></ol></ul></li></nobr></wbr></form></button></marquee></object></html></frameset></head></iframe></image></isindex></noembed></noframes></noscript></optgroup></option></plaintext></textarea>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <br>\n|     <table>\n|       <tbody>\n|         <tr>\n|     <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <br>\n|     <table>\n|       <tbody>\n|         <tr>\n|     <p>"
+  },
+  {
+   "file": "tests1.dat",
+   "data": "<frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><svg></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><svg></svg><![CDATA[a]]>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <!-- [CDATA[a]] -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "cdata-in-html-content",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "cdata-in-html-content",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <!-- [CDATA[a]] -->"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><svg></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><select><svg></svg></select>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <svg svg>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><select><option><svg></svg></option></select>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         <svg svg>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><svg></svg></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <table>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><svg><g>foo</g></svg></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|     <table>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><svg><g>foo</g><g>bar</g></svg></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <table>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><tbody><svg><g>foo</g><g>bar</g></svg></tbody></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <table>\n|       <tbody>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <table>\n|       <tbody>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><tbody><tr><svg><g>foo</g><g>bar</g></svg></tr></tbody></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><tbody><tr><td><svg><g>foo</g><g>bar</g></svg></td></tr></tbody></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg g>\n|                 \"foo\"\n|               <svg g>\n|                 \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg g>\n|                 \"foo\"\n|               <svg g>\n|                 \"bar\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><tbody><tr><td><svg><g>foo</g><g>bar</g></svg><p>baz</td></tr></tbody></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg g>\n|                 \"foo\"\n|               <svg g>\n|                 \"bar\"\n|             <p>\n|               \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg g>\n|                 \"foo\"\n|               <svg g>\n|                 \"bar\"\n|             <p>\n|               \"baz\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><caption><svg><g>foo</g><g>bar</g></svg><p>baz</caption></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <svg svg>\n|           <svg g>\n|             \"foo\"\n|           <svg g>\n|             \"bar\"\n|         <p>\n|           \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <svg svg>\n|           <svg g>\n|             \"foo\"\n|           <svg g>\n|             \"bar\"\n|         <p>\n|           \"baz\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><caption><svg><g>foo</g><g>bar</g><p>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <svg svg>\n|           <svg g>\n|             \"foo\"\n|           <svg g>\n|             \"bar\"\n|         <p>\n|           \"baz\"\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <svg svg>\n|           <svg g>\n|             \"foo\"\n|           <svg g>\n|             \"bar\"\n|         <p>\n|           \"baz\"\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><caption><svg><g>foo</g><g>bar</g>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <svg svg>\n|           <svg g>\n|             \"foo\"\n|           <svg g>\n|             \"bar\"\n|           \"baz\"\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <svg svg>\n|           <svg g>\n|             \"foo\"\n|           <svg g>\n|             \"bar\"\n|           \"baz\"\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><colgroup><svg><g>foo</g><g>bar</g><p>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <p>\n|       \"baz\"\n|     <table>\n|       <colgroup>\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <p>\n|       \"baz\"\n|     <table>\n|       <colgroup>\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><tr><td><select><svg><g>foo</g><g>bar</g><p>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <svg svg>\n|                 <svg g>\n|                   \"foo\"\n|                 <svg g>\n|                   \"bar\"\n|               <p>\n|                 \"baz\"\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <svg svg>\n|                 <svg g>\n|                   \"foo\"\n|                 <svg g>\n|                   \"bar\"\n|               <p>\n|                 \"baz\"\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body><table><select><svg><g>foo</g><g>bar</g><p>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <svg svg>\n|         <svg g>\n|           \"foo\"\n|         <svg g>\n|           \"bar\"\n|       <p>\n|         \"baz\"\n|     <table>\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <svg svg>\n|         <svg g>\n|           \"foo\"\n|         <svg g>\n|           \"bar\"\n|       <p>\n|         \"baz\"\n|     <table>\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body></body></html><svg><g>foo</g><g>bar</g><p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <p>\n|       \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <p>\n|       \"baz\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body></body><svg><g>foo</g><g>bar</g><p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <p>\n|       \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg g>\n|         \"foo\"\n|       <svg g>\n|         \"bar\"\n|     <p>\n|       \"baz\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><frameset><svg><g></g><g></g><p><span>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><frameset></frameset><svg><g></g><g></g><p><span>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body xlink:href=foo><svg xlink:href=foo></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     <svg svg>\n|       xlink href=\"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     <svg svg>\n|       xlink href=\"foo\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body xlink:href=foo xml:lang=en><svg><g xml:lang=en xlink:href=foo></g></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <svg svg>\n|       <svg g>\n|         xlink href=\"foo\"\n|         xml lang=\"en\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <svg svg>\n|       <svg g>\n|         xlink href=\"foo\"\n|         xml lang=\"en\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body xlink:href=foo xml:lang=en><svg><g xml:lang=en xlink:href=foo /></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <svg svg>\n|       <svg g>\n|         xlink href=\"foo\"\n|         xml lang=\"en\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <svg svg>\n|       <svg g>\n|         xlink href=\"foo\"\n|         xml lang=\"en\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><body xlink:href=foo xml:lang=en><svg><g xml:lang=en xlink:href=foo />bar</svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <svg svg>\n|       <svg g>\n|         xlink href=\"foo\"\n|         xml lang=\"en\"\n|       \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <svg svg>\n|       <svg g>\n|         xlink href=\"foo\"\n|         xml lang=\"en\"\n|       \"bar\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<svg></path>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<div><svg></div>a",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|     \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|     \"a\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<div><svg><path></div>a",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|     \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|     \"a\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<div><svg><path></svg><path>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|       <path>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|       <path>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<div><svg><path><foreignObject><math></div>a",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|           <svg foreignObject>\n|             <math math>\n|               \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|           <svg foreignObject>\n|             <math math>\n|               \"a\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<div><svg><path><foreignObject><p></div>a",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|           <svg foreignObject>\n|             <p>\n|               \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|           <svg foreignObject>\n|             <p>\n|               \"a\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><svg><desc><div><svg><ul>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg desc>\n|         <div>\n|           <svg svg>\n|           <ul>\n|             \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg desc>\n|         <div>\n|           <svg svg>\n|           <ul>\n|             \"a\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><svg><desc><svg><ul>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg desc>\n|         <svg svg>\n|         <ul>\n|           \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg desc>\n|         <svg svg>\n|         <ul>\n|           \"a\""
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><p><svg><desc><p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <svg svg>\n|         <svg desc>\n|           <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <svg svg>\n|         <svg desc>\n|           <p>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<!DOCTYPE html><p><svg><title><p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <svg svg>\n|         <svg title>\n|           <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <svg svg>\n|         <svg title>\n|           <p>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<div><svg><path><foreignObject><p></foreignObject><p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|           <svg foreignObject>\n|             <p>\n|             <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <svg svg>\n|         <svg path>\n|           <svg foreignObject>\n|             <p>\n|             <p>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mi><div><object><div><span></span></div></object></div></mi><mi>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         <div>\n|           <object>\n|             <div>\n|               <span>\n|       <math mi>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         <div>\n|           <object>\n|             <div>\n|               <span>\n|       <math mi>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mi><svg><foreignObject><div><div></div></div></foreignObject></svg></mi><mi>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         <svg svg>\n|           <svg foreignObject>\n|             <div>\n|               <div>\n|       <math mi>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         <svg svg>\n|           <svg foreignObject>\n|             <div>\n|               <div>\n|       <math mi>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<svg><script></script><path>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg script>\n|       <svg path>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg script>\n|       <svg path>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<table><svg></svg><tr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mi><mglyph>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         <math mglyph>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         <math mglyph>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mi><malignmark>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         <math malignmark>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         <math malignmark>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mo><mglyph>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mo>\n|         <math mglyph>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mo>\n|         <math mglyph>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mo><malignmark>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mo>\n|         <math malignmark>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mo>\n|         <math malignmark>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mn><mglyph>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mn>\n|         <math mglyph>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mn>\n|         <math mglyph>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mn><malignmark>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mn>\n|         <math malignmark>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mn>\n|         <math malignmark>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><ms><mglyph>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math ms>\n|         <math mglyph>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math ms>\n|         <math mglyph>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><ms><malignmark>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math ms>\n|         <math malignmark>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math ms>\n|         <math malignmark>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mtext><mglyph>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mtext>\n|         <math mglyph>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mtext>\n|         <math mglyph>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><mtext><malignmark>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mtext>\n|         <math malignmark>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mtext>\n|         <math malignmark>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><annotation-xml><svg></svg></annotation-xml><mi>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|       <math mi>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|       <math mi>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><annotation-xml><svg><foreignObject><div><math><mi></mi></math><span></span></div></foreignObject><path></path></svg></annotation-xml><mi>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|           <svg foreignObject>\n|             <div>\n|               <math math>\n|                 <math mi>\n|               <span>\n|           <svg path>\n|       <math mi>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|           <svg foreignObject>\n|             <div>\n|               <math math>\n|                 <math mi>\n|               <span>\n|           <svg path>\n|       <math mi>"
+  },
+  {
+   "file": "tests10.dat",
+   "data": "<math><annotation-xml><svg><foreignObject><math><mi><svg></svg></mi><mo></mo></math><span></span></foreignObject><path></path></svg></annotation-xml><mi>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|           <svg foreignObject>\n|             <math math>\n|               <math mi>\n|                 <svg svg>\n|               <math mo>\n|             <span>\n|           <svg path>\n|       <math mi>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|           <svg foreignObject>\n|             <math math>\n|               <math mi>\n|                 <svg svg>\n|               <math mo>\n|             <span>\n|           <svg path>\n|       <math mi>"
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><svg attributeName='' attributeType='' baseFrequency='' baseProfile='' calcMode='' clipPathUnits='' diffuseConstant='' edgeMode='' filterUnits='' glyphRef='' gradientTransform='' gradientUnits='' kernelMatrix='' kernelUnitLength='' keyPoints='' keySplines='' keyTimes='' lengthAdjust='' limitingConeAngle='' markerHeight='' markerUnits='' markerWidth='' maskContentUnits='' maskUnits='' numOctaves='' pathLength='' patternContentUnits='' patternTransform='' patternUnits='' pointsAtX='' pointsAtY='' pointsAtZ='' preserveAlpha='' preserveAspectRatio='' primitiveUnits='' refX='' refY='' repeatCount='' repeatDur='' requiredExtensions='' requiredFeatures='' specularConstant='' specularExponent='' spreadMethod='' startOffset='' stdDeviation='' stitchTiles='' surfaceScale='' systemLanguage='' tableValues='' targetX='' targetY='' textLength='' viewBox='' viewTarget='' xChannelSelector='' yChannelSelector='' zoomAndPan=''></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       attributeName=\"\"\n|       attributeType=\"\"\n|       baseFrequency=\"\"\n|       baseProfile=\"\"\n|       calcMode=\"\"\n|       clipPathUnits=\"\"\n|       diffuseConstant=\"\"\n|       edgeMode=\"\"\n|       filterUnits=\"\"\n|       glyphRef=\"\"\n|       gradientTransform=\"\"\n|       gradientUnits=\"\"\n|       kernelMatrix=\"\"\n|       kernelUnitLength=\"\"\n|       keyPoints=\"\"\n|       keySplines=\"\"\n|       keyTimes=\"\"\n|       lengthAdjust=\"\"\n|       limitingConeAngle=\"\"\n|       markerHeight=\"\"\n|       markerUnits=\"\"\n|       markerWidth=\"\"\n|       maskContentUnits=\"\"\n|       maskUnits=\"\"\n|       numOctaves=\"\"\n|       pathLength=\"\"\n|       patternContentUnits=\"\"\n|       patternTransform=\"\"\n|       patternUnits=\"\"\n|       pointsAtX=\"\"\n|       pointsAtY=\"\"\n|       pointsAtZ=\"\"\n|       preserveAlpha=\"\"\n|       preserveAspectRatio=\"\"\n|       primitiveUnits=\"\"\n|       refX=\"\"\n|       refY=\"\"\n|       repeatCount=\"\"\n|       repeatDur=\"\"\n|       requiredExtensions=\"\"\n|       requiredFeatures=\"\"\n|       specularConstant=\"\"\n|       specularExponent=\"\"\n|       spreadMethod=\"\"\n|       startOffset=\"\"\n|       stdDeviation=\"\"\n|       stitchTiles=\"\"\n|       surfaceScale=\"\"\n|       systemLanguage=\"\"\n|       tableValues=\"\"\n|       targetX=\"\"\n|       targetY=\"\"\n|       textLength=\"\"\n|       viewBox=\"\"\n|       viewTarget=\"\"\n|       xChannelSelector=\"\"\n|       yChannelSelector=\"\"\n|       zoomAndPan=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       attributeName=\"\"\n|       attributeType=\"\"\n|       baseFrequency=\"\"\n|       baseProfile=\"\"\n|       calcMode=\"\"\n|       clipPathUnits=\"\"\n|       diffuseConstant=\"\"\n|       edgeMode=\"\"\n|       filterUnits=\"\"\n|       glyphRef=\"\"\n|       gradientTransform=\"\"\n|       gradientUnits=\"\"\n|       kernelMatrix=\"\"\n|       kernelUnitLength=\"\"\n|       keyPoints=\"\"\n|       keySplines=\"\"\n|       keyTimes=\"\"\n|       lengthAdjust=\"\"\n|       limitingConeAngle=\"\"\n|       markerHeight=\"\"\n|       markerUnits=\"\"\n|       markerWidth=\"\"\n|       maskContentUnits=\"\"\n|       maskUnits=\"\"\n|       numOctaves=\"\"\n|       pathLength=\"\"\n|       patternContentUnits=\"\"\n|       patternTransform=\"\"\n|       patternUnits=\"\"\n|       pointsAtX=\"\"\n|       pointsAtY=\"\"\n|       pointsAtZ=\"\"\n|       preserveAlpha=\"\"\n|       preserveAspectRatio=\"\"\n|       primitiveUnits=\"\"\n|       refX=\"\"\n|       refY=\"\"\n|       repeatCount=\"\"\n|       repeatDur=\"\"\n|       requiredExtensions=\"\"\n|       requiredFeatures=\"\"\n|       specularConstant=\"\"\n|       specularExponent=\"\"\n|       spreadMethod=\"\"\n|       startOffset=\"\"\n|       stdDeviation=\"\"\n|       stitchTiles=\"\"\n|       surfaceScale=\"\"\n|       systemLanguage=\"\"\n|       tableValues=\"\"\n|       targetX=\"\"\n|       targetY=\"\"\n|       textLength=\"\"\n|       viewBox=\"\"\n|       viewTarget=\"\"\n|       xChannelSelector=\"\"\n|       yChannelSelector=\"\"\n|       zoomAndPan=\"\""
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><BODY><SVG ATTRIBUTENAME='' ATTRIBUTETYPE='' BASEFREQUENCY='' BASEPROFILE='' CALCMODE='' CLIPPATHUNITS='' DIFFUSECONSTANT='' EDGEMODE='' FILTERUNITS='' GLYPHREF='' GRADIENTTRANSFORM='' GRADIENTUNITS='' KERNELMATRIX='' KERNELUNITLENGTH='' KEYPOINTS='' KEYSPLINES='' KEYTIMES='' LENGTHADJUST='' LIMITINGCONEANGLE='' MARKERHEIGHT='' MARKERUNITS='' MARKERWIDTH='' MASKCONTENTUNITS='' MASKUNITS='' NUMOCTAVES='' PATHLENGTH='' PATTERNCONTENTUNITS='' PATTERNTRANSFORM='' PATTERNUNITS='' POINTSATX='' POINTSATY='' POINTSATZ='' PRESERVEALPHA='' PRESERVEASPECTRATIO='' PRIMITIVEUNITS='' REFX='' REFY='' REPEATCOUNT='' REPEATDUR='' REQUIREDEXTENSIONS='' REQUIREDFEATURES='' SPECULARCONSTANT='' SPECULAREXPONENT='' SPREADMETHOD='' STARTOFFSET='' STDDEVIATION='' STITCHTILES='' SURFACESCALE='' SYSTEMLANGUAGE='' TABLEVALUES='' TARGETX='' TARGETY='' TEXTLENGTH='' VIEWBOX='' VIEWTARGET='' XCHANNELSELECTOR='' YCHANNELSELECTOR='' ZOOMANDPAN=''></SVG>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       attributeName=\"\"\n|       attributeType=\"\"\n|       baseFrequency=\"\"\n|       baseProfile=\"\"\n|       calcMode=\"\"\n|       clipPathUnits=\"\"\n|       diffuseConstant=\"\"\n|       edgeMode=\"\"\n|       filterUnits=\"\"\n|       glyphRef=\"\"\n|       gradientTransform=\"\"\n|       gradientUnits=\"\"\n|       kernelMatrix=\"\"\n|       kernelUnitLength=\"\"\n|       keyPoints=\"\"\n|       keySplines=\"\"\n|       keyTimes=\"\"\n|       lengthAdjust=\"\"\n|       limitingConeAngle=\"\"\n|       markerHeight=\"\"\n|       markerUnits=\"\"\n|       markerWidth=\"\"\n|       maskContentUnits=\"\"\n|       maskUnits=\"\"\n|       numOctaves=\"\"\n|       pathLength=\"\"\n|       patternContentUnits=\"\"\n|       patternTransform=\"\"\n|       patternUnits=\"\"\n|       pointsAtX=\"\"\n|       pointsAtY=\"\"\n|       pointsAtZ=\"\"\n|       preserveAlpha=\"\"\n|       preserveAspectRatio=\"\"\n|       primitiveUnits=\"\"\n|       refX=\"\"\n|       refY=\"\"\n|       repeatCount=\"\"\n|       repeatDur=\"\"\n|       requiredExtensions=\"\"\n|       requiredFeatures=\"\"\n|       specularConstant=\"\"\n|       specularExponent=\"\"\n|       spreadMethod=\"\"\n|       startOffset=\"\"\n|       stdDeviation=\"\"\n|       stitchTiles=\"\"\n|       surfaceScale=\"\"\n|       systemLanguage=\"\"\n|       tableValues=\"\"\n|       targetX=\"\"\n|       targetY=\"\"\n|       textLength=\"\"\n|       viewBox=\"\"\n|       viewTarget=\"\"\n|       xChannelSelector=\"\"\n|       yChannelSelector=\"\"\n|       zoomAndPan=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       attributeName=\"\"\n|       attributeType=\"\"\n|       baseFrequency=\"\"\n|       baseProfile=\"\"\n|       calcMode=\"\"\n|       clipPathUnits=\"\"\n|       diffuseConstant=\"\"\n|       edgeMode=\"\"\n|       filterUnits=\"\"\n|       glyphRef=\"\"\n|       gradientTransform=\"\"\n|       gradientUnits=\"\"\n|       kernelMatrix=\"\"\n|       kernelUnitLength=\"\"\n|       keyPoints=\"\"\n|       keySplines=\"\"\n|       keyTimes=\"\"\n|       lengthAdjust=\"\"\n|       limitingConeAngle=\"\"\n|       markerHeight=\"\"\n|       markerUnits=\"\"\n|       markerWidth=\"\"\n|       maskContentUnits=\"\"\n|       maskUnits=\"\"\n|       numOctaves=\"\"\n|       pathLength=\"\"\n|       patternContentUnits=\"\"\n|       patternTransform=\"\"\n|       patternUnits=\"\"\n|       pointsAtX=\"\"\n|       pointsAtY=\"\"\n|       pointsAtZ=\"\"\n|       preserveAlpha=\"\"\n|       preserveAspectRatio=\"\"\n|       primitiveUnits=\"\"\n|       refX=\"\"\n|       refY=\"\"\n|       repeatCount=\"\"\n|       repeatDur=\"\"\n|       requiredExtensions=\"\"\n|       requiredFeatures=\"\"\n|       specularConstant=\"\"\n|       specularExponent=\"\"\n|       spreadMethod=\"\"\n|       startOffset=\"\"\n|       stdDeviation=\"\"\n|       stitchTiles=\"\"\n|       surfaceScale=\"\"\n|       systemLanguage=\"\"\n|       tableValues=\"\"\n|       targetX=\"\"\n|       targetY=\"\"\n|       textLength=\"\"\n|       viewBox=\"\"\n|       viewTarget=\"\"\n|       xChannelSelector=\"\"\n|       yChannelSelector=\"\"\n|       zoomAndPan=\"\""
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><svg attributename='' attributetype='' basefrequency='' baseprofile='' calcmode='' clippathunits='' diffuseconstant='' edgemode='' filterunits='' filterres='' glyphref='' gradienttransform='' gradientunits='' kernelmatrix='' kernelunitlength='' keypoints='' keysplines='' keytimes='' lengthadjust='' limitingconeangle='' markerheight='' markerunits='' markerwidth='' maskcontentunits='' maskunits='' numoctaves='' pathlength='' patterncontentunits='' patterntransform='' patternunits='' pointsatx='' pointsaty='' pointsatz='' preservealpha='' preserveaspectratio='' primitiveunits='' refx='' refy='' repeatcount='' repeatdur='' requiredextensions='' requiredfeatures='' specularconstant='' specularexponent='' spreadmethod='' startoffset='' stddeviation='' stitchtiles='' surfacescale='' systemlanguage='' tablevalues='' targetx='' targety='' textlength='' viewbox='' viewtarget='' xchannelselector='' ychannelselector='' zoomandpan=''></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       attributeName=\"\"\n|       attributeType=\"\"\n|       baseFrequency=\"\"\n|       baseProfile=\"\"\n|       calcMode=\"\"\n|       clipPathUnits=\"\"\n|       diffuseConstant=\"\"\n|       edgeMode=\"\"\n|       filterUnits=\"\"\n|       filterres=\"\"\n|       glyphRef=\"\"\n|       gradientTransform=\"\"\n|       gradientUnits=\"\"\n|       kernelMatrix=\"\"\n|       kernelUnitLength=\"\"\n|       keyPoints=\"\"\n|       keySplines=\"\"\n|       keyTimes=\"\"\n|       lengthAdjust=\"\"\n|       limitingConeAngle=\"\"\n|       markerHeight=\"\"\n|       markerUnits=\"\"\n|       markerWidth=\"\"\n|       maskContentUnits=\"\"\n|       maskUnits=\"\"\n|       numOctaves=\"\"\n|       pathLength=\"\"\n|       patternContentUnits=\"\"\n|       patternTransform=\"\"\n|       patternUnits=\"\"\n|       pointsAtX=\"\"\n|       pointsAtY=\"\"\n|       pointsAtZ=\"\"\n|       preserveAlpha=\"\"\n|       preserveAspectRatio=\"\"\n|       primitiveUnits=\"\"\n|       refX=\"\"\n|       refY=\"\"\n|       repeatCount=\"\"\n|       repeatDur=\"\"\n|       requiredExtensions=\"\"\n|       requiredFeatures=\"\"\n|       specularConstant=\"\"\n|       specularExponent=\"\"\n|       spreadMethod=\"\"\n|       startOffset=\"\"\n|       stdDeviation=\"\"\n|       stitchTiles=\"\"\n|       surfaceScale=\"\"\n|       systemLanguage=\"\"\n|       tableValues=\"\"\n|       targetX=\"\"\n|       targetY=\"\"\n|       textLength=\"\"\n|       viewBox=\"\"\n|       viewTarget=\"\"\n|       xChannelSelector=\"\"\n|       yChannelSelector=\"\"\n|       zoomAndPan=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       attributeName=\"\"\n|       attributeType=\"\"\n|       baseFrequency=\"\"\n|       baseProfile=\"\"\n|       calcMode=\"\"\n|       clipPathUnits=\"\"\n|       diffuseConstant=\"\"\n|       edgeMode=\"\"\n|       filterUnits=\"\"\n|       filterres=\"\"\n|       glyphRef=\"\"\n|       gradientTransform=\"\"\n|       gradientUnits=\"\"\n|       kernelMatrix=\"\"\n|       kernelUnitLength=\"\"\n|       keyPoints=\"\"\n|       keySplines=\"\"\n|       keyTimes=\"\"\n|       lengthAdjust=\"\"\n|       limitingConeAngle=\"\"\n|       markerHeight=\"\"\n|       markerUnits=\"\"\n|       markerWidth=\"\"\n|       maskContentUnits=\"\"\n|       maskUnits=\"\"\n|       numOctaves=\"\"\n|       pathLength=\"\"\n|       patternContentUnits=\"\"\n|       patternTransform=\"\"\n|       patternUnits=\"\"\n|       pointsAtX=\"\"\n|       pointsAtY=\"\"\n|       pointsAtZ=\"\"\n|       preserveAlpha=\"\"\n|       preserveAspectRatio=\"\"\n|       primitiveUnits=\"\"\n|       refX=\"\"\n|       refY=\"\"\n|       repeatCount=\"\"\n|       repeatDur=\"\"\n|       requiredExtensions=\"\"\n|       requiredFeatures=\"\"\n|       specularConstant=\"\"\n|       specularExponent=\"\"\n|       spreadMethod=\"\"\n|       startOffset=\"\"\n|       stdDeviation=\"\"\n|       stitchTiles=\"\"\n|       surfaceScale=\"\"\n|       systemLanguage=\"\"\n|       tableValues=\"\"\n|       targetX=\"\"\n|       targetY=\"\"\n|       textLength=\"\"\n|       viewBox=\"\"\n|       viewTarget=\"\"\n|       xChannelSelector=\"\"\n|       yChannelSelector=\"\"\n|       zoomAndPan=\"\""
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><math attributeName='' attributeType='' baseFrequency='' baseProfile='' calcMode='' clipPathUnits='' diffuseConstant='' edgeMode='' filterUnits='' glyphRef='' gradientTransform='' gradientUnits='' kernelMatrix='' kernelUnitLength='' keyPoints='' keySplines='' keyTimes='' lengthAdjust='' limitingConeAngle='' markerHeight='' markerUnits='' markerWidth='' maskContentUnits='' maskUnits='' numOctaves='' pathLength='' patternContentUnits='' patternTransform='' patternUnits='' pointsAtX='' pointsAtY='' pointsAtZ='' preserveAlpha='' preserveAspectRatio='' primitiveUnits='' refX='' refY='' repeatCount='' repeatDur='' requiredExtensions='' requiredFeatures='' specularConstant='' specularExponent='' spreadMethod='' startOffset='' stdDeviation='' stitchTiles='' surfaceScale='' systemLanguage='' tableValues='' targetX='' targetY='' textLength='' viewBox='' viewTarget='' xChannelSelector='' yChannelSelector='' zoomAndPan=''></math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       attributename=\"\"\n|       attributetype=\"\"\n|       basefrequency=\"\"\n|       baseprofile=\"\"\n|       calcmode=\"\"\n|       clippathunits=\"\"\n|       diffuseconstant=\"\"\n|       edgemode=\"\"\n|       filterunits=\"\"\n|       glyphref=\"\"\n|       gradienttransform=\"\"\n|       gradientunits=\"\"\n|       kernelmatrix=\"\"\n|       kernelunitlength=\"\"\n|       keypoints=\"\"\n|       keysplines=\"\"\n|       keytimes=\"\"\n|       lengthadjust=\"\"\n|       limitingconeangle=\"\"\n|       markerheight=\"\"\n|       markerunits=\"\"\n|       markerwidth=\"\"\n|       maskcontentunits=\"\"\n|       maskunits=\"\"\n|       numoctaves=\"\"\n|       pathlength=\"\"\n|       patterncontentunits=\"\"\n|       patterntransform=\"\"\n|       patternunits=\"\"\n|       pointsatx=\"\"\n|       pointsaty=\"\"\n|       pointsatz=\"\"\n|       preservealpha=\"\"\n|       preserveaspectratio=\"\"\n|       primitiveunits=\"\"\n|       refx=\"\"\n|       refy=\"\"\n|       repeatcount=\"\"\n|       repeatdur=\"\"\n|       requiredextensions=\"\"\n|       requiredfeatures=\"\"\n|       specularconstant=\"\"\n|       specularexponent=\"\"\n|       spreadmethod=\"\"\n|       startoffset=\"\"\n|       stddeviation=\"\"\n|       stitchtiles=\"\"\n|       surfacescale=\"\"\n|       systemlanguage=\"\"\n|       tablevalues=\"\"\n|       targetx=\"\"\n|       targety=\"\"\n|       textlength=\"\"\n|       viewbox=\"\"\n|       viewtarget=\"\"\n|       xchannelselector=\"\"\n|       ychannelselector=\"\"\n|       zoomandpan=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       attributename=\"\"\n|       attributetype=\"\"\n|       basefrequency=\"\"\n|       baseprofile=\"\"\n|       calcmode=\"\"\n|       clippathunits=\"\"\n|       diffuseconstant=\"\"\n|       edgemode=\"\"\n|       filterunits=\"\"\n|       glyphref=\"\"\n|       gradienttransform=\"\"\n|       gradientunits=\"\"\n|       kernelmatrix=\"\"\n|       kernelunitlength=\"\"\n|       keypoints=\"\"\n|       keysplines=\"\"\n|       keytimes=\"\"\n|       lengthadjust=\"\"\n|       limitingconeangle=\"\"\n|       markerheight=\"\"\n|       markerunits=\"\"\n|       markerwidth=\"\"\n|       maskcontentunits=\"\"\n|       maskunits=\"\"\n|       numoctaves=\"\"\n|       pathlength=\"\"\n|       patterncontentunits=\"\"\n|       patterntransform=\"\"\n|       patternunits=\"\"\n|       pointsatx=\"\"\n|       pointsaty=\"\"\n|       pointsatz=\"\"\n|       preservealpha=\"\"\n|       preserveaspectratio=\"\"\n|       primitiveunits=\"\"\n|       refx=\"\"\n|       refy=\"\"\n|       repeatcount=\"\"\n|       repeatdur=\"\"\n|       requiredextensions=\"\"\n|       requiredfeatures=\"\"\n|       specularconstant=\"\"\n|       specularexponent=\"\"\n|       spreadmethod=\"\"\n|       startoffset=\"\"\n|       stddeviation=\"\"\n|       stitchtiles=\"\"\n|       surfacescale=\"\"\n|       systemlanguage=\"\"\n|       tablevalues=\"\"\n|       targetx=\"\"\n|       targety=\"\"\n|       textlength=\"\"\n|       viewbox=\"\"\n|       viewtarget=\"\"\n|       xchannelselector=\"\"\n|       ychannelselector=\"\"\n|       zoomandpan=\"\""
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><svg contentScriptType='' contentStyleType='' externalResourcesRequired='' filterRes=''></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       contentscripttype=\"\"\n|       contentstyletype=\"\"\n|       externalresourcesrequired=\"\"\n|       filterres=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       contentscripttype=\"\"\n|       contentstyletype=\"\"\n|       externalresourcesrequired=\"\"\n|       filterres=\"\""
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><svg CONTENTSCRIPTTYPE='' CONTENTSTYLETYPE='' EXTERNALRESOURCESREQUIRED='' FILTERRES=''></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       contentscripttype=\"\"\n|       contentstyletype=\"\"\n|       externalresourcesrequired=\"\"\n|       filterres=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       contentscripttype=\"\"\n|       contentstyletype=\"\"\n|       externalresourcesrequired=\"\"\n|       filterres=\"\""
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><svg contentscripttype='' contentstyletype='' externalresourcesrequired='' filterres=''></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       contentscripttype=\"\"\n|       contentstyletype=\"\"\n|       externalresourcesrequired=\"\"\n|       filterres=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       contentscripttype=\"\"\n|       contentstyletype=\"\"\n|       externalresourcesrequired=\"\"\n|       filterres=\"\""
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><math contentScriptType='' contentStyleType='' externalResourcesRequired='' filterRes=''></math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       contentscripttype=\"\"\n|       contentstyletype=\"\"\n|       externalresourcesrequired=\"\"\n|       filterres=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       contentscripttype=\"\"\n|       contentstyletype=\"\"\n|       externalresourcesrequired=\"\"\n|       filterres=\"\""
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><svg><altGlyph /><altGlyphDef /><altGlyphItem /><animateColor /><animateMotion /><animateTransform /><clipPath /><feBlend /><feColorMatrix /><feComponentTransfer /><feComposite /><feConvolveMatrix /><feDiffuseLighting /><feDisplacementMap /><feDistantLight /><feFlood /><feFuncA /><feFuncB /><feFuncG /><feFuncR /><feGaussianBlur /><feImage /><feMerge /><feMergeNode /><feMorphology /><feOffset /><fePointLight /><feSpecularLighting /><feSpotLight /><feTile /><feTurbulence /><foreignObject /><glyphRef /><linearGradient /><radialGradient /><textPath /></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg altGlyph>\n|       <svg altGlyphDef>\n|       <svg altGlyphItem>\n|       <svg animateColor>\n|       <svg animateMotion>\n|       <svg animateTransform>\n|       <svg clipPath>\n|       <svg feBlend>\n|       <svg feColorMatrix>\n|       <svg feComponentTransfer>\n|       <svg feComposite>\n|       <svg feConvolveMatrix>\n|       <svg feDiffuseLighting>\n|       <svg feDisplacementMap>\n|       <svg feDistantLight>\n|       <svg feFlood>\n|       <svg feFuncA>\n|       <svg feFuncB>\n|       <svg feFuncG>\n|       <svg feFuncR>\n|       <svg feGaussianBlur>\n|       <svg feImage>\n|       <svg feMerge>\n|       <svg feMergeNode>\n|       <svg feMorphology>\n|       <svg feOffset>\n|       <svg fePointLight>\n|       <svg feSpecularLighting>\n|       <svg feSpotLight>\n|       <svg feTile>\n|       <svg feTurbulence>\n|       <svg foreignObject>\n|       <svg glyphRef>\n|       <svg linearGradient>\n|       <svg radialGradient>\n|       <svg textPath>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg altGlyph>\n|       <svg altGlyphDef>\n|       <svg altGlyphItem>\n|       <svg animateColor>\n|       <svg animateMotion>\n|       <svg animateTransform>\n|       <svg clipPath>\n|       <svg feBlend>\n|       <svg feColorMatrix>\n|       <svg feComponentTransfer>\n|       <svg feComposite>\n|       <svg feConvolveMatrix>\n|       <svg feDiffuseLighting>\n|       <svg feDisplacementMap>\n|       <svg feDistantLight>\n|       <svg feFlood>\n|       <svg feFuncA>\n|       <svg feFuncB>\n|       <svg feFuncG>\n|       <svg feFuncR>\n|       <svg feGaussianBlur>\n|       <svg feImage>\n|       <svg feMerge>\n|       <svg feMergeNode>\n|       <svg feMorphology>\n|       <svg feOffset>\n|       <svg fePointLight>\n|       <svg feSpecularLighting>\n|       <svg feSpotLight>\n|       <svg feTile>\n|       <svg feTurbulence>\n|       <svg foreignObject>\n|       <svg glyphRef>\n|       <svg linearGradient>\n|       <svg radialGradient>\n|       <svg textPath>"
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><svg><altglyph /><altglyphdef /><altglyphitem /><animatecolor /><animatemotion /><animatetransform /><clippath /><feblend /><fecolormatrix /><fecomponenttransfer /><fecomposite /><feconvolvematrix /><fediffuselighting /><fedisplacementmap /><fedistantlight /><feflood /><fefunca /><fefuncb /><fefuncg /><fefuncr /><fegaussianblur /><feimage /><femerge /><femergenode /><femorphology /><feoffset /><fepointlight /><fespecularlighting /><fespotlight /><fetile /><feturbulence /><foreignobject /><glyphref /><lineargradient /><radialgradient /><textpath /></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg altGlyph>\n|       <svg altGlyphDef>\n|       <svg altGlyphItem>\n|       <svg animateColor>\n|       <svg animateMotion>\n|       <svg animateTransform>\n|       <svg clipPath>\n|       <svg feBlend>\n|       <svg feColorMatrix>\n|       <svg feComponentTransfer>\n|       <svg feComposite>\n|       <svg feConvolveMatrix>\n|       <svg feDiffuseLighting>\n|       <svg feDisplacementMap>\n|       <svg feDistantLight>\n|       <svg feFlood>\n|       <svg feFuncA>\n|       <svg feFuncB>\n|       <svg feFuncG>\n|       <svg feFuncR>\n|       <svg feGaussianBlur>\n|       <svg feImage>\n|       <svg feMerge>\n|       <svg feMergeNode>\n|       <svg feMorphology>\n|       <svg feOffset>\n|       <svg fePointLight>\n|       <svg feSpecularLighting>\n|       <svg feSpotLight>\n|       <svg feTile>\n|       <svg feTurbulence>\n|       <svg foreignObject>\n|       <svg glyphRef>\n|       <svg linearGradient>\n|       <svg radialGradient>\n|       <svg textPath>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg altGlyph>\n|       <svg altGlyphDef>\n|       <svg altGlyphItem>\n|       <svg animateColor>\n|       <svg animateMotion>\n|       <svg animateTransform>\n|       <svg clipPath>\n|       <svg feBlend>\n|       <svg feColorMatrix>\n|       <svg feComponentTransfer>\n|       <svg feComposite>\n|       <svg feConvolveMatrix>\n|       <svg feDiffuseLighting>\n|       <svg feDisplacementMap>\n|       <svg feDistantLight>\n|       <svg feFlood>\n|       <svg feFuncA>\n|       <svg feFuncB>\n|       <svg feFuncG>\n|       <svg feFuncR>\n|       <svg feGaussianBlur>\n|       <svg feImage>\n|       <svg feMerge>\n|       <svg feMergeNode>\n|       <svg feMorphology>\n|       <svg feOffset>\n|       <svg fePointLight>\n|       <svg feSpecularLighting>\n|       <svg feSpotLight>\n|       <svg feTile>\n|       <svg feTurbulence>\n|       <svg foreignObject>\n|       <svg glyphRef>\n|       <svg linearGradient>\n|       <svg radialGradient>\n|       <svg textPath>"
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><BODY><SVG><ALTGLYPH /><ALTGLYPHDEF /><ALTGLYPHITEM /><ANIMATECOLOR /><ANIMATEMOTION /><ANIMATETRANSFORM /><CLIPPATH /><FEBLEND /><FECOLORMATRIX /><FECOMPONENTTRANSFER /><FECOMPOSITE /><FECONVOLVEMATRIX /><FEDIFFUSELIGHTING /><FEDISPLACEMENTMAP /><FEDISTANTLIGHT /><FEFLOOD /><FEFUNCA /><FEFUNCB /><FEFUNCG /><FEFUNCR /><FEGAUSSIANBLUR /><FEIMAGE /><FEMERGE /><FEMERGENODE /><FEMORPHOLOGY /><FEOFFSET /><FEPOINTLIGHT /><FESPECULARLIGHTING /><FESPOTLIGHT /><FETILE /><FETURBULENCE /><FOREIGNOBJECT /><GLYPHREF /><LINEARGRADIENT /><RADIALGRADIENT /><TEXTPATH /></SVG>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg altGlyph>\n|       <svg altGlyphDef>\n|       <svg altGlyphItem>\n|       <svg animateColor>\n|       <svg animateMotion>\n|       <svg animateTransform>\n|       <svg clipPath>\n|       <svg feBlend>\n|       <svg feColorMatrix>\n|       <svg feComponentTransfer>\n|       <svg feComposite>\n|       <svg feConvolveMatrix>\n|       <svg feDiffuseLighting>\n|       <svg feDisplacementMap>\n|       <svg feDistantLight>\n|       <svg feFlood>\n|       <svg feFuncA>\n|       <svg feFuncB>\n|       <svg feFuncG>\n|       <svg feFuncR>\n|       <svg feGaussianBlur>\n|       <svg feImage>\n|       <svg feMerge>\n|       <svg feMergeNode>\n|       <svg feMorphology>\n|       <svg feOffset>\n|       <svg fePointLight>\n|       <svg feSpecularLighting>\n|       <svg feSpotLight>\n|       <svg feTile>\n|       <svg feTurbulence>\n|       <svg foreignObject>\n|       <svg glyphRef>\n|       <svg linearGradient>\n|       <svg radialGradient>\n|       <svg textPath>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg altGlyph>\n|       <svg altGlyphDef>\n|       <svg altGlyphItem>\n|       <svg animateColor>\n|       <svg animateMotion>\n|       <svg animateTransform>\n|       <svg clipPath>\n|       <svg feBlend>\n|       <svg feColorMatrix>\n|       <svg feComponentTransfer>\n|       <svg feComposite>\n|       <svg feConvolveMatrix>\n|       <svg feDiffuseLighting>\n|       <svg feDisplacementMap>\n|       <svg feDistantLight>\n|       <svg feFlood>\n|       <svg feFuncA>\n|       <svg feFuncB>\n|       <svg feFuncG>\n|       <svg feFuncR>\n|       <svg feGaussianBlur>\n|       <svg feImage>\n|       <svg feMerge>\n|       <svg feMergeNode>\n|       <svg feMorphology>\n|       <svg feOffset>\n|       <svg fePointLight>\n|       <svg feSpecularLighting>\n|       <svg feSpotLight>\n|       <svg feTile>\n|       <svg feTurbulence>\n|       <svg foreignObject>\n|       <svg glyphRef>\n|       <svg linearGradient>\n|       <svg radialGradient>\n|       <svg textPath>"
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><math><altGlyph /><altGlyphDef /><altGlyphItem /><animateColor /><animateMotion /><animateTransform /><clipPath /><feBlend /><feColorMatrix /><feComponentTransfer /><feComposite /><feConvolveMatrix /><feDiffuseLighting /><feDisplacementMap /><feDistantLight /><feFlood /><feFuncA /><feFuncB /><feFuncG /><feFuncR /><feGaussianBlur /><feImage /><feMerge /><feMergeNode /><feMorphology /><feOffset /><fePointLight /><feSpecularLighting /><feSpotLight /><feTile /><feTurbulence /><foreignObject /><glyphRef /><linearGradient /><radialGradient /><textPath /></math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math altglyph>\n|       <math altglyphdef>\n|       <math altglyphitem>\n|       <math animatecolor>\n|       <math animatemotion>\n|       <math animatetransform>\n|       <math clippath>\n|       <math feblend>\n|       <math fecolormatrix>\n|       <math fecomponenttransfer>\n|       <math fecomposite>\n|       <math feconvolvematrix>\n|       <math fediffuselighting>\n|       <math fedisplacementmap>\n|       <math fedistantlight>\n|       <math feflood>\n|       <math fefunca>\n|       <math fefuncb>\n|       <math fefuncg>\n|       <math fefuncr>\n|       <math fegaussianblur>\n|       <math feimage>\n|       <math femerge>\n|       <math femergenode>\n|       <math femorphology>\n|       <math feoffset>\n|       <math fepointlight>\n|       <math fespecularlighting>\n|       <math fespotlight>\n|       <math fetile>\n|       <math feturbulence>\n|       <math foreignobject>\n|       <math glyphref>\n|       <math lineargradient>\n|       <math radialgradient>\n|       <math textpath>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math altglyph>\n|       <math altglyphdef>\n|       <math altglyphitem>\n|       <math animatecolor>\n|       <math animatemotion>\n|       <math animatetransform>\n|       <math clippath>\n|       <math feblend>\n|       <math fecolormatrix>\n|       <math fecomponenttransfer>\n|       <math fecomposite>\n|       <math feconvolvematrix>\n|       <math fediffuselighting>\n|       <math fedisplacementmap>\n|       <math fedistantlight>\n|       <math feflood>\n|       <math fefunca>\n|       <math fefuncb>\n|       <math fefuncg>\n|       <math fefuncr>\n|       <math fegaussianblur>\n|       <math feimage>\n|       <math femerge>\n|       <math femergenode>\n|       <math femorphology>\n|       <math feoffset>\n|       <math fepointlight>\n|       <math fespecularlighting>\n|       <math fespotlight>\n|       <math fetile>\n|       <math feturbulence>\n|       <math foreignobject>\n|       <math glyphref>\n|       <math lineargradient>\n|       <math radialgradient>\n|       <math textpath>"
+  },
+  {
+   "file": "tests11.dat",
+   "data": "<!DOCTYPE html><body><svg><solidColor /></svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg solidcolor>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg solidcolor>"
+  },
+  {
+   "file": "tests12.dat",
+   "data": "<!DOCTYPE html><body><p>foo<math><mtext><i>baz</i></mtext><annotation-xml><svg><desc><b>eggs</b></desc><g><foreignObject><P>spam<TABLE><tr><td><img></td></table></foreignObject></g><g>quux</g></svg></annotation-xml></math>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|       <math math>\n|         <math mtext>\n|           <i>\n|             \"baz\"\n|         <math annotation-xml>\n|           <svg svg>\n|             <svg desc>\n|               <b>\n|                 \"eggs\"\n|             <svg g>\n|               <svg foreignObject>\n|                 <p>\n|                   \"spam\"\n|                 <table>\n|                   <tbody>\n|                     <tr>\n|                       <td>\n|                         <img>\n|             <svg g>\n|               \"quux\"\n|       \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"\n|       <math math>\n|         <math mtext>\n|           <i>\n|             \"baz\"\n|         <math annotation-xml>\n|           <svg svg>\n|             <svg desc>\n|               <b>\n|                 \"eggs\"\n|             <svg g>\n|               <svg foreignObject>\n|                 <p>\n|                   \"spam\"\n|                 <table>\n|                   <tbody>\n|                     <tr>\n|                       <td>\n|                         <img>\n|             <svg g>\n|               \"quux\"\n|       \"bar\""
+  },
+  {
+   "file": "tests12.dat",
+   "data": "<!DOCTYPE html><body>foo<math><mtext><i>baz</i></mtext><annotation-xml><svg><desc><b>eggs</b></desc><g><foreignObject><P>spam<TABLE><tr><td><img></td></table></foreignObject></g><g>quux</g></svg></annotation-xml></math>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"foo\"\n|     <math math>\n|       <math mtext>\n|         <i>\n|           \"baz\"\n|       <math annotation-xml>\n|         <svg svg>\n|           <svg desc>\n|             <b>\n|               \"eggs\"\n|           <svg g>\n|             <svg foreignObject>\n|               <p>\n|                 \"spam\"\n|               <table>\n|                 <tbody>\n|                   <tr>\n|                     <td>\n|                       <img>\n|           <svg g>\n|             \"quux\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"foo\"\n|     <math math>\n|       <math mtext>\n|         <i>\n|           \"baz\"\n|       <math annotation-xml>\n|         <svg svg>\n|           <svg desc>\n|             <b>\n|               \"eggs\"\n|           <svg g>\n|             <svg foreignObject>\n|               <p>\n|                 \"spam\"\n|               <table>\n|                 <tbody>\n|                   <tr>\n|                     <td>\n|                       <img>\n|           <svg g>\n|             \"quux\"\n|     \"bar\""
+  },
+  {
+   "file": "tests14.dat",
+   "data": "<!DOCTYPE html><html><body><xyz:abc></xyz:abc>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <xyz:abc>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <xyz:abc>"
+  },
+  {
+   "file": "tests14.dat",
+   "data": "<!DOCTYPE html><html><body><xyz:abc></xyz:abc><span></span>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <xyz:abc>\n|     <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <xyz:abc>\n|     <span>"
+  },
+  {
+   "file": "tests14.dat",
+   "data": "<!DOCTYPE html><html><html abc:def=gh><xyz:abc></xyz:abc>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   abc:def=\"gh\"\n|   <head>\n|   <body>\n|     <xyz:abc>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   abc:def=\"gh\"\n|   <head>\n|   <body>\n|     <xyz:abc>"
+  },
+  {
+   "file": "tests14.dat",
+   "data": "<!DOCTYPE html><html xml:lang=bar><html xml:lang=foo>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   xml:lang=\"bar\"\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   xml:lang=\"bar\"\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests14.dat",
+   "data": "<!DOCTYPE html><html 123=456>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   123=\"456\"\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   123=\"456\"\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests14.dat",
+   "data": "<!DOCTYPE html><html 123=456><html 789=012>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   123=\"456\"\n|   789=\"012\"\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   123=\"456\"\n|   789=\"012\"\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests14.dat",
+   "data": "<!DOCTYPE html><html><body 789=012>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     789=\"012\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     789=\"012\""
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!DOCTYPE html><p><b><i><u></p> <p>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         <i>\n|           <u>\n|     <b>\n|       <i>\n|         <u>\n|           \" \"\n|           <p>\n|             \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         <i>\n|           <u>\n|     <b>\n|       <i>\n|         <u>\n|           \" \"\n|           <p>\n|             \"X\""
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<p><b><i><u></p>\n<p>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         <i>\n|           <u>\n|     <b>\n|       <i>\n|         <u>\n|           \"\n\"\n|           <p>\n|             \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         <i>\n|           <u>\n|     <b>\n|       <i>\n|         <u>\n|           \"\n\"\n|           <p>\n|             \"X\""
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html></html> <head>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" \""
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html></body><meta>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <meta>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <meta>"
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<html></html><!-- foo -->",
+   "document": "| <html>\n|   <head>\n|   <body>\n| <!--  foo  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n| <!--  foo  -->"
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html></body><title>X</title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"X\""
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html><table> X<meta></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" X\"\n|     <meta>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" X\"\n|     <meta>\n|     <table>"
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html><table> x</table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" x\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" x\"\n|     <table>"
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html><table> x </table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" x \"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" x \"\n|     <table>"
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html><table><tr> x</table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" x\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" x\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html><table>X<style> <tr>x </style> </table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <table>\n|       <style>\n|         \" <tr>x \"\n|       \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <table>\n|       <style>\n|         \" <tr>x \"\n|       \" \""
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!doctype html><div><table><a>foo</a> <tr><td>bar</td> </tr></table></div>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <a>\n|         \"foo\"\n|       <table>\n|         \" \"\n|         <tbody>\n|           <tr>\n|             <td>\n|               \"bar\"\n|             \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <a>\n|         \"foo\"\n|       <table>\n|         \" \"\n|         <tbody>\n|           <tr>\n|             <td>\n|               \"bar\"\n|             \" \""
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<frame></frame></frame><frameset><frame><frameset><frame></frameset><noframes></frameset><noframes>",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|     <frame>\n|     <frameset>\n|       <frame>\n|     <noframes>\n|       \"</frameset><noframes>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|     <frame>\n|     <frameset>\n|       <frame>\n|     <noframes>\n|       \"</frameset><noframes>\""
+  },
+  {
+   "file": "tests15.dat",
+   "data": "<!DOCTYPE html><object></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <object>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <object>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></S",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</S\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</S\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></SC",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SC\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SC\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></SCR",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SCR\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SCR\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></SCRI",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SCRI\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SCRI\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></SCRIP",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SCRIP\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SCRIP\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></SCRIPT",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SCRIPT\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</SCRIPT\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></SCRIPT ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></s",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</s\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</s\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></sc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</sc\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</sc\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></scr",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</scr\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</scr\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></scri",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</scri\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</scri\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></scrip",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</scrip\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</scrip\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></script",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"</script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script></script ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!-",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!-\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!-\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!-a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!-a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!-a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 28,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 28,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--</",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--</\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--</\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--</script",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--</script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 36,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 36,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--</script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--</script ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 37,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 37,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<s",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<s\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<s\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 36,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 36,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script <",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script <\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 37,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 37,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script <\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script <a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script <a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script <a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </s",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </s\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </s\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 44,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 44,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </scripta",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </scripta\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 45,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 45,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </scripta\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 45,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 45,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 45,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 45,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script>\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script/",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script/\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 45,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 45,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script/\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script <",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script <\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 46,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 46,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script <\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script <a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script <a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 47,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 47,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script <a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script </",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script </\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 47,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 47,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script </\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script </script",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script </script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 53,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 53,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script </script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script </script ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 54,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 54,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script </script/",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 54,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 54,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script </script </script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script -",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 37,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 37,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script -a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script -<",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -<\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -<\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --<",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --<\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --<\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script -->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --><",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --><\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --><\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --></",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --></\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --></\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --></script",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --></script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --></script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --></script ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 48,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 48,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --></script/",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 48,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 48,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script --></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script><\\/script>--></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script><\\/script>-->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script><\\/script>-->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script></scr'+'ipt>--></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></scr'+'ipt>-->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></scr'+'ipt>-->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script></script><script></script></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script></script><script></script>--><!--</script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>--><!--\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>--><!--\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script></script><script></script>-- ></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>-- >\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>-- >\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script></script><script></script>- -></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>- ->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>- ->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script></script><script></script>- - ></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>- - >\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>- - >\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script></script><script></script>-></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script>--!></script>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script>--!></script>X\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 50,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 50,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script>--!></script>X\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<scr'+'ipt></script>--></script>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<scr'+'ipt>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<scr'+'ipt>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><script><!--<script></scr'+'ipt></script>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></scr'+'ipt></script>X\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 58,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 58,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></scr'+'ipt></script>X\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><style><!--<style></style>--></style>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--<style>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--<style>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><style><!--</style>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><style><!--...</style>...--></style>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--...\"\n|   <body>\n|     \"...-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--...\"\n|   <body>\n|     \"...-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><style><!--<br><html xmlns:v=\"urn:schemas-microsoft-com:vml\"><!--[if !mso]><style></style>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--<br><html xmlns:v=\"urn:schemas-microsoft-com:vml\"><!--[if !mso]><style>\"\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--<br><html xmlns:v=\"urn:schemas-microsoft-com:vml\"><!--[if !mso]><style>\"\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><style><!--...<style><!--...--!></style>--></style>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--...<style><!--...--!>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--...<style><!--...--!>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><style><!--...</style><!-- --><style>@import ...</style>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--...\"\n|     <!--   -->\n|     <style>\n|       \"@import ...\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"<!--...\"\n|     <!--   -->\n|     <style>\n|       \"@import ...\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><style>...<style><!--...</style><!-- --></style>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"...<style><!--...\"\n|     <!--   -->\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"...<style><!--...\"\n|     <!--   -->\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><style>...<!--[if IE]><style>...</style>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"...<!--[if IE]><style>...\"\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <style>\n|       \"...<!--[if IE]><style>...\"\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><title><!--<title></title>--></title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"<!--<title>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"<!--<title>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><title>&lt;/title></title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"</title>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"</title>\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><title>foo/title><link></head><body>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"foo/title><link></head><body>X\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"foo/title><link></head><body>X\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noscript><!--<noscript></noscript>--></noscript>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       \"<!--<noscript>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       \"<!--<noscript>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noscript><!--<noscript></noscript>--></noscript>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       <!-- <noscript></noscript> -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       <!-- <noscript></noscript> -->\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noscript><!--</noscript>X<noscript>--></noscript>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       \"<!--\"\n|   <body>\n|     \"X\"\n|     <noscript>\n|       \"-->\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       \"<!--\"\n|   <body>\n|     \"X\"\n|     <noscript>\n|       \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noscript><!--</noscript>X<noscript>--></noscript>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       <!-- </noscript>X<noscript> -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       <!-- </noscript>X<noscript> -->\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noscript><iframe></noscript>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       \"<iframe>\"\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|       \"<iframe>\"\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noscript><iframe></noscript>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <iframe>\n|       \"</noscript>X\"",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <iframe>\n|       \"</noscript>X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noframes><!--<noframes></noframes>--></noframes>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noframes>\n|       \"<!--<noframes>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noframes>\n|       \"<!--<noframes>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noframes><body><script><!--...</script></body></noframes></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noframes>\n|       \"<body><script><!--...</script></body>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noframes>\n|       \"<body><script><!--...</script></body>\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><textarea><!--<textarea></textarea>--></textarea>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<!--<textarea>\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<!--<textarea>\"\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><textarea>&lt;/textarea></textarea>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"</textarea>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"</textarea>\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><textarea>&lt;</textarea>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><textarea>a&lt;b</textarea>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"a<b\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"a<b\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><iframe><!--<iframe></iframe>--></iframe>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \"<!--<iframe>\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \"<!--<iframe>\"\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><iframe>...<!--X->...<!--/X->...</iframe>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \"...<!--X->...<!--/X->...\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \"...<!--X->...<!--/X->...\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><xmp><!--<xmp></xmp>--></xmp>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <xmp>\n|       \"<!--<xmp>\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <xmp>\n|       \"<!--<xmp>\"\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><noembed><!--<noembed></noembed>--></noembed>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <noembed>\n|       \"<!--<noembed>\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <noembed>\n|       \"<!--<noembed>\"\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script>a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></S",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</S\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</S\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></SC",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</SC\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</SC\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></SCR",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</SCR\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</SCR\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></SCRI",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</SCRI\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</SCRI\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></SCRIP",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</SCRIP\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</SCRIP\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></SCRIPT",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</SCRIPT\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</SCRIPT\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></SCRIPT ",
+   "document": "| <html>\n|   <head>\n|     <script>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></s",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</s\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</s\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></sc",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</sc\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</sc\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></scr",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</scr\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</scr\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></scri",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</scri\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</scri\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></scrip",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</scrip\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</scrip\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></script",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script></script ",
+   "document": "| <html>\n|   <head>\n|     <script>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!-",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!-\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!-\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!-a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!-a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!-a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 13,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 13,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--</",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--</\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--</\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--</script",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--</script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--</script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--</script ",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<s",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<s\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<s\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 20,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 20,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script ",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script <",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script <\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script <\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script <a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script <a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script <a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </s",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </s\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </s\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </scripta",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </scripta\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </scripta\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script ",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script>\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script/",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script/\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script/\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script <",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script <\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 31,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 31,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script <\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script <a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script <a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 32,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 32,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script <a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script </",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script </\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 32,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 32,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script </\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script </script",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script </script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 38,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script </script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script </script ",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script </script/",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 39,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script </script </script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script </script \"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script -",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script -a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script --",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script --a",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --a\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --a\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script -->",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script --><",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --><\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --><\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script --></",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --></\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --></\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script --></script",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --></script\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script --></script\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script --></script ",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script --></script/",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script --></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script -->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script><\\/script>--></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script><\\/script>-->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script><\\/script>-->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script></scr'+'ipt>--></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></scr'+'ipt>-->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></scr'+'ipt>-->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script></script><script></script></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script></script><script></script>--><!--</script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>--><!--\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>--><!--\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script></script><script></script>-- ></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>-- >\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>-- >\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script></script><script></script>- -></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>- ->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>- ->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script></script><script></script>- - ></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>- - >\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>- - >\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script></script><script></script>-></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></script><script></script>->\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script>--!></script>X",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script>--!></script>X\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script>--!></script>X\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<scr'+'ipt></script>--></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<scr'+'ipt>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<scr'+'ipt>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<script><!--<script></scr'+'ipt></script>X",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></scr'+'ipt></script>X\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 43,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-script-html-comment-like-text",
+     "line": 1,
+     "col": 43,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"<!--<script></scr'+'ipt></script>X\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<style><!--<style></style>--></style>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--<style>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--<style>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<style><!--</style>X",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--\"\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<style><!--...</style>...--></style>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--...\"\n|   <body>\n|     \"...-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--...\"\n|   <body>\n|     \"...-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<style><!--<br><html xmlns:v=\"urn:schemas-microsoft-com:vml\"><!--[if !mso]><style></style>X",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--<br><html xmlns:v=\"urn:schemas-microsoft-com:vml\"><!--[if !mso]><style>\"\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--<br><html xmlns:v=\"urn:schemas-microsoft-com:vml\"><!--[if !mso]><style>\"\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<style><!--...<style><!--...--!></style>--></style>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--...<style><!--...--!>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--...<style><!--...--!>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<style><!--...</style><!-- --><style>@import ...</style>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--...\"\n|     <!--   -->\n|     <style>\n|       \"@import ...\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"<!--...\"\n|     <!--   -->\n|     <style>\n|       \"@import ...\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<style>...<style><!--...</style><!-- --></style>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"...<style><!--...\"\n|     <!--   -->\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"...<style><!--...\"\n|     <!--   -->\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<style>...<!--[if IE]><style>...</style>X",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \"...<!--[if IE]><style>...\"\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \"...<!--[if IE]><style>...\"\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<title><!--<title></title>--></title>",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \"<!--<title>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \"<!--<title>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<title>&lt;/title></title>",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \"</title>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \"</title>\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<title>foo/title><link></head><body>X",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \"foo/title><link></head><body>X\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \"foo/title><link></head><body>X\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noscript><!--<noscript></noscript>--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       \"<!--<noscript>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       \"<!--<noscript>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noscript><!--<noscript></noscript>--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- <noscript></noscript> -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- <noscript></noscript> -->\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noscript><!--</noscript>X<noscript>--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       \"<!--\"\n|   <body>\n|     \"X\"\n|     <noscript>\n|       \"-->\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       \"<!--\"\n|   <body>\n|     \"X\"\n|     <noscript>\n|       \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noscript><!--</noscript>X<noscript>--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- </noscript>X<noscript> -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- </noscript>X<noscript> -->\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noscript><iframe></noscript>X",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       \"<iframe>\"\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       \"<iframe>\"\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noscript><iframe></noscript>X",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <iframe>\n|       \"</noscript>X\"",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <iframe>\n|       \"</noscript>X\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noframes><!--<noframes></noframes>--></noframes>",
+   "document": "| <html>\n|   <head>\n|     <noframes>\n|       \"<!--<noframes>\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noframes>\n|       \"<!--<noframes>\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noframes><body><script><!--...</script></body></noframes></html>",
+   "document": "| <html>\n|   <head>\n|     <noframes>\n|       \"<body><script><!--...</script></body>\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noframes>\n|       \"<body><script><!--...</script></body>\"\n|   <body>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<textarea><!--<textarea></textarea>--></textarea>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<!--<textarea>\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"<!--<textarea>\"\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<textarea>&lt;/textarea></textarea>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"</textarea>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"</textarea>\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<iframe><!--<iframe></iframe>--></iframe>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \"<!--<iframe>\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \"<!--<iframe>\"\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<iframe>...<!--X->...<!--/X->...</iframe>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \"...<!--X->...<!--/X->...\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \"...<!--X->...<!--/X->...\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<xmp><!--<xmp></xmp>--></xmp>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <xmp>\n|       \"<!--<xmp>\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <xmp>\n|       \"<!--<xmp>\"\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<noembed><!--<noembed></noembed>--></noembed>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <noembed>\n|       \"<!--<noembed>\"\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <noembed>\n|       \"<!--<noembed>\"\n|     \"-->\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><table>\n",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"\n\""
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><table><td><span><font></span><span>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <span>\n|               <font>\n|             <font>\n|               <span>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <span>\n|               <font>\n|             <font>\n|               <span>"
+  },
+  {
+   "file": "tests16.dat",
+   "data": "<!doctype html><form><table></form><form></table></form>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <form>\n|       <table>\n|         <form>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <form>\n|       <table>\n|         <form>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><table><tbody><select><tr>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><table><tr><select><td>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><table><tr><td><select><td>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|           <td>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><table><tr><th><select><td>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <th>\n|             <select>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <th>\n|             <select>\n|           <td>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><table><caption><select><tr>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <select>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <select>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><select><tr>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><select><td>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><select><th>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><select><tbody>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><select><thead>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><select><tfoot>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><select><caption>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "tests17.dat",
+   "data": "<!doctype html><table><tr></table>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|     \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|     \"a\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<plaintext></plaintext>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><html><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><head><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><html><noscript><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <noscript>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html></head><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><body><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"\n|     <table>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><tbody><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"\n|     <table>\n|       <tbody>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"\n|     <table>\n|       <tbody>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><tbody><tr><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><td><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <plaintext>\n|               \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <plaintext>\n|               \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><caption><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <plaintext>\n|           \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <plaintext>\n|           \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><colgroup><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"\n|     <table>\n|       <colgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"\n|     <table>\n|       <colgroup>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><select><plaintext></plaintext>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <plaintext>\n|         \"</plaintext>X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <plaintext>\n|         \"</plaintext>X\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><select><plaintext>a<caption>b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <plaintext>\n|         \"a<caption>b\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <plaintext>\n|         \"a<caption>b\"\n|     <table>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><template><plaintext>a</template>b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <template>\n|       content\n|         <plaintext>\n|           \"a</template>b\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <template>\n|       content\n|         <plaintext>\n|           \"a</template>b\"\n|   <body>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><body></body><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><frameset><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><frameset></frameset><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><body></body></html><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><frameset></frameset></html><plaintext></plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><svg><plaintext>a</plaintext>b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg plaintext>\n|         \"a\"\n|       \"b\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg plaintext>\n|         \"a\"\n|       \"b\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><svg><title><plaintext>a</plaintext>b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         <plaintext>\n|           \"a</plaintext>b\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         <plaintext>\n|           \"a</plaintext>b\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><tr><style></script></style>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"abc\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <style>\n|             \"</script>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"abc\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <style>\n|             \"</script>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><tr><script></style></script>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"abc\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <script>\n|             \"</style>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"abc\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <script>\n|             \"</style>\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><caption><style></script></style>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <style>\n|           \"</script>\"\n|         \"abc\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <style>\n|           \"</script>\"\n|         \"abc\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><td><style></script></style>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <style>\n|               \"</script>\"\n|             \"abc\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <style>\n|               \"</script>\"\n|             \"abc\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><select><script></style></script>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <script>\n|         \"</style>\"\n|       \"abc\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <script>\n|         \"</style>\"\n|       \"abc\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><select><script></style></script>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <script>\n|         \"</style>\"\n|       \"abc\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <script>\n|         \"</style>\"\n|       \"abc\"\n|     <table>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><tr><select><script></style></script>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <script>\n|         \"</style>\"\n|       \"abc\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <script>\n|         \"</style>\"\n|       \"abc\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><frameset></frameset><noframes>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   <noframes>\n|     \"abc\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   <noframes>\n|     \"abc\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><frameset></frameset><noframes>abc</noframes><!--abc-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   <noframes>\n|     \"abc\"\n|   <!-- abc -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   <noframes>\n|     \"abc\"\n|   <!-- abc -->"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><frameset></frameset></html><noframes>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   <noframes>\n|     \"abc\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   <noframes>\n|     \"abc\""
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><frameset></frameset></html><noframes>abc</noframes><!--abc-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   <noframes>\n|     \"abc\"\n| <!-- abc -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   <noframes>\n|     \"abc\"\n| <!-- abc -->"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><tr></tbody><tfoot>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|       <tfoot>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|       <tfoot>"
+  },
+  {
+   "file": "tests18.dat",
+   "data": "<!doctype html><table><td><svg></svg>abc<td>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|             \"abc\"\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|             \"abc\"\n|           <td>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><math><mn DefinitionUrl=\"foo\">",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mn>\n|         definitionURL=\"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mn>\n|         definitionURL=\"foo\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html></p><!--foo-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <!-- foo -->\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <!-- foo -->\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><head></head></p><!--foo-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <!-- foo -->\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <!-- foo -->\n|   <body>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><body><p><pre>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <pre>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <pre>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><body><p><listing>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <listing>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <listing>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <plaintext>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <plaintext>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><h1>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <h1>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <h1>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><isindex type=\"hidden\">",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <isindex>\n|       type=\"hidden\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <isindex>\n|       type=\"hidden\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><ruby><p><rp>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <p>\n|       <rp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <p>\n|       <rp>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><ruby><div><span><rp>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <span>\n|           <rp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <span>\n|           <rp>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><ruby><div><p><rp>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <p>\n|         <rp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <p>\n|         <rp>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><ruby><p><rt>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <p>\n|       <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <p>\n|       <rt>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><ruby><div><span><rt>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <span>\n|           <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <span>\n|           <rt>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><ruby><div><p><rt>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <p>\n|         <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <p>\n|         <rt>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<html><ruby>a<rb>b<rt></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rb>\n|         \"b\"\n|       <rt>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<html><ruby>a<rp>b<rt></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rp>\n|         \"b\"\n|       <rt>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<html><ruby>a<rt>b<rt></ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rt>\n|         \"b\"\n|       <rt>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<html><ruby>a<rtc>b<rt>c<rb>d</ruby></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|         <rt>\n|           \"c\"\n|       <rb>\n|         \"d\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       \"a\"\n|       <rtc>\n|         \"b\"\n|         <rt>\n|           \"c\"\n|       <rb>\n|         \"d\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><math/><foo>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|     <foo>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|     <foo>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><svg/><foo>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <foo>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <foo>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><div></body><!--foo-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|   <!-- foo -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|   <!-- foo -->"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><h1><div><h3><span></h1>foo",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <h1>\n|       <div>\n|         <h3>\n|           <span>\n|         \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <h1>\n|       <div>\n|         <h3>\n|           <span>\n|         \"foo\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p></h3>foo",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"foo\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><h3><li>abc</h2>foo",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <h3>\n|       <li>\n|         \"abc\"\n|     \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <h3>\n|       <li>\n|         \"abc\"\n|     \"foo\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><table>abc<!--foo-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"abc\"\n|     <table>\n|       <!-- foo -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"abc\"\n|     <table>\n|       <!-- foo -->"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><table>  <!--foo-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"  \"\n|       <!-- foo -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"  \"\n|       <!-- foo -->"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><table> b <!--foo-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" b \"\n|     <table>\n|       <!-- foo -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \" b \"\n|     <table>\n|       <!-- foo -->"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><select><option><option>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <option>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><select><option></optgroup>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><dd><optgroup><dd>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dd>\n|       <optgroup>\n|     <dd>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dd>\n|       <optgroup>\n|     <dd>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><math><mi><p><h1>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mi>\n|           <p>\n|           <h1>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mi>\n|           <p>\n|           <h1>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><math><mo><p><h1>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mo>\n|           <p>\n|           <h1>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mo>\n|           <p>\n|           <h1>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><math><mn><p><h1>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mn>\n|           <p>\n|           <h1>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mn>\n|           <p>\n|           <h1>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><math><ms><p><h1>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math ms>\n|           <p>\n|           <h1>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math ms>\n|           <p>\n|           <h1>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><math><mtext><p><h1>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mtext>\n|           <p>\n|           <h1>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mtext>\n|           <p>\n|           <h1>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><frameset></noframes>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html c=d><body></html><html a=b>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   a=\"b\"\n|   c=\"d\"\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   a=\"b\"\n|   c=\"d\"\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html c=d><frameset></frameset></html><html a=b>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   a=\"b\"\n|   c=\"d\"\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   a=\"b\"\n|   c=\"d\"\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html><frameset></frameset></html><!--foo-->",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n| <!-- foo -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n| <!-- foo -->"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html><frameset></frameset></html>  ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   \"  \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   \"  \""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html><frameset></frameset></html>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html><frameset></frameset></html><p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html><frameset></frameset></html></p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<html><frameset></frameset></html><!doctype html>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><body><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><frameset><frame>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p>a<frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"a\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p> <frameset><frame>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><pre><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><listing><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <listing>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <listing>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><li><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <li>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <li>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><dd><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dd>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dd>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><dt><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dt>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><button><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <button>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <button>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><applet><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <applet>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <applet>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><marquee><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <marquee>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <marquee>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><object><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <object>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <object>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><table><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><area><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <area>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <area>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><basefont><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <basefont>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <basefont>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><bgsound><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <bgsound>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <bgsound>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><br><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <br>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <br>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><embed><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <embed>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <embed>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><img><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <img>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <img>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><input><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <input>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <input>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><keygen><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <keygen>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <keygen>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><wbr><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <wbr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <wbr>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><hr><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <hr>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><textarea></textarea><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><xmp></xmp><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <xmp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <xmp>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><iframe></iframe><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <iframe>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <iframe>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><select></select><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><svg></svg><frameset><frame>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><math></math><frameset><frame>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><svg><foreignObject><div> <frameset><frame>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><svg>a</svg><frameset><frame>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"a\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><svg> </svg><frameset><frame>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     <frame>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<html>aaa<frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"aaa\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"aaa\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<html> a <frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"a \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"a \""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><div><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><div><body><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><math></p>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|     \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|     \"a\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><math><mn><span></p>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mn>\n|           <span>\n|             <p>\n|             \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <math math>\n|         <math mn>\n|           <span>\n|             <p>\n|             \"a\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><math></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><meta charset=\"ascii\">",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <meta>\n|       charset=\"ascii\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <meta>\n|       charset=\"ascii\"\n|   <body>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><meta http-equiv=\"content-type\" content=\"text/html;charset=ascii\">",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <meta>\n|       content=\"text/html;charset=ascii\"\n|       http-equiv=\"content-type\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <meta>\n|       content=\"text/html;charset=ascii\"\n|       http-equiv=\"content-type\"\n|   <body>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><head><!--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa--><meta charset=\"utf8\">",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <!-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->\n|     <meta>\n|       charset=\"utf8\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <!-- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa -->\n|     <meta>\n|       charset=\"utf8\"\n|   <body>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><html a=b><head></head><html c=d>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   a=\"b\"\n|   c=\"d\"\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   a=\"b\"\n|   c=\"d\"\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><image/>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <img>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <img>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html>a<i>b<table>c<b>d</i>e</b>f",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"a\"\n|     <i>\n|       \"bc\"\n|       <b>\n|         \"de\"\n|       \"f\"\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"a\"\n|     <i>\n|       \"bc\"\n|       <b>\n|         \"de\"\n|       \"f\"\n|       <table>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><table><i>a<b>b<div>c<a>d</i>e</b>f",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"a\"\n|       <b>\n|         \"b\"\n|     <b>\n|     <div>\n|       <b>\n|         <i>\n|           \"c\"\n|           <a>\n|             \"d\"\n|         <a>\n|           \"e\"\n|       <a>\n|         \"f\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"a\"\n|       <b>\n|         \"b\"\n|     <b>\n|     <div>\n|       <b>\n|         <i>\n|           \"c\"\n|           <a>\n|             \"d\"\n|         <a>\n|           \"e\"\n|       <a>\n|         \"f\"\n|     <table>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><i>a<b>b<div>c<a>d</i>e</b>f",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"a\"\n|       <b>\n|         \"b\"\n|     <b>\n|     <div>\n|       <b>\n|         <i>\n|           \"c\"\n|           <a>\n|             \"d\"\n|         <a>\n|           \"e\"\n|       <a>\n|         \"f\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"a\"\n|       <b>\n|         \"b\"\n|     <b>\n|     <div>\n|       <b>\n|         <i>\n|           \"c\"\n|           <a>\n|             \"d\"\n|         <a>\n|           \"e\"\n|       <a>\n|         \"f\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><table><i>a<b>b<div>c</i>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"a\"\n|       <b>\n|         \"b\"\n|     <b>\n|       <div>\n|         <i>\n|           \"c\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"a\"\n|       <b>\n|         \"b\"\n|     <b>\n|       <div>\n|         <i>\n|           \"c\"\n|     <table>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><table><i>a<div>b<tr>c<b>d</i>e",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"a\"\n|       <div>\n|         \"b\"\n|     <i>\n|       \"c\"\n|       <b>\n|         \"d\"\n|     <b>\n|       \"e\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <i>\n|       \"a\"\n|       <div>\n|         \"b\"\n|     <i>\n|       \"c\"\n|       <b>\n|         \"d\"\n|     <b>\n|       \"e\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><table><td><table><i>a<div>b<b>c</i>d",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <i>\n|               \"a\"\n|             <div>\n|               <i>\n|                 \"b\"\n|                 <b>\n|                   \"c\"\n|               <b>\n|                 \"d\"\n|             <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <i>\n|               \"a\"\n|             <div>\n|               <i>\n|                 \"b\"\n|                 <b>\n|                   \"c\"\n|               <b>\n|                 \"d\"\n|             <table>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><body><bgsound>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <bgsound>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <bgsound>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><body><basefont>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <basefont>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <basefont>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><a><b></a><basefont>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <basefont>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <basefont>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><a><b></a><bgsound>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <bgsound>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <bgsound>"
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><figcaption><article></figcaption>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <figcaption>\n|       <article>\n|     \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <figcaption>\n|       <article>\n|     \"a\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><summary><article></summary>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <summary>\n|       <article>\n|     \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <summary>\n|       <article>\n|     \"a\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!doctype html><p><a><plaintext>b",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <a>\n|     <plaintext>\n|       <a>\n|         \"b\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <a>\n|     <plaintext>\n|       <a>\n|         \"b\""
+  },
+  {
+   "file": "tests19.dat",
+   "data": "<!DOCTYPE html><div>a<a></div>b<p>c</p>d",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"a\"\n|       <a>\n|     <a>\n|       \"b\"\n|       <p>\n|         \"c\"\n|       \"d\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"a\"\n|       <a>\n|     <a>\n|       \"b\"\n|       <p>\n|         \"c\"\n|       \"d\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html>Test",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"Test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"Test\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<textarea>test</div>test",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"test</div>test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"test</div>test\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<table><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<table><td>test</tbody></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"test\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<frame>test",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"test\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><frameset>test",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><frameset> te st",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     \"  \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|     \"  \""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><frameset></frameset> te st",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   \"  \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>\n|   \"  \""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><frameset><!DOCTYPE html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><font><p><b>test</font>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <font>\n|     <p>\n|       <font>\n|         <b>\n|           \"test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <font>\n|     <p>\n|       <font>\n|         <b>\n|           \"test\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><dt><div><dd>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dt>\n|       <div>\n|     <dd>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <dt>\n|       <div>\n|     <dd>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<script></x",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \"</x\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \"</x\"\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<table><plaintext><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"<td>\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"<td>\"\n|     <table>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<plaintext></plaintext>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"</plaintext>\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><table><tr>TEST",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"TEST\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"TEST\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><body t1=1><body t2=2><body t3=3 t4=4>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     t1=\"1\"\n|     t2=\"2\"\n|     t3=\"3\"\n|     t4=\"4\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     t1=\"1\"\n|     t2=\"2\"\n|     t3=\"3\"\n|     t4=\"4\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "</b test",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html></b test<b &=&amp>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 33,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!doctypehtml><scrIPt type=text/x-foobar;baz>X</SCRipt",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       type=\"text/x-foobar;baz\"\n|       \"X</SCRipt\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       type=\"text/x-foobar;baz\"\n|       \"X</SCRipt\"\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "&",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "&#",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&#\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&#\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "&#X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&#X\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 4,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 4,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&#X\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "&#x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&#x\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 4,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "absence-of-digits-in-numeric-character-reference",
+     "line": 1,
+     "col": 4,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&#x\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "&#45",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"-\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"-\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "&x-test",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&x-test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&x-test\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!doctypehtml><p><li>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <li>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <li>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!doctypehtml><p><dt>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <dt>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <dt>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!doctypehtml><p><dd>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <dd>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <dd>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!doctypehtml><p><form>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <form>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-whitespace-before-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <form>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><p></P>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     \"X\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "&AMP",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-semicolon-after-character-reference",
+     "line": 1,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "&AMp;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"&AMp;\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unknown-named-character-reference",
+     "line": 1,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unknown-named-character-reference",
+     "line": 1,
+     "col": 5,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"&AMp;\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><thisISasillyTESTelementNameToMakeSureCrazyTagNamesArePARSEDcorrectLY>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <thisisasillytestelementnametomakesurecrazytagnamesareparsedcorrectly>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <thisisasillytestelementnametomakesurecrazytagnamesareparsedcorrectly>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html>X</body>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"XX\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"XX\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><!-- X",
+   "document": "| <!DOCTYPE html>\n| <!--  X -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <!--  X -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><table><caption>test TEST</caption><td>test",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         \"test TEST\"\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         \"test TEST\"\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"test\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><select><option><optgroup>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <optgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <optgroup>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><select><optgroup><option></optgroup><option><select><option>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>\n|         <option>\n|       <option>\n|     <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>\n|         <option>\n|       <option>\n|     <option>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><select><optgroup><option><optgroup>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>\n|         <option>\n|       <optgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>\n|         <option>\n|       <optgroup>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><datalist><option>foo</datalist>bar",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <datalist>\n|       <option>\n|         \"foo\"\n|     \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <datalist>\n|       <option>\n|         \"foo\"\n|     \"bar\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><font><input><input></font>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <input>\n|       <input>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <input>\n|       <input>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><!-- XXX - XXX -->",
+   "document": "| <!DOCTYPE html>\n| <!--  XXX - XXX  -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <!--  XXX - XXX  -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><!-- XXX - XXX",
+   "document": "| <!DOCTYPE html>\n| <!--  XXX - XXX -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 30,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <!--  XXX - XXX -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><!-- XXX - XXX - XXX -->",
+   "document": "| <!DOCTYPE html>\n| <!--  XXX - XXX - XXX  -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <!--  XXX - XXX - XXX  -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html> <!DOCTYPE html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "test\ntest",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"test\ntest\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"test\ntest\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><body><title>test</body></title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"test</body>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"test</body>\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><body><title>X</title><meta name=z><link rel=foo><style>\nx { content:\"</style\" } </style>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"X\"\n|     <meta>\n|       name=\"z\"\n|     <link>\n|       rel=\"foo\"\n|     <style>\n|       \"\nx { content:\"</style\" } \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"X\"\n|     <meta>\n|       name=\"z\"\n|     <link>\n|       rel=\"foo\"\n|     <style>\n|       \"\nx { content:\"</style\" } \""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><select><optgroup></optgroup></select>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": " \n ",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html>  <html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><script>\n</script>  <title>x</title>  </head>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"\n\"\n|     \"  \"\n|     <title>\n|       \"x\"\n|     \"  \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <script>\n|       \"\n\"\n|     \"  \"\n|     <title>\n|       \"x\"\n|     \"  \"\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><html><body><html id=x>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   id=\"x\"\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   id=\"x\"\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html>X</body><html id=\"x\">",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   id=\"x\"\n|   <head>\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   id=\"x\"\n|   <head>\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><head><html id=x>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   id=\"x\"\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   id=\"x\"\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html>X</html>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"XX\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"XX\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html>X</html> ",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X \""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html>X</html><p>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <p>\n|       \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <p>\n|       \"X\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html>X<p/x/y/z>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <p>\n|       x=\"\"\n|       y=\"\"\n|       z=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 20,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 20,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 24,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <p>\n|       x=\"\"\n|       y=\"\"\n|       z=\"\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><!--x--",
+   "document": "| <!DOCTYPE html>\n| <!-- x -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 23,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <!-- x -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE html><table><tr><td></p></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <p>"
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!DOCTYPE <!DOCTYPE HTML>><!--<!--x-->-->",
+   "document": "| <!DOCTYPE <!doctype>\n| <html>\n|   <head>\n|   <body>\n|     \">\"\n|     <!-- <!--x -->\n|     \"-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "nested-comment",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-character-sequence-after-doctype-name",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "nested-comment",
+     "line": 1,
+     "col": 35,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE <!doctype>\n| <html>\n|   <head>\n|   <body>\n|     \">\"\n|     <!-- <!--x -->\n|     \"-->\""
+  },
+  {
+   "file": "tests2.dat",
+   "data": "<!doctype html><div><form></form><div></div></div>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <form>\n|       <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <form>\n|       <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><button>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|       <button>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|       <button>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><address>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <address>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <address>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><article>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <article>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <article>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><aside>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <aside>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <aside>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><blockquote>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <blockquote>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <blockquote>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><center>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <center>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <center>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><details>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <details>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <details>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><dialog>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dialog>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dialog>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><dir>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dir>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dir>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><div>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><dl>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dl>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dl>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><fieldset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <fieldset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <fieldset>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><figcaption>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <figcaption>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <figcaption>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><figure>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <figure>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <figure>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><footer>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <footer>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <footer>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><header>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <header>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <header>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><hgroup>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <hgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <hgroup>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><main>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <main>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <main>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><menu>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <menu>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <menu>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><nav>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <nav>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <nav>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><ol>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <ol>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <ol>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <p>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><search>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <search>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <search>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><section>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <section>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <section>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><summary>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <summary>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <summary>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><ul>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <ul>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <ul>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><h1>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <h1>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <h1>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><h6>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <h6>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <h6>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><listing>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <listing>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <listing>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><pre>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <pre>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <pre>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><form>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <form>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <form>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><li>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <li>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <li>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><dd>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dd>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dd>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><dt>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dt>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <dt>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><plaintext>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <plaintext>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <plaintext>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <table>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><hr>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <hr>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button><xmp>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <xmp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <xmp>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><button></p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <button>\n|         <p>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><button><p></button>x",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <button>\n|       <p>\n|     \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <button>\n|       <p>\n|     \"x\""
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><address><button></address>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <address>\n|       <button>\n|     \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <address>\n|       <button>\n|     \"a\""
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<p><table></p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <p>\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <p>\n|       <table>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><svg>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><figcaption>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <figcaption>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <figcaption>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><p><summary>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <summary>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <summary>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><form><table><form>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <form>\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <form>\n|       <table>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><table><form><form>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <form>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <form>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><table><form></table><form>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <form>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <form>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><svg><foreignObject><p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         <p>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         <p>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<!doctype html><svg><title>abc",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         \"abc\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         \"abc\""
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<option><span><option>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <option>\n|       <span>\n|         <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <option>\n|       <span>\n|         <option>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<option><option>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <option>\n|     <option>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <option>\n|     <option>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|     <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml encoding=\"application/svg+xml\"><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"application/svg+xml\"\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"application/svg+xml\"\n|     <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml encoding=\"application/xhtml+xml\"><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"application/xhtml+xml\"\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"application/xhtml+xml\"\n|         <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml encoding=\"aPPlication/xhtmL+xMl\"><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"aPPlication/xhtmL+xMl\"\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"aPPlication/xhtmL+xMl\"\n|         <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml encoding=\"text/html\"><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"text/html\"\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"text/html\"\n|         <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml encoding=\"Text/htmL\"><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"Text/htmL\"\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\"Text/htmL\"\n|         <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml encoding=\" text/html \"><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\" text/html \"\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         encoding=\" text/html \"\n|     <div>"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml> </annotation-xml>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         \" \""
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml>c</annotation-xml>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         \"c\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         \"c\""
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml><!--foo-->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <!-- foo -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <!-- foo -->"
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml></svg>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         \"x\""
+  },
+  {
+   "file": "tests20.dat",
+   "data": "<math><annotation-xml><svg>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|           \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|           \"x\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[foo]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<math><![CDATA[foo]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       \"foo\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<div><![CDATA[foo]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <!-- [CDATA[foo]] -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "cdata-in-html-content",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "cdata-in-html-content",
+     "line": 1,
+     "col": 14,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <!-- [CDATA[foo]] -->"
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[foo",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 15,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>"
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>"
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[]] >]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"]] >\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"]] >\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[]]",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"]]\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"]]\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[]",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"]\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 16,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"]\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[]>a",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"]>a\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 18,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"]>a\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<!DOCTYPE html><svg><![CDATA[foo]]]>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo]\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo]\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<!DOCTYPE html><svg><![CDATA[foo]]]]>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo]]\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo]]\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<!DOCTYPE html><svg><![CDATA[foo]]]]]>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo]]]\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"foo]]]\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><foreignObject><div><![CDATA[foo]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         <div>\n|           <!-- [CDATA[foo]] -->",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "cdata-in-html-content",
+     "line": 1,
+     "col": 34,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "cdata-in-html-content",
+     "line": 1,
+     "col": 34,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         <div>\n|           <!-- [CDATA[foo]] -->"
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[<svg>]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[</svg>a]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"</svg>a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"</svg>a\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[<svg>a",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>a\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>a\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[</svg>a",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"</svg>a\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-cdata",
+     "line": 1,
+     "col": 22,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"</svg>a\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[<svg>]]><path>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>\"\n|       <svg path>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>\"\n|       <svg path>"
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[<svg>]]></path>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[<svg>]]><!--path-->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>\"\n|       <!-- path -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>\"\n|       <!-- path -->"
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[<svg>]]>path",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>path\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<svg>path\""
+  },
+  {
+   "file": "tests21.dat",
+   "data": "<svg><![CDATA[<!--svg-->]]>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<!--svg-->\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       \"<!--svg-->\""
+  },
+  {
+   "file": "tests22.dat",
+   "data": "<a><b><big><em><strong><div>X</a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|         <big>\n|           <em>\n|             <strong>\n|     <big>\n|       <em>\n|         <strong>\n|           <div>\n|             <a>\n|               \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|         <big>\n|           <em>\n|             <strong>\n|     <big>\n|       <em>\n|         <strong>\n|           <div>\n|             <a>\n|               \"X\""
+  },
+  {
+   "file": "tests22.dat",
+   "data": "<a><b><div id=1><div id=2><div id=3><div id=4><div id=5><div id=6><div id=7><div id=8>A</a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <b>\n|       <div>\n|         id=\"1\"\n|         <a>\n|         <div>\n|           id=\"2\"\n|           <a>\n|           <div>\n|             id=\"3\"\n|             <a>\n|             <div>\n|               id=\"4\"\n|               <a>\n|               <div>\n|                 id=\"5\"\n|                 <a>\n|                 <div>\n|                   id=\"6\"\n|                   <a>\n|                   <div>\n|                     id=\"7\"\n|                     <a>\n|                     <div>\n|                       id=\"8\"\n|                       <a>\n|                         \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <b>\n|       <div>\n|         id=\"1\"\n|         <a>\n|         <div>\n|           id=\"2\"\n|           <a>\n|           <div>\n|             id=\"3\"\n|             <a>\n|             <div>\n|               id=\"4\"\n|               <a>\n|               <div>\n|                 id=\"5\"\n|                 <a>\n|                 <div>\n|                   id=\"6\"\n|                   <a>\n|                   <div>\n|                     id=\"7\"\n|                     <a>\n|                     <div>\n|                       id=\"8\"\n|                       <a>\n|                         \"A\""
+  },
+  {
+   "file": "tests22.dat",
+   "data": "<a><b><div id=1><div id=2><div id=3><div id=4><div id=5><div id=6><div id=7><div id=8><div id=9>A</a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <b>\n|       <div>\n|         id=\"1\"\n|         <a>\n|         <div>\n|           id=\"2\"\n|           <a>\n|           <div>\n|             id=\"3\"\n|             <a>\n|             <div>\n|               id=\"4\"\n|               <a>\n|               <div>\n|                 id=\"5\"\n|                 <a>\n|                 <div>\n|                   id=\"6\"\n|                   <a>\n|                   <div>\n|                     id=\"7\"\n|                     <a>\n|                     <div>\n|                       id=\"8\"\n|                       <a>\n|                         <div>\n|                           id=\"9\"\n|                           \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <b>\n|       <div>\n|         id=\"1\"\n|         <a>\n|         <div>\n|           id=\"2\"\n|           <a>\n|           <div>\n|             id=\"3\"\n|             <a>\n|             <div>\n|               id=\"4\"\n|               <a>\n|               <div>\n|                 id=\"5\"\n|                 <a>\n|                 <div>\n|                   id=\"6\"\n|                   <a>\n|                   <div>\n|                     id=\"7\"\n|                     <a>\n|                     <div>\n|                       id=\"8\"\n|                       <a>\n|                         <div>\n|                           id=\"9\"\n|                           \"A\""
+  },
+  {
+   "file": "tests22.dat",
+   "data": "<a><b><div id=1><div id=2><div id=3><div id=4><div id=5><div id=6><div id=7><div id=8><div id=9><div id=10>A</a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <b>\n|       <div>\n|         id=\"1\"\n|         <a>\n|         <div>\n|           id=\"2\"\n|           <a>\n|           <div>\n|             id=\"3\"\n|             <a>\n|             <div>\n|               id=\"4\"\n|               <a>\n|               <div>\n|                 id=\"5\"\n|                 <a>\n|                 <div>\n|                   id=\"6\"\n|                   <a>\n|                   <div>\n|                     id=\"7\"\n|                     <a>\n|                     <div>\n|                       id=\"8\"\n|                       <a>\n|                         <div>\n|                           id=\"9\"\n|                           <div>\n|                             id=\"10\"\n|                             \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       <b>\n|     <b>\n|       <div>\n|         id=\"1\"\n|         <a>\n|         <div>\n|           id=\"2\"\n|           <a>\n|           <div>\n|             id=\"3\"\n|             <a>\n|             <div>\n|               id=\"4\"\n|               <a>\n|               <div>\n|                 id=\"5\"\n|                 <a>\n|                 <div>\n|                   id=\"6\"\n|                   <a>\n|                   <div>\n|                     id=\"7\"\n|                     <a>\n|                     <div>\n|                       id=\"8\"\n|                       <a>\n|                         <div>\n|                           id=\"9\"\n|                           <div>\n|                             id=\"10\"\n|                             \"A\""
+  },
+  {
+   "file": "tests22.dat",
+   "data": "<cite><b><cite><i><cite><i><cite><i><div>X</b>TEST",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <cite>\n|       <b>\n|         <cite>\n|           <i>\n|             <cite>\n|               <i>\n|                 <cite>\n|                   <i>\n|       <i>\n|         <i>\n|           <div>\n|             <b>\n|               \"X\"\n|             \"TEST\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <cite>\n|       <b>\n|         <cite>\n|           <i>\n|             <cite>\n|               <i>\n|                 <cite>\n|                   <i>\n|       <i>\n|         <i>\n|           <div>\n|             <b>\n|               \"X\"\n|             \"TEST\""
+  },
+  {
+   "file": "tests23.dat",
+   "data": "<p><font size=4><font color=red><font size=4><font size=4><font size=4><font size=4><font size=4><font color=red><p>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           color=\"red\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|               <font>\n|                 size=\"4\"\n|                 <font>\n|                   size=\"4\"\n|                   <font>\n|                     size=\"4\"\n|                     <font>\n|                       color=\"red\"\n|     <p>\n|       <font>\n|         color=\"red\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|               <font>\n|                 color=\"red\"\n|                 \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           color=\"red\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|               <font>\n|                 size=\"4\"\n|                 <font>\n|                   size=\"4\"\n|                   <font>\n|                     size=\"4\"\n|                     <font>\n|                       color=\"red\"\n|     <p>\n|       <font>\n|         color=\"red\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|               <font>\n|                 color=\"red\"\n|                 \"X\""
+  },
+  {
+   "file": "tests23.dat",
+   "data": "<p><font size=4><font size=4><font size=4><font size=4><p>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             \"X\""
+  },
+  {
+   "file": "tests23.dat",
+   "data": "<p><font size=4><font size=4><font size=4><font size=\"5\"><font size=4><p>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"5\"\n|               <font>\n|                 size=\"4\"\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"5\"\n|             <font>\n|               size=\"4\"\n|               \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"5\"\n|               <font>\n|                 size=\"4\"\n|     <p>\n|       <font>\n|         size=\"4\"\n|         <font>\n|           size=\"4\"\n|           <font>\n|             size=\"5\"\n|             <font>\n|               size=\"4\"\n|               \"X\""
+  },
+  {
+   "file": "tests23.dat",
+   "data": "<p><font size=4 id=a><font size=4 id=b><font size=4><font size=4><p>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         id=\"a\"\n|         size=\"4\"\n|         <font>\n|           id=\"b\"\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|     <p>\n|       <font>\n|         id=\"a\"\n|         size=\"4\"\n|         <font>\n|           id=\"b\"\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|               \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <font>\n|         id=\"a\"\n|         size=\"4\"\n|         <font>\n|           id=\"b\"\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|     <p>\n|       <font>\n|         id=\"a\"\n|         size=\"4\"\n|         <font>\n|           id=\"b\"\n|           size=\"4\"\n|           <font>\n|             size=\"4\"\n|             <font>\n|               size=\"4\"\n|               \"X\""
+  },
+  {
+   "file": "tests23.dat",
+   "data": "<p><b id=a><b id=a><b id=a><b><object><b id=a><b id=a>X</object><p>Y",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         id=\"a\"\n|         <b>\n|           id=\"a\"\n|           <b>\n|             id=\"a\"\n|             <b>\n|               <object>\n|                 <b>\n|                   id=\"a\"\n|                   <b>\n|                     id=\"a\"\n|                     \"X\"\n|     <p>\n|       <b>\n|         id=\"a\"\n|         <b>\n|           id=\"a\"\n|           <b>\n|             id=\"a\"\n|             <b>\n|               \"Y\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <b>\n|         id=\"a\"\n|         <b>\n|           id=\"a\"\n|           <b>\n|             id=\"a\"\n|             <b>\n|               <object>\n|                 <b>\n|                   id=\"a\"\n|                   <b>\n|                     id=\"a\"\n|                     \"X\"\n|     <p>\n|       <b>\n|         id=\"a\"\n|         <b>\n|           id=\"a\"\n|           <b>\n|             id=\"a\"\n|             <b>\n|               \"Y\""
+  },
+  {
+   "file": "tests24.dat",
+   "data": "<!DOCTYPE html>&NotEqualTilde;",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"≂̸\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"≂̸\""
+  },
+  {
+   "file": "tests24.dat",
+   "data": "<!DOCTYPE html>&NotEqualTilde;A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"≂̸A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"≂̸A\""
+  },
+  {
+   "file": "tests24.dat",
+   "data": "<!DOCTYPE html>&ThickSpace;",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"  \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"  \""
+  },
+  {
+   "file": "tests24.dat",
+   "data": "<!DOCTYPE html>&ThickSpace;A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"  A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"  A\""
+  },
+  {
+   "file": "tests24.dat",
+   "data": "<!DOCTYPE html>&NotSubset;",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"⊂⃒\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"⊂⃒\""
+  },
+  {
+   "file": "tests24.dat",
+   "data": "<!DOCTYPE html>&NotSubset;A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"⊂⃒A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"⊂⃒A\""
+  },
+  {
+   "file": "tests24.dat",
+   "data": "<!DOCTYPE html>&Gopf;",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"𝔾\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"𝔾\""
+  },
+  {
+   "file": "tests24.dat",
+   "data": "<!DOCTYPE html>&Gopf;A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"𝔾A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"𝔾A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><foo>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><area>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <area>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <area>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><base>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <base>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <base>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><basefont>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <basefont>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <basefont>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><bgsound>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <bgsound>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <bgsound>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><br>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <br>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <br>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><col>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><command>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <command>\n|       \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <command>\n|       \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><embed>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <embed>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <embed>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><frame>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><hr>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <hr>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <hr>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><img>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <img>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <img>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><input>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <input>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <input>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><keygen>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <keygen>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <keygen>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><keygen>A</keygen>B",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <keygen>\n|     \"AB\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <keygen>\n|     \"AB\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "</keygen>A",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html></keygen>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><head></keygen>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><head></head></keygen>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body></keygen>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><link>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <link>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <link>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><meta>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <meta>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <meta>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><param>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <param>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <param>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><source>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <source>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <source>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><track>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <track>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <track>\n|     \"A\""
+  },
+  {
+   "file": "tests25.dat",
+   "data": "<!DOCTYPE html><body><wbr>A",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <wbr>\n|     \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <wbr>\n|     \"A\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><a href='#1'><nobr>1<nobr></a><br><a href='#2'><nobr>2<nobr></a><br><a href='#3'><nobr>3<nobr></a>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"#1\"\n|       <nobr>\n|         \"1\"\n|       <nobr>\n|     <nobr>\n|       <br>\n|       <a>\n|         href=\"#2\"\n|     <a>\n|       href=\"#2\"\n|       <nobr>\n|         \"2\"\n|       <nobr>\n|     <nobr>\n|       <br>\n|       <a>\n|         href=\"#3\"\n|     <a>\n|       href=\"#3\"\n|       <nobr>\n|         \"3\"\n|       <nobr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <a>\n|       href=\"#1\"\n|       <nobr>\n|         \"1\"\n|       <nobr>\n|     <nobr>\n|       <br>\n|       <a>\n|         href=\"#2\"\n|     <a>\n|       href=\"#2\"\n|       <nobr>\n|         \"2\"\n|       <nobr>\n|     <nobr>\n|       <br>\n|       <a>\n|         href=\"#3\"\n|     <a>\n|       href=\"#3\"\n|       <nobr>\n|         \"3\"\n|       <nobr>"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><b><nobr>1<nobr></b><i><nobr>2<nobr></i>3",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|       <nobr>\n|     <nobr>\n|       <i>\n|     <i>\n|       <nobr>\n|         \"2\"\n|       <nobr>\n|     <nobr>\n|       \"3\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|       <nobr>\n|     <nobr>\n|       <i>\n|     <i>\n|       <nobr>\n|         \"2\"\n|       <nobr>\n|     <nobr>\n|       \"3\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><b><nobr>1<table><nobr></b><i><nobr>2<nobr></i>3",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|         <nobr>\n|           <i>\n|         <i>\n|           <nobr>\n|             \"2\"\n|           <nobr>\n|         <nobr>\n|           \"3\"\n|         <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|         <nobr>\n|           <i>\n|         <i>\n|           <nobr>\n|             \"2\"\n|           <nobr>\n|         <nobr>\n|           \"3\"\n|         <table>"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><b><nobr>1<table><tr><td><nobr></b><i><nobr>2<nobr></i>3",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|         <table>\n|           <tbody>\n|             <tr>\n|               <td>\n|                 <nobr>\n|                   <i>\n|                 <i>\n|                   <nobr>\n|                     \"2\"\n|                   <nobr>\n|                 <nobr>\n|                   \"3\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|         <table>\n|           <tbody>\n|             <tr>\n|               <td>\n|                 <nobr>\n|                   <i>\n|                 <i>\n|                   <nobr>\n|                     \"2\"\n|                   <nobr>\n|                 <nobr>\n|                   \"3\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><b><nobr>1<div><nobr></b><i><nobr>2<nobr></i>3",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|     <div>\n|       <b>\n|         <nobr>\n|         <nobr>\n|       <nobr>\n|         <i>\n|       <i>\n|         <nobr>\n|           \"2\"\n|         <nobr>\n|       <nobr>\n|         \"3\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|     <div>\n|       <b>\n|         <nobr>\n|         <nobr>\n|       <nobr>\n|         <i>\n|       <i>\n|         <nobr>\n|           \"2\"\n|         <nobr>\n|       <nobr>\n|         \"3\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><b><nobr>1<nobr></b><div><i><nobr>2<nobr></i>3",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|       <nobr>\n|     <div>\n|       <nobr>\n|         <i>\n|       <i>\n|         <nobr>\n|           \"2\"\n|         <nobr>\n|       <nobr>\n|         \"3\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|       <nobr>\n|     <div>\n|       <nobr>\n|         <i>\n|       <i>\n|         <nobr>\n|           \"2\"\n|         <nobr>\n|       <nobr>\n|         \"3\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><b><nobr>1<nobr><ins></b><i><nobr>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|       <nobr>\n|         <ins>\n|     <nobr>\n|       <i>\n|     <i>\n|       <nobr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|       <nobr>\n|         <ins>\n|     <nobr>\n|       <i>\n|     <i>\n|       <nobr>"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><b><nobr>1<ins><nobr></b><i>2",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|         <ins>\n|       <nobr>\n|     <nobr>\n|       <i>\n|         \"2\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <nobr>\n|         \"1\"\n|         <ins>\n|       <nobr>\n|     <nobr>\n|       <i>\n|         \"2\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><b>1<nobr></b><i><nobr>2</i>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"1\"\n|       <nobr>\n|     <nobr>\n|       <i>\n|     <i>\n|       <nobr>\n|         \"2\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"1\"\n|       <nobr>\n|     <nobr>\n|       <i>\n|     <i>\n|       <nobr>\n|         \"2\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<p><code x</code></p>\n",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <code>\n|         code=\"\"\n|         x<=\"\"\n|     <code>\n|       code=\"\"\n|       x<=\"\"\n|       \"\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 11,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 13,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 11,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 13,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <code>\n|         code=\"\"\n|         x<=\"\"\n|     <code>\n|       code=\"\"\n|       x<=\"\"\n|       \"\n\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><svg><foreignObject><p><i></p>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         <p>\n|           <i>\n|         <i>\n|           \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         <p>\n|           <i>\n|         <i>\n|           \"a\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><table><tr><td><svg><foreignObject><p><i></p>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg foreignObject>\n|                 <p>\n|                   <i>\n|                 <i>\n|                   \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg foreignObject>\n|                 <p>\n|                   <i>\n|                 <i>\n|                   \"a\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><math><mtext><p><i></p>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mtext>\n|         <p>\n|           <i>\n|         <i>\n|           \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mtext>\n|         <p>\n|           <i>\n|         <i>\n|           \"a\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><table><tr><td><math><mtext><p><i></p>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <math math>\n|               <math mtext>\n|                 <p>\n|                   <i>\n|                 <i>\n|                   \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <math math>\n|               <math mtext>\n|                 <p>\n|                   <i>\n|                 <i>\n|                   \"a\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<!DOCTYPE html><body><div><!/div>a",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <!-- /div -->\n|       \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "incorrectly-opened-comment",
+     "line": 1,
+     "col": 29,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <!-- /div -->\n|       \"a\""
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<button><p><button>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <button>\n|       <p>\n|     <button>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <button>\n|       <p>\n|     <button>"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<svg></p><foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <p>\n|     <foo>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <p>\n|       <svg foo>"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<svg></br><foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <br>\n|     <foo>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <br>\n|       <svg foo>"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<math></p><foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|     <p>\n|     <foo>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <p>\n|       <math foo>"
+  },
+  {
+   "file": "tests26.dat",
+   "data": "<math></br><foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|     <br>\n|     <foo>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <br>\n|       <math foo>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<head></head><style></style>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|   <body>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<head></head><script></script>",
+   "document": "| <html>\n|   <head>\n|     <script>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|   <body>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<head></head><!-- --><style></style><!-- --><script></script>",
+   "document": "| <html>\n|   <head>\n|     <style>\n|     <script>\n|   <!--   -->\n|   <!--   -->\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|     <script>\n|   <!--   -->\n|   <!--   -->\n|   <body>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<head></head><!-- -->x<style></style><!-- --><script></script>",
+   "document": "| <html>\n|   <head>\n|   <!--   -->\n|   <body>\n|     \"x\"\n|     <style>\n|     <!--   -->\n|     <script>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <!--   -->\n|   <body>\n|     \"x\"\n|     <style>\n|     <!--   -->\n|     <script>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><pre>\n</pre></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><pre>\nfoo</pre></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"foo\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><pre>\n\nfoo</pre></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"\nfoo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"\nfoo\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><pre>\nfoo\n</pre></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"foo\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"foo\n\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><pre>x</pre><span>\n</span></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"x\"\n|     <span>\n|       \"\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"x\"\n|     <span>\n|       \"\n\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><pre>x\ny</pre></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"x\ny\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"x\ny\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><pre>x<div>\ny</pre></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"x\"\n|       <div>\n|         \"\ny\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"x\"\n|       <div>\n|         \"\ny\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><pre>&#x0a;&#x0a;A</pre>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"\nA\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <pre>\n|       \"\nA\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><HTML><META><HEAD></HEAD></HTML>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <meta>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <meta>\n|   <body>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><HTML><HEAD><head></HEAD></HTML>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<textarea>foo<span>bar</span><i>baz",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"foo<span>bar</span><i>baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"foo<span>bar</span><i>baz\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<title>foo<span>bar</em><i>baz",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \"foo<span>bar</em><i>baz\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \"foo<span>bar</em><i>baz\"\n|   <body>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><textarea>\n</textarea>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><textarea>\nfoo</textarea>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"foo\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><textarea>\n\nfoo</textarea>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"\nfoo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \"\nfoo\""
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!DOCTYPE html><html><head></head><body><ul><li><div><p><li></ul></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|         <div>\n|           <p>\n|       <li>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|         <div>\n|           <p>\n|       <li>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!doctype html><nobr><nobr><nobr>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <nobr>\n|     <nobr>\n|     <nobr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <nobr>\n|     <nobr>\n|     <nobr>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!doctype html><nobr><nobr></nobr><nobr>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <nobr>\n|     <nobr>\n|     <nobr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <nobr>\n|     <nobr>\n|     <nobr>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<!doctype html><html><body><p><table></table></body></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <table>"
+  },
+  {
+   "file": "tests3.dat",
+   "data": "<p><table></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <table>"
+  },
+  {
+   "file": "tests4.dat",
+   "data": "direct div content",
+   "document": "| \"direct div content\"",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"direct div content\""
+  },
+  {
+   "file": "tests4.dat",
+   "data": "direct textarea content",
+   "document": "| \"direct textarea content\"",
+   "context": "textarea",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"direct textarea content\""
+  },
+  {
+   "file": "tests4.dat",
+   "data": "textarea content with <em>pseudo</em> <foo>markup",
+   "document": "| \"textarea content with <em>pseudo</em> <foo>markup\"",
+   "context": "textarea",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"textarea content with <em>pseudo</em> <foo>markup\""
+  },
+  {
+   "file": "tests4.dat",
+   "data": "this is &#x0043;DATA inside a <style> element",
+   "document": "| \"this is &#x0043;DATA inside a <style> element\"",
+   "context": "style",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"this is &#x0043;DATA inside a <style> element\""
+  },
+  {
+   "file": "tests4.dat",
+   "data": "</plaintext>",
+   "document": "| \"</plaintext>\"",
+   "context": "plaintext",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"</plaintext>\""
+  },
+  {
+   "file": "tests4.dat",
+   "data": "setting html's innerHTML",
+   "document": "| <head>\n| <body>\n|   \"setting html's innerHTML\"",
+   "context": "html",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <head>\n| <body>\n|   \"setting html's innerHTML\""
+  },
+  {
+   "file": "tests4.dat",
+   "data": "<title>setting head's innerHTML</title>",
+   "document": "| <title>\n|   \"setting head's innerHTML\"",
+   "context": "head",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <title>\n|   \"setting head's innerHTML\""
+  },
+  {
+   "file": "tests4.dat",
+   "data": "direct <title> content",
+   "document": "| \"direct <title> content\"",
+   "context": "title",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"direct <title> content\""
+  },
+  {
+   "file": "tests4.dat",
+   "data": "<!-- inside </script> -->",
+   "document": "| \"<!-- inside </script> -->\"",
+   "context": "script",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"<!-- inside </script> -->\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<style> <!-- </style>x",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \" <!-- \"\n|   <body>\n|     \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \" <!-- \"\n|   <body>\n|     \"x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<style> <!-- </style> --> </style>x",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \" <!-- \"\n|     \" \"\n|   <body>\n|     \"--> x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \" <!-- \"\n|     \" \"\n|   <body>\n|     \"--> x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<style> <!--> </style>x",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \" <!--> \"\n|   <body>\n|     \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \" <!--> \"\n|   <body>\n|     \"x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<style> <!---> </style>x",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \" <!---> \"\n|   <body>\n|     \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \" <!---> \"\n|   <body>\n|     \"x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<iframe> <!---> </iframe>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \" <!---> \"\n|     \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \" <!---> \"\n|     \"x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<iframe> <!--- </iframe>->x</iframe> --> </iframe>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \" <!--- \"\n|     \"->x --> x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <iframe>\n|       \" <!--- \"\n|     \"->x --> x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<script> <!-- </script> --> </script>x",
+   "document": "| <html>\n|   <head>\n|     <script>\n|       \" <!-- \"\n|     \" \"\n|   <body>\n|     \"--> x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <script>\n|       \" <!-- \"\n|     \" \"\n|   <body>\n|     \"--> x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<title> <!-- </title> --> </title>x",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \" <!-- \"\n|     \" \"\n|   <body>\n|     \"--> x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \" <!-- \"\n|     \" \"\n|   <body>\n|     \"--> x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<textarea> <!--- </textarea>->x</textarea> --> </textarea>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \" <!--- \"\n|     \"->x --> x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <textarea>\n|       \" <!--- \"\n|     \"->x --> x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<style> <!</-- </style>x",
+   "document": "| <html>\n|   <head>\n|     <style>\n|       \" <!</-- \"\n|   <body>\n|     \"x\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|       \" <!</-- \"\n|   <body>\n|     \"x\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<p><xmp></xmp>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <xmp>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|     <xmp>"
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<xmp> <!-- > --> </xmp>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <xmp>\n|       \" <!-- > --> \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <xmp>\n|       \" <!-- > --> \""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<title>&amp;</title>",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \"&\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \"&\"\n|   <body>"
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<title><!--&amp;--></title>",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \"<!--&-->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \"<!--&-->\"\n|   <body>"
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<title><!--</title>",
+   "document": "| <html>\n|   <head>\n|     <title>\n|       \"<!--\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <title>\n|       \"<!--\"\n|   <body>"
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<noscript><!--</noscript>--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       \"<!--\"\n|   <body>\n|     \"-->\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       \"<!--\"\n|   <body>\n|     \"-->\""
+  },
+  {
+   "file": "tests5.dat",
+   "data": "<noscript><!--</noscript>--></noscript>",
+   "document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- </noscript> -->\n|   <body>",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <noscript>\n|       <!-- </noscript> -->\n|   <body>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<!doctype html></head> <head>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   \" \"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   \" \"\n|   <body>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<!doctype html><form><div></form><div>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <form>\n|       <div>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <form>\n|       <div>\n|         <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<!doctype html><title>&amp;</title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"&\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"&\"\n|   <body>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<!doctype html><title><!--&amp;--></title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"<!--&-->\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"<!--&-->\"\n|   <body>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<!doctype>",
+   "document": "| <!DOCTYPE >\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "missing-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "missing-doctype-name",
+     "line": 1,
+     "col": 10,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!DOCTYPE >\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<!---x",
+   "document": "| <!-- -x -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-comment",
+     "line": 1,
+     "col": 7,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!-- -x -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<body>\n<div>",
+   "document": "| \"\n\"\n| <div>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| \"\n\"\n| <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<frameset></frameset>\nfoo",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\""
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<frameset></frameset>\n<noframes>",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\"\n|   <noframes>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\"\n|   <noframes>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<frameset></frameset>\n<div>",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\""
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<frameset></frameset>\n</html>",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\""
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<frameset></frameset>\n</div>",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|   \"\n\""
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<form><form>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <form>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <form>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<button><button>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <button>\n|     <button>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <button>\n|     <button>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><tr><td></th>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><caption><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><caption><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</caption><div>",
+   "document": "| <div>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><caption><div></caption>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><caption></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</table><div>",
+   "document": "| <div>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><caption></body></col></colgroup></html></tbody></td></tfoot></th></thead></tr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><caption><div></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><tr><td></body></caption></col></colgroup></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</table></tbody></tfoot></thead></tr><div>",
+   "document": "| <div>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><colgroup>foo",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"foo\"\n|     <table>\n|       <colgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"foo\"\n|     <table>\n|       <colgroup>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "foo<col>",
+   "document": "| <col>",
+   "context": "colgroup",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <col>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><colgroup></col>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <colgroup>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<frameset><div>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</frameset><frame>",
+   "document": "| <frame>",
+   "context": "frameset",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <frame>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<frameset></div>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</body><div>",
+   "document": "| <div>",
+   "context": "body",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <div>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><tr><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</tr><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</tbody></tfoot></thead><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><tr><div><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<caption><col><colgroup><tbody><tfoot><thead><tr>",
+   "document": "| <tr>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <tr>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><tbody></thead>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</table><tr>",
+   "document": "| <tr>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <tr>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><tbody></body></caption></col></colgroup></html></td></th></tr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><tbody></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table><table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|     <table>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<table></body></caption></col></colgroup></html></tbody></td></tfoot></th></thead></tr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</table><tr>",
+   "document": "| <tbody>\n|   <tr>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <tbody>\n|   <tr>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<body></body></html>",
+   "document": "| <head>\n| <body>",
+   "context": "html",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <head>\n| <body>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<html><frameset></frameset></html> ",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|   \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|   \" \""
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\"><html></html>",
+   "document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"\">\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html \"-//W3C//DTD HTML 4.01//EN\" \"\">\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<param><frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<source><frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "<track><frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</html><frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests6.dat",
+   "data": "</body><frameset></frameset>",
+   "document": "| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><body><title>X</title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table><title>X</title></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"X\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <title>\n|       \"X\"\n|     <table>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><head></head><title>X</title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"X\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"X\"\n|   <body>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html></head><title>X</title>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"X\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <title>\n|       \"X\"\n|   <body>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html></head><base>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <base>\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <base>\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html></head><basefont>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <basefont>\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <basefont>\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html></head><bgsound>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <bgsound>\n|   <body>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|     <bgsound>\n|   <body>\n|     \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table><meta></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <meta>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <meta>\n|     <table>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table>X<tr><td><table> <meta></table></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <meta>\n|             <table>\n|               \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <meta>\n|             <table>\n|               \" \""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><html> <head>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html> <head>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table><style> <tr>x </style> </table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <style>\n|         \" <tr>x \"\n|       \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <style>\n|         \" <tr>x \"\n|       \" \""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table><TBODY><script> <tr>x </script> </table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <script>\n|           \" <tr>x \"\n|         \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <script>\n|           \" <tr>x \"\n|         \" \""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><p><applet><p>X</p></applet>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <applet>\n|         <p>\n|           \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <applet>\n|         <p>\n|           \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><p><object type=\"application/x-non-existant-plugin\"><p>X</p></object>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <object>\n|         type=\"application/x-non-existant-plugin\"\n|         <p>\n|           \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <object>\n|         type=\"application/x-non-existant-plugin\"\n|         <p>\n|           \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><listing>\nX</listing>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <listing>\n|       \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <listing>\n|       \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><select><input>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <input>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <input>\n|     \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><select><select>X",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|     \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|     \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table><input type=hidDEN></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <input>\n|         type=\"hidDEN\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <input>\n|         type=\"hidDEN\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table>X<input type=hidDEN></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <table>\n|       <input>\n|         type=\"hidDEN\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     \"X\"\n|     <table>\n|       <input>\n|         type=\"hidDEN\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table>  <input type=hidDEN></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"  \"\n|       <input>\n|         type=\"hidDEN\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"  \"\n|       <input>\n|         type=\"hidDEN\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table>  <input type='hidDEN'></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"  \"\n|       <input>\n|         type=\"hidDEN\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       \"  \"\n|       <input>\n|         type=\"hidDEN\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table><input type=\" hidden\"><input type=hidDEN></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <input>\n|       type=\" hidden\"\n|     <table>\n|       <input>\n|         type=\"hidDEN\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <input>\n|       type=\" hidden\"\n|     <table>\n|       <input>\n|         type=\"hidDEN\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><table><select>X<tr>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       \"X\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       \"X\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!doctype html><select>X</select>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!DOCTYPE hTmL><html></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<!DOCTYPE HTML><html></html>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<body>X</body></body>",
+   "document": "| <head>\n| <body>\n|   \"X\"",
+   "context": "html",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <head>\n| <body>\n|   \"X\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<div><p>a</x> b",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <p>\n|         \"a b\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <p>\n|         \"a b\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<table><tr><td><code></code> </table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <code>\n|             \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <code>\n|             \" \""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<table><b><tr><td>aaa</td></tr>bbb</table>ccc",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <b>\n|       \"bbb\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"aaa\"\n|     <b>\n|       \"ccc\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <b>\n|       \"bbb\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"aaa\"\n|     <b>\n|       \"ccc\""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "A<table><tr> B</tr> B</table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"A B B\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"A B B\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests7.dat",
+   "data": "A<table><tr> B</tr> </em>C</table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"A BC\"\n|     <table>\n|       <tbody>\n|         <tr>\n|         \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"A BC\"\n|     <table>\n|       <tbody>\n|         <tr>\n|         \" \""
+  },
+  {
+   "file": "tests7.dat",
+   "data": "<select><keygen>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <keygen>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <keygen>"
+  },
+  {
+   "file": "tests8.dat",
+   "data": "<div>\n<div></div>\n</span>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"\n\"\n|       <div>\n|       \"\nx\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"\n\"\n|       <div>\n|       \"\nx\""
+  },
+  {
+   "file": "tests8.dat",
+   "data": "<div>x<div></div>\n</span>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"x\"\n|       <div>\n|       \"\nx\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"x\"\n|       <div>\n|       \"\nx\""
+  },
+  {
+   "file": "tests8.dat",
+   "data": "<div>x<div></div>x</span>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"x\"\n|       <div>\n|       \"xx\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"x\"\n|       <div>\n|       \"xx\""
+  },
+  {
+   "file": "tests8.dat",
+   "data": "<div>x<div></div>y</span>z",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"x\"\n|       <div>\n|       \"yz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"x\"\n|       <div>\n|       \"yz\""
+  },
+  {
+   "file": "tests8.dat",
+   "data": "<table><div>x<div></div>x</span>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"x\"\n|       <div>\n|       \"xx\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"x\"\n|       <div>\n|       \"xx\"\n|     <table>"
+  },
+  {
+   "file": "tests8.dat",
+   "data": "<table><li><li></table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <li>\n|     <li>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <li>\n|     <li>\n|     <table>"
+  },
+  {
+   "file": "tests8.dat",
+   "data": "x<table>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"xx\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"xx\"\n|     <table>"
+  },
+  {
+   "file": "tests8.dat",
+   "data": "x<table><table>x",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"x\"\n|     <table>\n|     \"x\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"x\"\n|     <table>\n|     \"x\"\n|     <table>"
+  },
+  {
+   "file": "tests8.dat",
+   "data": "<b>a<div></div><div></b>y",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"a\"\n|       <div>\n|     <div>\n|       <b>\n|       \"y\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       \"a\"\n|       <div>\n|     <div>\n|       <b>\n|       \"y\""
+  },
+  {
+   "file": "tests8.dat",
+   "data": "<a><div><p></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <div>\n|       <a>\n|       <p>\n|         <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <div>\n|       <a>\n|       <p>\n|         <a>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><math></math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><math></math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><math><mi>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><math><annotation-xml><svg><u>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|     <u>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math annotation-xml>\n|         <svg svg>\n|     <u>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><select><math></math></select>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <math math>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <math math>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><select><option><math></math></option></select>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         <math math>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         <math math>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><math></math></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|     <table>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><math><mi>foo</mi></math></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|     <table>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><math><mi>foo</mi><mi>bar</mi></math></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <table>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><tbody><math><mi>foo</mi><mi>bar</mi></math></tbody></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <table>\n|       <tbody>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <table>\n|       <tbody>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><tbody><tr><math><mi>foo</mi><mi>bar</mi></math></tr></tbody></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><tbody><tr><td><math><mi>foo</mi><mi>bar</mi></math></td></tr></tbody></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <math math>\n|               <math mi>\n|                 \"foo\"\n|               <math mi>\n|                 \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <math math>\n|               <math mi>\n|                 \"foo\"\n|               <math mi>\n|                 \"bar\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><tbody><tr><td><math><mi>foo</mi><mi>bar</mi></math><p>baz</td></tr></tbody></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <math math>\n|               <math mi>\n|                 \"foo\"\n|               <math mi>\n|                 \"bar\"\n|             <p>\n|               \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <math math>\n|               <math mi>\n|                 \"foo\"\n|               <math mi>\n|                 \"bar\"\n|             <p>\n|               \"baz\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><caption><math><mi>foo</mi><mi>bar</mi></math><p>baz</caption></table>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <math math>\n|           <math mi>\n|             \"foo\"\n|           <math mi>\n|             \"bar\"\n|         <p>\n|           \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <math math>\n|           <math mi>\n|             \"foo\"\n|           <math mi>\n|             \"bar\"\n|         <p>\n|           \"baz\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><caption><math><mi>foo</mi><mi>bar</mi><p>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <math math>\n|           <math mi>\n|             \"foo\"\n|           <math mi>\n|             \"bar\"\n|         <p>\n|           \"baz\"\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <math math>\n|           <math mi>\n|             \"foo\"\n|           <math mi>\n|             \"bar\"\n|         <p>\n|           \"baz\"\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><caption><math><mi>foo</mi><mi>bar</mi>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <math math>\n|           <math mi>\n|             \"foo\"\n|           <math mi>\n|             \"bar\"\n|           \"baz\"\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <caption>\n|         <math math>\n|           <math mi>\n|             \"foo\"\n|           <math mi>\n|             \"bar\"\n|           \"baz\"\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><colgroup><math><mi>foo</mi><mi>bar</mi><p>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <p>\n|       \"baz\"\n|     <table>\n|       <colgroup>\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <p>\n|       \"baz\"\n|     <table>\n|       <colgroup>\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><tr><td><select><math><mi>foo</mi><mi>bar</mi><p>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <math math>\n|                 <math mi>\n|                   \"foo\"\n|                 <math mi>\n|                   \"bar\"\n|               <p>\n|                 \"baz\"\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <math math>\n|                 <math mi>\n|                   \"foo\"\n|                 <math mi>\n|                   \"bar\"\n|               <p>\n|                 \"baz\"\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body><table><select><math><mi>foo</mi><mi>bar</mi><p>baz</table><p>quux",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <math math>\n|         <math mi>\n|           \"foo\"\n|         <math mi>\n|           \"bar\"\n|       <p>\n|         \"baz\"\n|     <table>\n|     <p>\n|       \"quux\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <math math>\n|         <math mi>\n|           \"foo\"\n|         <math mi>\n|           \"bar\"\n|       <p>\n|         \"baz\"\n|     <table>\n|     <p>\n|       \"quux\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body></body></html><math><mi>foo</mi><mi>bar</mi><p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <p>\n|       \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <p>\n|       \"baz\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body></body><math><mi>foo</mi><mi>bar</mi><p>baz",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <p>\n|       \"baz\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mi>\n|         \"foo\"\n|       <math mi>\n|         \"bar\"\n|     <p>\n|       \"baz\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><frameset><math><mi></mi><mi></mi><p><span>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><frameset></frameset><math><mi></mi><mi></mi><p><span>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body xlink:href=foo><math xlink:href=foo></math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     <math math>\n|       xlink href=\"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     <math math>\n|       xlink href=\"foo\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body xlink:href=foo xml:lang=en><math><mi xml:lang=en xlink:href=foo></mi></math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <math math>\n|       <math mi>\n|         xlink href=\"foo\"\n|         xml lang=\"en\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <math math>\n|       <math mi>\n|         xlink href=\"foo\"\n|         xml lang=\"en\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body xlink:href=foo xml:lang=en><math><mi xml:lang=en xlink:href=foo /></math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <math math>\n|       <math mi>\n|         xlink href=\"foo\"\n|         xml lang=\"en\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <math math>\n|       <math mi>\n|         xlink href=\"foo\"\n|         xml lang=\"en\""
+  },
+  {
+   "file": "tests9.dat",
+   "data": "<!DOCTYPE html><body xlink:href=foo xml:lang=en><math><mi xml:lang=en xlink:href=foo />bar</math>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <math math>\n|       <math mi>\n|         xlink href=\"foo\"\n|         xml lang=\"en\"\n|       \"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     xlink:href=\"foo\"\n|     xml:lang=\"en\"\n|     <math math>\n|       <math mi>\n|         xlink href=\"foo\"\n|         xml lang=\"en\"\n|       \"bar\""
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<body><span>",
+   "document": "| <span>",
+   "context": "body",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><body>",
+   "document": "| <span>",
+   "context": "body",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><body>",
+   "document": "| <span>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<body><span>",
+   "document": "| <head>\n| <body>\n|   <span>",
+   "context": "html",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <head>\n| <body>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<frameset><span>",
+   "document": "| <span>",
+   "context": "body",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><frameset>",
+   "document": "| <span>",
+   "context": "body",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><frameset>",
+   "document": "| <span>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<frameset><span>",
+   "document": "| <head>\n| <frameset>",
+   "context": "html",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <head>\n| <frameset>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<table><tr>",
+   "document": "| <tbody>\n|   <tr>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <tbody>\n|   <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</table><tr>",
+   "document": "| <tbody>\n|   <tr>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <tbody>\n|   <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a>",
+   "document": "| <a>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><caption>a",
+   "document": "| <a>\n| <caption>\n|   \"a\"",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <caption>\n|   \"a\""
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><colgroup><col>",
+   "document": "| <a>\n| <colgroup>\n|   <col>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <colgroup>\n|   <col>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><tbody><tr>",
+   "document": "| <a>\n| <tbody>\n|   <tr>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <tbody>\n|   <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><tfoot><tr>",
+   "document": "| <a>\n| <tfoot>\n|   <tr>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <tfoot>\n|   <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><thead><tr>",
+   "document": "| <a>\n| <thead>\n|   <tr>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <thead>\n|   <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><tr>",
+   "document": "| <a>\n| <tbody>\n|   <tr>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <tbody>\n|   <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><th>",
+   "document": "| <a>\n| <tbody>\n|   <tr>\n|     <th>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <tbody>\n|   <tr>\n|     <th>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><td>",
+   "document": "| <a>\n| <tbody>\n|   <tr>\n|     <td>",
+   "context": "table",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <tbody>\n|   <tr>\n|     <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<table></table><tbody>",
+   "document": "| <table>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <table>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</table><span>",
+   "document": "| <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span></table>",
+   "document": "| <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</caption><span>",
+   "document": "| <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span></caption><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><caption><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><col><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><colgroup><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><html><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><tbody><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><td><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><tfoot><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><thead><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><th><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span><tr><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<span></table><span>",
+   "document": "| <span>\n|   <span>",
+   "context": "caption",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <span>\n|   <span>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</colgroup><col>",
+   "document": "| <col>",
+   "context": "colgroup",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <col>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><col>",
+   "document": "| <col>",
+   "context": "colgroup",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <col>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<caption><a>",
+   "document": "| <a>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<col><a>",
+   "document": "| <a>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<colgroup><a>",
+   "document": "| <a>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<tbody><a>",
+   "document": "| <a>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<tfoot><a>",
+   "document": "| <a>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<thead><a>",
+   "document": "| <a>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</table><a>",
+   "document": "| <a>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><tr>",
+   "document": "| <a>\n| <tr>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<a><td>",
+   "document": "| <a>\n| <tr>\n|   <td>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>\n| <tr>\n|   <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<td><table><tbody><a><tr>",
+   "document": "| <tr>\n|   <td>\n|     <a>\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": "tbody",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <tr>\n|   <td>\n|     <a>\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</tr><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<td><table><a><tr></tr><tr>",
+   "document": "| <td>\n|   <a>\n|   <table>\n|     <tbody>\n|       <tr>\n|       <tr>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>\n|   <a>\n|   <table>\n|     <tbody>\n|       <tr>\n|       <tr>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<caption><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<col><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<colgroup><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<tbody><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<tfoot><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<thead><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<tr><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</table><td>",
+   "document": "| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<td><table></table><td>",
+   "document": "| <td>\n|   <table>\n| <td>",
+   "context": "tr",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <td>\n|   <table>\n| <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<caption><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<col><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<colgroup><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<tbody><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<tfoot><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<th><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<thead><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<tr><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</table><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</tbody><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</td><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</tfoot><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</thead><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</th><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</tr><a>",
+   "document": "| <a>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <a>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<table><td><td>",
+   "document": "| <table>\n|   <tbody>\n|     <tr>\n|       <td>\n|       <td>",
+   "context": "td",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <table>\n|   <tbody>\n|     <tr>\n|       <td>\n|       <td>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</select><option>",
+   "document": "| <option>",
+   "context": "select",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <option>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<input><option>",
+   "document": "| <option>",
+   "context": "select",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <option>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<keygen><option>",
+   "document": "| <keygen>\n| <option>",
+   "context": "select",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <keygen>\n| <option>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "<textarea><option>",
+   "document": "| <textarea>\n|   \"<option>\"",
+   "context": "select",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <textarea>\n|   \"<option>\""
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</html><!--abc-->",
+   "document": "| <head>\n| <body>\n| <!-- abc -->",
+   "context": "html",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <head>\n| <body>\n| <!-- abc -->"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "</frameset><frame>",
+   "document": "| <frame>",
+   "context": "frameset",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <frame>"
+  },
+  {
+   "file": "tests_innerHTML_1.dat",
+   "data": "",
+   "document": "| <head>\n| <body>",
+   "context": "html",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <head>\n| <body>"
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<b><p>Bold </b> Not bold</p>\nAlso not bold.",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <p>\n|       <b>\n|         \"Bold \"\n|       \" Not bold\"\n|     \"\nAlso not bold.\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|     <p>\n|       <b>\n|         \"Bold \"\n|       \" Not bold\"\n|     \"\nAlso not bold.\""
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<html>\n<font color=red><i>Italic and Red<p>Italic and Red </font> Just italic.</p> Italic only.</i> Plain\n<p>I should not be red. <font color=red>Red. <i>Italic and red.</p>\n<p>Italic and red. </i> Red.</font> I should not be red.</p>\n<b>Bold <i>Bold and italic</b> Only Italic </i> Plain",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <font>\n|       color=\"red\"\n|       <i>\n|         \"Italic and Red\"\n|     <i>\n|       <p>\n|         <font>\n|           color=\"red\"\n|           \"Italic and Red \"\n|         \" Just italic.\"\n|       \" Italic only.\"\n|     \" Plain\n\"\n|     <p>\n|       \"I should not be red. \"\n|       <font>\n|         color=\"red\"\n|         \"Red. \"\n|         <i>\n|           \"Italic and red.\"\n|     <font>\n|       color=\"red\"\n|       <i>\n|         \"\n\"\n|     <p>\n|       <font>\n|         color=\"red\"\n|         <i>\n|           \"Italic and red. \"\n|         \" Red.\"\n|       \" I should not be red.\"\n|     \"\n\"\n|     <b>\n|       \"Bold \"\n|       <i>\n|         \"Bold and italic\"\n|     <i>\n|       \" Only Italic \"\n|     \" Plain\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <font>\n|       color=\"red\"\n|       <i>\n|         \"Italic and Red\"\n|     <i>\n|       <p>\n|         <font>\n|           color=\"red\"\n|           \"Italic and Red \"\n|         \" Just italic.\"\n|       \" Italic only.\"\n|     \" Plain\n\"\n|     <p>\n|       \"I should not be red. \"\n|       <font>\n|         color=\"red\"\n|         \"Red. \"\n|         <i>\n|           \"Italic and red.\"\n|     <font>\n|       color=\"red\"\n|       <i>\n|         \"\n\"\n|     <p>\n|       <font>\n|         color=\"red\"\n|         <i>\n|           \"Italic and red. \"\n|         \" Red.\"\n|       \" I should not be red.\"\n|     \"\n\"\n|     <b>\n|       \"Bold \"\n|       <i>\n|         \"Bold and italic\"\n|     <i>\n|       \" Only Italic \"\n|     \" Plain\""
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<html><body>\n<p><font size=\"7\">First paragraph.</p>\n<p>Second paragraph.</p></font>\n<b><p><i>Bold and Italic</b> Italic</p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"\n\"\n|     <p>\n|       <font>\n|         size=\"7\"\n|         \"First paragraph.\"\n|     <font>\n|       size=\"7\"\n|       \"\n\"\n|       <p>\n|         \"Second paragraph.\"\n|     \"\n\"\n|     <b>\n|     <p>\n|       <b>\n|         <i>\n|           \"Bold and Italic\"\n|       <i>\n|         \" Italic\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"\n\"\n|     <p>\n|       <font>\n|         size=\"7\"\n|         \"First paragraph.\"\n|     <font>\n|       size=\"7\"\n|       \"\n\"\n|       <p>\n|         \"Second paragraph.\"\n|     \"\n\"\n|     <b>\n|     <p>\n|       <b>\n|         <i>\n|           \"Bold and Italic\"\n|       <i>\n|         \" Italic\""
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<html>\n<dl>\n<dt><b>Boo\n<dd>Goo?\n</dl>\n</html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <dl>\n|       \"\n\"\n|       <dt>\n|         <b>\n|           \"Boo\n\"\n|       <dd>\n|         <b>\n|           \"Goo?\n\"\n|     <b>\n|       \"\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <dl>\n|       \"\n\"\n|       <dt>\n|         <b>\n|           \"Boo\n\"\n|       <dd>\n|         <b>\n|           \"Goo?\n\"\n|     <b>\n|       \"\n\""
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<html><body>\n<label><a><div>Hello<div>World</div></a></label>  \n</body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"\n\"\n|     <label>\n|       <a>\n|       <div>\n|         <a>\n|           \"Hello\"\n|           <div>\n|             \"World\"\n|         \"  \n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"\n\"\n|     <label>\n|       <a>\n|       <div>\n|         <a>\n|           \"Hello\"\n|           <div>\n|             \"World\"\n|         \"  \n\""
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<table><center> <font>a</center> <img> <tr><td> </td> </tr> </table>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <center>\n|       \" \"\n|       <font>\n|         \"a\"\n|     <font>\n|       <img>\n|       \" \"\n|     <table>\n|       \" \"\n|       <tbody>\n|         <tr>\n|           <td>\n|             \" \"\n|           \" \"\n|         \" \"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <center>\n|       \" \"\n|       <font>\n|         \"a\"\n|     <font>\n|       <img>\n|       \" \"\n|     <table>\n|       \" \"\n|       <tbody>\n|         <tr>\n|           <td>\n|             \" \"\n|           \" \"\n|         \" \""
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<table><tr><p><a><p>You should see this text.",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <a>\n|     <p>\n|       <a>\n|         \"You should see this text.\"\n|     <table>\n|       <tbody>\n|         <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <a>\n|     <p>\n|       <a>\n|         \"You should see this text.\"\n|     <table>\n|       <tbody>\n|         <tr>"
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<TABLE>\n<TR>\n<CENTER><CENTER><TD></TD></TR><TR>\n<FONT>\n<TABLE><tr></tr></TABLE>\n</P>\n<a></font><font></a>\nThis page contains an insanely badly-nested tag sequence.",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <center>\n|       <center>\n|     <font>\n|       \"\n\"\n|     <table>\n|       \"\n\"\n|       <tbody>\n|         <tr>\n|           \"\n\"\n|           <td>\n|         <tr>\n|           \"\n\"\n|     <table>\n|       <tbody>\n|         <tr>\n|     <font>\n|       \"\n\"\n|       <p>\n|       \"\n\"\n|       <a>\n|     <a>\n|       <font>\n|     <font>\n|       \"\nThis page contains an insanely badly-nested tag sequence.\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <center>\n|       <center>\n|     <font>\n|       \"\n\"\n|     <table>\n|       \"\n\"\n|       <tbody>\n|         <tr>\n|           \"\n\"\n|           <td>\n|         <tr>\n|           \"\n\"\n|     <table>\n|       <tbody>\n|         <tr>\n|     <font>\n|       \"\n\"\n|       <p>\n|       \"\n\"\n|       <a>\n|     <a>\n|       <font>\n|     <font>\n|       \"\nThis page contains an insanely badly-nested tag sequence.\""
+  },
+  {
+   "file": "tricky01.dat",
+   "data": "<html>\n<body>\n<b><nobr><div>This text is in a div inside a nobr</nobr>More text that should not be in the nobr, i.e., the\nnobr should have closed the div inside it implicitly. </b><pre>A pre tag outside everything else.</pre>\n</body>\n</html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"\n\"\n|     <b>\n|       <nobr>\n|     <div>\n|       <b>\n|         <nobr>\n|           \"This text is in a div inside a nobr\"\n|         \"More text that should not be in the nobr, i.e., the\nnobr should have closed the div inside it implicitly. \"\n|       <pre>\n|         \"A pre tag outside everything else.\"\n|       \"\n\n\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"\n\"\n|     <b>\n|       <nobr>\n|     <div>\n|       <b>\n|         <nobr>\n|           \"This text is in a div inside a nobr\"\n|         \"More text that should not be in the nobr, i.e., the\nnobr should have closed the div inside it implicitly. \"\n|       <pre>\n|         \"A pre tag outside everything else.\"\n|       \"\n\n\""
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p><br></p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <br>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <br>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p><br>text</p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <br>\n|       \"text\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <br>\n|       \"text\""
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p>before<br>after</p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"before\"\n|       <br>\n|       \"after\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"before\"\n|       <br>\n|       \"after\""
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p><br><br></p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <br>\n|       <br>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <br>\n|       <br>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p>a<br>b<br>c</p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"a\"\n|       <br>\n|       \"b\"\n|       <br>\n|       \"c\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"a\"\n|       <br>\n|       \"b\"\n|       <br>\n|       \"c\""
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><h1><br></h1>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <h1>\n|       <br>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <h1>\n|       <br>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p><input></p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <input>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <input>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p><img></p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <img>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <img>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p><wbr></p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <wbr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <wbr>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><p><embed></p>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <embed>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <p>\n|       <embed>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><h2><input></h2>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <h2>\n|       <input>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <h2>\n|       <input>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><em><br></em>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <em>\n|       <br>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <em>\n|       <br>"
+  },
+  {
+   "file": "void-in-phrasing.dat",
+   "data": "<!DOCTYPE html><body><strong><br>text</strong>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <strong>\n|       <br>\n|       \"text\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <strong>\n|       <br>\n|       \"text\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "Test",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"Test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"Test\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<div></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<div>Test</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"Test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"Test\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<di",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 4,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 4,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<div>Hello</div>\n<script>\nconsole.log(\"PASS\");\n</script>\n<div>Bye</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"Hello\"\n|     \"\n\"\n|     <script>\n|       \"\nconsole.log(\"PASS\");\n\"\n|     \"\n\"\n|     <div>\n|       \"Bye\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"Hello\"\n|     \"\n\"\n|     <script>\n|       \"\nconsole.log(\"PASS\");\n\"\n|     \"\n\"\n|     <div>\n|       \"Bye\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<div foo=\"bar\">Hello</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       foo=\"bar\"\n|       \"Hello\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       foo=\"bar\"\n|       \"Hello\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<div>Hello</div>\n<script>\nconsole.log(\"FOO<span>BAR</span>BAZ\");\n</script>\n<div>Bye</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"Hello\"\n|     \"\n\"\n|     <script>\n|       \"\nconsole.log(\"FOO<span>BAR</span>BAZ\");\n\"\n|     \"\n\"\n|     <div>\n|       \"Bye\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       \"Hello\"\n|     \"\n\"\n|     <script>\n|       \"\nconsole.log(\"FOO<span>BAR</span>BAZ\");\n\"\n|     \"\n\"\n|     <div>\n|       \"Bye\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<foo bar=\"baz\"></foo><potato quack=\"duck\"></potato>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       bar=\"baz\"\n|     <potato>\n|       quack=\"duck\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       bar=\"baz\"\n|     <potato>\n|       quack=\"duck\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<foo bar=\"baz\"><potato quack=\"duck\"></potato></foo>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       bar=\"baz\"\n|       <potato>\n|         quack=\"duck\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       bar=\"baz\"\n|       <potato>\n|         quack=\"duck\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<foo></foo bar=\"baz\"><potato></potato quack=\"duck\">",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|     <potato>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 51,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 51,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|     <potato>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "</ tttt>",
+   "document": "| <!--  tttt -->\n| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 3,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <!--  tttt -->\n| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<div FOO ><img><img></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       foo=\"\"\n|       <img>\n|       <img>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       foo=\"\"\n|       <img>\n|       <img>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<p>Test</p<p>Test2</p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"TestTest2\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       \"TestTest2\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<rdar://problem/6869687>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <rdar:>\n|       6869687=\"\"\n|       problem=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 8,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    },
+    {
+     "code": "unexpected-solidus-in-tag",
+     "line": 1,
+     "col": 17,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <rdar:>\n|       6869687=\"\"\n|       problem=\"\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<A>test< /A>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"test< /A>\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "invalid-first-character-of-tag-name",
+     "line": 1,
+     "col": 9,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|       \"test< /A>\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "&lt;",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"<\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"<\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<body foo='bar'><body foo='baz' yo='mama'>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     foo=\"bar\"\n|     yo=\"mama\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     foo=\"bar\"\n|     yo=\"mama\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<body></br foo=\"bar\"></body>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <br>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 21,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <br>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<bdy><br foo=\"bar\"></body>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <bdy>\n|       <br>\n|         foo=\"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <bdy>\n|       <br>\n|         foo=\"bar\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<body></body></br foo=\"bar\">",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <br>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 28,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "end-tag-with-attributes",
+     "line": 1,
+     "col": 28,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <br>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<bdy></body><br foo=\"bar\">",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <bdy>\n|       <br>\n|         foo=\"bar\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <bdy>\n|       <br>\n|         foo=\"bar\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body></body></html><!-- Hi there -->",
+   "document": "| <html>\n|   <head>\n|   <body>\n| <!--  Hi there  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n| <!--  Hi there  -->"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body></body></html><!-- Comment A --><!-- Comment B --><!-- Comment C --><!-- Comment D --><!-- Comment E -->",
+   "document": "| <html>\n|   <head>\n|   <body>\n| <!--  Comment A  -->\n| <!--  Comment B  -->\n| <!--  Comment C  -->\n| <!--  Comment D  -->\n| <!--  Comment E  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n| <!--  Comment A  -->\n| <!--  Comment B  -->\n| <!--  Comment C  -->\n| <!--  Comment D  -->\n| <!--  Comment E  -->"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body></body></html>x<!-- Hi there -->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"x\"\n|     <!--  Hi there  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"x\"\n|     <!--  Hi there  -->"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body></body></html>x<!-- Hi there --></html><!-- Again -->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"x\"\n|     <!--  Hi there  -->\n| <!--  Again  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"x\"\n|     <!--  Hi there  -->\n| <!--  Again  -->"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body></body></html>x<!-- Hi there --></body></html><!-- Again -->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"x\"\n|     <!--  Hi there  -->\n| <!--  Again  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"x\"\n|     <!--  Hi there  -->\n| <!--  Again  -->"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body></body>\n   <!-- Hi there --></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"\n   \"\n|   <!--  Hi there  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"\n   \"\n|   <!--  Hi there  -->"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body></body></html>\n   <!-- Hi there -->",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"\n   \"\n| <!--  Hi there  -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"\n   \"\n| <!--  Hi there  -->"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body><ruby><div><rp>xx</rp></div></ruby></body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <rp>\n|           \"xx\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <rp>\n|           \"xx\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><body><ruby><div><rt>xx</rt></div></ruby></body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <rt>\n|           \"xx\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ruby>\n|       <div>\n|         <rt>\n|           \"xx\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<html><frameset><!--1--><noframes>A</noframes><!--2--></frameset><!--3--><noframes>B</noframes><!--4--></html><!--5--><noframes>C</noframes><!--6-->",
+   "document": "| <html>\n|   <head>\n|   <frameset>\n|     <!-- 1 -->\n|     <noframes>\n|       \"A\"\n|     <!-- 2 -->\n|   <!-- 3 -->\n|   <noframes>\n|     \"B\"\n|   <!-- 4 -->\n|   <noframes>\n|     \"C\"\n| <!-- 5 -->\n| <!-- 6 -->",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <frameset>\n|     <!-- 1 -->\n|     <noframes>\n|       \"A\"\n|     <!-- 2 -->\n|   <!-- 3 -->\n|   <noframes>\n|     \"B\"\n|   <!-- 4 -->\n|   <noframes>\n|     \"C\"\n| <!-- 5 -->\n| <!-- 6 -->"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<select><option>A<select><option>B<select><option>C<select><option>D<select><option>E<select><option>F<select><option>G<select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         \"A\"\n|     <option>\n|       \"B\"\n|       <select>\n|         <option>\n|           \"C\"\n|     <option>\n|       \"D\"\n|       <select>\n|         <option>\n|           \"E\"\n|     <option>\n|       \"F\"\n|       <select>\n|         <option>\n|           \"G\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|         \"A\"\n|     <option>\n|       \"B\"\n|       <select>\n|         <option>\n|           \"C\"\n|     <option>\n|       \"D\"\n|       <select>\n|         <option>\n|           \"E\"\n|     <option>\n|       \"F\"\n|       <select>\n|         <option>\n|           \"G\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<dd><dd><dt><dt><dd><li><li>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <dd>\n|     <dd>\n|     <dt>\n|     <dt>\n|     <dd>\n|       <li>\n|       <li>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <dd>\n|     <dd>\n|     <dt>\n|     <dt>\n|     <dd>\n|       <li>\n|       <li>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<div><b></div><div><nobr>a<nobr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <b>\n|     <div>\n|       <b>\n|         <nobr>\n|           \"a\"\n|         <nobr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <b>\n|     <div>\n|       <b>\n|         <nobr>\n|           \"a\"\n|         <nobr>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<head></head>\n<body></body>",
+   "document": "| <html>\n|   <head>\n|   \"\n\"\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   \"\n\"\n|   <body>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<head></head> <style></style>ddd",
+   "document": "| <html>\n|   <head>\n|     <style>\n|   \" \"\n|   <body>\n|     \"ddd\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|     <style>\n|   \" \"\n|   <body>\n|     \"ddd\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<kbd><table></kbd><col><select><tr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <kbd>\n|       <select>\n|       <table>\n|         <colgroup>\n|           <col>\n|         <tbody>\n|           <tr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <kbd>\n|       <select>\n|       <table>\n|         <colgroup>\n|           <col>\n|         <tbody>\n|           <tr>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<kbd><table></kbd><col><select><tr></table><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <kbd>\n|       <select>\n|       <table>\n|         <colgroup>\n|           <col>\n|         <tbody>\n|           <tr>\n|       <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <kbd>\n|       <select>\n|       <table>\n|         <colgroup>\n|           <col>\n|         <tbody>\n|           <tr>\n|       <div>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<a><li><style></style><title></title></a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <li>\n|       <a>\n|         <style>\n|         <title>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <li>\n|       <a>\n|         <style>\n|         <title>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<font></p><p><meta><title></title></font>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <p>\n|     <p>\n|       <font>\n|         <meta>\n|         <title>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <p>\n|     <p>\n|       <font>\n|         <meta>\n|         <title>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<a><center><title></title><a>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <center>\n|       <a>\n|         <title>\n|       <a>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <a>\n|     <center>\n|       <a>\n|         <title>\n|       <a>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<svg><title><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         <div>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<svg><title><rect><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         <rect>\n|           <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         <rect>\n|           <div>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<svg><title><svg><div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         <svg svg>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg title>\n|         <svg svg>\n|         <div>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<img <=\"\" FAIL>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <img>\n|       <=\"\"\n|       fail=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "unexpected-character-in-attribute-name",
+     "line": 1,
+     "col": 6,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <img>\n|       <=\"\"\n|       fail=\"\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<ul><li><div id='foo'/>A</li><li>B<div>C</div></li></ul>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|         <div>\n|           id=\"foo\"\n|           \"A\"\n|       <li>\n|         \"B\"\n|         <div>\n|           \"C\"",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 9,
+     "end_line": 1,
+     "end_col": 24
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "non-void-html-element-start-tag-with-trailing-solidus",
+     "line": 1,
+     "col": 9,
+     "end_line": 1,
+     "end_col": 24
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <ul>\n|       <li>\n|         <div>\n|           id=\"foo\"\n|           \"A\"\n|       <li>\n|         \"B\"\n|         <div>\n|           \"C\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<svg><em><desc></em>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <em>\n|       <desc>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|     <em>\n|       <desc>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<table><tr><td><svg><desc><td></desc><circle>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg desc>\n|           <td>\n|             <circle>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <svg svg>\n|               <svg desc>\n|           <td>\n|             <circle>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<svg><tfoot></mi><td>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg tfoot>\n|         <svg td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg tfoot>\n|         <svg td>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<math><mrow><mrow><mn>1</mn></mrow><mi>a</mi></mrow></math>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mrow>\n|         <math mrow>\n|           <math mn>\n|             \"1\"\n|         <math mi>\n|           \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <math mrow>\n|         <math mrow>\n|           <math mn>\n|             \"1\"\n|         <math mi>\n|           \"a\""
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<!doctype html><input type=\"hidden\"><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <frameset>"
+  },
+  {
+   "file": "webkit01.dat",
+   "data": "<!doctype html><input type=\"button\"><frameset>",
+   "document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <input>\n|       type=\"button\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <!DOCTYPE html>\n| <html>\n|   <head>\n|   <body>\n|     <input>\n|       type=\"button\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<foo bar=qux/>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       bar=\"qux/\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <foo>\n|       bar=\"qux/\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<p id=\"status\"><noscript><strong>A</strong></noscript><span>B</span></p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       id=\"status\"\n|       <noscript>\n|         \"<strong>A</strong>\"\n|       <span>\n|         \"B\"",
+   "context": null,
+   "scripting": true,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       id=\"status\"\n|       <noscript>\n|         \"<strong>A</strong>\"\n|       <span>\n|         \"B\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<p id=\"status\"><noscript><strong>A</strong></noscript><span>B</span></p>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       id=\"status\"\n|       <noscript>\n|         <strong>\n|           \"A\"\n|       <span>\n|         \"B\"",
+   "context": null,
+   "scripting": false,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <p>\n|       id=\"status\"\n|       <noscript>\n|         <strong>\n|           \"A\"\n|       <span>\n|         \"B\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<div><sarcasm><div></div></sarcasm></div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <sarcasm>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <sarcasm>\n|         <div>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<html><body><img src=\"\" border=\"0\" alt=\"><div>A</div></body></html>",
+   "document": "| <html>\n|   <head>\n|   <body>",
+   "context": null,
+   "scripting": null,
+   "errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 68,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_errors": [
+    {
+     "code": "eof-in-tag",
+     "line": 1,
+     "col": 68,
+     "end_line": null,
+     "end_col": null
+    }
+   ],
+   "spec_document": "| <html>\n|   <head>\n|   <body>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><td></tbody>A",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     \"A\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     \"A\"\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><td></thead>A",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"A\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><td></tfoot>A",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             \"A\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><thead><td></tbody>A",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <thead>\n|         <tr>\n|           <td>\n|             \"A\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <thead>\n|         <tr>\n|           <td>\n|             \"A\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<legend>test</legend>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <legend>\n|       \"test\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <legend>\n|       \"test\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><input>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <input>\n|     <table>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <input>\n|     <table>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<b><em><dcell><postfield><postfield><postfield><postfield><missing_glyph><missing_glyph><missing_glyph><missing_glyph><hkern><aside></b></em>",
+   "document": "| <b>\n|   <em>\n|     <dcell>\n|       <postfield>\n|         <postfield>\n|           <postfield>\n|             <postfield>\n|               <missing_glyph>\n|                 <missing_glyph>\n|                   <missing_glyph>\n|                     <missing_glyph>\n|                       <hkern>\n| <aside>\n|   <b>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <b>\n|   <em>\n|     <dcell>\n|       <postfield>\n|         <postfield>\n|           <postfield>\n|             <postfield>\n|               <missing_glyph>\n|                 <missing_glyph>\n|                   <missing_glyph>\n|                     <missing_glyph>\n|                       <hkern>\n| <aside>\n|   <b>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<b><em><foo><foo><aside></b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <em>\n|         <foo>\n|           <foo>\n|     <em>\n|       <aside>\n|         <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <em>\n|         <foo>\n|           <foo>\n|     <em>\n|       <aside>\n|         <b>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<b><em><foo><foo><aside></b></em>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <em>\n|         <foo>\n|           <foo>\n|     <em>\n|     <aside>\n|       <em>\n|         <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <em>\n|         <foo>\n|           <foo>\n|     <em>\n|     <aside>\n|       <em>\n|         <b>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<b><em><foo><foo><foo><aside></b>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <em>\n|         <foo>\n|           <foo>\n|             <foo>\n|     <aside>\n|       <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <em>\n|         <foo>\n|           <foo>\n|             <foo>\n|     <aside>\n|       <b>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<b><em><foo><foo><foo><aside></b></em>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <em>\n|         <foo>\n|           <foo>\n|             <foo>\n|     <aside>\n|       <b>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <b>\n|       <em>\n|         <foo>\n|           <foo>\n|             <foo>\n|     <aside>\n|       <b>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<b><em><foo><foo><foo><foo><foo><foo><foo><foo><foo><foo><aside></b></em>",
+   "document": "| <b>\n|   <em>\n|     <foo>\n|       <foo>\n|         <foo>\n|           <foo>\n|             <foo>\n|               <foo>\n|                 <foo>\n|                   <foo>\n|                     <foo>\n|                       <foo>\n| <aside>\n|   <b>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <b>\n|   <em>\n|     <foo>\n|       <foo>\n|         <foo>\n|           <foo>\n|             <foo>\n|               <foo>\n|                 <foo>\n|                   <foo>\n|                     <foo>\n|                       <foo>\n| <aside>\n|   <b>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<b><em><foo><foob><foob><foob><foob><fooc><fooc><fooc><fooc><food><aside></b></em>",
+   "document": "| <b>\n|   <em>\n|     <foo>\n|       <foob>\n|         <foob>\n|           <foob>\n|             <foob>\n|               <fooc>\n|                 <fooc>\n|                   <fooc>\n|                     <fooc>\n|                       <food>\n| <aside>\n|   <b>",
+   "context": "div",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <b>\n|   <em>\n|     <foo>\n|       <foob>\n|         <foob>\n|           <foob>\n|             <foob>\n|               <fooc>\n|                 <fooc>\n|                   <fooc>\n|                     <fooc>\n|                       <food>\n| <aside>\n|   <b>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<option><XH<optgroup></optgroup>",
+   "document": "| <option>\n|   <xh<optgroup>",
+   "context": "select",
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <option>\n|   <xh<optgroup>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<svg><foreignObject><div>foo</div><plaintext></foreignObject></svg><div>bar</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         <div>\n|           \"foo\"\n|         <plaintext>\n|           \"</foreignObject></svg><div>bar</div>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|         <div>\n|           \"foo\"\n|         <plaintext>\n|           \"</foreignObject></svg><div>bar</div>\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<svg><foreignObject></foreignObject><title></svg>foo",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|       <svg title>\n|     \"foo\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <svg foreignObject>\n|       <svg title>\n|     \"foo\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "</foreignObject><plaintext><div>foo</div>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"<div>foo</div>\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <plaintext>\n|       \"<div>foo</div>\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<svg xml:base xml:lang xml:space xml:baaah definitionurl>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       definitionurl=\"\"\n|       xml lang=\"\"\n|       xml space=\"\"\n|       xml:baaah=\"\"\n|       xml:base=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       definitionurl=\"\"\n|       xml lang=\"\"\n|       xml space=\"\"\n|       xml:baaah=\"\"\n|       xml:base=\"\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<math definitionurl xlink:title xlink:show>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       definitionURL=\"\"\n|       xlink show=\"\"\n|       xlink title=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       definitionURL=\"\"\n|       xlink show=\"\"\n|       xlink title=\"\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<math DEFINITIONURL>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       definitionURL=\"\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       definitionURL=\"\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><option><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><optgroup><option><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>\n|         <option>\n|       <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>\n|         <option>\n|       <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><optgroup><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>\n|       <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <optgroup>\n|       <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><option><optgroup><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <optgroup>\n|       <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <option>\n|       <optgroup>\n|       <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><tr><td><select><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><tr><td><select><option><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <option>\n|               <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <option>\n|               <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><tr><td><select><optgroup><option><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <optgroup>\n|                 <option>\n|               <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <optgroup>\n|                 <option>\n|               <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><tr><td><select><optgroup><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <optgroup>\n|               <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <optgroup>\n|               <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<table><tr><td><select><option><optgroup><hr>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <option>\n|               <optgroup>\n|               <hr>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <option>\n|               <optgroup>\n|               <hr>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><div><i></div><option>option",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <div>\n|         <i>\n|       <i>\n|         <option>\n|           \"option\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <div>\n|         <i>\n|       <i>\n|         <option>\n|           \"option\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<div><i></div><option>option",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <i>\n|     <i>\n|       <option>\n|         \"option\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <i>\n|     <i>\n|       <option>\n|         \"option\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><div>div 1</div><button>button</button><div>div 2</div><datalist><option>option</option></datalist><div>div 3</div></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <div>\n|         \"div 1\"\n|       <button>\n|         \"button\"\n|       <div>\n|         \"div 2\"\n|       <datalist>\n|         <option>\n|           \"option\"\n|       <div>\n|         \"div 3\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <div>\n|         \"div 1\"\n|       <button>\n|         \"button\"\n|       <div>\n|         \"div 2\"\n|       <datalist>\n|         <option>\n|           \"option\"\n|       <div>\n|         \"div 3\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><button>button</select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         \"button\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         \"button\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><datalist>datalist</select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <datalist>\n|         \"datalist\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <datalist>\n|         \"datalist\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><button><select></select></button></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><button><div><select></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <div>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <div>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><div><option><img>option</option></div></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <div>\n|         <option>\n|           <img>\n|           \"option\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <div>\n|         <option>\n|           <img>\n|           \"option\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><input>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <input>",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|     <input>"
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><button><selectedcontent></button><option>X",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <selectedcontent>\n|           \"X\"\n|       <option>\n|         \"X\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <selectedcontent>\n|           \"X\"\n|       <option>\n|         \"X\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><button><selectedcontent></button><option>x<i>i<b>ib</i>b",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <selectedcontent>\n|           \"x\"\n|           <i>\n|             \"i\"\n|             <b>\n|               \"ib\"\n|           <b>\n|             \"b\"\n|       <option>\n|         \"x\"\n|         <i>\n|           \"i\"\n|           <b>\n|             \"ib\"\n|         <b>\n|           \"b\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <selectedcontent>\n|           \"x\"\n|           <i>\n|             \"i\"\n|             <b>\n|               \"ib\"\n|           <b>\n|             \"b\"\n|       <option>\n|         \"x\"\n|         <i>\n|           \"i\"\n|           <b>\n|             \"ib\"\n|         <b>\n|           \"b\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><button><selectedcontent></button><option>X<option>Y",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <selectedcontent>\n|           \"X\"\n|       <option>\n|         \"X\"\n|       <option>\n|         \"Y\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <selectedcontent>\n|           \"X\"\n|       <option>\n|         \"X\"\n|       <option>\n|         \"Y\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<select><button><selectedcontent></button><option>X<option selected>Y",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <selectedcontent>\n|           \"Y\"\n|       <option>\n|         \"X\"\n|       <option>\n|         selected=\"\"\n|         \"Y\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <select>\n|       <button>\n|         <selectedcontent>\n|           \"Y\"\n|       <option>\n|         \"X\"\n|       <option>\n|         selected=\"\"\n|         \"Y\""
+  },
+  {
+   "file": "webkit02.dat",
+   "data": "<font><select><option>a</option></font></select>",
+   "document": "| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <select>\n|         <option>\n|           \"a\"",
+   "context": null,
+   "scripting": null,
+   "errors": null,
+   "spec_errors": null,
+   "spec_document": "| <html>\n|   <head>\n|   <body>\n|     <font>\n|       <select>\n|         <option>\n|           \"a\""
+  }
+ ]
+}

--- a/tests/conformance/test_html_wpt_tree_conformance.py
+++ b/tests/conformance/test_html_wpt_tree_conformance.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Final, TypedDict, cast
+
+import pytest
+
+from turbohtml import _html, parse  # public serializers cannot reproduce WPT's namespace dump
+
+
+class _Error(TypedDict):
+    code: str
+    line: int
+    col: int
+    end_line: int | None
+    end_col: int | None
+
+
+class _Input(TypedDict):
+    file: str
+    data: str
+    context: str | None
+    scripting: bool | None
+
+
+class _Case(_Input):
+    document: str
+    spec_errors: list[_Error] | None
+    spec_document: str
+
+
+class _Decision(_Input):
+    reason: str
+    spec: str
+    fixture: str
+
+
+class _Exclusion(_Decision):
+    document: str
+
+
+class _Corpus(TypedDict):
+    source: str
+    revision: str
+    files: list[str]
+    fixture_counts: dict[str, int]
+    applicable_fixture_counts: dict[str, int]
+    normative_adjustments: list[_Decision]
+    error_adjustments: list[_Decision]
+    exclusions: list[_Exclusion]
+    cases: list[_Case]
+
+
+_CORPUS: Final[_Corpus] = cast(
+    "_Corpus",
+    json.loads((Path(__file__).parent / "data" / "wpt_html_tree.json").read_text(encoding="utf-8")),
+)
+_EXCLUSION_KEYS: Final[frozenset[tuple[str, str, str | None, bool | None]]] = frozenset(
+    (item["file"], item["data"], item["context"], item["scripting"]) for item in _CORPUS["exclusions"]
+)
+_APPLICABLE: Final[tuple[_Case, ...]] = tuple(
+    case
+    for case in _CORPUS["cases"]
+    if (case["file"], case["data"], case["context"], case["scripting"]) not in _EXCLUSION_KEYS
+)
+_ERROR_CASES: Final[tuple[_Case, ...]] = tuple(
+    case for case in _APPLICABLE if case["context"] is None and case["spec_errors"] is not None
+)
+
+
+def test_wpt_corpus_provenance_and_denominators() -> None:
+    assert {
+        "source": _CORPUS["source"],
+        "revision": _CORPUS["revision"],
+        "files": len(_CORPUS["files"]),
+        "source_cases": sum(_CORPUS["fixture_counts"].values()),
+        "applicable_cases": sum(_CORPUS["applicable_fixture_counts"].values()),
+        "adjustments": len(_CORPUS["normative_adjustments"]),
+        "error_adjustments": len(_CORPUS["error_adjustments"]),
+        "exclusions": len(_CORPUS["exclusions"]),
+    } == {
+        "source": (
+            "https://github.com/web-platform-tests/wpt/tree/"
+            "4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources"
+        ),
+        "revision": "4830edb033cb486fd0cd6f85b5e937cfc718704d",
+        "files": 61,
+        "source_cases": 1_920,
+        "applicable_cases": 1_916,
+        "adjustments": 8,
+        "error_adjustments": 8,
+        "exclusions": 4,
+    }
+
+
+def test_wpt_corpus_records_normative_sources() -> None:
+    assert {
+        "tree_specs": {item["spec"] for item in _CORPUS["normative_adjustments"]},
+        "tree_fixtures": {item["fixture"] for item in _CORPUS["normative_adjustments"]},
+        "error_specs": {item["spec"] for item in _CORPUS["error_adjustments"]},
+        "script_specs": {item["spec"] for item in _CORPUS["exclusions"]},
+        "script_fixtures": {item["fixture"] for item in _CORPUS["exclusions"]},
+    } == {
+        "tree_specs": {"https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign"},
+        "tree_fixtures": {
+            (
+                "https://github.com/web-platform-tests/wpt/blob/"
+                "4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/"
+                "foreign-fragment.dat#L565-L612"
+            ),
+            (
+                "https://github.com/web-platform-tests/wpt/blob/"
+                "4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453"
+            ),
+        },
+        "error_specs": {"https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state"},
+        "script_specs": {"https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model"},
+        "script_fixtures": {
+            (
+                "https://github.com/web-platform-tests/wpt/blob/"
+                "4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/"
+                "scripted_adoption01.dat#L1-L16"
+            ),
+            (
+                "https://github.com/web-platform-tests/wpt/blob/"
+                "4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/"
+                "scripted_ark.dat#L1-L27"
+            ),
+            (
+                "https://github.com/web-platform-tests/wpt/blob/"
+                "4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/"
+                "scripted_webkit01.dat#L1-L12"
+            ),
+            (
+                "https://github.com/web-platform-tests/wpt/blob/"
+                "4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/"
+                "scripted_webkit01.dat#L14-L30"
+            ),
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "case",
+    tuple(pytest.param(case, id=f"{case['file']}:{index}") for index, case in enumerate(_APPLICABLE)),
+)
+def test_wpt_spec_correct_tree(case: _Case) -> None:
+    assert _tree(case) == case["spec_document"]
+
+
+def test_wpt_raw_tree_count() -> None:
+    assert sum(_tree(case) == case["document"] for case in _APPLICABLE) == 1_908
+
+
+@pytest.mark.parametrize(
+    "case",
+    tuple(pytest.param(case, id=f"{case['file']}:{index}") for index, case in enumerate(_ERROR_CASES)),
+)
+def test_wpt_exact_document_errors(case: _Case) -> None:
+    expected = cast("list[_Error]", case["spec_errors"])
+    assert _errors_match(expected, _errors(case))
+
+
+@pytest.mark.parametrize(
+    "exclusion",
+    tuple(
+        pytest.param(exclusion, id=f"{exclusion['file']}:{index}")
+        for index, exclusion in enumerate(_CORPUS["exclusions"])
+    ),
+)
+def test_wpt_script_exclusion_without_javascript(exclusion: _Exclusion) -> None:
+    assert _tree(exclusion) == exclusion["document"]
+
+
+def _tree(case: _Input) -> str:
+    if (context := case["context"]) is not None:
+        result = _html._parse_fragment(case["data"], context, bool(case["scripting"]))
+    else:
+        result = _html._parse_tree(case["data"], bool(case["scripting"]))
+    return result.rstrip("\n")
+
+
+def _errors(case: _Input) -> list[_Error]:
+    return [
+        {"code": error.code, "line": error.line, "col": error.col + 1, "end_line": None, "end_col": None}
+        for error in parse(case["data"], scripting=bool(case["scripting"])).errors
+    ]
+
+
+def _errors_match(expected: list[_Error], actual: list[_Error]) -> bool:
+    if len(expected) != len(actual):
+        return False
+    for wanted, raised in zip(expected, actual, strict=True):
+        if wanted["code"] != raised["code"]:
+            return False
+        position = raised["line"], raised["col"]
+        start = wanted["line"], wanted["col"]
+        if (end_line := wanted["end_line"]) is None:
+            if position != start:
+                return False
+        elif (end_col := wanted["end_col"]) is None or not start <= position <= (end_line, end_col):
+            return False
+    return True

--- a/tools/generate_wpt_tree_corpus.py
+++ b/tools/generate_wpt_tree_corpus.py
@@ -1,0 +1,475 @@
+"""
+Refresh and check the living WPT HTML tree-construction corpus.
+
+Usage: python tools/generate_wpt_tree_corpus.py WPT_CHECKOUT OUTPUT_JSON
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Final, TypedDict
+
+from turbohtml import _html, parse  # ruff:ignore[import-private-name]  # native WPT-format dumper
+
+
+class _Error(TypedDict):
+    code: str
+    line: int
+    col: int
+    end_line: int | None
+    end_col: int | None
+
+
+class _Case(TypedDict):
+    file: str
+    data: str
+    document: str
+    context: str | None
+    scripting: bool | None
+    errors: list[_Error] | None
+    spec_errors: list[_Error] | None
+    spec_document: str
+
+
+class _Decision(TypedDict):
+    file: str
+    data: str
+    context: str | None
+    scripting: bool | None
+    reason: str
+    spec: str
+    fixture: str
+
+
+class _Exclusion(_Decision):
+    document: str
+
+
+_Key = tuple[str, str, str | None, bool | None]
+_FOREIGN_SPEC: Final[str] = "https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign"
+_PI_SPEC: Final[str] = "https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state"
+_SCRIPT_SPEC: Final[str] = "https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model"
+_WPT_BASE: Final[str] = (
+    "https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/"
+    "html/syntax/parsing/resources"
+)
+_NEW_ERROR: Final[re.Pattern[str]] = re.compile(r"\((\d+):(\d+)(?:-(\d+):(\d+))?\) ([a-z0-9-]+)")
+_SECTION: Final[re.Pattern[str]] = re.compile(
+    r"(?m)^#(errors|new-errors|document-fragment|script-on|script-off)(?:\n|$)"
+)
+
+_FOREIGN_CONTENT_OVERRIDES: Final[dict[_Key, tuple[str, str]]] = {
+    ("tests26.dat", "<svg></p><foo>", None, None): (
+        "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <p>\n|       <svg foo>",
+        f"{_WPT_BASE}/tests26.dat#L395-L453",
+    ),
+    ("tests26.dat", "<math></p><foo>", None, None): (
+        "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <p>\n|       <math foo>",
+        f"{_WPT_BASE}/tests26.dat#L395-L453",
+    ),
+    ("foreign-fragment.dat", "<svg></p><foo>", "div", None): (
+        "| <svg svg>\n|   <p>\n|   <svg foo>",
+        f"{_WPT_BASE}/foreign-fragment.dat#L565-L612",
+    ),
+    ("foreign-fragment.dat", "</p><foo>", "svg svg", None): (
+        "| <svg foo>",
+        f"{_WPT_BASE}/foreign-fragment.dat#L565-L612",
+    ),
+    ("tests26.dat", "<svg></br><foo>", None, None): (
+        "| <html>\n|   <head>\n|   <body>\n|     <svg svg>\n|       <br>\n|       <svg foo>",
+        f"{_WPT_BASE}/tests26.dat#L395-L453",
+    ),
+    ("tests26.dat", "<math></br><foo>", None, None): (
+        "| <html>\n|   <head>\n|   <body>\n|     <math math>\n|       <br>\n|       <math foo>",
+        f"{_WPT_BASE}/tests26.dat#L395-L453",
+    ),
+    ("foreign-fragment.dat", "<svg></br><foo>", "div", None): (
+        "| <svg svg>\n|   <br>\n|   <svg foo>",
+        f"{_WPT_BASE}/foreign-fragment.dat#L565-L612",
+    ),
+    ("foreign-fragment.dat", "</br><foo>", "svg svg", None): (
+        "| <svg foo>",
+        f"{_WPT_BASE}/foreign-fragment.dat#L565-L612",
+    ),
+}
+
+_SCRIPT_EXECUTION_EXCLUSIONS: Final[dict[_Key, tuple[str, str]]] = {
+    (
+        "scripted_adoption01.dat",
+        '<p><b id="A"><script>document.getElementById("A").id = "B"</script></p>TEXT</b>',
+        None,
+        True,
+    ): (
+        (
+            "| <html>\n"
+            "|   <head>\n"
+            "|   <body>\n"
+            "|     <p>\n"
+            "|       <b>\n"
+            '|         id="A"\n'
+            "|         <script>\n"
+            '|           "document.getElementById("A").id = "B""\n'
+            "|     <b>\n"
+            '|       id="A"\n'
+            '|       "TEXT"'
+        ),
+        f"{_WPT_BASE}/scripted_adoption01.dat#L1-L16",
+    ),
+    (
+        "scripted_ark.dat",
+        (
+            '<p><font size=4><font size=4><font size=4><script>document.getElementsByTagName("font")[2]'
+            '.setAttribute("size", "5");</script><font size=4><p>X'
+        ),
+        None,
+        True,
+    ): (
+        (
+            "| <html>\n"
+            "|   <head>\n"
+            "|   <body>\n"
+            "|     <p>\n"
+            "|       <font>\n"
+            '|         size="4"\n'
+            "|         <font>\n"
+            '|           size="4"\n'
+            "|           <font>\n"
+            '|             size="4"\n'
+            "|             <script>\n"
+            '|               "document.getElementsByTagName("font")[2].setAttribute("size", "5");"\n'
+            "|             <font>\n"
+            '|               size="4"\n'
+            "|     <p>\n"
+            "|       <font>\n"
+            '|         size="4"\n'
+            "|         <font>\n"
+            '|           size="4"\n'
+            "|           <font>\n"
+            '|             size="4"\n'
+            '|             "X"'
+        ),
+        f"{_WPT_BASE}/scripted_ark.dat#L1-L27",
+    ),
+    (
+        "scripted_webkit01.dat",
+        '1<script>document.write("2")</script>3',
+        None,
+        True,
+    ): (
+        '| <html>\n|   <head>\n|   <body>\n|     "1"\n|     <script>\n|       "document.write("2")"\n|     "3"',
+        f"{_WPT_BASE}/scripted_webkit01.dat#L1-L12",
+    ),
+    (
+        "scripted_webkit01.dat",
+        (
+            "1<script>document.write(\"<script>document.write('2')</scr\"+ \"ipt><script>document.write('3')</scr\" "
+            '+ "ipt>")</script>4'
+        ),
+        None,
+        True,
+    ): (
+        (
+            "| <html>\n"
+            "|   <head>\n"
+            "|   <body>\n"
+            '|     "1"\n'
+            "|     <script>\n"
+            '|       "document.write("<script>document.write(\'2\')</scr"+ '
+            '"ipt><script>document.write(\'3\')</scr" + "ipt>")"\n'
+            '|     "4"'
+        ),
+        f"{_WPT_BASE}/scripted_webkit01.dat#L14-L30",
+    ),
+}
+
+_ERROR_OVERRIDES: Final[dict[_Key, tuple[list[_Error], str]]] = {
+    ("comments01.dat", '<?xml version="1.0">Hi', None, None): (
+        [{"code": "disallowed-processing-instruction-target", "line": 1, "col": 6, "end_line": None, "end_col": None}],
+        f"{_WPT_BASE}/comments01.dat#L155-L195",
+    ),
+    ("comments01.dat", '<?xml version="1.0">', None, None): (
+        [{"code": "disallowed-processing-instruction-target", "line": 1, "col": 6, "end_line": None, "end_col": None}],
+        f"{_WPT_BASE}/comments01.dat#L155-L195",
+    ),
+    ("comments01.dat", "<?xml version", None, None): (
+        [{"code": "disallowed-processing-instruction-target", "line": 1, "col": 6, "end_line": None, "end_col": None}],
+        f"{_WPT_BASE}/comments01.dat#L155-L195",
+    ),
+    ("html5test-com.dat", '<?import namespace="foo" implementation="#bar">', None, None): (
+        [],
+        f"{_WPT_BASE}/html5test-com.dat#L129-L139",
+    ),
+    ("tests1.dat", "<?", None, None): (
+        [{"code": "eof-in-processing-instruction", "line": 1, "col": 3, "end_line": None, "end_col": None}],
+        f"{_WPT_BASE}/tests1.dat#L551-L570",
+    ),
+    ("tests1.dat", "<?#", None, None): (
+        [
+            {
+                "code": "invalid-first-character-of-processing-instruction-target",
+                "line": 1,
+                "col": 3,
+                "end_line": None,
+                "end_col": None,
+            }
+        ],
+        f"{_WPT_BASE}/tests1.dat#L551-L570",
+    ),
+    ("tests1.dat", "<?COMMENT?>", None, None): ([], f"{_WPT_BASE}/tests1.dat#L602-L614"),
+    ("tests1.dat", "<?COM--MENT?>", None, None): ([], f"{_WPT_BASE}/tests1.dat#L641-L653"),
+}
+
+
+def generate(checkout: Path, out_path: Path) -> None:
+    """Pin WPT data so upstream changes cannot alter CI without a reviewed diff."""
+    resources = checkout / "html" / "syntax" / "parsing" / "resources"
+    files = sorted(resources.glob("*.dat"))
+    if not files:
+        msg = f"no HTML tree-construction .dat files found under {resources}"
+        raise SystemExit(msg)
+    cases = [case for path in files for case in _parse_file(path)]
+    revision = _revision(checkout)
+    adjustments, exclusions, error_adjustments = _decisions()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(
+            {
+                "source": f"https://github.com/web-platform-tests/wpt/tree/{revision}/html/syntax/parsing/resources",
+                "revision": revision,
+                "files": [path.name for path in files],
+                "fixture_counts": {path.name: sum(case["file"] == path.name for case in cases) for path in files},
+                "applicable_fixture_counts": {
+                    path.name: sum(
+                        case["file"] == path.name
+                        and (case["file"], case["data"], case["context"], case["scripting"])
+                        not in _SCRIPT_EXECUTION_EXCLUSIONS
+                        for case in cases
+                    )
+                    for path in files
+                },
+                "normative_adjustments": adjustments,
+                "error_adjustments": error_adjustments,
+                "exclusions": exclusions,
+                "cases": cases,
+            },
+            ensure_ascii=False,
+            indent=1,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {out_path}: {len(cases)} cases from {len(files)} files at {revision[:12]}")
+    _report(cases)
+
+
+def _parse_file(path: Path) -> list[_Case]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        source = handle.read()
+    cases: list[_Case] = []
+    for block in source.split("#data\n")[1:]:
+        before_document, marker, document = block.partition("\n#document\n")
+        if not marker:
+            msg = f"{path}: #data block has no #document section"
+            raise ValueError(msg)
+        data, sections = _sections(before_document)
+        context = None
+        if fragment := sections.get("document-fragment"):
+            context = fragment.splitlines()[0].strip()
+        scripting = True if "script-on" in sections else False if "script-off" in sections else None
+        key = (path.name, data, context, scripting)
+        expected = document.rstrip("\n")
+        errors = _new_errors(sections.get("new-errors"), path)
+        cases.append({
+            "file": path.name,
+            "data": data,
+            "document": expected,
+            "context": context,
+            "scripting": scripting,
+            "errors": errors,
+            "spec_errors": _ERROR_OVERRIDES.get(key, (errors, ""))[0],
+            "spec_document": _FOREIGN_CONTENT_OVERRIDES.get(key, (expected, ""))[0],
+        })
+    return cases
+
+
+def _sections(text: str) -> tuple[str, dict[str, str]]:
+    matches = list(_SECTION.finditer(text))
+    if not matches:
+        return text, {}
+    sections = {
+        match[1]: text[match.end() : matches[index + 1].start() if index + 1 < len(matches) else None].removesuffix(
+            "\n"
+        )
+        for index, match in enumerate(matches)
+    }
+    return text[: matches[0].start()].removesuffix("\n"), sections
+
+
+def _new_errors(value: str | None, path: Path) -> list[_Error] | None:
+    if value is None:
+        return None
+    errors: list[_Error] = []
+    for line in value.splitlines():
+        if not line:
+            continue
+        if (match := _NEW_ERROR.fullmatch(line)) is None:
+            msg = f"{path}: invalid #new-errors entry: {line!r}"
+            raise ValueError(msg)
+        errors.append({
+            "code": match[5],
+            "line": int(match[1]),
+            "col": int(match[2]),
+            "end_line": int(match[3]) if match[3] is not None else None,
+            "end_col": int(match[4]) if match[4] is not None else None,
+        })
+    return errors
+
+
+def _revision(checkout: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _decisions() -> tuple[list[_Decision], list[_Exclusion], list[_Decision]]:
+    adjustment_reason = (
+        "The foreign-content any-other-end-tag rule keeps the foreign root current before the token is reprocessed."
+    )
+    adjustments: list[_Decision] = [
+        {
+            "file": file,
+            "data": data,
+            "context": context,
+            "scripting": scripting,
+            "reason": adjustment_reason,
+            "spec": _FOREIGN_SPEC,
+            "fixture": fixture,
+        }
+        for (file, data, context, scripting), (_, fixture) in _FOREIGN_CONTENT_OVERRIDES.items()
+    ]
+    exclusion_reason = "The expected tree requires JavaScript execution; turbohtml has no JavaScript runtime."
+    exclusions: list[_Exclusion] = [
+        {
+            "file": file,
+            "data": data,
+            "context": context,
+            "scripting": scripting,
+            "reason": exclusion_reason,
+            "spec": _SCRIPT_SPEC,
+            "fixture": fixture,
+            "document": document,
+        }
+        for (file, data, context, scripting), (document, fixture) in _SCRIPT_EXECUTION_EXCLUSIONS.items()
+    ]
+    error_reason = "These fixtures retain parse errors from the bogus-comment rules that preceded HTML instructions."
+    error_adjustments: list[_Decision] = [
+        {
+            "file": file,
+            "data": data,
+            "context": context,
+            "scripting": scripting,
+            "reason": error_reason,
+            "spec": _PI_SPEC,
+            "fixture": fixture,
+        }
+        for (file, data, context, scripting), (_, fixture) in _ERROR_OVERRIDES.items()
+    ]
+    return adjustments, exclusions, error_adjustments
+
+
+def _report(cases: list[_Case]) -> None:
+    applicable = [
+        case
+        for case in cases
+        if (case["file"], case["data"], case["context"], case["scripting"]) not in _SCRIPT_EXECUTION_EXCLUSIONS
+    ]
+    results = [(case, _build(case)) for case in applicable]
+    raw_failures = [(case, result) for case, result in results if result != case["document"]]
+    adjusted_failures = [(case, result) for case, result in results if result != case["spec_document"]]
+    error_cases = [
+        (case, expected)
+        for case in applicable
+        if case["context"] is None and (expected := case["spec_errors"]) is not None
+    ]
+    error_failures = [
+        (case, actual) for case, expected in error_cases if not _errors_match(expected, actual := _errors(case))
+    ]
+    totals = Counter(case["file"] for case in applicable)
+    raw_failure_counts = Counter(case["file"] for case, _ in raw_failures)
+    adjusted_failure_counts = Counter(case["file"] for case, _ in adjusted_failures)
+    for filename, total in sorted(totals.items()):
+        print(
+            f"{filename}: raw {total - raw_failure_counts[filename]}/{total}, "
+            f"spec-adjusted {total - adjusted_failure_counts[filename]}/{total}"
+        )
+    count = len(applicable)
+    print(f"raw: {count - len(raw_failures)}/{count} ({(count - len(raw_failures)) / count:.2%})")
+    print(f"spec-adjusted: {count - len(adjusted_failures)}/{count} ({(count - len(adjusted_failures)) / count:.2%})")
+    print(f"normative adjustments: {len(_FOREIGN_CONTENT_OVERRIDES)}")
+    print(f"unsupported script-execution cases: {len(_SCRIPT_EXECUTION_EXCLUSIONS)}")
+    checked_errors = len(error_cases)
+    print(f"exact parse errors: {checked_errors - len(error_failures)}/{checked_errors}")
+    failures = [
+        *(
+            f"{case['file']}: tree for {case['data']!r}\nexpected:\n{case['spec_document']}\ngot:\n{result}"
+            for case, result in adjusted_failures
+        ),
+        *(
+            f"{case['file']}: errors for {case['data']!r}\nexpected: {case['spec_errors']}\ngot: {actual}"
+            for case, actual in error_failures
+        ),
+    ]
+    if failures:
+        print("\n\n".join(failures))
+        msg = f"{len(failures)} applicable WPT cases failed"
+        raise SystemExit(msg)
+
+
+def _build(case: _Case) -> str:
+    if (context := case["context"]) is not None:
+        result = _html._parse_fragment(  # ruff:ignore[private-member-access]  # native WPT-format dumper
+            case["data"], context, bool(case["scripting"])
+        )
+    else:
+        result = _html._parse_tree(  # ruff:ignore[private-member-access]  # native WPT-format dumper
+            case["data"], bool(case["scripting"])
+        )
+    return result.rstrip("\n")
+
+
+def _errors(case: _Case) -> list[_Error]:
+    return [
+        {"code": error.code, "line": error.line, "col": error.col + 1, "end_line": None, "end_col": None}
+        for error in parse(case["data"], scripting=bool(case["scripting"])).errors
+    ]
+
+
+def _errors_match(expected: list[_Error], actual: list[_Error]) -> bool:
+    if len(expected) != len(actual):
+        return False
+    for wanted, raised in zip(expected, actual, strict=True):
+        if wanted["code"] != raised["code"]:
+            return False
+        position = raised["line"], raised["col"]
+        start = wanted["line"], wanted["col"]
+        if (end_line := wanted["end_line"]) is None:
+            if position != start:
+                return False
+        elif (end_col := wanted["end_col"]) is None or not start <= position <= (end_line, end_col):
+            return False
+    return True
+
+
+__all__ = ["generate"]
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        msg = "usage: generate_wpt_tree_corpus.py WPT_CHECKOUT OUTPUT_JSON"
+        raise SystemExit(msg)
+    generate(Path(sys.argv[1]), Path(sys.argv[2]))


### PR DESCRIPTION
TurboHTML matches 100% of the spec-correct tree cases in the pinned living WPT corpus. The frozen html5lib corpus could not expose later processing-instruction, `keygen`, or adoption-agency changes before release.

🧪 The committed report pins WPT at `4830edb` and retains all 1920 source cases. Four fixtures require JavaScript execution, which leaves 1916 applicable parser cases. TurboHTML matches 1908/1916 raw fixture trees and 1916/1916 after applying the living standard to eight stale foreign-content expectations. Each adjustment and exclusion carries its fixture and normative source, and the generator prints per-file results from one refresh command.

WPT publishes exact parse-error expectations for 283 supported document cases. One parser dependency remains before this draft can leave draft status: an unacknowledged self-closing flag must report `non-void-html-element-start-tag-with-trailing-solidus` under the [living rule](https://html.spec.whatwg.org/multipage/parsing.html#acknowledge-self-closing-flag) and [`webkit01.dat`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/webkit01.dat#L675-L690). Issues #716, #717, and #718 supply the stacked parser changes. Closes #719.
