### PR TITLE
⚡ perf(linkify): move traversal into C

### DIFF
--- a/docs/changelog/715.bugfix.rst
+++ b/docs/changelog/715.bugfix.rst
@@ -1,0 +1,1 @@
+Move HTML-aware linkifier traversal and mutation into one native operation.

--- a/docs/development/performance.rst
+++ b/docs/development/performance.rst
@@ -86,6 +86,10 @@ thirty. Its figure there is the cost of finding nothing.
 .. bench-table::
     :file: bench/linkify.json
 
+A single C walk creates wrappers only for eligible text and anchor targets; Python no longer visits every node. CodSpeed
+tracks a text-heavy tree, 2,000 small text nodes, and 2,000 empty elements. Separate cases cover skip-tag pruning and
+callback-heavy HTML. Callbacks run in document order after target collection releases the tree lock.
+
 The detection primitive on its own, :meth:`turbohtml.clean.LinkDetector.find` against ``LinkifyIt().match`` and
 :meth:`~turbohtml.clean.LinkDetector.has_link` against ``LinkifyIt().test``, scans a run of plain text without rewriting
 HTML. Both libraries stop on the first valid match; turbohtml allocates no span list. The large-tail case starts with a

--- a/docs/how-to/links.rst
+++ b/docs/how-to/links.rst
@@ -108,6 +108,10 @@ allowlist of explicit URL schemes:
 
     <a href="https://docs.example" data-seen="author">docs</a>, ping <a href="http://app.internal" data-seen="auto">app.internal</a>, skip ftp://x.example
 
+The native walk collects target references in document order. It copies each target's text and attributes under the tree
+lock, releases the lock, then invokes Python. One :class:`~turbohtml.clean.Linker` can serve concurrent calls; candidate
+mutations remain local to each call.
+
 **************************
  Find links in plain text
 **************************

--- a/src/turbohtml/_c/clean/linkify.c
+++ b/src/turbohtml/_c/clean/linkify.c
@@ -1,8 +1,8 @@
-/* URL and email detection for linkify, the hot scan kept in C.
+/* URL and email detection plus linkification.
 
-   The Python layer (turbohtml/linkify.py) walks the parsed tree and hands each
-   eligible text run here; this file finds the link spans in it. The algorithm
-   is the trigger-then-expand model the Rust `linkify` crate uses, not a regex:
+   C snapshots eligible nodes, scans text runs, and applies completed rewrites.
+   Python runs for configured callbacks. Detection uses the trigger-then-expand
+   model from the Rust `linkify` crate, not a regex:
    scan for the few bytes that can begin a link (`:` for a scheme, `@` for an
    email, `.` for a bare domain), then expand left and right from the trigger to
    the link's bounds. A bare domain counts as a link only when its last label is
@@ -12,6 +12,8 @@
 
 #include "core/ascii.h"
 #include "core/common.h"
+#include "dom/tree.h"
+#include "tokenizer/binding.h"
 #include "url/url.h"
 
 #include "data/tld_table.h"
@@ -557,4 +559,596 @@ PyObject *turbohtml_linkify_has(PyObject *Py_UNUSED(module), PyObject *args) {
         return NULL;
     }
     return PyBool_FromLong(scan_matches(text, emails, bare_domains, extra_tlds, schemes, url_schemes, NULL));
+}
+
+static int tag_matches_str(const th_node *node, PyObject *tag) {
+    Py_ssize_t len = PyUnicode_GET_LENGTH(tag);
+    if (node->text_len != len) {
+        return 0;
+    }
+    int kind = PyUnicode_KIND(tag);
+    const void *data = PyUnicode_DATA(tag);
+    for (Py_ssize_t index = 0; index < len; index++) {
+        if (node->text[index] != PyUnicode_READ(kind, data, index)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int tag_in_tuple(const th_node *node, PyObject *tags) {
+    for (Py_ssize_t index = 0; index < PyTuple_GET_SIZE(tags); index++) {
+        if (tag_matches_str(node, PyTuple_GET_ITEM(tags, index))) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static th_node *after_subtree(th_node *node, th_node *root) {
+    while (node != root) {
+        if (node->next_sibling != NULL) {
+            return node->next_sibling;
+        }
+        node = node->parent;
+    }
+    return NULL;
+}
+
+static int append_target(PyObject *targets, PyObject *owner, th_node *node) {
+    PyObject *wrapped = turbohtml_node_wrap_in(owner, node);
+    if (wrapped == NULL || PyList_Append(targets, wrapped) < 0) { /* GCOVR_EXCL_BR_LINE: wrapper/list allocation */
+        Py_XDECREF(wrapped);                                      /* GCOVR_EXCL_LINE */
+        return -1;                                                /* GCOVR_EXCL_LINE */
+    }
+    Py_DECREF(wrapped);
+    return 0;
+}
+
+static PyObject *collect_targets(PyObject *module, PyObject *owner, int process_existing, PyObject *skip_tags) {
+    PyObject *targets = PyList_New(0);
+    if (targets == NULL) { /* GCOVR_EXCL_BR_LINE: target list allocation cannot be forced from a test */
+        return NULL;       /* GCOVR_EXCL_LINE */
+    }
+    int error = 0;
+    PyObject *handle = turbohtml_node_handle(owner);
+    (void)handle;
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    th_tree *tree;
+    th_node *root;
+    (void)turbohtml_node_borrow(module, owner, &tree, &root);
+    (void)tree;
+    th_node *node = root->first_child;
+    while (node != NULL) {
+        if (node->type == TH_NODE_TEXT) {
+            if (append_target(targets, owner, node) < 0) { /* GCOVR_EXCL_BR_LINE: wrapper/list allocation */
+                error = 1;                                 /* GCOVR_EXCL_LINE */
+                break;                                     /* GCOVR_EXCL_LINE */
+            }
+        } else if (node->type == TH_NODE_ELEMENT && (node->atom == TH_TAG_A || node->atom == TH_TAG_SCRIPT ||
+                                                     node->atom == TH_TAG_STYLE || tag_in_tuple(node, skip_tags))) {
+            if (process_existing && node->atom == TH_TAG_A) {
+                if (append_target(targets, owner, node) < 0) { /* GCOVR_EXCL_BR_LINE: wrapper/list allocation */
+                    error = 1;                                 /* GCOVR_EXCL_LINE */
+                    break;                                     /* GCOVR_EXCL_LINE */
+                }
+            }
+            node = after_subtree(node, root);
+            continue;
+        }
+        node = node->first_child != NULL ? node->first_child : after_subtree(node, root);
+    }
+    Py_END_CRITICAL_SECTION();
+    if (error) {            /* GCOVR_EXCL_BR_LINE: target wrapper/list allocation cannot be forced from a test */
+        Py_DECREF(targets); /* GCOVR_EXCL_LINE */
+        return NULL;        /* GCOVR_EXCL_LINE */
+    }
+    return targets;
+}
+
+static PyObject *attr_text(const th_node_attr *attr) {
+    return attr == NULL || attr->value == NULL
+               ? PyUnicode_FromString("")
+               : PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, attr->value, attr->value_len);
+}
+
+static PyObject *anchor_attrs(th_tree *tree, th_node *anchor) {
+    PyObject *attrs = PyDict_New();
+    if (attrs == NULL) { /* GCOVR_EXCL_BR_LINE: attribute dict allocation cannot be forced from a test */
+        return NULL;     /* GCOVR_EXCL_LINE */
+    }
+    for (Py_ssize_t index = 0; index < anchor->attr_count; index++) {
+        Py_ssize_t name_len;
+        const char *name = th_attr_name(tree, anchor->attrs[index].name_atom, &name_len);
+        if (name_len == 4 && memcmp(name, "href", 4) == 0) {
+            continue;
+        }
+        PyObject *key = PyUnicode_FromStringAndSize(name, name_len);
+        PyObject *value = attr_text(&anchor->attrs[index]);
+        if (key == NULL || value == NULL || /* GCOVR_EXCL_BR_LINE: attribute string allocation cannot be forced */
+            PyDict_SetItem(attrs, key, value) < 0) { /* GCOVR_EXCL_BR_LINE: attribute dict insertion allocation */
+            Py_XDECREF(key);                         /* GCOVR_EXCL_LINE */
+            Py_XDECREF(value);                       /* GCOVR_EXCL_LINE */
+            Py_DECREF(attrs);                        /* GCOVR_EXCL_LINE */
+            return NULL;                             /* GCOVR_EXCL_LINE */
+        }
+        Py_DECREF(key);
+        Py_DECREF(value);
+    }
+    return attrs;
+}
+
+static PyObject *new_candidate(PyObject *candidate_type, PyObject *url, PyObject *text, PyObject *attrs, int existing) {
+    PyObject *candidate = PyObject_CallFunctionObjArgs(candidate_type, url, text, attrs, NULL);
+    if (candidate != NULL && existing) { /* GCOVR_EXCL_BR_LINE: LinkCandidate allocation failure */
+        if (PyObject_SetAttrString(candidate, "existing", Py_True) < 0) { /* GCOVR_EXCL_BR_LINE: fixed writable field */
+            Py_CLEAR(candidate);                                          /* GCOVR_EXCL_LINE */
+        } /* GCOVR_EXCL_LINE */
+    }
+    return candidate;
+}
+
+static int run_callbacks(PyObject *callbacks, PyObject **candidate) {
+    for (Py_ssize_t index = 0; index < PyTuple_GET_SIZE(callbacks); index++) {
+        PyObject *result = PyObject_CallOneArg(PyTuple_GET_ITEM(callbacks, index), *candidate);
+        if (result == NULL) {
+            return -1;
+        }
+        Py_SETREF(*candidate, result);
+        if (result == Py_None) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+typedef struct {
+    PyObject *url;
+    PyObject *text;
+    PyObject *attrs;
+    int vetoed;
+} candidate_result;
+
+static void clear_candidate_result(candidate_result *result) {
+    Py_CLEAR(result->url);
+    Py_CLEAR(result->text);
+    Py_CLEAR(result->attrs);
+}
+
+static int prepare_candidate(PyObject *candidate_type, PyObject *url, PyObject *text, PyObject *attrs, int existing,
+                             PyObject *callbacks, candidate_result *result) {
+    PyObject *candidate = new_candidate(candidate_type, url, text, attrs, existing);
+    if (candidate == NULL) { /* GCOVR_EXCL_BR_LINE: LinkCandidate allocation failure */
+        return -1;           /* GCOVR_EXCL_LINE */
+    }
+    int status = run_callbacks(callbacks, &candidate);
+    if (status != 0) {
+        Py_DECREF(candidate);
+        if (status > 0) {
+            result->vetoed = 1;
+            return 0;
+        }
+        return -1;
+    }
+    result->url = PyObject_GetAttrString(candidate, "url");
+    result->text = PyObject_GetAttrString(candidate, "text");
+    PyObject *candidate_attrs = PyObject_GetAttrString(candidate, "attrs");
+    Py_DECREF(candidate);
+    if (result->url == NULL || result->text == NULL || candidate_attrs == NULL) {
+        Py_XDECREF(candidate_attrs);
+        clear_candidate_result(result);
+        return -1;
+    }
+    if (!PyUnicode_Check(result->url) || !PyUnicode_Check(result->text) || !PyDict_Check(candidate_attrs)) {
+        Py_DECREF(candidate_attrs);
+        clear_candidate_result(result);
+        PyErr_SetString(PyExc_TypeError, "a link callback must return string fields and a dict of attributes");
+        return -1;
+    }
+    result->attrs = PyDict_Copy(candidate_attrs);
+    Py_DECREF(candidate_attrs);
+    if (result->attrs == NULL) {        /* GCOVR_EXCL_BR_LINE: attribute dict copy cannot be forced from a test */
+        clear_candidate_result(result); /* GCOVR_EXCL_LINE */
+        return -1;                      /* GCOVR_EXCL_LINE */
+    }
+    PyObject *name;
+    PyObject *value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(result->attrs, &pos, &name, &value)) {
+        if (!PyUnicode_Check(name) || !PyUnicode_Check(value)) {
+            clear_candidate_result(result);
+            PyErr_SetString(PyExc_TypeError, "link attribute names and values must be str");
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int set_candidate_attrs(th_tree *tree, th_node *anchor, PyObject *url, PyObject *attrs, int include_empty_url) {
+    anchor->attr_count = 0;
+    PyObject *name;
+    PyObject *value;
+    Py_ssize_t pos = 0;
+    int status = 0;
+    if (include_empty_url || PyUnicode_GET_LENGTH(url) > 0) {
+        Py_UCS4 *url_points = PyUnicode_AsUCS4Copy(url);
+        if (url_points == NULL) { /* GCOVR_EXCL_BR_LINE: URL UCS4 allocation cannot be forced from a test */
+            return -1;            /* GCOVR_EXCL_LINE */
+        }
+        status = th_node_attr_set(tree, anchor, "href", 4, url_points, PyUnicode_GET_LENGTH(url), 1);
+        PyMem_Free(url_points);
+        if (status < 0) { /* GCOVR_EXCL_BR_LINE: attribute arena allocation cannot be forced from a test */
+            return -1;    /* GCOVR_EXCL_LINE */
+        }
+    }
+    while (PyDict_Next(attrs, &pos, &name, &value)) {
+        Py_ssize_t name_len;
+        const char *name_bytes = PyUnicode_AsUTF8AndSize(name, &name_len);
+        Py_UCS4 *value_points = PyUnicode_AsUCS4Copy(value);
+        if (name_bytes == NULL || value_points == NULL) { /* GCOVR_EXCL_BR_LINE: UTF-8/UCS4 allocation */
+            PyMem_Free(value_points);                     /* GCOVR_EXCL_LINE */
+            return -1;                                    /* GCOVR_EXCL_LINE */
+        }
+        status = th_node_attr_set(tree, anchor, name_bytes, name_len, value_points, PyUnicode_GET_LENGTH(value), 1);
+        PyMem_Free(value_points);
+        if (status < 0) { /* GCOVR_EXCL_BR_LINE: attribute arena allocation cannot be forced from a test */
+            return -1;    /* GCOVR_EXCL_LINE */
+        }
+    }
+    return 0;
+}
+
+static int replace_anchor_text(th_tree *tree, th_node *anchor, PyObject *text) {
+    Py_UCS4 *points = PyUnicode_AsUCS4Copy(text);
+    if (points == NULL) { /* GCOVR_EXCL_BR_LINE: text UCS4 allocation cannot be forced from a test */
+        return -1;        /* GCOVR_EXCL_LINE */
+    }
+    while (anchor->first_child != NULL) {
+        th_node_remove(anchor->first_child);
+    }
+    Py_ssize_t text_len = PyUnicode_GET_LENGTH(text);
+    th_node *child = text_len > 0 ? th_tree_make_data_node(tree, TH_NODE_TEXT, points, text_len) : NULL;
+    PyMem_Free(points);
+    if (text_len > 0 && child == NULL) { /* GCOVR_EXCL_BR_LINE: text-node arena allocation */
+        return -1;                       /* GCOVR_EXCL_LINE */
+    }
+    if (child != NULL) {
+        th_node_append_child(anchor, child);
+    }
+    return 0;
+}
+
+static void unwrap_anchor(th_node *anchor) {
+    th_node *parent = anchor->parent;
+    while (anchor->first_child != NULL) {
+        th_node *child = anchor->first_child;
+        th_node_remove(child);
+        th_node_insert_before(parent, child, anchor);
+    }
+    th_node_remove(anchor);
+}
+
+static int snapshot_existing(PyObject *module, PyObject *target, PyObject **text_out, PyObject **url_out,
+                             PyObject **attrs_out) {
+    PyObject *handle = turbohtml_node_handle(target);
+    (void)handle;
+    th_tree *tree;
+    th_node *anchor;
+    PyObject *text;
+    PyObject *url;
+    PyObject *attrs;
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    (void)turbohtml_node_borrow(module, target, &tree, &anchor);
+    Py_ssize_t text_len;
+    Py_UCS4 *points = th_node_text(tree, anchor, &text_len);
+    if (text_len == 0) {
+        text = PyUnicode_FromString("");
+    } else if (points == NULL) { /* GCOVR_EXCL_BR_LINE: flattened-text allocation */
+        text = NULL;             /* GCOVR_EXCL_LINE */
+    } else {                     /* GCOVR_EXCL_LINE: llvm-cov assigns this line to the allocation-failure edge */
+        text = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, points, text_len);
+    }
+    PyMem_Free(points);
+    Py_ssize_t href_index = th_node_attr_find(tree, anchor, "href", 4);
+    url = attr_text(href_index < 0 ? NULL : &anchor->attrs[href_index]);
+    attrs = anchor_attrs(tree, anchor);
+    Py_END_CRITICAL_SECTION();
+    if (text == NULL || url == NULL || attrs == NULL) { /* GCOVR_EXCL_BR_LINE: text/URL/attribute snapshot allocation */
+        Py_XDECREF(text);                               /* GCOVR_EXCL_LINE */
+        Py_XDECREF(url);                                /* GCOVR_EXCL_LINE */
+        Py_XDECREF(attrs);                              /* GCOVR_EXCL_LINE */
+        return -1;                                      /* GCOVR_EXCL_LINE */
+    }
+    *text_out = text;
+    *url_out = url;
+    *attrs_out = attrs;
+    return 0;
+}
+
+static int apply_existing(PyObject *module, PyObject *target, const candidate_result *result, int replace_text) {
+    PyObject *handle = turbohtml_node_handle(target);
+    (void)handle;
+    th_tree *tree;
+    th_node *anchor;
+    int status = 0;
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    (void)turbohtml_node_borrow(module, target, &tree, &anchor);
+    if (result->vetoed) {
+        unwrap_anchor(anchor);
+    } else {
+        status = set_candidate_attrs(tree, anchor, result->url, result->attrs, 0);
+        if (status == 0 && replace_text) { /* GCOVR_EXCL_BR_LINE: attribute encoding/arena allocation */
+            status = replace_anchor_text(tree, anchor, result->text);
+        }
+    }
+    Py_END_CRITICAL_SECTION();
+    return status;
+}
+
+static int process_existing(PyObject *module, PyObject *target, PyObject *callbacks, PyObject *candidate_type) {
+    PyObject *text;
+    PyObject *url;
+    PyObject *attrs;
+    if (snapshot_existing(module, target, &text, &url, &attrs) < 0) { /* GCOVR_EXCL_BR_LINE: snapshot allocation */
+        return -1;                                                    /* GCOVR_EXCL_LINE */
+    }
+    candidate_result result = {NULL, NULL, NULL, 0};
+    int status = prepare_candidate(candidate_type, url, text, attrs, 1, callbacks, &result);
+    Py_DECREF(url);
+    Py_DECREF(attrs);
+    if (status == 0) {
+        int replace_text = 0;
+        if (!result.vetoed) {
+            int equal = PyObject_RichCompareBool(text, result.text, Py_EQ);
+            if (equal < 0) {
+                status = -1;
+            } else {
+                replace_text = equal == 0;
+            }
+        }
+        if (status == 0) {
+            status = apply_existing(module, target, &result, replace_text);
+        }
+    }
+    clear_candidate_result(&result);
+    Py_DECREF(text);
+    return status;
+}
+
+static PyObject *matched_url(PyObject *matched, int kind) {
+    if (kind == TH_LINK_EMAIL) {
+        PyObject *prefix = PyUnicode_FromString("mailto:");
+        /* GCOVR_EXCL_BR_START: prefix/concatenation allocation cannot be forced */
+        PyObject *url = prefix == NULL ? NULL : PyUnicode_Concat(prefix, matched);
+        /* GCOVR_EXCL_BR_STOP */
+        Py_XDECREF(prefix);
+        return url;
+    }
+    if (kind == TH_LINK_URL) {
+        PyObject *prefix = PyUnicode_FromString("http://");
+        /* GCOVR_EXCL_BR_START: prefix/concatenation allocation cannot be forced */
+        PyObject *url = prefix == NULL ? NULL : PyUnicode_Concat(prefix, matched);
+        /* GCOVR_EXCL_BR_STOP */
+        Py_XDECREF(prefix);
+        return url;
+    }
+    return Py_NewRef(matched);
+}
+
+static int append_data_slice(th_tree *tree, th_node *fragment, const Py_UCS4 *points, Py_ssize_t start,
+                             Py_ssize_t end) {
+    if (end <= start) {
+        return 0;
+    }
+    th_node *text = th_tree_make_data_node(tree, TH_NODE_TEXT, points + start, end - start);
+    if (text == NULL) { /* GCOVR_EXCL_BR_LINE: text-node arena allocation cannot be forced from a test */
+        return -1;      /* GCOVR_EXCL_LINE */
+    }
+    th_node_append_child(fragment, text);
+    return 0;
+}
+
+static int prepare_detected(PyObject *matched, int kind, PyObject *callbacks, PyObject *candidate_type,
+                            candidate_result *result) {
+    PyObject *url = matched_url(matched, kind);
+    PyObject *attrs = PyDict_New();
+    if (url == NULL || attrs == NULL) { /* GCOVR_EXCL_BR_LINE: URL/dict allocation cannot be forced from a test */
+        Py_XDECREF(url);                /* GCOVR_EXCL_LINE */
+        Py_XDECREF(attrs);              /* GCOVR_EXCL_LINE */
+        return -1;                      /* GCOVR_EXCL_LINE */
+    }
+    int status = prepare_candidate(candidate_type, url, matched, attrs, 0, callbacks, result);
+    Py_DECREF(url);
+    Py_DECREF(attrs);
+    return status;
+}
+
+static int append_result(th_tree *tree, th_node *fragment, const Py_UCS4 *points, Py_ssize_t start, Py_ssize_t end,
+                         const candidate_result *result) {
+    if (result->vetoed) {
+        return append_data_slice(tree, fragment, points, start, end);
+    }
+    static const Py_UCS4 anchor_tag[] = {'a'};
+    th_node *anchor = th_tree_make_element(tree, anchor_tag, 1, TH_TAG_A, 0);
+    /* GCOVR_EXCL_BR_START: anchor arena allocation cannot be forced */
+    int status = anchor == NULL ? -1 : set_candidate_attrs(tree, anchor, result->url, result->attrs, 1);
+    /* GCOVR_EXCL_BR_STOP */
+    if (status == 0) { /* GCOVR_EXCL_BR_LINE: attribute encoding/arena allocation */
+        status = replace_anchor_text(tree, anchor, result->text);
+    }
+    if (status == 0) { /* GCOVR_EXCL_BR_LINE: text encoding/arena allocation */
+        th_node_append_child(fragment, anchor);
+    }
+    return status;
+}
+
+static PyObject *snapshot_text(PyObject *module, PyObject *target) {
+    PyObject *handle = turbohtml_node_handle(target);
+    (void)handle;
+    th_tree *tree;
+    th_node *node;
+    PyObject *text;
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    (void)turbohtml_node_borrow(module, target, &tree, &node);
+    const Py_UCS4 *points = th_node_realize_text(tree, node);
+    /* GCOVR_EXCL_BR_START: text realization and Unicode snapshot allocation cannot be forced */
+    text = points == NULL ? NULL : PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, points, node->text_len);
+    /* GCOVR_EXCL_BR_STOP */
+    Py_END_CRITICAL_SECTION();
+    return text;
+}
+
+static int apply_text(PyObject *module, PyObject *target, PyObject *text, PyObject *spans,
+                      const candidate_result *results) {
+    Py_UCS4 *points = PyUnicode_AsUCS4Copy(text);
+    if (points == NULL) { /* GCOVR_EXCL_BR_LINE: UCS4 input copy cannot be forced from a test */
+        return -1;        /* GCOVR_EXCL_LINE */
+    }
+    PyObject *handle = turbohtml_node_handle(target);
+    (void)handle;
+    th_tree *tree;
+    th_node *node;
+    int status = 0;
+    Py_BEGIN_CRITICAL_SECTION(handle);
+    (void)turbohtml_node_borrow(module, target, &tree, &node);
+    th_node *fragment = th_tree_make_fragment(tree);
+    if (fragment == NULL) { /* GCOVR_EXCL_BR_LINE: fragment arena allocation cannot be forced from a test */
+        status = -1;        /* GCOVR_EXCL_LINE */
+    } else {                /* GCOVR_EXCL_LINE: brace of the allocation-failure branch */
+        Py_ssize_t cursor = 0;
+        /* GCOVR_EXCL_BR_START: child allocation failure short-circuits the loop */
+        for (Py_ssize_t index = 0; status == 0 && index < PyList_GET_SIZE(spans); index++) {
+            /* GCOVR_EXCL_BR_STOP */
+            PyObject *span = PyList_GET_ITEM(spans, index);
+            Py_ssize_t start = PyLong_AsSsize_t(PyTuple_GET_ITEM(span, 0));
+            Py_ssize_t end = PyLong_AsSsize_t(PyTuple_GET_ITEM(span, 1));
+            status = append_data_slice(tree, fragment, points, cursor, start);
+            if (status == 0) { /* GCOVR_EXCL_BR_LINE: leading text-node allocation */
+                status = append_result(tree, fragment, points, start, end, &results[index]);
+            }
+            cursor = end;
+        }
+        if (status == 0) { /* GCOVR_EXCL_BR_LINE: prior child allocation */
+            status = append_data_slice(tree, fragment, points, cursor, PyUnicode_GET_LENGTH(text));
+        }
+        if (status == 0) { /* GCOVR_EXCL_BR_LINE: fragment child allocation */
+            th_node *parent = node->parent;
+            while (fragment->first_child != NULL) {
+                th_node *child = fragment->first_child;
+                th_node_remove(child);
+                th_node_insert_before(parent, child, node);
+            }
+            th_node_remove(node);
+        }
+    }
+    Py_END_CRITICAL_SECTION();
+    PyMem_Free(points);
+    return status;
+}
+
+static int process_text(PyObject *module, PyObject *target, int parse_email, PyObject *extra_tlds,
+                        PyObject *url_schemes, PyObject *callbacks, PyObject *candidate_type) {
+    PyObject *text = snapshot_text(module, target);
+    if (text == NULL) { /* GCOVR_EXCL_BR_LINE: text snapshot allocation cannot be forced from a test */
+        return -1;      /* GCOVR_EXCL_LINE */
+    }
+    PyObject *spans = collect_matches(text, parse_email, 1, extra_tlds, NULL, url_schemes);
+    if (spans == NULL) { /* GCOVR_EXCL_BR_LINE: span list/tuple allocation cannot be forced from a test */
+        Py_DECREF(text); /* GCOVR_EXCL_LINE */
+        return -1;       /* GCOVR_EXCL_LINE */
+    }
+    if (PyList_GET_SIZE(spans) == 0) {
+        Py_DECREF(spans);
+        Py_DECREF(text);
+        return 0;
+    }
+    Py_ssize_t count = PyList_GET_SIZE(spans);
+    candidate_result *results = PyMem_Calloc((size_t)count, sizeof(candidate_result));
+    if (results == NULL) { /* GCOVR_EXCL_BR_LINE: candidate result array allocation cannot be forced from a test */
+        Py_DECREF(spans);  /* GCOVR_EXCL_LINE */
+        Py_DECREF(text);   /* GCOVR_EXCL_LINE */
+        return -1;         /* GCOVR_EXCL_LINE */
+    }
+    int status = 0;
+    Py_ssize_t prepared = 0;
+    for (; prepared < count; prepared++) {
+        PyObject *span = PyList_GET_ITEM(spans, prepared);
+        Py_ssize_t start = PyLong_AsSsize_t(PyTuple_GET_ITEM(span, 0));
+        Py_ssize_t end = PyLong_AsSsize_t(PyTuple_GET_ITEM(span, 1));
+        int kind = (int)PyLong_AsLong(PyTuple_GET_ITEM(span, 2));
+        PyObject *matched = PyUnicode_Substring(text, start, end);
+        if (matched == NULL) { /* GCOVR_EXCL_BR_LINE: matched substring allocation */
+            status = -1;       /* GCOVR_EXCL_LINE */
+            break;             /* GCOVR_EXCL_LINE */
+        }
+        if (prepare_detected(matched, kind, callbacks, candidate_type, &results[prepared]) < 0) {
+            Py_DECREF(matched);
+            status = -1;
+            break;
+        }
+        Py_DECREF(matched);
+    }
+    if (status == 0) {
+        status = apply_text(module, target, text, spans, results);
+    }
+    for (Py_ssize_t index = 0; index < prepared; index++) {
+        clear_candidate_result(&results[index]);
+    }
+    PyMem_Free(results);
+    Py_DECREF(spans);
+    Py_DECREF(text);
+    return status;
+}
+
+PyObject *turbohtml_linkify_apply(PyObject *module, PyObject *args) {
+    PyObject *owner;
+    PyObject *callbacks;
+    int parse_email;
+    PyObject *extra_tlds;
+    PyObject *url_schemes;
+    int process_existing_flag;
+    PyObject *skip_tags;
+    PyObject *candidate_type;
+    /* GCOVR_EXCL_BR_START: Linker passes tuple-backed compiled fields */
+    if (!PyArg_ParseTuple(args, "OO!pO!O!pO!O:_linkify_apply", &owner, &PyTuple_Type, &callbacks, &parse_email,
+                          &PyTuple_Type, &extra_tlds, &PyTuple_Type, &url_schemes, &process_existing_flag,
+                          &PyTuple_Type, &skip_tags, &candidate_type)) {
+        return NULL; /* GCOVR_EXCL_LINE */
+    }
+    /* GCOVR_EXCL_BR_STOP */
+    th_tree *tree;
+    th_node *root;
+    if (turbohtml_node_borrow(module, owner, &tree, &root) < 0) { /* GCOVR_EXCL_BR_LINE: Linker supplies a fragment */
+        return NULL;                                              /* GCOVR_EXCL_LINE */
+    }
+    (void)tree;
+    (void)root;
+    PyObject *targets = collect_targets(module, owner, process_existing_flag, skip_tags);
+    if (targets == NULL) { /* GCOVR_EXCL_BR_LINE: target list/wrapper allocation */
+        return NULL;       /* GCOVR_EXCL_LINE */
+    }
+    int status = 0;
+    for (Py_ssize_t index = 0; status == 0 && index < PyList_GET_SIZE(targets); index++) {
+        PyObject *target = PyList_GET_ITEM(targets, index);
+        PyObject *handle = turbohtml_node_handle(target);
+        (void)handle;
+        th_node *node;
+        th_tree *target_tree;
+        int text_target;
+        Py_BEGIN_CRITICAL_SECTION(handle);
+        (void)turbohtml_node_borrow(module, target, &target_tree, &node);
+        (void)target_tree;
+        text_target = node->type == TH_NODE_TEXT;
+        Py_END_CRITICAL_SECTION();
+        if (text_target) {
+            status = process_text(module, target, parse_email, extra_tlds, url_schemes, callbacks, candidate_type);
+        } else {
+            status = process_existing(module, target, callbacks, candidate_type);
+        }
+    }
+    Py_DECREF(targets);
+    if (status < 0) {
+        return NULL;
+    }
+    Py_RETURN_NONE;
 }

--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -89,12 +89,12 @@ PyObject *turbohtml_css_escape_identifier(PyObject *module, PyObject *arg);
    registers it on import. */
 PyObject *turbohtml_register_selector_error(PyObject *module, PyObject *type);
 
-/* Implemented in linkify.c. _linkify_scan finds URL/email spans in a text run;
-   _linkify_find adds the detector's custom TLD and scheme-less scheme config.
-   Both signatures match METH_VARARGS. */
+/* Implemented in linkify.c. The scan methods find URL/email spans in text runs;
+   _linkify_apply snapshots targets and rewrites them around callback invocations. */
 PyObject *turbohtml_linkify_scan(PyObject *module, PyObject *args);
 PyObject *turbohtml_linkify_find(PyObject *module, PyObject *args);
 PyObject *turbohtml_linkify_has(PyObject *module, PyObject *args);
+PyObject *turbohtml_linkify_apply(PyObject *module, PyObject *args);
 
 /* Implemented in url/url.c. _url_split(url) breaks a URL into (scheme, netloc,
    path, query, fragment, userinfo, host, port, has_port, host_kind) the way the

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -226,6 +226,7 @@ static PyMethodDef html_methods[] = {
     {"_linkify_scan", turbohtml_linkify_scan, METH_VARARGS, NULL},
     {"_linkify_find", turbohtml_linkify_find, METH_VARARGS, NULL},
     {"_linkify_has", turbohtml_linkify_has, METH_VARARGS, NULL},
+    {"_linkify_apply", turbohtml_linkify_apply, METH_VARARGS, NULL},
     {"_registrable_domain", turbohtml_registrable_domain, METH_O, NULL},
     {"_date_scan", turbohtml_date_scan, METH_VARARGS, NULL},
     {"_date_scan_all", turbohtml_date_scan_all, METH_VARARGS, NULL},

--- a/src/turbohtml/_c/dom/mutate.c
+++ b/src/turbohtml/_c/dom/mutate.c
@@ -255,7 +255,9 @@ int th_node_attr_set(th_tree *tree, th_node *node, const char *name, Py_ssize_t 
     if (grown == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
         return -1;       /* GCOVR_EXCL_LINE: allocation-failure path */
     }
-    memcpy(grown, node->attrs, (size_t)node->attr_count * sizeof(th_node_attr));
+    if (node->attr_count > 0) {
+        memcpy(grown, node->attrs, (size_t)node->attr_count * sizeof(th_node_attr));
+    }
     grown[node->attr_count].name_atom = atom;
     grown[node->attr_count].value = owned;
     grown[node->attr_count].value_len = has_value ? value_len : 0;

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -120,6 +120,9 @@ from ._stubs.features import (
     _date_url as _date_url,
 )
 from ._stubs.features import (
+    _linkify_apply as _linkify_apply,
+)
+from ._stubs.features import (
     _linkify_find as _linkify_find,
 )
 from ._stubs.features import (

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -34,6 +34,17 @@ def _linkify_has(
     url_schemes: tuple[str, ...] = ...,
     /,
 ) -> bool: ...
+def _linkify_apply(
+    root: Element,
+    callbacks: tuple[Callable[..., object], ...],
+    parse_email: bool,
+    extra_tlds: tuple[str, ...],
+    url_schemes: tuple[str, ...],
+    process_existing: bool,
+    skip_tags: tuple[str, ...],
+    candidate_type: type,
+    /,
+) -> None: ...
 def _registrable_domain(host: str, /) -> str: ...
 def _date_scan(text: str, current_year: int, /) -> tuple[int, int, int] | None: ...
 def _date_scan_all(text: str, current_year: int, /) -> list[tuple[int, int, int]]: ...

--- a/src/turbohtml/clean/_linkify.py
+++ b/src/turbohtml/clean/_linkify.py
@@ -1,12 +1,10 @@
 """
 Turn URLs and email addresses in HTML into links, the way bleach.linkify did.
 
-bleach is the only library that shipped an HTML-aware linkifier, and it is end of life, so this is its replacement. The
-work splits in two: :mod:`turbohtml._html` finds the link spans in a text run in C, and this module does the HTML-aware
-part. It parses the input with turbohtml's WHATWG tree builder, walks the text nodes, and leaves alone any text inside
-an existing ``<a>`` (so links never nest), inside a raw-text element (``<script>``/``<style>``, whose content is not
-prose), or inside a caller's ``skip_tags``. Each found link becomes a :class:`LinkCandidate` that a chain of
-``callbacks`` can mutate or veto before it is written as an ``<a>``, and the tree serializes back to HTML.
+bleach is the only library that shipped an HTML-aware linkifier, and it is end of life, so this is its replacement.
+The typed layer compiles the options and parses the input with turbohtml's WHATWG tree builder. The C core snapshots
+eligible text and anchors, scans each text run, invokes callbacks in document order, and mutates the tree. Text inside
+an existing ``<a>``, a raw-text element (``<script>``/``<style>``), or a caller's ``skip_tags`` stays unchanged.
 """
 
 from __future__ import annotations
@@ -14,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, TypeAlias
 
-from turbohtml._html import Element, Text, _linkify_find, _linkify_has, _linkify_scan, parse_fragment
+from turbohtml._html import _linkify_apply, _linkify_find, _linkify_has, parse_fragment
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -34,10 +32,6 @@ _HAS_SCHEME_KIND: Final = 3
 # scheme or a ``javascript://`` payload stays plain text. A ``Linkify.schemes`` restricts to its own set (bleach), while
 # a ``LinkDetector``'s ``schemes`` extends this one; the low-level scanner without an allowlist stays permissive.
 _DEFAULT_URL_SCHEMES: Final = ("ftp", "http", "https")
-
-# Text inside these never becomes a link: an existing anchor (no nested links) and the raw-text elements whose content
-# is not markup. A caller's skip_tags is added on top.
-_NEVER_LINKIFY: Final = frozenset({"a", "script", "style"})
 
 
 class LinkCandidate:
@@ -73,15 +67,6 @@ class LinkCandidate:
 # A callback receives the generated :class:`LinkCandidate` and returns it to keep the link, or ``None`` to leave the
 # text bare.
 Callback: TypeAlias = "Callable[[LinkCandidate], LinkCandidate | None]"
-
-
-def _attr_str(value: str | list[str] | None) -> str:
-    """Flatten an attribute value to a string for a callback: a token list joins, a bare name is empty."""
-    if value is None:
-        return ""
-    if isinstance(value, list):
-        return " ".join(value)
-    return value
 
 
 def _is_web_url(url: str) -> bool:
@@ -157,9 +142,9 @@ class Linker:
     def __init__(self, options: Linkify | None = None) -> None:
         """Compile a configuration into the form the walk consumes."""
         config = options if options is not None else Linkify()
-        self.callbacks = list(config.callbacks)
+        self.callbacks = tuple(config.callbacks)
         self.skip_tags = (
-            frozenset(tag.lower() for tag in config.skip_tags) if config.skip_tags is not None else frozenset()
+            tuple(sorted({tag.lower() for tag in config.skip_tags})) if config.skip_tags is not None else ()
         )
         self.parse_email = config.parse_email
         self.process_existing = config.process_existing
@@ -178,86 +163,17 @@ class Linker:
         :returns: the linkified HTML.
         """
         root = parse_fragment(text)
-        self._walk(root, linkifiable=True)
+        _linkify_apply(
+            root,
+            self.callbacks,
+            self.parse_email,
+            self.extra_tlds,
+            self.url_schemes,
+            self.process_existing,
+            self.skip_tags,
+            LinkCandidate,
+        )
         return root.inner_html
-
-    def _walk(self, element: Element, *, linkifiable: bool) -> None:
-        """Recurse, linkifying text only where it is not inside an anchor, raw-text element, or skip tag."""
-        for child in list(element.children):
-            if isinstance(child, Text):
-                if linkifiable:
-                    self._linkify_text(child)
-            elif isinstance(child, Element):
-                if linkifiable and child.tag == "a" and self.process_existing:
-                    self._process_existing_anchor(child)
-                else:
-                    nested = linkifiable and child.tag not in _NEVER_LINKIFY and child.tag not in self.skip_tags
-                    self._walk(child, linkifiable=nested)
-
-    def _process_existing_anchor(self, anchor: Element) -> None:
-        """Run the callbacks over an ``<a>`` already in the input; unwrap it if one vetoes, else rewrite its attrs."""
-        original_text = anchor.text
-        href = anchor.attrs.get("href")
-        attrs = {name: _attr_str(value) for name, value in anchor.attrs.items() if name != "href"}
-        link = LinkCandidate(_attr_str(href), original_text, attrs, existing=True)
-        for callback in self.callbacks:
-            result = callback(link)
-            if result is None:
-                anchor.unwrap()
-                return
-            link = result
-        merged: dict[str, str] = {"href": link.url} if link.url else {}
-        merged.update(link.attrs)
-        anchor_attrs = anchor.attrs
-        for name in list(anchor_attrs):
-            if name not in merged:
-                del anchor_attrs[name]
-        for name, value in merged.items():
-            anchor_attrs[name] = value
-        if link.text != original_text:
-            anchor.clear()
-            anchor.append(Text(link.text))
-
-    def _linkify_text(self, node: Text) -> None:
-        """Replace a text node with the text and anchors that the link spans in it imply."""
-        data = node.data
-        spans = _linkify_scan(data, self.parse_email, True, self.extra_tlds, self.url_schemes)  # ruff:ignore[boolean-positional-value-in-call]  # True enables bare domains
-        if not spans:
-            return
-        pieces: list[Element | Text] = []
-        pos = 0
-        for start, end, kind in spans:
-            if start > pos:
-                pieces.append(Text(data[pos:start]))
-            anchor = self._build_anchor(data[start:end], kind)
-            pieces.append(anchor if anchor is not None else Text(data[start:end]))
-            pos = end
-        if pos < len(data):
-            pieces.append(Text(data[pos:]))
-        node.replace_with(*pieces)
-
-    def _build_anchor(self, matched: str, kind: int) -> Element | None:
-        """Build the ``<a>`` for one matched link, running the callbacks; return ``None`` if a callback vetoes it."""
-        if kind == _EMAIL_KIND:
-            url = "mailto:" + matched
-        elif kind == _HAS_SCHEME_KIND:  # the scanner flagged a ``scheme://`` URL, kept with its own scheme
-            url = matched
-        else:
-            url = "http://" + matched
-        if len(self.callbacks) == 1 and self.callbacks[0] is nofollow:
-            attrs = {"href": url}
-            if _is_web_url(url):
-                attrs["rel"] = "nofollow"
-            return Element("a", attrs, [Text(matched)])
-        link = LinkCandidate(url, matched)
-        for callback in self.callbacks:
-            result = callback(link)
-            if result is None:
-                return None
-            link = result
-        anchor = Element("a", {"href": link.url, **link.attrs})
-        anchor.append(Text(link.text))
-        return anchor
 
 
 def linkify(text: str, options: Linkify | None = None) -> str:

--- a/tests/clean/test_linkify.py
+++ b/tests/clean/test_linkify.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from typing import TYPE_CHECKING
 
 import pytest
@@ -133,6 +135,10 @@ def test_linkify_default_callback_adds_nofollow() -> None:
     assert linkify("see http://example.com") == 'see <a href="http://example.com" rel="nofollow">http://example.com</a>'
 
 
+def test_linkify_single_url() -> None:
+    assert linkify("x.com") == '<a href="http://x.com" rel="nofollow">x.com</a>'
+
+
 def test_linkify_leaves_existing_anchor_untouched() -> None:
     html = '<a href="http://x.com">http://y.com</a> and http://z.com'
     assert linkify(html, Linkify(callbacks=_no_callbacks())) == (
@@ -158,6 +164,17 @@ def test_linkify_skip_tags(skip_tag: str) -> None:
 def test_linkify_nested_skip_tag_stays_skipped() -> None:
     html = "<code><span>http://x.com</span></code>"
     assert linkify(html, Linkify(skip_tags=["code"], callbacks=_no_callbacks())) == html
+
+
+def test_linkify_checks_each_skip_tag_by_exact_name() -> None:
+    out = linkify("<code>http://x.com</code>", Linkify(skip_tags=["pre", "samp", "coder"], callbacks=_no_callbacks()))
+    assert out == '<code><a href="http://x.com">http://x.com</a></code>'
+
+
+def test_linkify_walk_does_not_depend_on_python_recursion_limit() -> None:
+    html = "<div>" * 1_200 + "http://x.com" + "</div>" * 1_200
+    out = linkify(html, Linkify(callbacks=_no_callbacks()))
+    assert out.count('<a href="http://x.com">') == 1
 
 
 def test_linkify_leaves_comment_nodes_untouched() -> None:
@@ -203,6 +220,14 @@ def test_linkify_callback_can_change_text() -> None:
     assert linkify("http://x.com", Linkify(callbacks=[shorten])) == '<a href="http://x.com">link</a>'
 
 
+def test_linkify_callback_can_clear_text() -> None:
+    def clear(link: LinkCandidate) -> LinkCandidate:
+        link.text = ""
+        return link
+
+    assert linkify("http://x.com", Linkify(callbacks=[clear])) == '<a href="http://x.com"></a>'
+
+
 def test_linkify_callback_can_add_attribute() -> None:
     def add_class(link: LinkCandidate) -> LinkCandidate:
         link.attrs["class"] = "ext"
@@ -217,10 +242,117 @@ def test_linkify_callback_chain_runs_in_order() -> None:
     assert out == '<a href="http://x.com" rel="nofollow" target="_blank">http://x.com</a>'
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        pytest.param("url", 1, id="url"),
+        pytest.param("text", 1, id="text"),
+        pytest.param("attrs", [], id="attrs"),
+    ],
+)
+def test_linkify_rejects_invalid_callback_field(field: str, value: object) -> None:
+    def invalidate(link: LinkCandidate) -> LinkCandidate:
+        setattr(link, field, value)
+        return link
+
+    with pytest.raises(TypeError):
+        linkify("http://x.com", Linkify(callbacks=[invalidate]))
+
+
+@pytest.mark.parametrize(
+    "attrs",
+    [pytest.param({1: "value"}, id="name"), pytest.param({"name": 1}, id="value")],
+)
+def test_linkify_rejects_invalid_callback_attribute(attrs: dict[object, object]) -> None:
+    def invalidate(link: LinkCandidate) -> LinkCandidate:
+        link.attrs = attrs  # ty: ignore[invalid-assignment]  # callback validation requires an invalid attrs mapping
+        return link
+
+    with pytest.raises(TypeError):
+        linkify("http://x.com", Linkify(callbacks=[invalidate]))
+
+
+@pytest.mark.parametrize(
+    ("html", "process_existing"),
+    [
+        pytest.param("http://x.com", False, id="detected"),
+        pytest.param('<a href="http://x.com">x</a>', True, id="existing"),
+    ],
+)
+def test_linkify_propagates_callback_exception(
+    html: str,
+    *,
+    process_existing: bool,
+) -> None:
+    def fail(_link: LinkCandidate) -> LinkCandidate:
+        msg = "callback failed"
+        raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="callback failed"):
+        linkify(html, Linkify(callbacks=[fail], process_existing=process_existing))
+
+
+@pytest.mark.parametrize(
+    ("html", "process_existing"),
+    [
+        pytest.param("http://x.com", False, id="detected"),
+        pytest.param('<a href="http://x.com">x</a>', True, id="existing"),
+    ],
+)
+def test_linkify_rejects_non_candidate_callback_result(
+    html: str,
+    *,
+    process_existing: bool,
+) -> None:
+    def replace(_link: LinkCandidate) -> LinkCandidate:
+        return object()  # ty: ignore[invalid-return-type]  # callback validation requires an invalid result type
+
+    with pytest.raises(AttributeError):
+        linkify(html, Linkify(callbacks=[replace], process_existing=process_existing))
+
+
+@pytest.mark.parametrize("field", ["text", "attrs"])
+@pytest.mark.parametrize(
+    ("html", "process_existing"),
+    [
+        pytest.param("http://x.com", False, id="detected"),
+        pytest.param('<a href="http://x.com">x</a>', True, id="existing"),
+    ],
+)
+def test_linkify_rejects_callback_result_with_missing_field(
+    field: str,
+    html: str,
+    *,
+    process_existing: bool,
+) -> None:
+    def remove(link: LinkCandidate) -> LinkCandidate:
+        delattr(link, field)
+        return link
+
+    with pytest.raises(AttributeError):
+        linkify(html, Linkify(callbacks=[remove], process_existing=process_existing))
+
+
 def test_linker_is_reusable() -> None:
     linker = Linker(Linkify(callbacks=_no_callbacks()))
     assert linker.linkify("http://a.example.com") == '<a href="http://a.example.com">http://a.example.com</a>'
     assert linker.linkify("http://b.example.com") == '<a href="http://b.example.com">http://b.example.com</a>'
+
+
+def test_linker_is_reusable_across_concurrent_callbacks() -> None:
+    callback_start = Barrier(4)
+
+    def annotate(link: LinkCandidate) -> LinkCandidate:
+        callback_start.wait()
+        link.attrs["data-url"] = link.url
+        link.text = link.text.upper()
+        return link
+
+    linker = Linker(Linkify(callbacks=[annotate]))
+    urls = [f"http://x{index}.com" for index in range(4)]
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(linker.linkify, urls))
+    assert results == [f'<a href="{url}" data-url="{url}">{url.upper()}</a>' for url in urls]
 
 
 def test_default_callbacks_is_nofollow() -> None:

--- a/tests/clean/test_linkify_process_existing.py
+++ b/tests/clean/test_linkify_process_existing.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from turbohtml.clean import LinkCandidate, Linkify, linkify, nofollow, target_blank
 
 if TYPE_CHECKING:
@@ -44,6 +46,24 @@ def test_process_existing_can_change_text() -> None:
     assert linkify(html, Linkify(callbacks=[relabel], process_existing=True)) == '<a href="http://x.com">link</a>'
 
 
+def test_process_existing_propagates_text_comparison_error() -> None:
+    class UncomparableText(str):  # ruff:ignore[subclass-builtin]  # native comparison accepts str subclasses
+        __slots__ = ()
+
+        def __eq__(self, _other: object) -> bool:
+            msg = "comparison failed"
+            raise RuntimeError(msg)
+
+        __hash__ = str.__hash__
+
+    def replace(link: LinkCandidate) -> LinkCandidate:
+        link.text = UncomparableText(link.text)
+        return link
+
+    with pytest.raises(RuntimeError, match="comparison failed"):
+        linkify('<a href="http://x.com">x</a>', Linkify(callbacks=[replace], process_existing=True))
+
+
 def test_process_existing_keeps_inner_markup_when_text_unchanged() -> None:
     def add_rel(link: LinkCandidate) -> LinkCandidate:
         link.attrs["rel"] = "ext"
@@ -72,6 +92,11 @@ def test_process_existing_flattens_valueless_attr() -> None:
     assert out == '<a download="">x</a>'
 
 
+def test_process_existing_preserves_empty_text_and_four_character_attr() -> None:
+    html = '<a href="http://x.com" data="x"></a>'
+    assert linkify(html, Linkify(callbacks=_no_callbacks(), process_existing=True)) == html
+
+
 def test_process_existing_anchor_without_href_stays_bare() -> None:
     html = "<a>plain</a>"
     assert linkify(html, Linkify(callbacks=[nofollow], process_existing=True)) == "<a>plain</a>"
@@ -86,6 +111,24 @@ def test_existing_flag_distinguishes_existing_from_detected() -> None:
     out = linkify(html, Linkify(callbacks=[mark], process_existing=True))
     assert '<a href="http://x.com" data-kind="existing">x</a>' in out
     assert 'data-kind="new"' in out
+
+
+def test_callbacks_follow_document_order_across_existing_and_detected_links() -> None:
+    seen: list[tuple[str, bool]] = []
+
+    def record(link: LinkCandidate) -> LinkCandidate:
+        seen.append((link.url, link.existing))
+        return link
+
+    linkify(
+        'first.com <a href="https://second.example">second</a> third.com',
+        Linkify(callbacks=[record], process_existing=True),
+    )
+    assert seen == [
+        ("http://first.com", False),
+        ("https://second.example", True),
+        ("http://third.com", False),
+    ]
 
 
 def test_process_existing_still_detects_links_in_other_tags() -> None:

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -156,7 +156,13 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "normalize": ("normalize-decomposed", lambda: INPUTS["normalize"]()[2][1]),
     "decode": ("decode-gb18030-ranges", lambda: INPUTS["decode"]()[1][1]),
 }
-_ADDITIONAL_CASES: Final[dict[str, tuple[str, int]]] = {"idna-varied": ("idna", 1)}
+_ADDITIONAL_CASES: Final[dict[str, tuple[str, int]]] = {
+    "idna-varied": ("idna", 1),
+    "linkify-traversal-small-nodes": ("linkify-traversal", 1),
+    "linkify-traversal-skipped": ("linkify-traversal", 2),
+    "linkify-traversal-callbacks": ("linkify-traversal", 3),
+    "linkify-traversal-empty-nodes": ("linkify-traversal", 4),
+}
 
 
 def _inline(operation: str, case_index: int = 0) -> object:

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -108,6 +108,11 @@ _STRIP = "code, a, q"  # a bulk set of tags to drop or unwrap
 _SET_HTML = "<p>Updated <a href='/x'>link</a> and <b>bold</b>.</p><ul><li>one</li><li>two</li></ul>"
 _SET_TEXT = "Replacement text, escaped & verbatim."
 _DETECTOR = _LinkDetector()
+_LINKER: Final[_clean.Linker] = _clean.Linker()
+_LINKER_SKIP: Final[_clean.Linker] = _clean.Linker(_clean.Linkify(skip_tags=("code",)))
+_LINKER_CALLBACKS: Final[_clean.Linker] = _clean.Linker(
+    _clean.Linkify(callbacks=(_clean.nofollow, _clean.target_blank), process_existing=True)
+)
 _ANNOTATION_RULES = {"h1": ["heading"], "b": ["emphasis"], "a": ["link"]}
 _XML = turbohtml.Html(xml=True)  # the XML/XHTML serialization config, reused across the timed calls
 
@@ -519,6 +524,17 @@ def markup_op(case: tuple[str, object]) -> None:
 def linkify(text: str) -> None:
     """Auto-link URLs and emails in HTML with turbohtml, parsing and rewriting the tree."""
     _linkify(text)
+
+
+def linkify_traversal(case: tuple[str, str]) -> None:
+    """Reuse compiled options so the benchmark isolates traversal."""
+    kind, text = case
+    if kind == "skip":
+        _LINKER_SKIP.linkify(text)
+    elif kind == "callbacks":
+        _LINKER_CALLBACKS.linkify(text)
+    else:
+        _LINKER.linkify(text)
 
 
 def detect(case: tuple[str, str]) -> None:
@@ -980,6 +996,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "markup": (markup, "turbohtml"),
     "markup-op": (markup_op, "turbohtml"),
     "linkify": (linkify, "turbohtml"),
+    "linkify-traversal": (linkify_traversal, "turbohtml"),
     "detect": (detect, "turbohtml"),
     "normalize": (normalize, "turbohtml"),
     "escape-identifier": (escape_identifier, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -332,6 +332,7 @@ OPERATIONS: dict[str, Operation] = {
     "markup": Operation("markupsafe-compatible escape", "ns"),
     "markup-op": Operation("Markup operations", "ns"),
     "linkify": Operation("linkify HTML", "us"),
+    "linkify-traversal": Operation("linkify with native tree traversal", "us"),
     "detect": Operation("detect links in text", "us"),
     "markdown": Operation("HTML to Markdown", "us"),
     "markdown-google": Operation("Google Docs export to Markdown", "us"),
@@ -448,6 +449,17 @@ _LINKIFY_CASES = (
     ("comment (1 link, 1 email)", "Ping me at bob@example.com or see https://example.com for details."),
     ("prose (1 KiB)", "See https://example.com/path?q=1 and visit www.example.org for more. " * 15),
     ("markup (4 KiB)", '<p>Read <a href="https://kept.example">the post</a> then go to https://example.com/x. ' * 45),
+)
+
+_LINKIFY_TRAVERSAL_CASES: Final[tuple[tuple[str, tuple[str, str]], ...]] = (
+    ("text-heavy tree", ("default", "<article><p>" + "plain prose " * 8_000 + "https://example.com</p></article>")),
+    ("2,000 small text nodes", ("default", "<div>" + "<span>plain</span>" * 2_000 + "</div>")),
+    ("2,000 skipped nodes", ("skip", "<code><span>https://example.com</span></code>" * 2_000)),
+    (
+        "400 callback links",
+        ("callbacks", '<a href="https://kept.example">kept</a> https://example.com ' * 200),
+    ),
+    ("2,000 nodes without text", ("default", "<div></div>" * 2_000)),
 )
 
 _MARKDOWN_ARTICLE = "<h2>Heading</h2><p>A <b>bold</b> <a href='/x'>link</a> and <code>code</code>.</p>" * 18
@@ -952,6 +964,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("join (escapes operands)", ("join", _MARKUP_JOIN_PARTS)),
     ),
     "linkify": lambda: _LINKIFY_CASES,
+    "linkify-traversal": lambda: _LINKIFY_TRAVERSAL_CASES,
     "detect": lambda: (
         ("find comment (1 link, 1 email)", ("find", _LINKIFY_CASES[0][1])),
         ("find prose (1 KiB)", ("find", _LINKIFY_CASES[1][1])),

--- a/tox.toml
+++ b/tox.toml
@@ -120,6 +120,7 @@ commands = [
   { replace = "if", condition = "factor['3.14t'] or factor['3.15t']", then = [
     "pytest",
     "{tox_root}{/}tests{/}dom{/}test_tree_freethread.py",
+    "{tox_root}{/}tests{/}clean{/}test_linkify.py::test_linker_is_reusable_across_concurrent_callbacks",
     "--no-cov",
     "--parallel-threads=auto",
     "--iterations=20",
@@ -471,12 +472,14 @@ commands_pre = [
 ]
 commands = [
   [
+    # let TSan reports reach the console; pytest otherwise captures them
     "pytest",
-    "-s",                                                 # let TSan reports reach the console; pytest otherwise captures them
+    "-s",
     "--no-cov",
     "--parallel-threads=auto",
     "--iterations=20",
     "{tox_root}{/}tests{/}dom{/}test_tree_freethread.py",
+    "{tox_root}{/}tests{/}clean{/}test_linkify.py::test_linker_is_reusable_across_concurrent_callbacks",
   ],
 ]
 


### PR DESCRIPTION
⚡ `Linker.linkify()` crossed into Python for every node, creating wrappers and recursive calls before native link detection began. Closes #715 by keeping structural traversal off the Python hot path. This draft follows the replacement stack #742 → #732 → #737.

🧵 One native operation now collects eligible text and existing-anchor targets in document order, snapshots callback inputs while holding the tree lock, releases the lock for Python callbacks, and applies each result afterward. The target list owns its wrappers across callbacks, and candidate state remains local to each call so a `Linker` can serve concurrent callers. Fresh anchors skip the zero-length attribute-array copy before setting their first attribute.

Across the five requested local pyperf cases, the issue-711 base to this branch measured 222.1 to 206.8 µs for text-heavy HTML, 918.3 to 339.1 µs for 2,000 small text nodes, 1,093.4 to 450.8 µs for 2,000 skipped nodes, 746.5 to 393.5 µs for 400 callback links, and 514.1 to 163.7 µs for 2,000 empty nodes. The 2,000-small-node cProfile fell from 12,007 Python calls, including 2,002 recursive walks and 2,000 scanner calls, to four calls.
