### PR TITLE
🐛 fix(clean): block SVG animation

### DIFF
--- a/docs/changelog/709.bugfix.rst
+++ b/docs/changelog/709.bugfix.rst
@@ -1,0 +1,1 @@
+Reject SVG animation elements that can assign event handlers or script URLs at runtime.

--- a/docs/explanation/sanitizing.rst
+++ b/docs/explanation/sanitizing.rst
@@ -68,6 +68,11 @@ event-handler and URL baseline unconditional, so a custom-element policy is safe
 ``style`` policy is. Only basic custom-element names reach the matcher -- a hyphenated name clear of the reserved
 ``annotation-xml``/``font-face`` set -- so a matcher cannot be tricked into keeping a real foreign element by its name.
 
+SVG animation needs an element rule in addition to direct attribute checks. ``animate``, ``set``, ``animateMotion``,
+``animateTransform``, and ``animateColor`` can assign the attribute named by ``attributeName`` at runtime. A value in
+``from``, ``to``, or ``values`` can write a script URL or event handler without placing that value in a direct URL or
+``on*`` attribute. The baseline blocks these animation elements under custom SVG allowlists.
+
 The string API parses into the private tree that the native walk mutates. The internal Element entrypoint snapshots its
 input under the tree's critical section, then releases the shared tree before invoking a policy callback. Callback code
 may retain or mutate the original tree without racing the sanitizer's private copy.

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -119,7 +119,8 @@ element. The safety baseline still runs on whatever the matcher keeps, so an ``o
 
 ``Policy.allow_html``, ``Policy.allow_svg``, and ``Policy.allow_mathml`` gate each namespace independently, DOMPurify's
 ``USE_PROFILES``. All default on; turning one off drops that whole namespace even when its tags are allowlisted, so a
-policy can keep SVG but not MathML:
+policy can keep SVG but not MathML. The baseline blocks SVG animation elements under an SVG policy because they can
+assign event handlers or script URLs at runtime.
 
 .. testcode::
 

--- a/src/turbohtml/_c/clean/sanitize.c
+++ b/src/turbohtml/_c/clean/sanitize.c
@@ -101,6 +101,27 @@ static int is_unsafe_tag(uint16_t atom) {
     }
 }
 
+static int is_unsafe_svg_animation(const th_node *element) {
+    if (element->ns != TH_NS_SVG) {
+        return 0;
+    }
+    static const char *const names[] = {"animate", "animateColor", "animateMotion", "animateTransform", "set"};
+    for (size_t index = 0; index < sizeof(names) / sizeof(names[0]); index++) {
+        size_t len = strlen(names[index]);
+        if (element->text_len != (Py_ssize_t)len) {
+            continue;
+        }
+        size_t position = 0;
+        while (position < len && element->text[position] == (Py_UCS4)names[index][position]) {
+            position++;
+        }
+        if (position == len) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* Attributes whose value is a URL, so its scheme is checked against the allowlist. Matched on the interned name bytes.
  */
 static int is_url_attr(const char *name, Py_ssize_t len) {
@@ -1669,7 +1690,9 @@ static int sanitize_element(sanitizer *s, th_node *element, int parent_kept) {
        the unsafe-tag block: a policy that allowlists it keeps it with its body scrubbed
        against css_properties (like a `style` attribute), rather than dropping its CSS. */
     int style_element = element->atom == TH_TAG_STYLE && is_html;
-    int allowed = (is_unsafe_tag(element->atom) && !style_element) ? 0 : PySet_Contains(s->tags, tag);
+    int allowed = ((is_unsafe_tag(element->atom) && !style_element) || is_unsafe_svg_animation(element))
+                      ? 0
+                      : PySet_Contains(s->tags, tag);
     /* USE_PROFILES: a policy enables the HTML, SVG, and MathML namespaces independently, so a whole namespace can be
        dropped regardless of the tag allowlist (an SVG-only policy keeps <svg> and drops <math>, or the reverse) */
     int ns_allowed = element->ns == TH_NS_HTML  ? s->allow_html

--- a/src/turbohtml/clean/_sanitizer.py
+++ b/src/turbohtml/clean/_sanitizer.py
@@ -199,7 +199,8 @@ class Policy:
         ``USE_PROFILES.html``. Independent of the tag allowlist, so it composes with ``allow_svg``/``allow_mathml`` to
         select which content languages a policy admits.
     :param allow_svg: keep SVG-namespace elements, DOMPurify's ``USE_PROFILES.svg``. Off drops every SVG element even
-        when its tag is in ``tags``.
+        when its tag is in ``tags``. The baseline rejects SVG animation elements because they can assign event handlers
+        or script URLs at runtime; an allowlist cannot keep them.
     :param allow_mathml: keep MathML-namespace elements, DOMPurify's ``USE_PROFILES.mathMl``. Off drops every MathML
         element even when its tag is in ``tags``.
     :param xml: emit well-formed XML/XHTML instead of HTML, DOMPurify's ``RETURN_DOM`` served through the XML

--- a/tests/clean/test_sanitizer.py
+++ b/tests/clean/test_sanitizer.py
@@ -158,6 +158,32 @@ def test_allowlisted_foreign_script_is_still_escaped() -> None:
     assert "<script>" not in out
 
 
+@pytest.mark.parametrize(
+    "tag",
+    [
+        pytest.param("animate", id="animate"),
+        pytest.param("animateColor", id="animate-color"),
+        pytest.param("animateMotion", id="animate-motion"),
+        pytest.param("animateTransform", id="animate-transform"),
+        pytest.param("set", id="set"),
+    ],
+)
+def test_svg_animation_is_blocked_by_an_allowlist(tag: str) -> None:
+    policy = Policy(tags=frozenset({"svg", tag}), attributes={"*": frozenset({"*"})})
+    assert f"<{tag}" not in sanitize(f'<svg><{tag} attributeName="xlink:href" to="javascript:x"></{tag}></svg>', policy)
+
+
+def test_svg_animation_name_matching_is_case_adjusted() -> None:
+    policy = Policy(tags=frozenset({"svg", "animate"}), attributes={"*": frozenset({"*"})})
+    assert "<animate" not in sanitize(
+        '<svg><ANIMATE ATTRIBUTENAME="xlink:href" TO="javascript:x"></ANIMATE></svg>', policy
+    )
+
+
+def test_html_element_named_animate_is_not_svg_animation() -> None:
+    assert sanitize("<animate>text</animate>", Policy(tags=frozenset({"animate"}))) == "<animate>text</animate>"
+
+
 def test_set_attributes_adds_absent_attributes() -> None:
     # set_attributes forces attributes onto kept elements even when the allowlist would not admit them
     policy = Policy(

--- a/tests/clean/test_sanitizer_dompurify.py
+++ b/tests/clean/test_sanitizer_dompurify.py
@@ -75,10 +75,11 @@ _IDS = [
 _PERMISSIVE_TAGS = frozenset({
     "a", "abbr", "b", "blockquote", "br", "button", "caption", "cite", "code", "col", "colgroup", "dd", "del", "div",
     "dl", "dt", "em", "figcaption", "figure", "form", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "input",
-    "ins", "label", "li", "mark", "ol", "option", "p", "pre", "q", "s", "select", "small", "span", "strong", "style",
+    "ins", "label", "li", "mark", "ol", "option", "p", "pre", "q", "s", "script", "select", "small", "span",
+    "strong", "style",
     "sub", "sup", "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "tr", "u", "ul",
     "svg", "g", "rect", "circle", "path", "defs", "filter", "fegaussianblur", "image", "title", "desc",
-    "foreignobject", "text", "use", "animate", "set",
+    "foreignobject", "text", "use", "animate", "animateColor", "animateMotion", "animateTransform", "set",
     "math", "mi", "mo", "mn", "ms", "mtext", "mrow", "mglyph", "annotation-xml",
 })  # fmt: skip
 _PERMISSIVE = Policy(
@@ -97,6 +98,7 @@ _POLICIES = [
 _DANGER_TAGS = frozenset({"script", "iframe", "object", "embed", "frame", "style", "noscript", "base"})
 _DANGER_SCHEMES = ("javascript:", "data:", "vbscript:")
 _URL_ATTRS = frozenset({"href", "src", "action", "xlink:href", "formaction", "poster", "background", "cite", "ping"})
+_SVG_ANIMATION_TAGS = frozenset({"animate", "animateColor", "animateMotion", "animateTransform", "set"})
 # CSS constructs that execute or fetch when a kept <style> body or style attribute survives the property scrub.
 _CSS_DANGER = ("javascript:", "vbscript:", "expression(", "@import", "behavior:", "-moz-binding")
 
@@ -120,12 +122,23 @@ def _bad_scheme(value: str) -> bool:
 
 
 def _dangerous_element(node: Element) -> str | None:
-    """A label for a scriptable element kept in the HTML namespace (a kept ``<style>`` only if its body survived)."""
-    if node.tag not in _DANGER_TAGS or node.namespace.value != "html":
+    namespace = node.namespace.value
+    if namespace == "svg" and node.tag in _SVG_ANIMATION_TAGS:
+        attrs = {name.lower(): _attr_value(value) for name, value in node.attrs.items()}
+        target = attrs.get("attributename", "")
+        if target.startswith("on"):
+            return f"<{node.tag}>->{target}"
+        if target in _URL_ATTRS:
+            for name in ("from", "to", "values"):
+                if any(_bad_scheme(value) for value in attrs.get(name, "").split(";")):
+                    return f"<{node.tag}>->{target}"
+    if node.tag == "script" and namespace in {"html", "svg"}:
+        return "<script>"
+    if node.tag == "style" and namespace in {"html", "svg"}:
+        return "style-body" if any(token in _style_body(node) for token in _CSS_DANGER) else None
+    if node.tag not in _DANGER_TAGS or namespace != "html":
         return None
-    if node.tag != "style":
-        return f"<{node.tag}>"
-    return "style-body" if any(token in _style_body(node) for token in _CSS_DANGER) else None
+    return f"<{node.tag}>"
 
 
 def _dangerous_attribute(name: str, value: str) -> str | None:
@@ -184,14 +197,52 @@ def test_attr_value_normalizes_every_shape() -> None:
     ("html", "survived"),
     [
         pytest.param("<script>alert(1)</script>", ["<script>"], id="scriptable-element"),
-        pytest.param("<svg><script>alert(1)</script></svg>", [], id="scriptable-element-in-svg-namespace-inert"),
+        pytest.param("<svg><script>alert(1)</script></svg>", ["<script>"], id="svg-script"),
         pytest.param("<style>a{background:url(javascript:alert(1))}</style>", ["style-body"], id="style-body-danger"),
         pytest.param("<style>a{color:red}</style>", [], id="style-body-benign"),
+        pytest.param("<svg><style>a{behavior:url(#x)}</style></svg>", ["style-body"], id="svg-style-danger"),
+        pytest.param("<svg><style>a{fill:red}</style></svg>", [], id="svg-style-benign"),
         pytest.param('<img src=x onerror="alert(1)">', ["@onerror"], id="event-handler"),
         pytest.param('<p style="behavior:url(#x)">x</p>', ["@style"], id="style-attr-danger"),
         pytest.param('<p style="color:red">x</p>', [], id="style-attr-benign"),
         pytest.param('<a href="javascript:alert(1)">x</a>', ["href=javascript:alert(1)"], id="url-danger"),
         pytest.param('<a href="https://example.com">x</a>', [], id="url-benign"),
+        pytest.param(
+            '<svg><animate attributeName="xlink:href" from="javascript:x"></animate></svg>',
+            ["<animate>->xlink:href"],
+            id="svg-animation-from",
+        ),
+        pytest.param(
+            '<svg><set attributeName="XLINK:HREF" to="JAVASCRIPT:x"></set></svg>',
+            ["<set>->xlink:href"],
+            id="svg-animation-to-case",
+        ),
+        pytest.param(
+            '<svg><animateTransform attributeName="xlink:href" values="https://safe;javascript:x"></animateTransform></svg>',
+            ["<animateTransform>->xlink:href"],
+            id="svg-animation-values",
+        ),
+        pytest.param(
+            '<svg><animate attributeName="onload" to="alert(1)"></animate></svg>',
+            ["<animate>->onload"],
+            id="svg-animation-handler",
+        ),
+        pytest.param(
+            '<svg><animate attributeName="fill" to="red"></animate></svg>',
+            [],
+            id="svg-animation-non-url-target",
+        ),
+        pytest.param(
+            '<svg><animate attributeName="xlink:href" from="https://example.com"></animate></svg>',
+            [],
+            id="svg-animation-safe-url",
+        ),
+        pytest.param(
+            '<animate attributeName="xlink:href" from="javascript:x"></animate>',
+            [],
+            id="html-animation-name-inert",
+        ),
+        pytest.param("<iframe></iframe>", ["<iframe>"], id="dangerous-html-element"),
     ],
 )
 def test_live_danger_labels_every_executable_construct(html: str, survived: list[str]) -> None:

--- a/tests/conformance/test_sanitizer_dompurify_conformance.py
+++ b/tests/conformance/test_sanitizer_dompurify_conformance.py
@@ -122,7 +122,9 @@ _REMOVE_WITH_CONTENT = frozenset({
     "script", "style", "noscript", "template", "noembed", "noframes", "iframe", "object", "embed",
 })  # fmt: skip
 _STRUCTURAL_TAGS = frozenset(Policy.relaxed().tags | {
-    "form", "input", "select", "button", "svg", "circle", "rect", "g", "path", "defs", "filter", "image", "text",
+    "form", "input", "select", "button", "script", "svg", "circle", "rect", "g", "path", "defs", "filter", "image",
+    "text",
+    "animate", "animateColor", "animateMotion", "animateTransform", "set",
     "math", "mi", "mn", "mo", "mrow", "mtext", "ms", "style",
 })  # fmt: skip
 
@@ -150,10 +152,10 @@ _MODES: dict[str, Policy] = {
     "profile-mathml": replace(_BASE, allow_html=False, allow_svg=False),
 }
 
-# --- inertness oracle: what executes if a sanitized string is assigned to innerHTML ---------------------------------
 _DANGER_TAGS = frozenset({"script", "iframe", "object", "embed", "frame", "style", "noscript", "base"})
 _DANGER_SCHEMES = ("javascript:", "data:", "vbscript:")
 _URL_ATTRS = frozenset({"href", "src", "action", "xlink:href", "formaction", "poster", "background", "cite", "ping"})
+_SVG_ANIMATION_TAGS = frozenset({"animate", "animateColor", "animateMotion", "animateTransform", "set"})
 _CSS_DANGER = ("javascript:", "vbscript:", "expression(", "@import", "behavior:", "-moz-binding")
 _TEMPLATE_OPENERS = ("{{", "${", "<%")
 
@@ -186,12 +188,27 @@ def _live_danger(html: str) -> list[str]:
     while stack:
         node = stack.pop()
         if isinstance(node, Element):
-            if node.tag in _DANGER_TAGS and node.namespace.value == "html":
+            namespace = node.namespace.value
+            if namespace == "svg" and node.tag in _SVG_ANIMATION_TAGS:
+                attrs = {name.lower(): _attr_value(value) for name, value in node.attrs.items()}
+                target = attrs.get("attributename", "")
+                if target.startswith("on") or (
+                    target in _URL_ATTRS
+                    and any(
+                        _bad_scheme(value)
+                        for name in ("from", "to", "values")
+                        for value in attrs.get(name, "").split(";")
+                    )
+                ):
+                    survived.append(f"<{node.tag}>->{target}")
+            if node.tag == "script" and namespace in {"html", "svg"}:
+                survived.append("<script>")
+            elif node.tag == "style" and namespace in {"html", "svg"}:
                 body = "".join(getattr(child, "data", "") for child in node.children).lower()
-                if node.tag != "style":
-                    survived.append(f"<{node.tag}>")
-                elif any(token in body for token in _CSS_DANGER):
+                if any(token in body for token in _CSS_DANGER):
                     survived.append("style-body")
+            elif node.tag in _DANGER_TAGS and namespace == "html":
+                survived.append(f"<{node.tag}>")
             survived.extend(
                 hit
                 for name, raw in node.attrs.items()
@@ -345,11 +362,23 @@ def test_corpus_exercises_the_oracle() -> None:
     ("html", "survived"),
     [
         pytest.param("<script>alert(1)</script>", ["<script>"], id="scriptable-element"),
-        pytest.param("<svg><script>alert(1)</script></svg>", [], id="svg-namespace-script-inert"),
+        pytest.param("<svg><script>alert(1)</script></svg>", ["<script>"], id="svg-script"),
+        pytest.param("<svg><style>a{behavior:url(#x)}</style></svg>", ["style-body"], id="svg-style-danger"),
+        pytest.param("<svg><style>a{fill:red}</style></svg>", [], id="svg-style-benign"),
         pytest.param('<img src=x onerror="alert(1)">', ["@onerror"], id="event-handler"),
         pytest.param('<a href="javascript:alert(1)">x</a>', ["href=javascript:alert(1)"], id="url-danger"),
         pytest.param('<a href="https://example.com">x</a>', [], id="url-benign"),
         pytest.param("<style>a{behavior:url(#x)}</style>", ["style-body"], id="style-body-danger"),
+        pytest.param(
+            '<svg><animate attributeName="xlink:href" from="javascript:x"></animate></svg>',
+            ["<animate>->xlink:href"],
+            id="svg-animation-url",
+        ),
+        pytest.param(
+            '<svg><set attributeName="onload" to="alert(1)"></set></svg>',
+            ["<set>->onload"],
+            id="svg-animation-handler",
+        ),
     ],
 )
 def test_live_danger_labels_every_executable_construct(html: str, survived: list[str]) -> None:


### PR DESCRIPTION
A permissive custom policy could retain SVG animation elements that assign a script URL or event handler at runtime without storing the executable value in a direct attribute. 🔒 This replacement preserves the scope of [#731](https://github.com/tox-dev/turbohtml/pull/731) after that PR was merged into a stacked base that had to be restored.

The native sanitizer baseline rejects active SVG animation before consulting policy. The DOMPurify compatibility oracle classifies SVG script, style, and animation output by their runtime behavior rather than treating every retained SVG element as inert.

The branch builds on the final safety pass in [#728](https://github.com/tox-dev/turbohtml/pull/728), so policy-written attributes and active SVG elements share one mandatory native boundary. This replacement closes #709.
