### PR TITLE
🧪 test(parser): use living WPT data

### DIFF
--- a/docs/changelog/719.misc.rst
+++ b/docs/changelog/719.misc.rst
@@ -1,1 +1,2 @@
-Track the pinned living WPT tree-construction corpus with fixture and parse-error results.
+Use the pinned living WPT tree-construction corpus in the ordinary parser, serializer, and PGO suites. Compare
+foreign-content ``</p>`` and ``</br>`` trees directly with WPT's fixture expectations.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -37,10 +37,10 @@ turbohtml uses `tox <https://tox.wiki>`_ with `tox-uv <https://github.com/tox-de
     $ git submodule update --init tests/html5lib-tests   # tokenizer and encoding conformance data
     $ uvx --with tox-uv tox r -e 3.14   # build, test, and check coverage
 
-The ``tests/html5lib-tests`` submodule holds the tokenizer and encoding conformance data. Do not initialize
-every submodule: the ``tools/bench-data`` submodules reference multi-MiB real documents (pinned upstream commits,
-nothing copied into this repository) that ``tox r -e bench`` reads and nothing else; fetch them on demand with ``git
-submodule update --init --depth 1 tools/bench-data/whatwg-html tools/bench-data/war-and-peace``.
+The ``tests/html5lib-tests`` submodule holds the tokenizer and encoding conformance data. Do not initialize every
+submodule: the ``tools/bench-data`` submodules reference multi-MiB real documents (pinned upstream commits, nothing
+copied into this repository) that ``tox r -e bench`` reads and nothing else; fetch them on demand with ``git submodule
+update --init --depth 1 tools/bench-data/whatwg-html tools/bench-data/war-and-peace``.
 
 ``tox r -e 3.14`` builds the extension, runs the test suite, and **fails unless both Python and C coverage are 100%**
 (line and branch). Other environments: ``type`` (`ty <https://github.com/astral-sh/ty>`_), ``docs`` (Sphinx), ``fix``

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -34,10 +34,10 @@ turbohtml uses `tox <https://tox.wiki>`_ with `tox-uv <https://github.com/tox-de
 
     $ git clone https://github.com/tox-dev/turbohtml
     $ cd turbohtml
-    $ git submodule update --init tests/html5lib-tests   # conformance data for the test suite
+    $ git submodule update --init tests/html5lib-tests   # tokenizer and encoding conformance data
     $ uvx --with tox-uv tox r -e 3.14   # build, test, and check coverage
 
-The ``tests/html5lib-tests`` submodule holds the conformance suite that one of the tests runs against. Do not initialize
+The ``tests/html5lib-tests`` submodule holds the tokenizer and encoding conformance data. Do not initialize
 every submodule: the ``tools/bench-data`` submodules reference multi-MiB real documents (pinned upstream commits,
 nothing copied into this repository) that ``tox r -e bench`` reads and nothing else; fetch them on demand with ``git
 submodule update --init --depth 1 tools/bench-data/whatwg-html tools/bench-data/war-and-peace``.
@@ -91,13 +91,13 @@ parse5). The convention is deliberate:
     $ git submodule update --init tests/conformance/parse5   # fetch one oracle
     $ tox r -e conformance                                    # run the suites against their oracles
 
-The vendored ``html5lib-tests`` conformance data is separate: it lives under ``tests/dom``, ``tests/tokenizer``, and
-``tests/encoding`` (not ``tests/conformance``) and runs in the ordinary matrix, so it is unaffected by the above.
+The vendored ``html5lib-tests`` tokenizer and encoding data runs in the ordinary matrix, so it is unaffected by the
+above.
 
-The committed ``tests/conformance/data/wpt_html_tree.json`` tracks the living WPT tree-construction corpus as a source
-apart from the frozen ``html5lib-tests`` data. Refresh it every three months and before releases or after WHATWG parsing
-changes. Check out the desired WPT revision before running the one command that updates the pin and prints the tree and
-parse-error results:
+The committed ``tests/conformance/data/wpt_html_tree.json`` supplies the living WPT tree-construction corpus to the
+ordinary parser, serializer, and PGO suites as well as the dedicated conformance job. Refresh it every three months and
+before releases or after WHATWG parsing changes. Check out the desired WPT revision before running the command that
+updates the pin and prints the tree and parse-error results:
 
 ::
 

--- a/docs/explanation/parsing.rst
+++ b/docs/explanation/parsing.rst
@@ -61,9 +61,8 @@ its input stream's encoding and its parser's ``documentEncoding``.
 <https://html.spec.whatwg.org/multipage/parsing.html#tokenization>`_ (the same state machine inside every browser)
 rather than a regex approximation like :class:`python:html.parser.HTMLParser`. The C implementation mirrors the spec
 state by state so the two read side by side, and the shared `html5lib-tests
-<https://github.com/html5lib/html5lib-tests>`_ conformance suite that browsers and parser libraries validate against
-checks it at all three input storage widths, once per width, because the token stream must be invariant to how CPython
-stores the string.
+<https://github.com/html5lib/html5lib-tests>`_ tokenizer suite checks it at all three input storage widths, once per
+width, because the token stream must be invariant to how CPython stores the string.
 
 Two decisions bound the tokenizer's scope:
 
@@ -108,9 +107,9 @@ times faster.
 
 :func:`turbohtml.parse` runs the full `WHATWG tree-construction algorithm
 <https://html.spec.whatwg.org/multipage/parsing.html#tree-construction>`_ on top of the tokenizer (the insertion modes,
-the adoption agency, foreign content, and the error recovery a browser performs); the same `html5lib-tests
-<https://github.com/html5lib/html5lib-tests>`_ tree-construction suite browsers use validates it. The result is the tree
-a browser builds for the same bytes.
+the adoption agency, foreign content, and the error recovery a browser performs); WPT's living `HTML parsing data
+<https://github.com/web-platform-tests/wpt/tree/master/html/syntax/parsing/resources>`_ validates it. The result is the
+tree a browser builds for the same bytes.
 
 turbohtml builds the tree in C as a pointer-linked node graph in a single bump-allocated arena, the layout `lexbor
 <https://lexbor.com>`_, Go's ``x/net/html``, and html5ever all converge on. It holds **no Python objects**. Element

--- a/docs/explanation/parsing.rst
+++ b/docs/explanation/parsing.rst
@@ -107,9 +107,10 @@ times faster.
 
 :func:`turbohtml.parse` runs the full `WHATWG tree-construction algorithm
 <https://html.spec.whatwg.org/multipage/parsing.html#tree-construction>`_ on top of the tokenizer (the insertion modes,
-the adoption agency, foreign content, and the error recovery a browser performs); WPT's living `HTML parsing data
-<https://github.com/web-platform-tests/wpt/tree/master/html/syntax/parsing/resources>`_ validates it. The result is the
-tree a browser builds for the same bytes.
+the adoption agency, foreign content, and the error recovery a browser performs); the pinned revision of WPT's `HTML
+parsing data
+<https://github.com/web-platform-tests/wpt/tree/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources>`_
+validates it. The result is the tree a browser builds for the same bytes.
 
 turbohtml builds the tree in C as a pointer-linked node graph in a single bump-allocated arena, the layout `lexbor
 <https://lexbor.com>`_, Go's ``x/net/html``, and html5ever all converge on. It holds **no Python objects**. Element

--- a/docs/explanation/serialization.rst
+++ b/docs/explanation/serialization.rst
@@ -29,7 +29,7 @@ is one rendering of it.
 A :class:`~turbohtml.Minify` is a serialization mode on that same conformant tree, and its design rule is that the
 minified bytes must reparse to the same tree: the hard part, a spec-correct parse, is already done, so minifying is only
 allowed to drop or fold what the parser reconstructs on the way back in. That gives a single correctness gate:
-``minify(parse(minify(parse(src))))`` equals ``minify(parse(src))``, checked across the html5lib-tests corpus and real
+``minify(parse(minify(parse(src))))`` equals ``minify(parse(src))``, checked across the WPT parsing corpus and real
 pages. Whitespace folds to one space rather than disappearing (a single space reparses in place, so the fold is
 idempotent); optional tags are omitted only away from open formatting elements, because the adoption agency would
 otherwise reconstruct one across the gap and shift the tree; and a value is unquoted only when no character could end or

--- a/docs/how-this-was-built.rst
+++ b/docs/how-this-was-built.rst
@@ -13,6 +13,6 @@ None of this would exist without that prior work. turbohtml stands on the should
 those ecosystems and on the specifications for HTML, CSS, and JavaScript and the people who wrote them. My thanks to all
 of them.
 
-Some engines owe a specific debt. The html5lib-tests conformance suite and lexbor shaped the parser and tree builder;
-the encoding and language detectors follow the models chardetng and whatlang published. Where I reused another project's
-code or data, its license requires attribution, which lives in the ``LICENSE`` file at the repository root.
+Some engines owe a specific debt. The html5lib-tests and WPT conformance data and lexbor shaped the parser and tree
+builder; the encoding and language detectors follow the models chardetng and whatlang published. Where I reused another
+project's code or data, its license requires attribution, which lives in the ``LICENSE`` file at the repository root.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,9 +94,9 @@ These rules shape every part of turbohtml, from the C core to the typed surface 
    toolchains alike, before a change lands.
 4. **WHATWG conformance first.** The tokenizer and tree builder follow the `WHATWG HTML standard
    <https://html.spec.whatwg.org/>`_ state by state. The tokenizer uses `html5lib-tests
-   <https://github.com/html5lib/html5lib-tests>`_; the tree builder uses WPT's living `HTML parsing data
-   <https://github.com/web-platform-tests/wpt/tree/master/html/syntax/parsing/resources>`_. turbohtml matches a
-   competitor's behavior only where the spec leaves it open.
+   <https://github.com/html5lib/html5lib-tests>`_; the tree builder uses the pinned revision of WPT's `HTML parsing data
+   <https://github.com/web-platform-tests/wpt/tree/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources>`_.
+   turbohtml matches a competitor's behavior only where the spec leaves it open.
 5. **Free-threading ready.** The extension holds no shared mutable state and declares free-threading support, and every
    tree edit and string read runs under a per-tree critical section. A read snapshots the arena before any Python
    callback runs, so a concurrent mutation can never tear a walk.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,9 +93,10 @@ These rules shape every part of turbohtml, from the C core to the typed surface 
    documentation. Both Python and C coverage gates require 100% line and branch coverage, on the gcc and llvm-cov
    toolchains alike, before a change lands.
 4. **WHATWG conformance first.** The tokenizer and tree builder follow the `WHATWG HTML standard
-   <https://html.spec.whatwg.org/>`_ state by state, validated against the shared `html5lib-tests
-   <https://github.com/html5lib/html5lib-tests>`_ suite browsers use. turbohtml matches a competitor's behavior only
-   where the spec leaves it open.
+   <https://html.spec.whatwg.org/>`_ state by state. The tokenizer uses `html5lib-tests
+   <https://github.com/html5lib/html5lib-tests>`_; the tree builder uses WPT's living `HTML parsing data
+   <https://github.com/web-platform-tests/wpt/tree/master/html/syntax/parsing/resources>`_. turbohtml matches a
+   competitor's behavior only where the spec leaves it open.
 5. **Free-threading ready.** The extension holds no shared mutable state and declares free-threading support, and every
    tree edit and string read runs under a per-tree critical section. A read snapshots the arena before any Python
    callback runs, so a concurrent mutation can never tear a walk.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,45 +267,45 @@ lint.select = [
   "ALL",
 ]
 lint.ignore = [
-  "COM812",  # conflicts with the formatter
+  "missing-trailing-comma",  # conflicts with the formatter
   "CPY",     # no copyright statements
-  "D203",    # incompatible with D211
-  "D212",    # incompatible with D213
+  "incorrect-blank-line-before-class",    # incompatible with D211
+  "multi-line-summary-first-line",    # incompatible with D213
   "DOC",     # no support yet
-  "ISC001",  # conflicts with the formatter
-  "PLR2004", # comparing against literal numbers is clear enough on its own
+  "single-line-implicit-string-concatenation",  # conflicts with the formatter
+  "magic-value-comparison", # comparing against literal numbers is clear enough on its own
 ]
 lint.per-file-ignores."docs/conf.py" = [
-  "ANN401",  # the autodoc-engine wrappers forward Sphinx's arbitrary *args/**kwargs
-  "INP001",  # Sphinx config is not part of a package
-  "PLC0415", # Sphinx internals are imported lazily inside setup(), only when the build runs
-  "PLC2701", # patching the Sphinx 9 functional autodoc engine requires its private _dynamic modules
-  "SLF001",  # ... and replacing their private signature/property builders for the C extension
+  "any-type",  # the autodoc-engine wrappers forward Sphinx's arbitrary *args/**kwargs
+  "implicit-namespace-package",  # Sphinx config is not part of a package
+  "import-outside-top-level", # Sphinx internals are imported lazily inside setup(), only when the build runs
+  "import-private-name", # patching the Sphinx 9 functional autodoc engine requires its private _dynamic modules
+  "private-member-access",  # ... and replacing their private signature/property builders for the C extension
 ]
 lint.per-file-ignores."src/turbohtml/{clean,extract,query}/__init__.py" = [
-  "RUF067", # the public module's implementation lives in its package __init__, re-exported unchanged
+  "non-empty-init-module", # the public module's implementation lives in its package __init__, re-exported unchanged
 ]
 lint.per-file-ignores."tasks/**/*.py" = [
-  "INP001", # no implicit namespace
-  "S404",   # subprocess is required to drive git, gh and towncrier
-  "S603",   # the release script runs fixed git/gh subcommands, not external input
-  "S607",   # git and gh are resolved from PATH
-  "T201",   # progress output to the console is intentional
+  "implicit-namespace-package", # no implicit namespace
+  "suspicious-subprocess-import",   # subprocess is required to drive git, gh and towncrier
+  "subprocess-without-shell-equals-true",   # the release script runs fixed git/gh subcommands, not external input
+  "start-process-with-partial-path",   # git and gh are resolved from PATH
+  "print",   # progress output to the console is intentional
 ]
 lint.per-file-ignores."tests/**/*.py" = [
   "D",       # don't document tests
-  "INP001",  # no implicit namespace
-  "PLC2701", # the conformance harness drives the private _html._tokenize_states hook
-  "S101",    # asserts allowed in tests
-  "SLF001",  # same private hook
+  "implicit-namespace-package",  # no implicit namespace
+  "import-private-name", # the conformance harness drives the private _html._tokenize_states hook
+  "assert",    # asserts allowed in tests
+  "private-member-access",  # same private hook
 ]
 lint.per-file-ignores."tools/**/*.py" = [
-  "INP001", # no implicit namespace
-  "S311",   # benchmark data is pseudo-random on purpose, nothing cryptographic
-  "S404",   # generate_version.py shells out to git to derive the version
-  "S603",   # fixed git subcommands, not external input
-  "S607",   # git is resolved from PATH
-  "T201",   # print allowed in scripts
+  "implicit-namespace-package", # no implicit namespace
+  "suspicious-non-cryptographic-random-usage",   # benchmark data is pseudo-random on purpose, nothing cryptographic
+  "suspicious-subprocess-import",   # generate_version.py shells out to git to derive the version
+  "subprocess-without-shell-equals-true",   # fixed git subcommands, not external input
+  "start-process-with-partial-path",   # git is resolved from PATH
+  "print",   # print allowed in scripts
 ]
 lint.isort = { known-first-party = [
   "turbohtml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,45 +267,45 @@ lint.select = [
   "ALL",
 ]
 lint.ignore = [
-  "missing-trailing-comma",  # conflicts with the formatter
-  "CPY",     # no copyright statements
-  "incorrect-blank-line-before-class",    # incompatible with D211
-  "multi-line-summary-first-line",    # incompatible with D213
-  "DOC",     # no support yet
-  "single-line-implicit-string-concatenation",  # conflicts with the formatter
-  "magic-value-comparison", # comparing against literal numbers is clear enough on its own
+  "CPY",                                       # no copyright statements
+  "DOC",                                       # no support yet
+  "incorrect-blank-line-before-class",         # incompatible with D211
+  "magic-value-comparison",                    # comparing against literal numbers is clear enough on its own
+  "missing-trailing-comma",                    # conflicts with the formatter
+  "multi-line-summary-first-line",             # incompatible with D213
+  "single-line-implicit-string-concatenation", # conflicts with the formatter
 ]
 lint.per-file-ignores."docs/conf.py" = [
-  "any-type",  # the autodoc-engine wrappers forward Sphinx's arbitrary *args/**kwargs
-  "implicit-namespace-package",  # Sphinx config is not part of a package
-  "import-outside-top-level", # Sphinx internals are imported lazily inside setup(), only when the build runs
-  "import-private-name", # patching the Sphinx 9 functional autodoc engine requires its private _dynamic modules
-  "private-member-access",  # ... and replacing their private signature/property builders for the C extension
+  "any-type",                   # the autodoc-engine wrappers forward Sphinx's arbitrary *args/**kwargs
+  "implicit-namespace-package", # Sphinx config is not part of a package
+  "import-outside-top-level",   # Sphinx internals are imported lazily inside setup(), only when the build runs
+  "import-private-name",        # patching the Sphinx 9 functional autodoc engine requires its private _dynamic modules
+  "private-member-access",      # ... and replacing their private signature/property builders for the C extension
 ]
 lint.per-file-ignores."src/turbohtml/{clean,extract,query}/__init__.py" = [
   "non-empty-init-module", # the public module's implementation lives in its package __init__, re-exported unchanged
 ]
 lint.per-file-ignores."tasks/**/*.py" = [
-  "implicit-namespace-package", # no implicit namespace
-  "suspicious-subprocess-import",   # subprocess is required to drive git, gh and towncrier
-  "subprocess-without-shell-equals-true",   # the release script runs fixed git/gh subcommands, not external input
-  "start-process-with-partial-path",   # git and gh are resolved from PATH
-  "print",   # progress output to the console is intentional
+  "implicit-namespace-package",           # no implicit namespace
+  "print",                                # progress output to the console is intentional
+  "start-process-with-partial-path",      # git and gh are resolved from PATH
+  "subprocess-without-shell-equals-true", # the release script runs fixed git/gh subcommands, not external input
+  "suspicious-subprocess-import",         # subprocess is required to drive git, gh and towncrier
 ]
 lint.per-file-ignores."tests/**/*.py" = [
-  "D",       # don't document tests
-  "implicit-namespace-package",  # no implicit namespace
-  "import-private-name", # the conformance harness drives the private _html._tokenize_states hook
-  "assert",    # asserts allowed in tests
-  "private-member-access",  # same private hook
+  "assert",                     # asserts allowed in tests
+  "D",                          # don't document tests
+  "implicit-namespace-package", # no implicit namespace
+  "import-private-name",        # the conformance harness drives the private _html._tokenize_states hook
+  "private-member-access",      # same private hook
 ]
 lint.per-file-ignores."tools/**/*.py" = [
-  "implicit-namespace-package", # no implicit namespace
-  "suspicious-non-cryptographic-random-usage",   # benchmark data is pseudo-random on purpose, nothing cryptographic
-  "suspicious-subprocess-import",   # generate_version.py shells out to git to derive the version
-  "subprocess-without-shell-equals-true",   # fixed git subcommands, not external input
-  "start-process-with-partial-path",   # git is resolved from PATH
-  "print",   # print allowed in scripts
+  "implicit-namespace-package",                # no implicit namespace
+  "print",                                     # print allowed in scripts
+  "start-process-with-partial-path",           # git is resolved from PATH
+  "subprocess-without-shell-equals-true",      # fixed git subcommands, not external input
+  "suspicious-non-cryptographic-random-usage", # benchmark data is pseudo-random on purpose, nothing cryptographic
+  "suspicious-subprocess-import",              # generate_version.py shells out to git to derive the version
 ]
 lint.isort = { known-first-party = [
   "turbohtml",

--- a/src/turbohtml/_c/dom/tree.c
+++ b/src/turbohtml/_c/dom/tree.c
@@ -3915,6 +3915,18 @@ static void setup_input(th_tree *tree, th_tokenizer *sm, int kind, const void *d
     tree->data = th_tok_input_data(sm, &tree->kind);
 }
 
+static void retain_normalized_source(th_tree *tree, th_tokenizer *sm) {
+    if (tree->can_span) {
+        return;
+    }
+    if (tree->track_locations) {
+        tree->owned_data = th_tok_take_input(sm, &tree->kind, &tree->length);
+        tree->data = tree->owned_data;
+    } else {
+        tree->data = NULL;
+    }
+}
+
 /* The first element child of parent with this atom, or NULL. */
 static th_node *child_with_atom(th_node *parent, uint16_t atom) {
     for (th_node *child = parent->first_child; child != NULL; child = child->next_sibling) {
@@ -4022,6 +4034,7 @@ th_tree *th_tree_parse(int kind, const void *data, Py_ssize_t length, int positi
     run_state_init(&run_state, M_INITIAL);
     run_drain(tree, sm, &run_state);
     run_close(tree);
+    retain_normalized_source(tree, sm);
     th_tok_free(sm);
     finalize_document(tree);
 
@@ -4166,6 +4179,7 @@ th_tree *th_tree_parse_fragment(int kind, const void *data, Py_ssize_t length, c
     run_state_init(&run_state, ctx_ns == TH_NS_HTML ? fragment_mode(ctx_atom) : M_IN_BODY);
     run_drain(tree, sm, &run_state);
     run_close(tree);
+    retain_normalized_source(tree, sm);
     th_tok_free(sm);
 
     /* an html-context fragment starts in "before head"; at EOF the same
@@ -4216,6 +4230,7 @@ void th_tree_free(th_tree *tree) {
     PyMem_Free(tree->attr_recs);
     PyMem_Free(tree->shadows);
     PyMem_Free(tree->meta_labels);
+    PyMem_Free(tree->owned_data);
     th_error_sink_free(&tree->errors);
     PyMem_Free(tree);
 }

--- a/src/turbohtml/_c/dom/tree_internal.h
+++ b/src/turbohtml/_c/dom/tree_internal.h
@@ -93,6 +93,7 @@ struct th_tree {
     int track_locations;    /* record each element's granular source spans (implies track_positions) */
     int kind;               /* borrowed input storage */
     const void *data;
+    void *owned_data; /* normalized one-shot input retained when source spans need it */
     Py_ssize_t length;
     int failed; /* an allocation failed; abandon the parse */
     /* Dynamic intern table for attribute names outside attr_atom.h: the record

--- a/src/turbohtml/_c/tokenizer/statemachine.c
+++ b/src/turbohtml/_c/tokenizer/statemachine.c
@@ -579,6 +579,14 @@ const void *th_tok_input_data(const th_tokenizer *self, int *kind) {
     return self->input.data;
 }
 
+void *th_tok_take_input(th_tokenizer *self, int *kind, Py_ssize_t *length) {
+    *kind = self->input.kind;
+    *length = self->input.len;
+    void *data = self->input.data;
+    buf_init(&self->input);
+    return data;
+}
+
 void th_tok_close(th_tokenizer *self) {
     self->eof = 1;
 }

--- a/src/turbohtml/_c/tokenizer/statemachine.h
+++ b/src/turbohtml/_c/tokenizer/statemachine.h
@@ -237,6 +237,9 @@ void th_tok_borrow_input(th_tokenizer *self, int kind, const void *data, Py_ssiz
 /* The storage backing slice tokens: sets *kind, returns the base pointer. */
 const void *th_tok_input_data(const th_tokenizer *self, int *kind);
 
+/* Transfer the owned input buffer to the caller after a one-shot fed parse. */
+void *th_tok_take_input(th_tokenizer *self, int *kind, Py_ssize_t *length);
+
 /* Signal end of input; the next th_tok_next calls flush remaining tokens. */
 void th_tok_close(th_tokenizer *self);
 

--- a/tests/conformance/test_html_wpt_tree_conformance.py
+++ b/tests/conformance/test_html_wpt_tree_conformance.py
@@ -1,81 +1,37 @@
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import Final, TypedDict, cast
-
-import pytest
+from typing import TYPE_CHECKING, cast
 
 from turbohtml import _html, parse  # public serializers cannot reproduce WPT's namespace dump
 
-
-class _Error(TypedDict):
-    code: str
-    line: int
-    col: int
-    end_line: int | None
-    end_col: int | None
-
-
-class _Input(TypedDict):
-    file: str
-    data: str
-    context: str | None
-    scripting: bool | None
+if TYPE_CHECKING:
+    from wpt_tree_corpus import (
+        WptHtmlTreeCase,
+        WptHtmlTreeCorpus,
+        WptHtmlTreeError,
+        WptHtmlTreeExclusion,
+        WptHtmlTreeInput,
+    )
 
 
-class _Case(_Input):
-    document: str
-    spec_errors: list[_Error] | None
+def _applicable(corpus: WptHtmlTreeCorpus) -> list[WptHtmlTreeCase]:
+    exclusions = {(item["file"], item["data"], item["context"], item["scripting"]) for item in corpus["exclusions"]}
+    return [
+        case
+        for case in corpus["cases"]
+        if (case["file"], case["data"], case["context"], case["scripting"]) not in exclusions
+    ]
 
 
-class _Decision(_Input):
-    reason: str
-    spec: str
-    fixture: str
-
-
-class _Exclusion(_Decision):
-    document: str
-
-
-class _Corpus(TypedDict):
-    source: str
-    revision: str
-    files: list[str]
-    fixture_counts: dict[str, int]
-    applicable_fixture_counts: dict[str, int]
-    error_adjustments: list[_Decision]
-    exclusions: list[_Exclusion]
-    cases: list[_Case]
-
-
-_CORPUS: Final[_Corpus] = cast(
-    "_Corpus",
-    json.loads((Path(__file__).parent / "data" / "wpt_html_tree.json").read_text(encoding="utf-8")),
-)
-_EXCLUSION_KEYS: Final[frozenset[tuple[str, str, str | None, bool | None]]] = frozenset(
-    (item["file"], item["data"], item["context"], item["scripting"]) for item in _CORPUS["exclusions"]
-)
-_APPLICABLE: Final[tuple[_Case, ...]] = tuple(
-    case
-    for case in _CORPUS["cases"]
-    if (case["file"], case["data"], case["context"], case["scripting"]) not in _EXCLUSION_KEYS
-)
-_ERROR_CASES: Final[tuple[_Case, ...]] = tuple(
-    case for case in _APPLICABLE if case["context"] is None and case["spec_errors"] is not None
-)
-
-
-def test_wpt_corpus_provenance_and_denominators() -> None:
+def test_wpt_corpus_provenance_and_denominators(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
     assert {
-        "source": _CORPUS["source"],
-        "revision": _CORPUS["revision"],
-        "files": len(_CORPUS["files"]),
-        "source_cases": sum(_CORPUS["fixture_counts"].values()),
-        "applicable_cases": sum(_CORPUS["applicable_fixture_counts"].values()),
-        "error_adjustments": len(_CORPUS["error_adjustments"]),
-        "exclusions": len(_CORPUS["exclusions"]),
+        "source": wpt_html_tree_corpus["source"],
+        "revision": wpt_html_tree_corpus["revision"],
+        "files": len(wpt_html_tree_corpus["files"]),
+        "source_cases": sum(wpt_html_tree_corpus["fixture_counts"].values()),
+        "applicable_cases": sum(wpt_html_tree_corpus["applicable_fixture_counts"].values()),
+        "error_adjustments": len(wpt_html_tree_corpus["error_adjustments"]),
+        "exclusions": len(wpt_html_tree_corpus["exclusions"]),
     } == {
         "source": (
             "https://github.com/web-platform-tests/wpt/tree/"
@@ -90,11 +46,11 @@ def test_wpt_corpus_provenance_and_denominators() -> None:
     }
 
 
-def test_wpt_corpus_records_normative_sources() -> None:
+def test_wpt_corpus_records_normative_sources(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
     assert {
-        "error_specs": {item["spec"] for item in _CORPUS["error_adjustments"]},
-        "script_specs": {item["spec"] for item in _CORPUS["exclusions"]},
-        "script_fixtures": {item["fixture"] for item in _CORPUS["exclusions"]},
+        "error_specs": {item["spec"] for item in wpt_html_tree_corpus["error_adjustments"]},
+        "script_specs": {item["spec"] for item in wpt_html_tree_corpus["exclusions"]},
+        "script_fixtures": {item["fixture"] for item in wpt_html_tree_corpus["exclusions"]},
     } == {
         "error_specs": {"https://html.spec.whatwg.org/multipage/parsing.html#processing-instruction-open-state"},
         "script_specs": {"https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model"},
@@ -123,39 +79,36 @@ def test_wpt_corpus_records_normative_sources() -> None:
     }
 
 
-@pytest.mark.parametrize(
-    "case",
-    tuple(pytest.param(case, id=f"{case['file']}:{index}") for index, case in enumerate(_APPLICABLE)),
-)
-def test_wpt_tree(case: _Case) -> None:
-    assert _tree(case) == case["document"]
+def test_wpt_tree(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
+    cases = _applicable(wpt_html_tree_corpus)
+    failures = [case for case in cases if _tree(case) != case["document"]]
+    assert not failures, f"{len(failures)}/{len(cases)} tree mismatches: {failures[:5]!r}"
 
 
-def test_wpt_tree_count() -> None:
-    assert sum(_tree(case) == case["document"] for case in _APPLICABLE) == 1_916
+def test_wpt_tree_count(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
+    cases = _applicable(wpt_html_tree_corpus)
+    assert sum(_tree(case) == case["document"] for case in cases) == 1_916
 
 
-@pytest.mark.parametrize(
-    "case",
-    tuple(pytest.param(case, id=f"{case['file']}:{index}") for index, case in enumerate(_ERROR_CASES)),
-)
-def test_wpt_exact_document_errors(case: _Case) -> None:
-    expected = cast("list[_Error]", case["spec_errors"])
-    assert _errors_match(expected, _errors(case))
+def test_wpt_exact_document_errors(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
+    cases = [
+        case
+        for case in _applicable(wpt_html_tree_corpus)
+        if case["context"] is None and case["spec_errors"] is not None
+    ]
+    failures = [
+        case for case in cases if not _errors_match(cast("list[WptHtmlTreeError]", case["spec_errors"]), _errors(case))
+    ]
+    assert not failures, f"{len(failures)}/{len(cases)} error mismatches: {failures[:5]!r}"
 
 
-@pytest.mark.parametrize(
-    "exclusion",
-    tuple(
-        pytest.param(exclusion, id=f"{exclusion['file']}:{index}")
-        for index, exclusion in enumerate(_CORPUS["exclusions"])
-    ),
-)
-def test_wpt_script_exclusion_without_javascript(exclusion: _Exclusion) -> None:
-    assert _tree(exclusion) == exclusion["document"]
+def test_wpt_script_exclusion_without_javascript(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
+    exclusions = wpt_html_tree_corpus["exclusions"]
+    failures = [exclusion for exclusion in exclusions if _tree(exclusion) != exclusion["document"]]
+    assert not failures, f"{len(failures)}/{len(exclusions)} unexpected matches: {failures!r}"
 
 
-def _tree(case: _Input) -> str:
+def _tree(case: WptHtmlTreeInput | WptHtmlTreeExclusion) -> str:
     if (context := case["context"]) is not None:
         result = _html._parse_fragment(case["data"], context, bool(case["scripting"]))
     else:
@@ -163,14 +116,14 @@ def _tree(case: _Input) -> str:
     return result.rstrip("\n")
 
 
-def _errors(case: _Input) -> list[_Error]:
+def _errors(case: WptHtmlTreeInput) -> list[WptHtmlTreeError]:
     return [
         {"code": error.code, "line": error.line, "col": error.col + 1, "end_line": None, "end_col": None}
         for error in parse(case["data"], scripting=bool(case["scripting"])).errors
     ]
 
 
-def _errors_match(expected: list[_Error], actual: list[_Error]) -> bool:
+def _errors_match(expected: list[WptHtmlTreeError], actual: list[WptHtmlTreeError]) -> bool:
     if len(expected) != len(actual):
         return False
     for wanted, raised in zip(expected, actual, strict=True):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,14 @@ from __future__ import annotations
 
 import sys
 import sysconfig
+from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
 import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "tools"))
+
+from wpt_tree_corpus import WptHtmlTreeCorpus, load_wpt_html_tree
 
 from turbohtml import Element, Node, parse
 
@@ -19,6 +24,12 @@ _N = TypeVar("_N", bound=Node)
 
 _FREE_THREADED = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 _gil_enabled_at_start = sys._is_gil_enabled() if _FREE_THREADED else True
+
+
+@pytest.fixture(scope="session")
+def wpt_html_tree_corpus() -> WptHtmlTreeCorpus:
+    """Return the pinned WPT tree-construction corpus."""
+    return load_wpt_html_tree()
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:

--- a/tests/dom/test_treebuilder_conformance.py
+++ b/tests/dom/test_treebuilder_conformance.py
@@ -1,92 +1,39 @@
-"""Verify the tree builder against the html5lib tree-construction suite.
+"""Verify the tree builder against the WPT tree-construction suite.
 
-The ``.dat`` files under ``tests/html5lib-tests/tree-construction`` give, for
-each input, the document tree a conformant parser must build, serialized in the
-``| ``-indented "#document" format. This harness parses each ``#data`` block and
-compares ``turbohtml``'s serialization against the ``#document`` expectation.
-Every case must pass. A ``#script-on`` block asserts the tree a scripting host
-builds (``<noscript>`` as raw text); those run through the ``scripting=True``
-parse path.
+The committed corpus pins WPT's living ``html/syntax/parsing/resources`` data so
+upstream changes cannot alter CI without a reviewed diff. Every case TurboHTML
+can execute must match its ``#document`` tree.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
+from typing import TYPE_CHECKING
 
 from turbohtml import _html
 
-_TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
-
-# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
-if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
-    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
-    raise RuntimeError(msg)
+if TYPE_CHECKING:
+    from wpt_tree_corpus import WptHtmlTreeCase, WptHtmlTreeCorpus
 
 
-def _parse_dat(path: Path) -> list[tuple[str, str, bool, str | None]]:
-    """Return (input, expected-document, script-on, fragment-context) per block."""
-    cases: list[tuple[str, str, bool, str | None]] = []
-    with path.open(encoding="utf-8", newline="") as handle:  # a literal \r in a case is data
-        raw_text = handle.read()
-    for raw in raw_text.split("\n#data\n"):
-        block = raw.removeprefix("#data\n")
-        data, _, rest = block.partition("\n#errors")
-        document_marker = "\n#document\n"
-        if document_marker not in rest:
-            continue
-        before, _, document = rest.partition(document_marker)
-        script_on = "#script-on" in before
-        context: str | None = None
-        if "#document-fragment\n" in before:
-            context = before.partition("#document-fragment\n")[2].splitlines()[0].strip()
-        cases.append((data, document.rstrip("\n"), script_on, context))
-    return cases
+def _build(case: WptHtmlTreeCase) -> str:
+    if (context := case["context"]) is not None:
+        return _html._parse_fragment(case["data"], context, bool(case["scripting"])).rstrip("\n")
+    return _html._parse_tree(case["data"], bool(case["scripting"])).rstrip("\n")
 
 
-def _iter_cases() -> list[tuple[str, str, str, str | None, bool]]:
-    cases: list[tuple[str, str, str, str | None, bool]] = []
-    for path in sorted(_TREE_DIR.glob("*.dat")):
-        for data, document, script_on, context in _parse_dat(path):
-            cases.append((path.name, data, document, context, script_on))
-    return cases
-
-
-_CASES = _iter_cases()
-
-
-def _build(data: str, context: str | None, *, scripting: bool = False) -> str:
-    if context is not None:
-        return _html._parse_fragment(data, context, scripting).rstrip("\n")
-    return _html._parse_tree(data, scripting).rstrip("\n")
-
-
-_DOCUMENT_OVERRIDES: dict[tuple[str, str, str | None], str] = {
-    # WHATWG added HTML processing instructions after the pinned html5lib-tests revision.
-    (
-        "html5test-com.dat",
-        '<?import namespace="foo" implementation="#bar">',
-        None,
-    ): ('| <?import namespace="foo" implementation="#bar"?>\n| <html>\n|   <head>\n|   <body>'),
-    ("tests1.dat", "<?", None): "| <html>\n|   <head>\n|   <body>",
-    ("tests1.dat", "<?COMMENT?>", None): "| <?COMMENT ?>\n| <html>\n|   <head>\n|   <body>",
-    ("tests1.dat", "<?COM--MENT?>", None): "| <?COM--MENT ?>\n| <html>\n|   <head>\n|   <body>",
-}
-
-
-@pytest.mark.parametrize("filename", sorted({name for name, _, _, _, _ in _CASES}))
-def test_tree_construction(filename: str) -> None:
+def test_tree_construction(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
+    exclusions = {
+        (item["file"], item["data"], item["context"], item["scripting"]) for item in wpt_html_tree_corpus["exclusions"]
+    }
     cases = [
-        (d, _DOCUMENT_OVERRIDES.get((filename, d, ctx), doc), ctx, script_on)
-        for name, d, doc, ctx, script_on in _CASES
-        if name == filename
+        case
+        for case in wpt_html_tree_corpus["cases"]
+        if (case["file"], case["data"], case["context"], case["scripting"]) not in exclusions
     ]
-    assert cases, f"no cases parsed from {filename}"
     failures = [
-        f"#data {data!r} (context={context!r}, scripting={script_on})\n"
-        f"expected:\n{document}\ngot:\n{_build(data, context, scripting=script_on)}"
-        for data, document, context, script_on in cases
-        if _build(data, context, scripting=script_on) != document
+        f"{case['file']}: #data {case['data']!r} (context={case['context']!r}, scripting={case['scripting']})\n"
+        f"expected:\n{case['document']}\ngot:\n{_build(case)}"
+        for case in cases
+        if _build(case) != case["document"]
     ]
-    assert not failures, f"{filename}: {len(failures)}/{len(cases)} failing\n\n" + "\n\n".join(failures[:5])
+    assert not failures, f"{len(failures)}/{len(cases)} failing\n\n" + "\n\n".join(failures[:5])

--- a/tests/dom/test_treebuilder_differential.py
+++ b/tests/dom/test_treebuilder_differential.py
@@ -7,42 +7,28 @@ sanitizer would vet one structure while the browser renders another -- a parser-
 bypass that no memory sanitizer can see.
 
 ``test_treebuilder_conformance`` already pins turbohtml's internal ``#document`` dump against
-the html5lib-tests tree-construction corpus (the canonical spec oracle). This suite closes the
+WPT's living tree-construction corpus. This suite closes the
 remaining gap: it rebuilds the same ``#document`` dump purely from the public Element API and
 asserts it matches the spec tree for every non-scripting case, document and fragment. Agreement
 over the full corpus -- 570-odd cases carry a sanitizer-relevant element (script, style, foreign
 content, event handlers, URL attributes) -- is the evidence that the tree a sanitizer walks is
 the tree the browser resolves.
 
-Two divergence classes are documented rather than silently skipped:
-
-- Spec-lag: a handful of pinned ``.dat`` cases encode pre-errata trees for ``</p>``/``</br>`` in
-  foreign content. turbohtml follows the modern WHATWG algorithm (as do lexbor and html5lib's own
-  library); the pinned data does not. For these the public tree is
-  asserted against turbohtml's spec-validated parse, which the conformance suite pins to the
-  corrected tree. See issues #32 and #63.
-- A ``.dat`` text-format limit: the html5lib ``#document`` dump wraps doctype identifiers in unescaped
-  quotes, so it cannot represent a quote embedded in one (``taco"`` reads back as ``taco``). turbohtml
-  keeps the quote, matching html5lib-python and the WHATWG tokenizer, so the public tree is asserted
-  against turbohtml's conformance-validated parse. See issue #478.
+One representation gap is documented rather than silently skipped: the ``.dat`` text format wraps doctype identifiers
+in unescaped quotes, so it cannot represent a quote embedded in one (``taco"`` reads back as ``taco``). turbohtml keeps
+the quote, matching html5lib-python and the WHATWG tokenizer, so the public tree is asserted against turbohtml's
+conformance-validated parse. See issue #478.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import cast
-
-import pytest
+from typing import TYPE_CHECKING, cast
 
 import turbohtml
 from turbohtml import Comment, Doctype, Document, Element, Namespace, Node, ProcessingInstruction, Text, _html
 
-_TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
-
-# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
-if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
-    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
-    raise RuntimeError(msg)
+if TYPE_CHECKING:
+    from wpt_tree_corpus import WptHtmlTreeCase, WptHtmlTreeCorpus
 
 # "adjust foreign attributes" (WHATWG 13.2.6.5): only these prefixed names on an SVG/MathML
 # element serialize with a namespace-separating space; any other xml:/xlink: name keeps its colon.
@@ -111,52 +97,9 @@ def _public_dump(data: str, context: str | None) -> str:
     return "\n".join(out)
 
 
-def _internal_dump(data: str, context: str | None) -> str:
-    if context is not None:
-        return _html._parse_fragment(data, context).rstrip("\n")
+def _internal_dump(data: str) -> str:
     return _html._parse_tree(data).rstrip("\n")
 
-
-def _parse_dat(path: Path) -> list[tuple[str, str, str | None]]:
-    cases: list[tuple[str, str, str | None]] = []
-    with path.open(encoding="utf-8", newline="") as handle:  # a literal \r in a case is data
-        raw_text = handle.read()
-    for raw in raw_text.split("\n#data\n"):
-        block = raw.removeprefix("#data\n")
-        data, _, rest = block.partition("\n#errors")
-        if "\n#document\n" not in rest:
-            continue
-        before, _, document = rest.partition("\n#document\n")
-        if "#script-on" in before:  # scripting-enabled cases need a script-executing host
-            continue
-        context = (
-            before.partition("#document-fragment\n")[2].splitlines()[0].strip()
-            if "#document-fragment\n" in before
-            else None
-        )
-        cases.append((data, document.rstrip("\n"), context))
-    return cases
-
-
-_CASES = [(path.name, *case) for path in sorted(_TREE_DIR.glob("*.dat")) for case in _parse_dat(path)]
-
-# The pinned .dat predates modern-spec errata for these cases; turbohtml is spec-correct (lexbor and
-# html5lib's own library agree). The public tree is checked against turbohtml's conformance-validated
-# parse, which test_treebuilder_conformance pins to the corrected tree. See issues #32 and #63.
-_SPEC_LAG: frozenset[tuple[str, str, str | None]] = frozenset({
-    ("tests26.dat", "<svg></p><foo>", None),
-    ("tests26.dat", "<math></p><foo>", None),
-    ("tests26.dat", "<svg></br><foo>", None),
-    ("tests26.dat", "<math></br><foo>", None),
-    ("foreign-fragment.dat", "<svg></p><foo>", "div"),
-    ("foreign-fragment.dat", "</p><foo>", "svg svg"),
-    ("foreign-fragment.dat", "<svg></br><foo>", "div"),
-    ("foreign-fragment.dat", "</br><foo>", "svg svg"),
-    ("html5test-com.dat", '<?import namespace="foo" implementation="#bar">', None),
-    ("tests1.dat", "<?", None),
-    ("tests1.dat", "<?COMMENT?>", None),
-    ("tests1.dat", "<?COM--MENT?>", None),
-})
 
 # The html5lib `#document` text format wraps each doctype identifier in unescaped quotes, so it cannot
 # represent a quote embedded in one: `taco"` serializes to a .dat that reads back as `taco`. turbohtml
@@ -167,30 +110,25 @@ _DAT_UNREPRESENTABLE: frozenset[tuple[str, str, str | None]] = frozenset({
 })
 
 
-def _expected(filename: str, data: str, document: str, context: str | None) -> str:
-    key = (filename, data, context)
-    if key in _SPEC_LAG or key in _DAT_UNREPRESENTABLE:
-        return _internal_dump(data, context)
-    return document
+def _expected(case: WptHtmlTreeCase) -> str:
+    if (case["file"], case["data"], case["context"]) in _DAT_UNREPRESENTABLE:
+        return _internal_dump(case["data"])
+    return case["document"]
 
 
-@pytest.mark.parametrize("filename", sorted({name for name, _, _, _ in _CASES}))
-def test_public_tree_matches_spec(filename: str) -> None:
-    cases = [(data, document, context) for name, data, document, context in _CASES if name == filename]
-    assert cases, f"no cases parsed from {filename}"
+def test_public_tree_matches_spec(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
+    cases = [case for case in wpt_html_tree_corpus["cases"] if case["scripting"] is not True]
     failures = [
-        f"#data {data!r} (context={context!r})\nexpected:\n{expected}\ngot:\n{got}"
-        for data, document, context in cases
-        for expected in [_expected(filename, data, document, context)]
-        for got in [_public_dump(data, context)]
+        f"{case['file']}: #data {case['data']!r} (context={case['context']!r})\nexpected:\n{expected}\ngot:\n{got}"
+        for case in cases
+        for expected in [_expected(case)]
+        for got in [_public_dump(case["data"], case["context"])]
         if got != expected
     ]
-    assert not failures, f"{filename}: {len(failures)}/{len(cases)} public/spec divergences\n\n" + "\n\n".join(
-        failures[:5]
-    )
+    assert not failures, f"{len(failures)}/{len(cases)} public/spec divergences\n\n" + "\n\n".join(failures[:5])
 
 
-def test_corpus_exercises_sanitizer_relevant_nodes() -> None:
+def test_corpus_exercises_sanitizer_relevant_nodes(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
     # a corpus edit that stops exercising the security surface (foreign content, script/style, handlers,
     # URL attributes) must fail loudly rather than let the oracle pass vacuously
     unsafe_tags = {
@@ -222,7 +160,12 @@ def test_corpus_exercises_sanitizer_relevant_nodes() -> None:
 
     relevant = sum(
         1
-        for _, data, _, context in _CASES
-        if is_relevant(turbohtml.parse_fragment(data, context) if context is not None else turbohtml.parse(data))
+        for case in wpt_html_tree_corpus["cases"]
+        if case["scripting"] is not True
+        if is_relevant(
+            turbohtml.parse_fragment(case["data"], context)
+            if (context := case["context"]) is not None
+            else turbohtml.parse(case["data"])
+        )
     )
     assert relevant >= 400

--- a/tests/serialize/test_minify_roundtrip.py
+++ b/tests/serialize/test_minify_roundtrip.py
@@ -1,8 +1,8 @@
 """Round-trip safety of serialize(layout=Minify(...)) over an adversarial corpus.
 
 Minification is only correct if the minified bytes reparse to the same tree. This
-suite enforces that property at scale against the html5lib-tests tree-construction
-suite -- 1.7k adversarial snippets from the vendored html5lib-tests corpus, already
+suite enforces that property at scale against WPT's tree-construction
+suite -- 1.9k adversarial snippets from the committed WPT corpus, already
 in place for the conformance harness.
 
 The check is idempotence under reparse: ``minify(parse(minify(parse(src))))`` must
@@ -15,35 +15,15 @@ the plain serializer itself round-trips.
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from turbohtml import Html, Minify, parse
 from turbohtml.clean import CSSMinify
 
-_TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
-
-# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
-if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
-    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
-    raise RuntimeError(msg)
-
-_MINIFY = Minify()
-# the CSS pass rewrites every <style> body and style="" value the corpus carries; the
-# value-safe engine is itself idempotent, so enabling it must keep the reparse a fixpoint
-_MINIFY_CSS = Minify(minify_css=CSSMinify())
-
-
-def _iter_dat(path: Path) -> list[str]:
-    cases: list[str] = []
-    for raw in path.read_text(encoding="utf-8").split("\n#data\n"):
-        block = raw.removeprefix("#data\n")
-        data, _, rest = block.partition("\n#errors")
-        if "#document-fragment\n" in rest or "#script-on" in rest or "\n#document\n" not in rest:
-            continue
-        cases.append(data)
-    return cases
+if TYPE_CHECKING:
+    from wpt_tree_corpus import WptHtmlTreeCorpus
 
 
 def _plain_roundtrips(source: str) -> bool:
@@ -56,18 +36,22 @@ def _minify_idempotent(source: str, layout: Minify) -> bool:
     return once == parse(once).serialize(Html(layout=layout))
 
 
-@pytest.mark.parametrize("layout", [pytest.param(_MINIFY, id="default"), pytest.param(_MINIFY_CSS, id="minify-css")])
-@pytest.mark.parametrize("filename", sorted(p.name for p in _TREE_DIR.glob("*.dat")))
-def test_minify_idempotent_over_tree_construction(filename: str, layout: Minify) -> None:
+@pytest.mark.parametrize(
+    "layout",
+    [pytest.param(Minify(), id="default"), pytest.param(Minify(minify_css=CSSMinify()), id="minify-css")],
+)
+def test_minify_idempotent_over_tree_construction(wpt_html_tree_corpus: WptHtmlTreeCorpus, layout: Minify) -> None:
     # only the subset the plain serializer round-trips can be asked of the minifier;
     # the rest are inherently non-idempotent adoption-agency reconstructions
     failures = [
-        f"{data!r}\n  once:    {parse(data).serialize(Html(layout=layout))!r}\n"
+        f"{case['file']}: {data!r}\n  once:    {parse(data).serialize(Html(layout=layout))!r}\n"
         f"  reparse: {parse(parse(data).serialize(Html(layout=layout))).serialize(Html(layout=layout))!r}"
-        for data in _iter_dat(_TREE_DIR / filename)
+        for case in wpt_html_tree_corpus["cases"]
+        if case["context"] is None and case["scripting"] is not True
+        for data in [case["data"]]
         if _plain_roundtrips(data) and not _minify_idempotent(data, layout)
     ]
-    assert not failures, f"{filename}: {len(failures)} non-idempotent\n\n" + "\n\n".join(failures[:5])
+    assert not failures, f"{len(failures)} non-idempotent\n\n" + "\n\n".join(failures[:5])
 
 
 def test_minify_idempotent_over_large_document() -> None:
@@ -88,6 +72,7 @@ def test_minify_idempotent_over_large_document() -> None:
         + "".join(section.format(i=index) for index in range(500))
         + "</body></html>"
     )
-    once = parse(big).serialize(Html(layout=_MINIFY))
-    assert once == parse(once).serialize(Html(layout=_MINIFY))
+    layout = Minify()
+    once = parse(big).serialize(Html(layout=layout))
+    assert once == parse(once).serialize(Html(layout=layout))
     assert len(once) < len(parse(big).serialize())  # minification actually shrinks the document

--- a/tests/serialize/test_to_source.py
+++ b/tests/serialize/test_to_source.py
@@ -45,6 +45,11 @@ def test_unedited_round_trip_is_byte_identical(markup: str) -> None:
     assert parse(markup, source_locations=True).to_source() == markup
 
 
+def test_carriage_returns_use_retained_normalized_source() -> None:
+    markup = _doc("<p>\r</p>" * 4096)
+    assert parse(markup, source_locations=True).to_source() == markup.replace("\r", "\n")
+
+
 def test_changing_an_attribute_rewrites_only_that_start_tag() -> None:
     markup = _doc('<p id="a">one</p><p id="b">two</p>')
     doc = parse(markup, source_locations=True)

--- a/tests/serialize/test_tree_markdown.py
+++ b/tests/serialize/test_tree_markdown.py
@@ -4,26 +4,22 @@ Two layers of validation: hand-written golden cases pin the exact output for
 every mapping and edge case, and a round-trip differential renders the output
 back to HTML with the markdown-it-py reference engine and asserts no visible
 text token was lost — the same property the competitor suites (markdownify,
-html2text) check by hand. The adversarial inputs are sampled from the vendored
-html5lib-tests corpus, so to_markdown() is exercised on malformed markup too.
+html2text) check by hand. The adversarial inputs are sampled from the committed
+WPT tree-construction corpus, so to_markdown() is exercised on malformed markup too.
 """
 
 from __future__ import annotations
 
 import re
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from markdown_it import MarkdownIt
 
 from turbohtml import parse
 
-_TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
-
-# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
-if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
-    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
-    raise RuntimeError(msg)
+if TYPE_CHECKING:
+    from wpt_tree_corpus import WptHtmlTreeCorpus
 
 
 def md(html: str) -> str:
@@ -487,21 +483,11 @@ def test_roundtrip_preserves_text(html: str) -> None:
     assert _tokens(rendered) == _tokens(html)
 
 
-def _corpus_inputs() -> list[str]:
-    """HTML fragments pulled from the vendored html5lib-tests tree-construction
-    .dat files: small, deliberately malformed markup that stresses the walker."""
-    inputs: list[str] = []
-    for dat in sorted(_TREE_DIR.glob("*.dat")):
-        for block in dat.read_text(encoding="utf-8").split("#data\n")[1:]:
-            data = block.split("\n#errors", 1)[0]
-            if "�" not in data and len(data) < 200:
-                inputs.append(data)
-    return inputs[:400]
-
-
-@pytest.mark.parametrize("html", _corpus_inputs())
-def test_corpus_never_crashes_and_renders(html: str) -> None:
-    result = md(html)
-    assert isinstance(result, str)
-    # whatever markup came in, the output is markdown a GFM engine can render
-    assert isinstance(_render(result), str)
+def test_corpus_never_crashes_and_renders(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:
+    inputs = [
+        case["data"] for case in wpt_html_tree_corpus["cases"] if "�" not in case["data"] and len(case["data"]) < 200
+    ][:400]
+    for html in inputs:
+        result = md(html)
+        assert isinstance(result, str)
+        assert isinstance(_render(result), str)

--- a/tests/serialize/test_tree_serialize.py
+++ b/tests/serialize/test_tree_serialize.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -12,6 +11,8 @@ from turbohtml import Comment, Doctype, Html, Indent, Markdown, Minify, Namespac
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from wpt_tree_corpus import WptHtmlTreeCorpus
 
     from turbohtml import Element, Node
 
@@ -268,37 +269,19 @@ def test_serialize_iter_propagates_a_raising_truthiness() -> None:
         parse("<p>x</p>").serialize_iter(Html(sort_attributes=_Boom()))  # ty: ignore[invalid-argument-type]  # a raising __bool__ on purpose
 
 
-_TREE_DIR = Path(__file__).parents[1] / "html5lib-tests" / "tree-construction"
-
-# CI always checks out the submodule (actions/checkout submodules: true); this guard fires only locally
-if not _TREE_DIR.is_dir() or not any(_TREE_DIR.glob("*.dat")):  # pragma: no cover
-    msg = "submodule tests/html5lib-tests not checked out; run: git submodule update --init tests/html5lib-tests"
-    raise RuntimeError(msg)
-
-
-def _corpus_sources(path: Path) -> list[str]:
-    sources: list[str] = []
-    for raw in path.read_text(encoding="utf-8").split("\n#data\n"):
-        block = raw.removeprefix("#data\n")
-        data, _, rest = block.partition("\n#errors")
-        if "#document-fragment\n" in rest or "#script-on" in rest or "\n#document\n" not in rest:
-            continue
-        sources.append(data)
-    return sources
-
-
 @pytest.mark.parametrize("layout", [pytest.param(None, id="compact"), pytest.param(Indent(2), id="indent")])
-@pytest.mark.parametrize("filename", sorted(path.name for path in _TREE_DIR.glob("*.dat")))
-def test_serialize_iter_joins_to_serialize_over_corpus(filename: str, layout: Indent | None) -> None:
+def test_serialize_iter_joins_to_serialize_over_corpus(
+    wpt_html_tree_corpus: WptHtmlTreeCorpus, layout: Indent | None
+) -> None:
     options = Html(layout=layout)
     mismatches = [
-        data
-        for data in _corpus_sources(_TREE_DIR / filename)
+        f"{case['file']}: {data!r}"
+        for case in wpt_html_tree_corpus["cases"]
+        if case["context"] is None and case["scripting"] is not True
+        for data in [case["data"]]
         if "".join((root := parse(data)).serialize_iter(options)) != root.serialize(options)
     ]
-    assert not mismatches, f"{filename}: {len(mismatches)} chunked outputs differ\n\n" + "\n\n".join(
-        repr(source) for source in mismatches[:5]
-    )
+    assert not mismatches, f"{len(mismatches)} chunked outputs differ\n\n" + "\n\n".join(mismatches[:5])
 
 
 @pytest.mark.parametrize(

--- a/tools/pgo_corpus.py
+++ b/tools/pgo_corpus.py
@@ -10,7 +10,7 @@ the profiled wheel on held-out pages the profile never trained on.
 Representativeness is code-path coverage, not input volume: the compiler lays out blocks and inlines from the branches a
 run takes, so each operation trains over a *set* spanning its branch classes rather than one clean document. The read
 path, the tokenizer, and the tree builder see clean markup (the whatwg spec and the wpt fixtures), deliberate tag soup
-(the html5lib-tests tree-construction fragments, which fire the adoption-agency, foster-parenting, and
+(the WPT tree-construction cases, which fire the adoption-agency, foster-parenting, and
 foreign-content-breakout recovery the clean spec never reaches), and real saved pages (the vendored mozilla/readability
 corpus). Encoding detection sees legacy multi-byte streams (Shift-JIS, GBK, EUC-KR, windows-1251/1252, UTF-16 with and
 without a BOM, plus the real Japanese and Big5 html5lib samples). The extractors see structured-data markup in all four
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))  # the bench package si
 from bench import corpus
 from bench.core import OPERATIONS
 from bench.operations import INPUTS
+from wpt_tree_corpus import load_wpt_html_tree
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -37,9 +38,7 @@ if TYPE_CHECKING:
 _TOOLS: Final = Path(__file__).resolve().parent
 _ROOT: Final = _TOOLS.parent
 _BENCH_DATA: Final = _TOOLS / "bench-data"
-_TREE_CONSTRUCTION: Final = _ROOT / "tests" / "html5lib-tests" / "tree-construction"
 _ENCODING_SAMPLES: Final = _ROOT / "tests" / "html5lib-tests" / "encoding"
-
 _SLICE: Final = 1 << 16  # 64 kB of book text: enough work per call without a multi-megabyte parse in the profile
 
 
@@ -57,33 +56,15 @@ def _clean_documents() -> tuple[str, ...]:
     return tuple(corpus.corpus_text(relative, encoding) for _name, relative, encoding in corpus.CORPUS_FILES)
 
 
-def _data_fragments(dat: Path) -> Iterator[str]:
-    """Yield each ``#data`` payload from an html5lib-tests ``.dat`` file (the deliberate tag-soup fragment)."""
-    collecting = False
-    payload: list[str] = []
-    for line in dat.read_text(encoding="utf-8").splitlines():
-        if line == "#data":
-            collecting, payload = True, []
-        elif line == "#errors":
-            if collecting:
-                yield "\n".join(payload)
-            collecting = False
-        elif collecting:
-            payload.append(line)
-
-
 _SOUP_BUCKETS: Final = 4
 
 
 @cache
 def _tag_soup() -> tuple[str, ...]:
     """Return the tree-construction fragments concatenated into a few documents that drive the recovery paths."""
-    fragments = [fragment for dat in sorted(_TREE_CONSTRUCTION.glob("*.dat")) for fragment in _data_fragments(dat)]
-    if not fragments:
-        return ()  # the html5lib-tests submodule is not checked out
     buckets = [""] * _SOUP_BUCKETS
-    for index, fragment in enumerate(fragments):
-        buckets[index % _SOUP_BUCKETS] += f"{fragment}\n"
+    for index, case in enumerate(load_wpt_html_tree()["cases"]):
+        buckets[index % _SOUP_BUCKETS] += f"{case['data']}\n"
     return tuple(buckets)
 
 

--- a/tools/wpt_tree_corpus.py
+++ b/tools/wpt_tree_corpus.py
@@ -1,0 +1,77 @@
+"""Read the committed WPT HTML tree-construction corpus."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TypedDict, cast
+
+
+class WptHtmlTreeError(TypedDict):
+    """One expected parse error and its source span."""
+
+    code: str
+    line: int
+    col: int
+    end_line: int | None
+    end_col: int | None
+
+
+class WptHtmlTreeInput(TypedDict):
+    """Fields identifying one WPT tree-construction input."""
+
+    file: str
+    data: str
+    context: str | None
+    scripting: bool | None
+
+
+class WptHtmlTreeCase(WptHtmlTreeInput):
+    """One pinned WPT tree-construction case."""
+
+    document: str
+    errors: list[WptHtmlTreeError] | None
+    spec_errors: list[WptHtmlTreeError] | None
+
+
+class WptHtmlTreeDecision(WptHtmlTreeInput):
+    """A corpus adjustment backed by fixture and specification links."""
+
+    reason: str
+    spec: str
+    fixture: str
+
+
+class WptHtmlTreeExclusion(WptHtmlTreeDecision):
+    """One input excluded because it requires script execution."""
+
+    document: str
+
+
+class WptHtmlTreeCorpus(TypedDict):
+    """The pinned cases, provenance, and reviewed adjustments."""
+
+    source: str
+    revision: str
+    files: list[str]
+    fixture_counts: dict[str, int]
+    applicable_fixture_counts: dict[str, int]
+    error_adjustments: list[WptHtmlTreeDecision]
+    exclusions: list[WptHtmlTreeExclusion]
+    cases: list[WptHtmlTreeCase]
+
+
+def load_wpt_html_tree() -> WptHtmlTreeCorpus:
+    """Load the pinned tree-construction cases and provenance."""
+    path = Path(__file__).parents[1] / "tests" / "conformance" / "data" / "wpt_html_tree.json"
+    return cast("WptHtmlTreeCorpus", json.loads(path.read_text(encoding="utf-8")))
+
+
+__all__ = [
+    "WptHtmlTreeCase",
+    "WptHtmlTreeCorpus",
+    "WptHtmlTreeError",
+    "WptHtmlTreeExclusion",
+    "WptHtmlTreeInput",
+    "load_wpt_html_tree",
+]


### PR DESCRIPTION
## Summary

[`html5lib-tests` now states that tree-construction data is maintained solely in WPT](https://github.com/html5lib/html5lib-tests/blob/master/README.md). This replaces its retired tree-construction copy in the ordinary tree-builder, public-tree differential, minifier, serializer, Markdown, and PGO paths with TurboHTML's pinned [`web-platform-tests/wpt` corpus at `4830edb033cb486fd0cd6f85b5e937cfc718704d`](https://github.com/web-platform-tests/wpt/tree/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources).

A session-scoped pytest fixture loads the committed corpus for every test suite that consumes it; no suite loads or filters the corpus at module scope. The PGO tool calls the same pure loader because it runs outside pytest. The `html5lib-tests` submodule remains the tokenizer and encoding source.

The larger PGO corpus exposed a deterministic use-after-free in CPython 3.10 musllinux/aarch64. Inputs containing carriage returns are normalized into tokenizer-owned storage; source-location trees retained a pointer to that storage after freeing the tokenizer. The tree now takes ownership of normalized input only when source spans require it, and a public `parse(..., source_locations=True).to_source()` regression covers the failing allocation path.

#735 and the closed [JustHTML #81](https://github.com/EmilStenstrom/justhtml/pull/81) misclassified eight foreign-content tree failures as stale WPT fixtures. The specification requires `</p>` and `</br>` to pop the foreign elements before the parser reprocesses the token. WPT had the correct trees. [#739](https://github.com/tox-dev/turbohtml/pull/739) changes TurboHTML to match them; this PR removes the stale local exemptions and compares those trees with WPT.

Eight processing-instruction cases retain stale WPT parse-error metadata from the bogus-comment rules that preceded HTML processing instructions, and [WPT #61846](https://github.com/web-platform-tests/wpt/pull/61846) fixes those records upstream. They did not cause JustHTML's tree mismatches. This PR records the spec-correct errors against the pinned corpus.

Four script-enabled cases require JavaScript execution to produce their expected trees. TurboHTML has no JavaScript runtime; the parser scope contains 1,916 cases, all of which it matches.

## Incorrect foreign-content exemptions in TurboHTML

The old differential harness exempted eight `</p>` and `</br>` cases as alleged fixture lag. WPT's expected trees are correct. The [foreign-content rule for `br` and `p` end tags](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign) requires a parse error, pops foreign elements through the nearest integration point or HTML node, and reprocesses the token in the current insertion mode. The [tree-construction dispatcher](https://html.spec.whatwg.org/multipage/parsing.html#tree-construction-dispatcher) selects the foreign-content rules from the adjusted current node.

| Fixture case | Required result | Governing clauses |
| --- | --- | --- |
| [`tests26.dat`: `<svg></p><foo>`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453) | Pop `svg`; reprocess `</p>` in “in body”; insert and close an empty HTML `p`; insert `foo` as its HTML sibling. | [foreign `p` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign), [“in body” `p` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody) |
| [`tests26.dat`: `<math></p><foo>`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453) | Pop `math`; reprocess `</p>` in “in body”; insert and close an empty HTML `p`; insert `foo` as its HTML sibling. | [foreign `p` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign), [“in body” `p` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody) |
| [`tests26.dat`: `<svg></br><foo>`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453) | Pop `svg`; reprocess `</br>` in “in body” as a `br` start tag; insert an HTML `br`; insert `foo` as its HTML sibling. | [foreign `br` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign), [“in body” `br` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody) |
| [`tests26.dat`: `<math></br><foo>`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/tests26.dat#L395-L453) | Pop `math`; reprocess `</br>` in “in body” as a `br` start tag; insert an HTML `br`; insert `foo` as its HTML sibling. | [foreign `br` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign), [“in body” `br` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody) |
| [`foreign-fragment.dat`, `div` context: `<svg></p><foo>`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612) | Pop `svg`; reprocess `</p>` against the HTML fragment root; return an empty HTML `p` and HTML `foo` after the SVG element. | [fragment parsing](https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-parsing-algorithm), [foreign `p` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign), [“in body” `p` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody) |
| [`foreign-fragment.dat`, `svg svg` context: `</p><foo>`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612) | Reprocess `</p>` against the artificial HTML root and insert an empty HTML `p`; the adjusted current node remains the SVG context for the next token, so `foo` is SVG. | [adjusted current node](https://html.spec.whatwg.org/multipage/parsing.html#adjusted-current-node), [dispatcher](https://html.spec.whatwg.org/multipage/parsing.html#tree-construction-dispatcher), [adjusted insertion location](https://html.spec.whatwg.org/multipage/parsing.html#adjusted-insertion-location) |
| [`foreign-fragment.dat`, `div` context: `<svg></br><foo>`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612) | Pop `svg`; reprocess `</br>` against the HTML fragment root; return an HTML `br` and HTML `foo` after the SVG element. | [fragment parsing](https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-parsing-algorithm), [foreign `br` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign), [“in body” `br` end tag](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody) |
| [`foreign-fragment.dat`, `svg svg` context: `</br><foo>`](https://github.com/web-platform-tests/wpt/blob/4830edb033cb486fd0cd6f85b5e937cfc718704d/html/syntax/parsing/resources/foreign-fragment.dat#L565-L612) | Reprocess `</br>` against the artificial HTML root and insert an HTML `br`; the adjusted current node remains the SVG context for the next token, so `foo` is SVG. | [adjusted current node](https://html.spec.whatwg.org/multipage/parsing.html#adjusted-current-node), [dispatcher](https://html.spec.whatwg.org/multipage/parsing.html#tree-construction-dispatcher), [adjusted insertion location](https://html.spec.whatwg.org/multipage/parsing.html#adjusted-insertion-location) |

The same foreign-content rule is present in the WHATWG source at [`c51fdd0eb76a60c2b9706a7017b4307b47b7bab6`](https://github.com/whatwg/html/blob/c51fdd0eb76a60c2b9706a7017b4307b47b7bab6/source#L115218-L115247), dated 2021-12-20, so these fixtures do not encode a pre-errata algorithm.

## Processing-instruction errors in WPT

[WPT #61083](https://github.com/web-platform-tests/wpt/pull/61083) updated the expected processing-instruction trees and left eight fixture cases with obsolete pre-PI tokenizer-error expectations. [WPT #61846](https://github.com/web-platform-tests/wpt/pull/61846) corrects those errors with a state-by-state explanation for each input. This PR records the same spec-backed corrections against its pinned pre-#61846 WPT revision.

## Validation

- `ruff format .`
- `ruff check . --fix --unsafe-fixes --output-format=concise`
- `tox run -e type`
- `prek run --all-files`
- Focused WPT consumers: 277 passed
- Native Python 3.14 coverage: 63,478 passed, 118 skipped; 100% Python coverage; 100% C line and branch coverage
- CPython 3.10 musllinux 1.2 aarch64 PGO generate/train/use: 110 operations exercised, zero skipped

Refs #719.
