### PR TITLE
📄 docs: publish llms.txt from the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ version = ".".join(release.split(".")[:2])
 doctest_global_setup = "import turbohtml\nfrom turbohtml import parse"
 
 extensions = [
+    "sphinx_llm.txt",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",  # reference any section by its title; prefixed by document to keep labels unique
     "sphinx.ext.doctest",  # run the testcode/testoutput examples so the docs cannot drift from the code
@@ -432,3 +433,6 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.connect("html-page-context", _add_page_description)
     app.add_directive("package-meta", _PackageMeta)
     return {"parallel_read_safe": True, "parallel_write_safe": True}
+
+
+markdown_http_base = os.environ.get("READTHEDOCS_CANONICAL_URL", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ docs = [
   "sphinx-design>=0.7",                # the card grid on the landing page
   "sphinx-issues>=6",
   "sphinx-last-updated-by-git>=0.3.8", # stamp each page with its last git edit
+  "sphinx-llm>=0.4.1",
   "sphinx-notfound-page>=1.1",         # a versioned 404 page
   "sphinx-reredirects>=1.1",           # keep old URLs alive after a page moves
   "sphinx-sitemap>=2.9",               # emit sitemap.xml for crawlers


### PR DESCRIPTION
The [sphinx-llm](https://github.com/NVIDIA/sphinx-llm) extension emits `llms.txt` ([llmstxt.org](https://llmstxt.org/)), `llms-full.txt`, and a markdown twin of each page during the HTML build; Read the Docs serves `llms.txt` from the docs domain root ([announcement](https://about.readthedocs.com/blog/2026/02/llms-txt-support/)). Plain markdown lets agents read the docs without rendering themed, JavaScript-dependent HTML. `markdown_http_base` keeps the sitemap links absolute so they resolve from the domain root.
