### PR TITLE
👷 ci(codspeed): run only on the upstream repo

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   codspeed:
     name: 🚀 CodSpeed
+    # OIDC only authenticates the repository registered with CodSpeed, so a fork's push runs fail with 401 Unauthorized
+    if: github.repository == 'tox-dev/turbohtml'
     runs-on: codspeed-macro
     permissions:
       contents: read


### PR DESCRIPTION
On a fork every push to `main` fails the `👷 benchmark` workflow with `##[error]Failed to retrieve upload data: 401 Unauthorized` (https://github.com/gaborbernat/turbohtml/actions/runs/31292351817), because the CodSpeed action authenticates through OIDC and CodSpeed only accepts a token minted for the repository registered with it. Guard the `codspeed` job with `if: github.repository == 'tox-dev/turbohtml'` so forks skip it; pull requests from forks still run, since `github.repository` there is the upstream repository.