### PR TITLE
🐛 fix(tokenizer): skip the empty first append

### DIFF
--- a/docs/changelog/752.bugfix.rst
+++ b/docs/changelog/752.bugfix.rst
@@ -1,0 +1,2 @@
+Parse a document, or feed a first stream chunk, that opens with a carriage return without touching the not yet allocated
+input buffer; UndefinedBehaviorSanitizer reported the empty append as a zero offset applied to a null pointer.

--- a/src/turbohtml/_c/tokenizer/statemachine.c
+++ b/src/turbohtml/_c/tokenizer/statemachine.c
@@ -480,6 +480,9 @@ void th_tok_set_initial(th_tokenizer *self, enum th_initial_state state, const P
 static void input_append(th_tokenizer *self, int kind, const void *data, Py_ssize_t from, Py_ssize_t to) {
     th_buf *buf = &self->input;
     Py_ssize_t count = to - from;
+    if (count == 0) { /* a chunk opening with '\r' on a still-NULL buffer: even a zero offset into NULL is undefined */
+        return;
+    }
     int promote = kind > buf->kind ? buf_promote(buf, kind) : 0;
     /* GCOVR_EXCL_START: allocation failure cannot be forced from a test */
     if (promote < 0 || buf_ensure(buf, (buf->len + count) * buf->kind) < 0) {

--- a/tests/tokenizer/test_tokenizer.py
+++ b/tests/tokenizer/test_tokenizer.py
@@ -361,6 +361,25 @@ def test_streaming_crlf_across_feeds() -> None:
     assert [token.data for token in tokenizer.close()] == ["a\nb"]
 
 
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        pytest.param("\ra", ["\na"], id="lone-cr"),
+        pytest.param("\r\na", ["\na"], id="crlf"),
+        pytest.param("\r\U0001f600", ["\n\U0001f600"], id="ucs4-lone-cr"),
+        pytest.param(
+            '\r-><a hre="p?q=1&r=" 4itle="he said"&qot;hi&qot;">link</a>\n',
+            ["\n->", "link", "\n"],
+            id="fuzz-reproducer",
+        ),
+    ],
+)
+def test_leading_carriage_return_into_an_empty_input(text: str, expected: list[str]) -> None:
+    # nothing precedes the '\r', so the first block appended has no code points and the input buffer is still
+    # unallocated; the append must return before it forms a pointer into NULL (the deep-fuzz UBSan finding)
+    assert [token.data for token in tokenize(text) if token.type is TokenType.TEXT] == expected
+
+
 def test_feed_after_close_is_rejected() -> None:
     tokenizer = Tokenizer()
     list(tokenizer.feed("<p>"))

--- a/tools/fuzz/corpus/parse/leading-cr-null-input.html
+++ b/tools/fuzz/corpus/parse/leading-cr-null-input.html
@@ -1,0 +1,1 @@
+-><a hre="p?q=1&r=" 4itle="he said"&qot;hi&qot;">link</a>


### PR DESCRIPTION
The scheduled deep-fuzz job aborted under UBSan with `statemachine.c:486:34: runtime error: applying zero offset to null pointer` in `input_append` on the 59-byte input `b'\r-><a hre="p?q=1&r=" 4itle="he said"&qot;hi&qot;">link</a>\n'` (https://github.com/tox-dev/turbohtml/actions/runs/31367280245/job/93388291681). When the first chunk fed to the tokenizer opens with `\r`, `th_tok_feed` appends the empty run before it while the input buffer is still unallocated, so `input_append` formed `(char *)NULL + 0` and passed it to `memcpy`; clang 18 on the Linux runner diagnoses that, clang 21+ no longer does in C (N3322), so macOS never saw it. `input_append` now returns before the copy when the run is empty; a tokenizer test covers a leading lone CR, CRLF, a wide chunk, and the exact reproducer, and the reproducer joins `tools/fuzz/corpus/parse` so the Linux ASan/UBSan smoke gate replays it on every PR.