### PR TITLE
🐛 fix(markdown): escape a table cell pipe where it is written

### DIFF
--- a/docs/changelog/764.bugfix.rst
+++ b/docs/changelog/764.bugfix.rst
@@ -1,0 +1,3 @@
+Escape a ``|`` where turbohtml writes a Markdown table cell's content rather than over the finished cell, so a nested
+table no longer adds a backslash per level; a table, list or ``<br>`` in a cell keeps its HTML unless
+``Markdown.Tables(cell_blocks="text")``.

--- a/docs/explanation/serialization.rst
+++ b/docs/explanation/serialization.rst
@@ -190,6 +190,15 @@ and a nested ordered list keeps its own counter through the recursion stack rath
 naive implementation corrupts on nesting. The output is opinionated GFM with no options, validated both by golden cases
 and by rendering it back to HTML with a reference Markdown engine and checking that no visible text was lost.
 
+GFM puts that pipe escape on the cell's *content* ("include a pipe in a cell's content by escaping it, including inside
+other inline spans"), so turbohtml escapes where it writes the content -- prose, code spans, URLs, alt text, embedded
+HTML, a converter's return -- and not over a finished cell. Escaping the rendered cell is the easier implementation, and
+the one most of the field picks. It cannot tell a literal pipe from one the writer already escaped, so ``\|`` turns into
+``\\|``, which a reader takes as a backslash followed by a live cell break, and each level of table nesting adds another
+backslash. The same cell context decides what becomes of a block the cell cannot hold: a nested table or list keeps its
+source HTML, legal there because raw HTML is inline content, rather than dropping its grid or its bullets onto the row
+as literal text.
+
 The walk holds no state outside its stack frame (no module-level buffers, no per-converter object), so two threads
 exporting two trees never interfere, and the binding takes the same per-tree critical section
 :attr:`~turbohtml.Node.text` and :attr:`~turbohtml.Node.html` use so a concurrent mutation cannot rewire the tree

--- a/docs/how-to/markdown.rst
+++ b/docs/how-to/markdown.rst
@@ -66,6 +66,31 @@ field.
 
     [1]: /x
 
+A pipe table holds one line of inline content per cell, so a table or a list *inside* a cell has no Markdown spelling of
+its own; the GFM spec is explicit that "block-level elements cannot be inserted in a table". Both keep their source
+HTML, which is legal in a cell and renders as the real thing wherever a reader takes embedded HTML, and a ``<br>`` in a
+cell stays a ``<br>`` for the same reason. Pass ``Markdown.Tables(cell_blocks="text")`` to flatten them to the text they
+hold instead:
+
+.. testcode::
+
+    nested = turbohtml.parse(
+        "<table><tr><th>Item</th><th>Sizes</th></tr>"
+        "<tr><td>Loaf</td><td><ul><li>small</li><li>large</li></ul></td></tr></table>"
+    )
+    print(nested.to_markdown())
+    print(nested.to_markdown(Markdown(tables=Markdown.Tables(cell_blocks="text"))))
+
+.. testoutput::
+    :options: +NORMALIZE_WHITESPACE
+
+    | Item | Sizes |
+    | --- | --- |
+    | Loaf | <ul><li>small</li><li>large</li></ul> |
+    | Item | Sizes |
+    | --- | --- |
+    | Loaf | small large |
+
 The ``Markdown.Wrapping`` sub-config shapes the result further. ``width`` word-wraps prose at a column (``0``, the
 default, leaves paragraphs unwrapped), honoring list and blockquote indentation; ``list_items`` extends wrapping into
 list items and ``links=False`` keeps a ``[text](url)`` construct on one line. ``Markdown.Images(mode="html")`` and

--- a/src/turbohtml/_c/dom/node.c
+++ b/src/turbohtml/_c/dom/node.c
@@ -713,7 +713,7 @@ static PyObject *node_render_with_options(PyObject *self, PyObject *args, PyObje
 static PyObject *node_markdown_render(PyObject *self, PyObject *spec) {
     md_opts opt = th_markdown_default_opts();
     PyObject *heading = NULL, *strike = NULL, *code_style = NULL, *link = NULL, *image = NULL, *table = NULL;
-    PyObject *header = NULL, *escape = NULL, *brk = NULL, *spacing = NULL, *docstrip = NULL;
+    PyObject *header = NULL, *cell_blocks = NULL, *escape = NULL, *brk = NULL, *spacing = NULL, *docstrip = NULL;
     PyObject *converters = NULL, *strip = NULL, *convert = NULL;
     int ignore_emphasis = 0, mark_code = 0;
     static char *kw[] = {"heading_style",
@@ -737,6 +737,7 @@ static PyObject *node_markdown_render(PyObject *self, PyObject *spec) {
                          "default_image_alt",
                          "table_mode",
                          "table_header",
+                         "cell_blocks",
                          "pad_tables",
                          "escape_mode",
                          "escape_asterisks",
@@ -762,10 +763,10 @@ static PyObject *node_markdown_render(PyObject *self, PyObject *spec) {
         return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     int parsed = PyArg_ParseTupleAndKeywords(
-        empty, spec, "|$OsssOpssOspOppppsOsOOpOppOOipppOsspipOOO", kw, &heading, &opt.bullets, &opt.strong,
+        empty, spec, "|$OsssOpssOspOppppsOsOOOpOppOOipppOsspipOOO", kw, &heading, &opt.bullets, &opt.strong,
         &opt.emphasis, &strike, &ignore_emphasis, &opt.sub, &opt.sup, &code_style, &opt.code_language, &mark_code,
         &link, &opt.autolink, &opt.link_title, &opt.ignore_links, &opt.skip_internal_links, &opt.base_url, &image,
-        &opt.default_image_alt, &table, &header, &opt.pad_tables, &escape, &opt.escape_asterisks,
+        &opt.default_image_alt, &table, &header, &cell_blocks, &opt.pad_tables, &escape, &opt.escape_asterisks,
         &opt.escape_underscores, &brk, &spacing, &opt.wrap_width, &opt.wrap_list_items, &opt.wrap_links,
         &opt.transliterate, &docstrip, &opt.quote_open, &opt.quote_close, &opt.google_doc, &opt.google_list_indent,
         &opt.hide_strikethrough, &strip, &convert, &converters);
@@ -780,6 +781,7 @@ static PyObject *node_markdown_render(PyObject *self, PyObject *spec) {
     static const char *const images[] = {"markdown", "alt", "ignore", "html"};
     static const char *const tables[] = {"markdown", "strip", "html"};
     static const char *const headers[] = {"first", "detect", "none"};
+    static const char *const cells[] = {"html", "text"};
     static const char *const escapes[] = {"minimal", "all"};
     static const char *const breaks[] = {"spaces", "backslash"};
     static const char *const spacings[] = {"double", "single"};
@@ -792,6 +794,7 @@ static PyObject *node_markdown_render(PyObject *self, PyObject *spec) {
         md_resolve_enum("image_mode", image, images, 4, &opt.image_mode) < 0 ||
         md_resolve_enum("table_mode", table, tables, 3, &opt.table_mode) < 0 ||
         md_resolve_enum("table_header", header, headers, 3, &opt.table_header) < 0 ||
+        md_resolve_enum("cell_blocks", cell_blocks, cells, 2, &opt.cell_blocks) < 0 ||
         md_resolve_enum("escape_mode", escape, escapes, 2, &opt.escape_mode) < 0 ||
         md_resolve_enum("line_break", brk, breaks, 2, &opt.line_break) < 0 ||
         md_resolve_enum("block_spacing", spacing, spacings, 2, &block_spacing) < 0 ||

--- a/src/turbohtml/_c/dom/tree.h
+++ b/src/turbohtml/_c/dom/tree.h
@@ -546,6 +546,10 @@ enum th_md_escape { TH_MD_ESCAPE_MINIMAL, TH_MD_ESCAPE_ALL };
 enum th_md_break { TH_MD_BREAK_SPACES, TH_MD_BREAK_BACKSLASH };
 enum th_md_doc_strip { TH_MD_DOC_STRIP, TH_MD_DOC_LSTRIP, TH_MD_DOC_RSTRIP, TH_MD_DOC_NONE };
 enum th_md_table_header { TH_MD_HEADER_FIRST, TH_MD_HEADER_DETECT, TH_MD_HEADER_NONE };
+/* A pipe-table cell holds inline content only, so a table or list inside one has
+   no markdown spelling: keep its source HTML (which renders as the real thing) or
+   flatten it to the text it contains. */
+enum th_md_cell_blocks { TH_MD_CELL_HTML, TH_MD_CELL_TEXT };
 /* No filter, a strip denylist (listed tags lose their markup), or a convert
    allowlist (only listed tags keep their markup). */
 enum th_md_filter { TH_MD_FILTER_NONE, TH_MD_FILTER_STRIP, TH_MD_FILTER_CONVERT };
@@ -576,6 +580,7 @@ typedef struct {
     const char *base_url;   /* prefix resolved onto a relative link/image href */
     int table_mode;         /* enum th_md_table */
     int table_header;       /* enum th_md_table_header */
+    int cell_blocks;        /* enum th_md_cell_blocks */
     int pad_tables;         /* align columns to a common width */
     const char *quote_open; /* <q> wrappers */
     const char *quote_close;

--- a/src/turbohtml/_c/serialize/markdown.c
+++ b/src/turbohtml/_c/serialize/markdown.c
@@ -56,6 +56,7 @@ md_opts th_markdown_default_opts(void) {
     opt.base_url = "";
     opt.table_mode = TH_MD_TABLE_MARKDOWN;
     opt.table_header = TH_MD_HEADER_FIRST;
+    opt.cell_blocks = TH_MD_CELL_HTML;
     opt.quote_open = "\"";
     opt.quote_close = "\"";
     opt.escape_mode = TH_MD_ESCAPE_MINIMAL;
@@ -114,6 +115,7 @@ typedef struct {
     int pending_word;     /* code points in the word the owed space precedes, for greedy wrapping */
     int no_wrap;          /* >0 inside verbatim/grid/unbreakable content: never insert a wrap break */
     int inline_only;      /* >0 inside link text: a block flattens to inline, never opens a line */
+    int in_cell;          /* inside a table cell: a pipe is escaped as it is written, a block turns into HTML */
     int drop_space;       /* swallow the next pending space (block/inline start) without emitting */
     int pending_loose;    /* the previous block wants a blank line after it */
     int suppress_break;   /* the next block attaches to the current (list marker) line */
@@ -317,11 +319,41 @@ static void md_put_char(md_ctx *ctx, Py_UCS4 ch) {
         }
     }
     int line_start_marker = !ctx->line_has_content && (ch == '#' || ch == '>' || ch == '-' || ch == '+');
-    if (md_needs_escape(ctx->opt, ch) || line_start_marker) {
+    if (md_needs_escape(ctx->opt, ch) || line_start_marker || (ctx->in_cell && ch == '|')) {
         sbuf_putc(&ctx->out, '\\');
     }
     sbuf_putc(&ctx->out, ch);
     ctx->line_has_content = 1;
+}
+
+/* Write one content code point, escaping a pipe that would otherwise end the table
+   cell it sits in. GFM puts that escape on the cell's *content* ("include a pipe in a
+   cell's content by escaping it, including inside other inline spans"), so every writer
+   of content goes through here or md_put_run and escapes it exactly once, where it is
+   written. Escaping the rendered cell instead cannot tell a literal pipe from one this
+   writer already escaped: `\|` becomes `\\|`, a backslash followed by a live break. */
+static void md_put_literal(md_ctx *ctx, Py_UCS4 ch) {
+    if (ctx->in_cell && ch == '|') {
+        sbuf_putc(&ctx->out, '\\');
+    }
+    sbuf_putc(&ctx->out, ch);
+}
+
+/* The same rule over a run, which is how prose and embedded markup are written. */
+static void md_put_run(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
+    if (!ctx->in_cell) {
+        sbuf_put_run(&ctx->out, text, len);
+        return;
+    }
+    Py_ssize_t start = 0;
+    for (Py_ssize_t index = 0; index < len; index++) {
+        if (text[index] == '|') {
+            sbuf_put_run(&ctx->out, &text[start], index - start);
+            sbuf_puts(&ctx->out, "\\|");
+            start = index + 1;
+        }
+    }
+    sbuf_put_run(&ctx->out, &text[start], len - start);
 }
 
 /* At a line start, "12. " or "3) " would be read as an ordered-list item, so a
@@ -380,7 +412,7 @@ static void md_emit_text(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t len) {
             index++;
         }
         if (index > start) {
-            sbuf_put_run(&ctx->out, &text[start], index - start);
+            md_put_run(ctx, &text[start], index - start);
         }
     }
 }
@@ -564,7 +596,7 @@ static void md_emit_code_span(md_ctx *ctx, th_node *node) {
     if (pad) {
         sbuf_putc(&ctx->out, ' ');
     }
-    sbuf_put_run(&ctx->out, content.data, len);
+    md_put_run(ctx, content.data, len);
     if (pad) {
         sbuf_putc(&ctx->out, ' ');
     }
@@ -586,21 +618,21 @@ static void md_emit_url(md_ctx *ctx, const Py_UCS4 *url, Py_ssize_t len) {
     }
     if (has_space) {
         sbuf_putc(&ctx->out, '<');
-        sbuf_put_run(&ctx->out, url, len);
+        md_put_run(ctx, url, len);
         sbuf_putc(&ctx->out, '>');
     } else {
-        sbuf_put_run(&ctx->out, url, len);
+        md_put_run(ctx, url, len);
     }
 }
 
 /* Write a link/image title inside its `"..."` delimiters: a `"` would close the
    title early and a `\` would escape the next character, so both are backslashed. */
-static void md_emit_title(sbuf *out, const Py_UCS4 *title, Py_ssize_t len) {
+static void md_emit_title(md_ctx *ctx, const Py_UCS4 *title, Py_ssize_t len) {
     for (Py_ssize_t index = 0; index < len; index++) {
         if (title[index] == '"' || title[index] == '\\') {
-            sbuf_putc(out, '\\');
+            sbuf_putc(&ctx->out, '\\');
         }
-        sbuf_putc(out, title[index]);
+        md_put_literal(ctx, title[index]);
     }
 }
 
@@ -711,7 +743,7 @@ static void md_emit_link(md_ctx *ctx, th_node *node) {
     md_emit_url(ctx, href, href_len);
     if (title != NULL) {
         sbuf_puts(&ctx->out, " \"");
-        md_emit_title(&ctx->out, title, title_len);
+        md_emit_title(ctx, title, title_len);
         sbuf_putc(&ctx->out, '"');
     }
     sbuf_putc(&ctx->out, ')');
@@ -734,6 +766,93 @@ static void md_emit_raw_html(md_ctx *ctx, th_node *node) {
     PyMem_Free(html);
 }
 
+/* The length of a bare `<tbody>`/`</tbody>` tag at the head of text, or 0 for
+   anything else. One with attributes is not bare and keeps its markup. */
+static Py_ssize_t md_tbody_tag(const Py_UCS4 *text, Py_ssize_t len) {
+    static const char *const tags[] = {"<tbody>", "</tbody>"};
+    for (size_t which = 0; which < sizeof(tags) / sizeof(tags[0]); which++) {
+        Py_ssize_t tag_len = (Py_ssize_t)strlen(tags[which]);
+        if (len < tag_len) {
+            continue;
+        }
+        Py_ssize_t index = 0;
+        while (index < tag_len && text[index] == (Py_UCS4)(unsigned char)tags[which][index]) {
+            index++;
+        }
+        if (index == tag_len) {
+            return tag_len;
+        }
+    }
+    return 0;
+}
+
+/* Write a block a pipe-table cell cannot hold -- a nested table or list -- as its
+   source HTML, which is inline content and so legal in a cell (and renders as the
+   real thing wherever embedded HTML is allowed). The `<tbody>` the parser inserts
+   around every row group is dropped on the way out: it reparses back in and only
+   widens the column. The caller's whitespace collapse puts the rest on one line. */
+static void md_emit_cell_html(md_ctx *ctx, th_node *node) {
+    Py_ssize_t len;
+    Py_UCS4 *html = th_node_html(ctx->tree, node, &len);
+    if (html == NULL) {      /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        ctx->out.failed = 1; /* GCOVR_EXCL_LINE: allocation-failure path */
+        return;              /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    md_before_visible(ctx);
+    Py_ssize_t start = 0;
+    for (Py_ssize_t index = 0; index < len; index++) {
+        Py_ssize_t tag = md_tbody_tag(&html[index], len - index);
+        if (tag > 0) {
+            md_put_run(ctx, &html[start], index - start);
+            index += tag - 1;
+            start = index + 1;
+        }
+    }
+    md_put_run(ctx, &html[start], len - start);
+    ctx->line_has_content = 1;
+    PyMem_Free(html);
+}
+
+/* The blocks a pipe-table cell cannot hold: a nested table, and the lists whose
+   bullets would otherwise land on the row as literal text. */
+static int md_is_cell_block(uint16_t atom) {
+    return atom == TH_TAG_TABLE || atom == TH_TAG_UL || atom == TH_TAG_OL || atom == TH_TAG_MENU;
+}
+
+/* The table and list scaffolding a flattened block is made of. Each one's boundary
+   owes a space, or the last word of a cell and the first of the next fuse. */
+static int md_is_cell_scaffold(uint16_t atom) {
+    switch (atom) {
+    case TH_TAG_TABLE:
+    case TH_TAG_THEAD:
+    case TH_TAG_TBODY:
+    case TH_TAG_TFOOT:
+    case TH_TAG_TR:
+    case TH_TAG_TD:
+    case TH_TAG_TH:
+    case TH_TAG_UL:
+    case TH_TAG_OL:
+    case TH_TAG_MENU:
+    case TH_TAG_LI:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/* Write a block a cell cannot hold as the text it holds, dropping the grid or the
+   bullets but keeping the inline markup inside each cell or item. */
+static void md_emit_cell_flat(md_ctx *ctx, th_node *node) {
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type == TH_NODE_ELEMENT && child->ns == TH_NS_HTML && md_is_cell_scaffold(child->atom)) {
+            ctx->space_pending = 1;
+            md_emit_cell_flat(ctx, child);
+        } else {
+            md_render_inline(ctx, child);
+        }
+    }
+}
+
 /* Write an image's alt text, falling back to the configured default. Inside the
    `![...]` description a bracket or backslash is escaped the same way link text
    escapes them (an unescaped `]` would close the description early); the plain
@@ -745,10 +864,10 @@ static void md_emit_alt(md_ctx *ctx, const Py_UCS4 *alt, Py_ssize_t alt_len, int
                 if (alt[index] == '[' || alt[index] == ']' || alt[index] == '\\') {
                     sbuf_putc(&ctx->out, '\\');
                 }
-                sbuf_putc(&ctx->out, alt[index]);
+                md_put_literal(ctx, alt[index]);
             }
         } else {
-            sbuf_put_run(&ctx->out, alt, alt_len);
+            md_put_run(ctx, alt, alt_len);
         }
     } else {
         md_puts8(&ctx->out, ctx->opt->default_image_alt);
@@ -787,7 +906,7 @@ static void md_emit_image(md_ctx *ctx, th_node *node) {
     const Py_UCS4 *title = md_attr(ctx->tree, node, "title", &title_len);
     if (title != NULL) {
         sbuf_puts(&ctx->out, " \"");
-        md_emit_title(&ctx->out, title, title_len);
+        md_emit_title(ctx, title, title_len);
         sbuf_putc(&ctx->out, '"');
     }
     sbuf_putc(&ctx->out, ')');
@@ -848,6 +967,18 @@ static void md_render_inline_tag(md_ctx *ctx, th_node *node) {
         md_emit_image(ctx, node);
         return;
     case TH_TAG_BR:
+        if (ctx->in_cell) {
+            /* a row is one line, so the markdown spellings of a break cannot be used
+               here: their marker would survive the collapse to a row and the break
+               itself would not. HTML's own break does work inside a cell. */
+            if (opt->cell_blocks == TH_MD_CELL_HTML) {
+                sbuf_puts(&ctx->out, "<br>");
+                ctx->line_has_content = 1;
+            } else {
+                ctx->space_pending = 1;
+            }
+            return;
+        }
         sbuf_puts(&ctx->out, opt->line_break == TH_MD_BREAK_BACKSLASH ? "\\" : "  ");
         md_newline(ctx);
         return;
@@ -1175,7 +1306,7 @@ static void md_emit_converted(md_ctx *ctx, th_node *node, PyObject *text) {
         if (character == '\n') {
             md_newline(ctx);
         } else {
-            sbuf_putc(&ctx->out, character);
+            md_put_literal(ctx, character);
             ctx->line_has_content = 1;
         }
     }
@@ -1348,8 +1479,10 @@ static void md_render_list(md_ctx *ctx, th_node *node, int ordered) {
     ctx->list_depth--;
 }
 
-/* Render a cell's inline content into dst, collapsing internal whitespace to
-   single spaces and escaping pipes so the cell stays on one row. */
+/* Render a cell's content into dst, collapsing internal whitespace to single spaces
+   so the cell stays on one row. in_cell steers the writers themselves: a pipe is
+   escaped where it is written and a block that a cell cannot hold becomes HTML, so
+   nothing here has to reinterpret finished markdown. */
 static void md_cell_text(md_ctx *ctx, th_node *node, sbuf *dst) {
     sbuf saved_out = ctx->out;
     sbuf saved_prefix = ctx->prefix;
@@ -1364,6 +1497,7 @@ static void md_cell_text(md_ctx *ctx, th_node *node, sbuf *dst) {
     ctx->line_has_content = 1;
     ctx->space_pending = 0;
     ctx->drop_space = 1;
+    ctx->in_cell = 1;
     md_inline_children(ctx, node);
     sbuf rendered = ctx->out;
     PyMem_Free(ctx->prefix.data);
@@ -1374,6 +1508,7 @@ static void md_cell_text(md_ctx *ctx, th_node *node, sbuf *dst) {
     ctx->line_has_content = saved_line;
     ctx->space_pending = saved_space;
     ctx->drop_space = saved_drop;
+    ctx->in_cell = 0;
     int space_run = 0;
     for (Py_ssize_t index = 0; index < rendered.len; index++) {
         Py_UCS4 ch = rendered.data[index];
@@ -1385,11 +1520,7 @@ static void md_cell_text(md_ctx *ctx, th_node *node, sbuf *dst) {
             sbuf_putc(dst, ' ');
             space_run = 0;
         }
-        if (ch == '|') {
-            sbuf_puts(dst, "\\|");
-        } else {
-            sbuf_putc(dst, ch);
-        }
+        sbuf_putc(dst, ch);
     }
     PyMem_Free(rendered.data);
 }
@@ -1611,7 +1742,7 @@ static void md_emit_pre_text(md_ctx *ctx, const Py_UCS4 *text, Py_ssize_t end) {
         if (text[index] == '\n') {
             md_newline(ctx);
         } else {
-            sbuf_putc(&ctx->out, text[index]);
+            md_put_literal(ctx, text[index]);
             ctx->line_has_content = 1;
         }
     }
@@ -1718,6 +1849,18 @@ static void md_render_block_body(md_ctx *ctx, th_node *node) {
     if (md_tag_filtered(ctx->opt, atom)) {
         /* drop the block's own markup but keep laying its children out as blocks */
         md_block_children(ctx, node);
+        return;
+    }
+    if (ctx->in_cell && md_is_cell_block(atom)) {
+        /* "Block-level elements cannot be inserted in a table" (GFM 4.10): a nested
+           table or list has no pipe-table spelling, so it either keeps its source
+           HTML -- inline content, and so legal in a cell -- or gives up its markup
+           and contributes the text it holds */
+        if (ctx->opt->cell_blocks == TH_MD_CELL_HTML) {
+            md_emit_cell_html(ctx, node);
+        } else {
+            md_emit_cell_flat(ctx, node);
+        }
         return;
     }
     switch (atom) {
@@ -1833,7 +1976,7 @@ static void md_flush_references(md_ctx *ctx) {
         sbuf_put_run(&ctx->out, ctx->refs[index].url, ctx->refs[index].url_len);
         if (ctx->refs[index].title != NULL) {
             sbuf_puts(&ctx->out, " \"");
-            md_emit_title(&ctx->out, ctx->refs[index].title, ctx->refs[index].title_len);
+            md_emit_title(ctx, ctx->refs[index].title, ctx->refs[index].title_len);
             sbuf_putc(&ctx->out, '"');
         }
     }

--- a/src/turbohtml/_internal/_render.py
+++ b/src/turbohtml/_internal/_render.py
@@ -153,11 +153,15 @@ class Markdown:
 
         :param mode: ``markdown`` (pipe table), ``strip`` (cell text only), or ``html`` (raw ``<table>``).
         :param header: which row is the header: ``first``, ``detect``, or ``none``.
+        :param cell_blocks: what a table or list *inside* a cell becomes, since a pipe cell holds no block:
+            ``html`` keeps its source markup (and a ``<br>`` for a line break), ``text`` flattens it to the text it
+            contains.
         :param pad: align columns to a common width.
         """
 
         mode: Literal["markdown", "strip", "html"] = "markdown"
         header: Literal["first", "detect", "none"] = "first"
+        cell_blocks: Literal["html", "text"] = "html"
         pad: bool = False
 
     @dataclass(frozen=True)
@@ -277,6 +281,7 @@ class Markdown:
             "default_image_alt": (self.images.default_alt, default.images.default_alt),
             "table_mode": (self.tables.mode, default.tables.mode),
             "table_header": (self.tables.header, default.tables.header),
+            "cell_blocks": (self.tables.cell_blocks, default.tables.cell_blocks),
             "pad_tables": (self.tables.pad, default.tables.pad),
             "escape_mode": (self.escaping.mode, default.escaping.mode),
             "escape_asterisks": (self.escaping.asterisks, default.escaping.asterisks),

--- a/tests/serialize/test_tree_markdown.py
+++ b/tests/serialize/test_tree_markdown.py
@@ -246,8 +246,28 @@ def test_breaks_quotes_rules(html: str, expected: str) -> None:
         ),
         pytest.param(
             "<table><tr><td>x<br>y</td></tr><tr><td>z</td></tr></table>",
-            "| x y |\n| --- |\n| z |",
-            id="table-cell-newline-flattened",
+            "| x<br>y |\n| --- |\n| z |",
+            id="table-cell-break-kept-as-html",
+        ),
+        pytest.param(
+            "<table><tr><td>a<table><tr><td>b</td></tr></table></td><td>c</td></tr></table>",
+            "| a<table><tr><td>b</td></tr></table> | c |\n| --- | --- |",
+            id="table-nested-becomes-cell-html",
+        ),
+        pytest.param(
+            "<table><tr><td><ul><li>x</li><li>y</li></ul></td></tr><tr><td>z</td></tr></table>",
+            "| <ul><li>x</li><li>y</li></ul> |\n| --- |\n| z |",
+            id="table-list-in-cell-becomes-html",
+        ),
+        pytest.param(
+            "<table><tr><td><table><tr><td>a|b</td></tr></table></td></tr></table>",
+            "| <table><tr><td>a\\|b</td></tr></table> |\n| --- |",
+            id="table-pipe-inside-nested-escaped-once",
+        ),
+        pytest.param(
+            "<table><tr><td><code>a|b</code></td></tr><tr><td>c</td></tr></table>",
+            "| `a\\|b` |\n| --- |\n| c |",
+            id="table-pipe-in-code-span-escaped",
         ),
     ],
 )
@@ -481,6 +501,28 @@ def _render(markdown: str) -> str:
 def test_roundtrip_preserves_text(html: str) -> None:
     rendered = _render(md(html))
     assert _tokens(rendered) == _tokens(html)
+
+
+def _nested_tables(depth: int) -> str:
+    """`depth` tables, each the only cell of the one above it, around a pipe in text."""
+    html = "a|b"
+    for _ in range(depth):
+        html = f"<table><tr><td>{html}</td></tr></table>"
+    return html
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3, 5], ids=lambda depth: f"depth-{depth}")
+def test_nested_table_pipe_escape_never_compounds(depth: int) -> None:
+    # `\\|` reads as an escaped backslash followed by a live cell break, and escaping
+    # an already-escaped cell once per nesting level is how it used to arrive
+    assert "\\\\|" not in md(_nested_tables(depth))
+
+
+@pytest.mark.parametrize("depth", [2, 3, 5], ids=lambda depth: f"depth-{depth}")
+def test_nested_table_survives_the_round_trip(depth: int) -> None:
+    # the word-token round-trip below passes on a cell flattened to junk, so pin the
+    # structure: every nested table comes back a table
+    assert _render(md(_nested_tables(depth))).count("<table") == depth
 
 
 def test_corpus_never_crashes_and_renders(wpt_html_tree_corpus: WptHtmlTreeCorpus) -> None:

--- a/tests/serialize/test_tree_markdown_converters.py
+++ b/tests/serialize/test_tree_markdown_converters.py
@@ -111,6 +111,13 @@ def test_converter_on_root_element() -> None:
     assert out == "S[hi **there**]"
 
 
+def test_converter_output_in_a_table_cell_escapes_its_pipes() -> None:
+    html = "<table><tr><td><span>x</span></td></tr></table>"
+    out = parse(html).to_markdown(Markdown(converters={"span": lambda _e, text: f"{text}|y"}))
+    # the trailing " |" of each row carries one space; compare line-rstripped
+    assert "\n".join(line.rstrip() for line in out.splitlines()) == "| x\\|y |\n| --- |"
+
+
 def test_reference_link_inside_converter_registers() -> None:
     html = "<div><a href='https://e.test'>e</a></div>"
     out = parse(html).to_markdown(Markdown(links=Markdown.Links(style="reference"), converters={"div": wrap("|")}))

--- a/tests/serialize/test_tree_markdown_options.py
+++ b/tests/serialize/test_tree_markdown_options.py
@@ -277,6 +277,111 @@ def test_images(html: str, opts: Markdown, expected: str) -> None:
             "|  |\n| --- |\n| H |\n| a |",
             id="table-header-none",
         ),
+        pytest.param(
+            "<table><tr><td>a<table><tr><td>b</td></tr></table></td><td>c</td></tr></table>",
+            Markdown(tables=Markdown.Tables(cell_blocks="text")),
+            "| a b | c |\n| --- | --- |",
+            id="cell-blocks-text-flattens-nested-table",
+        ),
+        pytest.param(
+            "<table><tr><td><ul><li>x</li><li>y</li></ul></td></tr></table>",
+            Markdown(tables=Markdown.Tables(cell_blocks="text")),
+            "| x y |\n| --- |",
+            id="cell-blocks-text-flattens-list",
+        ),
+        pytest.param(
+            "<table><tr><td>a<br>b</td></tr></table>",
+            Markdown(tables=Markdown.Tables(cell_blocks="text")),
+            "| a b |\n| --- |",
+            id="cell-blocks-text-break-is-a-space",
+        ),
+        pytest.param(
+            "<table><tr><td><table><tr><td><b>x</b>|y</td></tr></table></td></tr></table>",
+            Markdown(tables=Markdown.Tables(cell_blocks="text")),
+            "| **x**\\|y |\n| --- |",
+            id="cell-blocks-text-keeps-inline-markup",
+        ),
+        pytest.param(
+            "<table><tr><td><table><thead><tr><th>H</th></tr></thead>"
+            "<tbody><tr><td><ul><li>u</li></ul><ol><li>o</li></ol><menu><li>m</li></menu>"
+            "<table><tr><td>t</td></tr></table></td></tr></tbody>"
+            "<tfoot><tr><td>f</td></tr></tfoot></table></td></tr></table>",
+            Markdown(tables=Markdown.Tables(cell_blocks="text")),
+            "| H u o m t f |\n| --- |",
+            id="cell-blocks-text-spaces-every-boundary",
+        ),
+        pytest.param(
+            "<table><tr><td>a<table><tr><td>b</td></tr></table></td></tr></table>",
+            Markdown(tables=Markdown.Tables(cell_blocks="html", pad=True)),
+            "| a<table><tr><td>b</td></tr></table> |\n| ----------------------------------- |",
+            id="cell-blocks-html-widens-the-padded-column",
+        ),
+        pytest.param(
+            '<table><tr><td><table><tbody class="x"><tr><td>b</td></tr></tbody></table></td></tr></table>',
+            Markdown(),
+            '| <table><tbody class="x"><tr><td>b</td></tr></table> |\n| --- |',
+            id="cell-html-keeps-a-tbody-that-carries-attributes",
+        ),
+        pytest.param(
+            "<table><tr><td>a|b</td></tr></table>",
+            Markdown(escaping=Markdown.Escaping(mode="all")),
+            "| a\\|b |\n| --- |",
+            id="cell-pipe-escaped-once-under-escape-all",
+        ),
+        pytest.param(
+            '<table><tr><td><a href="u|v" title="t|t">a|b</a></td></tr></table>',
+            Markdown(),
+            '| [a\\|b](u\\|v "t\\|t") |\n| --- |',
+            id="cell-pipe-escaped-in-link-text-url-and-title",
+        ),
+        pytest.param(
+            '<table><tr><td><a href="u |v">x</a></td></tr></table>',
+            Markdown(),
+            "| [x](<u \\|v>) |\n| --- |",
+            id="cell-pipe-escaped-in-bracketed-url",
+        ),
+        pytest.param(
+            '<table><tr><td><img src="a|b.png" alt="x|y"></td></tr></table>',
+            Markdown(),
+            "| ![x\\|y](a\\|b.png) |\n| --- |",
+            id="cell-pipe-escaped-in-image",
+        ),
+        pytest.param(
+            '<table><tr><td><img src="s.png" alt="x|y"></td></tr></table>',
+            Markdown(images=Markdown.Images(mode="alt")),
+            "| x\\|y |\n| --- |",
+            id="cell-pipe-escaped-in-bare-alt-text",
+        ),
+        pytest.param(
+            '<table><tr><td><img src="a|b.png" alt="x"></td></tr></table>',
+            Markdown(images=Markdown.Images(mode="html")),
+            '| <img src="a\\|b.png" alt="x"> |\n| --- |',
+            id="cell-pipe-escaped-in-embedded-html",
+        ),
+        pytest.param(
+            "<table><tr><td><ol><li>x</li></ol></td></tr></table>",
+            Markdown(),
+            "| <ol><li>x</li></ol> |\n| --- |",
+            id="cell-ordered-list-becomes-html",
+        ),
+        pytest.param(
+            "<table><tr><td><menu><li>x</li></menu></td></tr></table>",
+            Markdown(),
+            "| <menu><li>x</li></menu> |\n| --- |",
+            id="cell-menu-becomes-html",
+        ),
+        pytest.param(
+            "<table><tr><td><table><tr><td><svg><text>s</text></svg>t</td></tr></table></td></tr></table>",
+            Markdown(tables=Markdown.Tables(cell_blocks="text")),
+            "| st |\n| --- |",
+            id="cell-blocks-text-flattens-foreign-content",
+        ),
+        pytest.param(
+            "<table><tr><td><pre>a|b</pre></td></tr></table>",
+            Markdown(),
+            "|  ``` a\\|b ``` |\n| --- |",
+            id="cell-pipe-escaped-in-preformatted-text",
+        ),
     ],
 )
 def test_tables(html: str, opts: Markdown, expected: str) -> None:
@@ -432,6 +537,7 @@ def test_invalid_options(operation: Callable[[Node], object], exc: type[Exceptio
         pytest.param(Markdown(images=Markdown.Images(mode="bogus")), "image_mode", id="image_mode"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
         pytest.param(Markdown(tables=Markdown.Tables(mode="bogus")), "table_mode", id="table_mode"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
         pytest.param(Markdown(tables=Markdown.Tables(header="bogus")), "table_header", id="table_header"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
+        pytest.param(Markdown(tables=Markdown.Tables(cell_blocks="bogus")), "cell_blocks", id="cell_blocks"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
         pytest.param(Markdown(escaping=Markdown.Escaping(mode="bogus")), "escape_mode", id="escape_mode"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
         pytest.param(Markdown(document=Markdown.Document(line_break="bogus")), "line_break", id="line_break"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check
         pytest.param(Markdown(document=Markdown.Document(block_spacing="bogus")), "block_spacing", id="block_spacing"),  # ty: ignore[invalid-argument-type]  # invalid value tests the runtime enum check


### PR DESCRIPTION
`to_markdown()` rendered a table cell first and escaped its pipes afterwards, over the finished Markdown. That pass cannot tell a literal pipe from one the writer had already escaped, so every level of table nesting added another backslash and the reproducer in #764 came out as `\\\\|`. `Markdown.Escaping(mode="all")` doubled the escape on a plain cell for the same reason. GFM puts the escape on the cell's *content* ("include a pipe in a cell's content by escaping it, including inside other inline spans"), so the writers now escape where they write 🔧. Prose, code spans, URLs, alt text, embedded HTML and a converter's return go through one helper that knows whether a cell is open, and a pipe picks up one backslash there and nowhere else.

The same cell context settles what a nested table should become. A pipe cell holds one line of inline content, and the GFM spec is explicit that "block-level elements cannot be inserted in a table", so flattening a nested table drops its grid onto the row as literal text and flattening a list drops its bullets there. Raw HTML is inline content and legal in a cell, so a table or list inside a cell keeps its source markup, minus the `<tbody>` the parser inserts, which reparses back in and only widens the column. A `<br>` in a cell stays a `<br>`. Callers whose reader takes no HTML pass the new `Markdown.Tables(cell_blocks="text")` and get the text those blocks hold, with a space at every cell and item boundary.

Both halves follow where the field landed, which I checked by running eighteen converters across nine languages on the same inputs. pandoc and Joplin's turndown fork promote a table with such a cell to HTML. Go's `html-to-markdown` and `remark` refuse the pipe grid and emit blocks instead. ReverseMarkdown keeps the outer grid and writes the offending child as HTML, which is what this does. On escaping, `remark` scopes it to the `tableCell` construct the way this does; `htmd` escapes to `&#124;`, which cmark-gfm renders as literal text inside a code span; markdownify, html2text and turndown's own GFM plugin emit the pipe unescaped.

Rendering the output back through cmark-gfm (GitHub's renderer) and markdown-it returns a real nested table for the issue's reproducer, where before it returned a row of literal text. A cell holding only inline content renders as it did; a cell holding a table, `ul`, `ol`, `menu` or `<br>` changes shape, which is the fix.

closes #764
