### PR TITLE
🐛 fix(linkify): reject a malformed scheme's host

### DIFF
--- a/docs/changelog/763.bugfix.rst
+++ b/docs/changelog/763.bugfix.rst
@@ -1,0 +1,3 @@
+Leave a URL whose scheme syntax is malformed entirely plain instead of linking its host on its own, so
+``https:/nonsense.com`` no longer renders as ``https:/<a href="http://nonsense.com">nonsense.com</a>``. Link a written
+``mailto:`` URI as one anchor covering its own scheme.

--- a/src/turbohtml/_c/clean/linkify.c
+++ b/src/turbohtml/_c/clean/linkify.c
@@ -34,6 +34,9 @@ enum th_link_kind {
     TH_LINK_HAS_SCHEME = 3,
     /* A phone number the recognizer accepted: the href is its tel: URI, built from the digits it resolved. */
     TH_LINK_PHONE = 4,
+    /* A written ``mailto:`` URI whose payload is an address: the span covers the scheme too, so the URI links as one
+       anchor rather than a stranded ``mailto:`` beside one. */
+    TH_LINK_MAILTO = 5,
 };
 
 /* A non-ASCII Unicode White_Space code point (the ASCII ones are c <= 0x20). UTS46
@@ -308,6 +311,28 @@ static int blocked_on_left(int kind, const void *data, Py_ssize_t start) {
     return before == '@' || before == '.' || is_label_char(before);
 }
 
+/* True when what sits left of `start` is URL syntax the scanner already declined, so
+   the host there belongs to that URL and is not an independent bare domain: a scheme's
+   ``:``, whatever slashes follow it (``https:x.com``, ``https:/x.com``, ``hppt://x.com``,
+   ``http:////x.com``, ``path:to:file.pm``), or a run of three or more slashes
+   (``///x.com``). Exactly ``//`` with no colon is a protocol-relative URL and still
+   links. Hyphens the caller trimmed off the first label are stepped back over, so
+   ``http://-example.com`` is seen for the declined scheme URL it is. */
+static int after_url_syntax(int kind, const void *data, Py_ssize_t start) {
+    Py_ssize_t pos = start;
+    while (pos > 0 && READ(pos - 1) == '-') {
+        pos--;
+    }
+    Py_ssize_t slash_end = pos;
+    while (pos > 0 && READ(pos - 1) == '/') {
+        pos--;
+    }
+    if (pos > 0 && READ(pos - 1) == ':') {
+        return 1;
+    }
+    return slash_end - pos > 2;
+}
+
 /* Expand left from a scheme's ``:`` over the scheme characters; returns the
    scheme start if one of the autolinked schemes is present, else -1. */
 static Py_ssize_t scan_scheme_start(int kind, const void *data, Py_ssize_t colon, Py_ssize_t start) {
@@ -382,14 +407,7 @@ static int match_domain(int kind, const void *data, Py_ssize_t dot, Py_ssize_t s
     while (pos < dot && READ(pos) == '-') { /* a label cannot start with a hyphen, so drop any the sweep pulled in */
         pos++;
     }
-    if (pos == dot || blocked_on_left(kind, data, pos)) {
-        return 0;
-    }
-    /* A ``://`` immediately left of the host is the authority of a scheme URL that
-       match_url declined (an unregistered or typo scheme like ``hppt://``); its host
-       is not an independent bare domain, so the whole thing stays plain text. A bare
-       ``//`` with no colon (``nothttp//example.com``) is not scheme syntax and links. */
-    if (pos >= 3 && READ(pos - 1) == '/' && READ(pos - 2) == '/' && READ(pos - 3) == ':') {
+    if (pos == dot || blocked_on_left(kind, data, pos) || after_url_syntax(kind, data, pos)) {
         return 0;
     }
     Py_ssize_t host_end = scan_host(kind, data, pos, len, 1, extra_tlds);
@@ -447,6 +465,45 @@ static int match_scheme_less(int kind, const void *data, Py_ssize_t colon, Py_ss
     }
     *out_start = scheme_start;
     *out_end = end;
+    return 1;
+}
+
+/* Does the scheme in [start, colon) equal the lowercase ASCII `name`? */
+static int scheme_is(int kind, const void *data, Py_ssize_t start, Py_ssize_t colon, const char *name,
+                     Py_ssize_t name_len) {
+    if (colon - start != name_len) {
+        return 0;
+    }
+    for (Py_ssize_t index = 0; index < name_len; index++) {
+        if (lower_ascii(READ(start + index)) != (Py_UCS4)(unsigned char)name[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* Try to match a written ``mailto:`` URI whose ``:`` is at `colon`: the scheme, then an
+   address the email matcher accepts. The span covers the URI as written, the way GFM's
+   protocol autolink does, so the whole URI becomes one anchor. */
+static int match_mailto(int kind, const void *data, Py_ssize_t colon, Py_ssize_t start, Py_ssize_t len,
+                        Py_ssize_t *out_start, Py_ssize_t *out_end, PyObject *extra_tlds) {
+    Py_ssize_t scheme_start = scan_scheme_start(kind, data, colon, start);
+    if (scheme_start < 0 || blocked_on_left(kind, data, scheme_start) ||
+        !scheme_is(kind, data, scheme_start, colon, "mailto", 6)) {
+        return 0;
+    }
+    Py_ssize_t at = colon + 1;
+    while (at < len && READ(at) != '@') {
+        if (!is_local_char(READ(at)) && READ(at) != '.') {
+            return 0;
+        }
+        at++;
+    }
+    if (at >= len || !match_email(kind, data, at, colon + 1, len, out_start, out_end, extra_tlds) ||
+        *out_start != colon + 1) {
+        return 0;
+    }
+    *out_start = scheme_start;
     return 1;
 }
 
@@ -556,18 +613,6 @@ static Py_ssize_t skip_plain(const uint8_t *bytes, Py_ssize_t pos, Py_ssize_t le
     return pos;
 }
 
-/* Is the scheme before `colon` the `tel` phone detection registered? A written tel: URI then links only when its
-   payload reads as a number, so `tel:not-a-number` stays text. */
-static int scheme_is_tel(int kind, const void *data, Py_ssize_t start, Py_ssize_t colon) {
-    if (colon - start != 3) {
-        return 0;
-    }
-    int letters = ((PyUnicode_READ(kind, data, start) | 0x20) == 't') +
-                  ((PyUnicode_READ(kind, data, start + 1) | 0x20) == 'e') +
-                  ((PyUnicode_READ(kind, data, start + 2) | 0x20) == 'l');
-    return letters == 3;
-}
-
 static int match_trigger(const scan_view *scan, Py_UCS4 c, Py_ssize_t pos, Py_ssize_t *start, Py_ssize_t *end,
                          enum th_link_kind *link_kind, th_phone_match *number) {
     int kind = scan->kind;
@@ -577,12 +622,17 @@ static int match_trigger(const scan_view *scan, Py_UCS4 c, Py_ssize_t pos, Py_ss
             *link_kind = TH_LINK_HAS_SCHEME; /* a scheme://host URL carries its own scheme, kept verbatim */
             return 1;
         }
+        if (scan->parse_email && match_mailto(kind, data, pos, scan->resume, scan->len, start, end, scan->extra_tlds)) {
+            *link_kind = TH_LINK_MAILTO;
+            return 1;
+        }
         *link_kind = TH_LINK_SCHEME;
         if (scan->schemes == NULL ||
             !match_scheme_less(kind, data, pos, scan->resume, scan->len, start, end, scan->schemes)) {
             return 0;
         }
-        if (scan->phone == NULL || !scheme_is_tel(kind, data, *start, pos)) {
+        /* a written tel: URI links only when its payload reads as a number, so `tel:not-a-number` stays text */
+        if (scan->phone == NULL || !scheme_is(kind, data, *start, pos, "tel", 3)) {
             return 1;
         }
         /* a written tel: URI is a phone link once its payload reads as a number: the href comes from that number,
@@ -644,7 +694,8 @@ static PyObject *phone_url(const th_phone_match *number) {
 static PyObject *matched_url(PyObject *text, Py_ssize_t start, Py_ssize_t end, enum th_link_kind link_kind) {
     PyObject *matched = PyUnicode_Substring(text, start, end);
     /* GCOVR_EXCL_BR_START: substring allocation cannot be forced */
-    if (matched == NULL || link_kind == TH_LINK_SCHEME || link_kind == TH_LINK_HAS_SCHEME) {
+    /* every other kind wrote its own scheme, so the match is already the href */
+    if (matched == NULL || (link_kind != TH_LINK_URL && link_kind != TH_LINK_EMAIL)) {
         return matched;
     }
     /* GCOVR_EXCL_BR_STOP */

--- a/src/turbohtml/clean/_linkify.py
+++ b/src/turbohtml/clean/_linkify.py
@@ -34,7 +34,8 @@ if TYPE_CHECKING:
 
     from turbohtml._html import _PhoneConfig
 
-_EMAIL_KIND: Final = 1
+# the two kinds the C scanner numbers as an address: a bare one and a written mailto: URI
+_EMAIL_KINDS: Final = (1, 5)
 
 # The ``scheme://host`` schemes autolinked when a config registers none: the fixed set linkify-it recognizes, so a typo
 # scheme or a ``javascript://`` payload stays plain text. A ``Linkify.schemes`` restricts to its own set (bleach), while
@@ -642,7 +643,7 @@ class LinkSpan:
 
 def _span_from_match(text: str, span: tuple[int, int, int, str, PhoneNumber | None]) -> LinkSpan:
     start, end, kind, url, phone = span
-    return LinkSpan(start, end, text[start:end], url, kind == _EMAIL_KIND, phone=phone)
+    return LinkSpan(start, end, text[start:end], url, kind in _EMAIL_KINDS, phone=phone)
 
 
 class LinkDetector:

--- a/tests/clean/test_linkify_scheme_syntax.py
+++ b/tests/clean/test_linkify_scheme_syntax.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from turbohtml.clean import LinkDetector, Linkify, linkify
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("https:nonsense.com", id="colon-no-slash"),
+        pytest.param("https:/nonsense.com", id="colon-one-slash"),
+        pytest.param("hppt://nonsense.com", id="typo-scheme"),
+        pytest.param("http:///nonsense.com", id="colon-three-slashes"),
+        pytest.param("http:////nonsense.com", id="colon-four-slashes"),
+        pytest.param("http://-nonsense.com", id="colon-slashes-then-hyphen"),
+        pytest.param("///nonsense.com", id="three-slashes-no-colon"),
+        pytest.param("path:to:nonsense.com", id="colon-inside-a-path"),
+    ],
+)
+def test_declined_scheme_leaves_its_host_plain(text: str) -> None:
+    # the host of a URL whose scheme syntax the scanner declined belongs to that URL, so neither half links
+    assert LinkDetector().find(text) == []
+
+
+@pytest.mark.parametrize(
+    ("text", "matched"),
+    [
+        pytest.param("//example.com", "example.com", id="protocol-relative"),
+        pytest.param("nothttp//example.com", "example.com", id="two-slashes-after-a-word"),
+        pytest.param("foo/example.com", "example.com", id="one-slash-after-a-word"),
+        pytest.param("-example.com", "example.com", id="leading-hyphen"),
+    ],
+)
+def test_slashes_without_a_scheme_colon_still_link(text: str, matched: str) -> None:
+    assert [span.text for span in LinkDetector().find(text)] == [matched]
+
+
+def test_declined_scheme_is_not_rewritten() -> None:
+    assert linkify("https:/nonsense.com") == "https:/nonsense.com"
+
+
+@pytest.mark.parametrize(
+    ("text", "matched"),
+    [
+        pytest.param("mailto:a@b.com", "mailto:a@b.com", id="bare"),
+        pytest.param("MAILTO:A@B.COM", "MAILTO:A@B.COM", id="uppercase-scheme"),
+        pytest.param("write to mailto:a@b.com now", "mailto:a@b.com", id="in-prose"),
+        pytest.param("mailto:foo.bar+baz@example.co.uk", "mailto:foo.bar+baz@example.co.uk", id="dotted-local-part"),
+    ],
+)
+def test_mailto_uri_spans_its_own_scheme(text: str, matched: str) -> None:
+    # GFM's protocol autolink: the URI is one link, not a stranded "mailto:" beside one
+    span = LinkDetector().find(text)[0]
+    assert (span.text, span.url, span.is_email) == (matched, matched, True)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("mailto:garbage", id="no-address"),
+        pytest.param("mailto:@example.com", id="empty-local-part"),
+        pytest.param("mailto:a@b", id="host-without-a-tld"),
+        pytest.param("mailto: a@b.com", id="space-before-the-address"),
+        pytest.param("mailto:.a@b.com", id="address-starts-past-the-colon"),
+        pytest.param("xmailto:a@b.com", id="scheme-is-a-longer-word"),
+        pytest.param("mailtp:a@b.com", id="scheme-is-a-typo"),
+        pytest.param("a.mailto:a@b.com", id="scheme-blocked-on-its-left"),
+        pytest.param(":a@b.com", id="colon-with-no-scheme"),
+    ],
+)
+def test_mailto_without_a_whole_address_is_not_a_scheme_link(text: str) -> None:
+    assert [span.text for span in LinkDetector().find(text) if span.text.lower().startswith("mailto")] == []
+
+
+def test_mailto_uri_rewrites_to_one_anchor() -> None:
+    assert linkify("mailto:a@b.com", Linkify(parse_email=True)) == '<a href="mailto:a@b.com">mailto:a@b.com</a>'
+
+
+def test_mailto_uri_stays_plain_without_email_detection() -> None:
+    assert linkify("mailto:a@b.com") == "mailto:a@b.com"
+
+
+def test_bare_address_still_gets_the_mailto_prefix() -> None:
+    span = LinkDetector().find("a@b.com")[0]
+    assert (span.text, span.url) == ("a@b.com", "mailto:a@b.com")


### PR DESCRIPTION
`linkify("https:/nonsense.com")` rendered as `https:/<a href="http://nonsense.com">nonsense.com</a>`: a stranded scheme sitting beside an anchor for a host nobody wrote that way. 🔗 A URL whose scheme syntax the scanner declined fell through to the bare-domain matcher, which then linked its authority on its own. [Reported in #763](https://github.com/tox-dev/turbohtml/issues/763#issuecomment-5493662837), where `bleach.linkify` keeps the malformed scheme in the `href` and linkify-it declines the whole run.

The old guard in `match_domain` recognised one exact byte sequence, `://`, so every other spelling leaked through: `https:nonsense.com` with no slash, `https:/nonsense.com` with one, `http:////example.com` with four, and `path:to:file.pm` where a colon precedes the host. `after_url_syntax` replaces it with the rule that covers the family: a scheme colon disqualifies the host that follows it whatever slashes come between, and so does a run of three or more slashes. Exactly `//` with no colon stays a protocol-relative URL, so `//example.com` and `nothttp//example.com` match as before.

A written `mailto:` URI had the same shape from the other side. The address matched and the scheme stayed outside the anchor, giving `mailto:<a href="mailto:a@b.com">a@b.com</a>` under `parse_email=True`. `match_mailto` claims the whole URI the way [GFM's protocol autolink](https://github.github.com/gfm/#autolinks-extension-) does, so it becomes one link carrying its own `href`, and `LinkSpan.is_email` stays true for it.

First of a seven-part stack for #763; the rest build on this branch.
