### PR TITLE
✨ feat(clean): read collapsed whitespace in phone numbers

### DIFF
--- a/docs/changelog/758.feature.rst
+++ b/docs/changelog/758.feature.rst
@@ -1,0 +1,2 @@
+``PhoneNumbers(collapse_whitespace=True)`` reads a run of HTML whitespace between the parts of a number as the one space
+it renders as, so a number a source formatter or a template broke across a line still links.

--- a/docs/explanation/phone-detection.rst
+++ b/docs/explanation/phone-detection.rst
@@ -30,13 +30,18 @@ the number, its region and type, or the position the next probe may start at.
 
 A run is up to 21 groups of up to 20 digits, the last of them starting within 250 code points of the first digit, joined
 by the punctuation a written number carries between groups, with an optional ``+`` or bracket in front and an extension
-at the end. The recognizer reads the whole run first; when that fails, it tries the inner splits in order: after a
-slash, each bracketed part, around a spaced hyphen, around a wide hyphen, between dots, between spaces. For each
-candidate and default region, the recognizer takes the country code after an international prefix, strips the region's
-own country code when the text carries it, or strips the national prefix and hands the remaining digits to the plan of
-each region sharing the calling code, in the plan's routing order. A national number read this way must carry the
-national prefix its number format writes, so ``2012-01-02 08`` is not a German number while ``030 12345678`` is;
-``require_national_prefix=False`` drops that rule for text where people write numbers the way a local caller dials them.
+at the end. A separator holds at most four of those characters, and a tab, a newline or a carriage return is not one of
+them, so a number a source formatter broke across a line reads as two. ``collapse_whitespace=True`` measures the run as
+the browser paints it: a run of HTML whitespace (tab, newline, form feed, carriage return, space) counts as the one
+space it renders as, in the separator, in the lead, in the extension and in the 250-code-point budget alike. ``U+00A0``
+and ``U+3000`` render as themselves, so they stay separators of their own and never join a run. The recognizer reads the
+whole run first; when that fails, it tries the inner splits in order: after a slash, each bracketed part, around a
+spaced hyphen, around a wide hyphen, between dots, between spaces. For each candidate and default region, the recognizer
+takes the country code after an international prefix, strips the region's own country code when the text carries it, or
+strips the national prefix and hands the remaining digits to the plan of each region sharing the calling code, in the
+plan's routing order. A national number read this way must carry the national prefix its number format writes, so
+``2012-01-02 08`` is not a German number while ``030 12345678`` is; ``require_national_prefix=False`` drops that rule
+for text where people write numbers the way a local caller dials them.
 
 ``grouping`` adds two stricter checks. Both start from a valid number and compare the digit groups as written against
 the groups of its number format, in the international layout, and against each alternate format the metadata lists for

--- a/docs/how-to/links.rst
+++ b/docs/how-to/links.rst
@@ -189,9 +189,30 @@ Use it for text with mistyped numbers; the default requires a number the plan as
 :doc:`/explanation/phone-detection` for the rules.
 
 ``require_national_prefix=False`` links a number written without the national prefix its format writes (``20 7946 0958``
-for a British text). :meth:`PhoneNumber.parse <turbohtml.clean.PhoneNumber.parse>` reads a string you already hold under
-the same rule: it accepts words before the number, a ``tel:`` scheme, brackets and an extension, and raises
-``ValueError`` when the string holds anything other than one number:
+for a British text).
+
+``collapse_whitespace=True`` reads a run of HTML whitespace as the one space it renders as, so a number a source
+formatter or a template broke across a line still links. Without it a separator holds at most four characters and a tab
+or a newline ends the number, which is what a browser's own rendering hides from the reader:
+
+.. testcode::
+
+    wrapped = "Call +41 79\n434 32 54 today"
+    print(linkify(wrapped, Linkify(phones=PhoneNumbers(regions=("CH",)))))
+    print(linkify(wrapped, Linkify(phones=PhoneNumbers(regions=("CH",), collapse_whitespace=True))))
+
+.. testoutput::
+
+    Call +41 79
+    434 32 54 today
+    Call <a href="tel:+41794343254">+41 79
+    434 32 54</a> today
+
+``U+00A0`` and ``U+3000`` survive rendering, so they stay separators of their own and never join a run.
+
+:meth:`PhoneNumber.parse <turbohtml.clean.PhoneNumber.parse>` reads a string you already hold under the same rule: it
+accepts words before the number, a ``tel:`` scheme, brackets and an extension, and raises ``ValueError`` when the string
+holds anything other than one number:
 
 .. testcode::
 

--- a/docs/migration/phonenumbers.rst
+++ b/docs/migration/phonenumbers.rst
@@ -181,3 +181,6 @@ no digits is the narrowest row, 8x to 9x, the cost of the trigger scan alone.
   number the tables assign (or, with ``require_valid=False``, one of a possible length).
 - A detected number must carry its national prefix; ``PhoneNumbers(require_national_prefix=False)`` links the
   prefix-less numbers ``parse`` accepts.
+- ``PhoneNumbers(collapse_whitespace=True)`` reads a run of HTML whitespace as the single space it renders as, which
+  links numbers ``PhoneNumberMatcher`` leaves plain: more than four separator characters, and the tab and newline a
+  source formatter leaves between two groups. The default matches ``PhoneNumberMatcher`` on both.

--- a/src/turbohtml/_c/clean/phone.c
+++ b/src/turbohtml/_c/clean/phone.c
@@ -174,6 +174,29 @@ static int is_punctuation(uint32_t code) {
     }
 }
 
+/* HTML paints a run of these as the one space the reader sees, which is what `collapse_whitespace` reads it as.
+   U+00A0 and U+3000 survive rendering, so they stay separators of their own and never join a run. */
+static int is_collapsing_space(uint32_t code) {
+    return code == ' ' || code == '\t' || code == '\n' || code == '\f' || code == '\r';
+}
+
+static int is_separator(uint32_t code, int collapse) {
+    return is_punctuation(code) || (collapse && is_collapsing_space(code));
+}
+
+/* Past the separator that starts at `position` and reads as `code`: one code point, or the whole whitespace run
+   it opens. The caller has the code in hand, so the common path never reads a character twice. */
+static size_t separator_end(th_phone_read read, const void *text, size_t position, size_t end, uint32_t code,
+                            int collapse) {
+    position++;
+    if (collapse && is_collapsing_space(code)) {
+        while (position < end && is_collapsing_space(read(text, position))) {
+            position++;
+        }
+    }
+    return position;
+}
+
 /* The extension markers that are also punctuation a run allows, so a group after one may be the extension. */
 static int is_extension_marker(uint32_t code) {
     return code == 'x' || code == '~' || code == 0xFF5E;
@@ -708,7 +731,8 @@ static void read_national(const th_phone_config *config, uint16_t region_index, 
 /* Java's lead, `(?:[lead][punct]{0,4}){0,2}`, consumed exactly over the text before the digits: a lead character,
    then the greedy punctuation run, at most twice. Every lead character that is also punctuation gets taken by the
    greedy run of the group before it, so the regex never needs to give punctuation back. */
-static int lead_groups_match_from(th_phone_read read, const void *text, size_t position, size_t end, int groups_left) {
+static int lead_groups_match_from(th_phone_read read, const void *text, size_t position, size_t end, int groups_left,
+                                  int collapse) {
     if (position == end) {
         return 1;
     }
@@ -718,15 +742,33 @@ static int lead_groups_match_from(th_phone_read read, const void *text, size_t p
     }
     position++;
     size_t punctuation = 0;
-    while (punctuation < MAX_LEAD_PUNCTUATION && position < end && is_punctuation(read(text, position))) {
-        position++;
+    while (punctuation < MAX_LEAD_PUNCTUATION && position < end) {
+        uint32_t punctuation_code = read(text, position);
+        if (!is_separator(punctuation_code, collapse)) {
+            break;
+        }
+        position = separator_end(read, text, position, end, punctuation_code, collapse);
         punctuation++;
     }
-    return lead_groups_match_from(read, text, position, end, groups_left - 1);
+    return lead_groups_match_from(read, text, position, end, groups_left - 1, collapse);
 }
 
-static int lead_groups_match(th_phone_read read, const void *text, size_t start, size_t end) {
-    return lead_groups_match_from(read, text, start, end, 2);
+static int lead_groups_match(th_phone_read read, const void *text, size_t start, size_t end, int collapse) {
+    return lead_groups_match_from(read, text, start, end, 2, collapse);
+}
+
+/* Where a lead may start: MAX_LEAD_CHARS characters of the text as it renders, so a collapsed run counts once
+   however long it is. */
+static size_t lead_window(th_phone_read read, const void *text, size_t left_bound, size_t digits_start) {
+    size_t position = digits_start;
+    for (size_t width = 0; width < MAX_LEAD_CHARS && position > left_bound; width++) {
+        position--;
+        while (position > left_bound && is_collapsing_space(read(text, position)) &&
+               is_collapsing_space(read(text, position - 1))) {
+            position--;
+        }
+    }
+    return position;
 }
 
 /* MATCHING_BRACKETS over the candidate: an optional leading opener, an optional leading "text then closer", then at
@@ -783,9 +825,10 @@ static int brackets_match(th_phone_read read, const void *text, size_t start, si
     return 1;
 }
 
-static int second_number_start(th_phone_read read, const void *text, size_t len, size_t slash, size_t *cut_end) {
+static int second_number_start(th_phone_read read, const void *text, size_t len, size_t slash, size_t *cut_end,
+                               int collapse) {
     size_t position = slash + 1;
-    while (position < len && read(text, position) == ' ') {
+    while (position < len && (read(text, position) == ' ' || (collapse && is_collapsing_space(read(text, position))))) {
         position++;
     }
     if (position >= len || read(text, position) != 'x') {
@@ -825,7 +868,7 @@ static uint16_t extension_dfa(const th_phone_config *config) {
 }
 
 static int walk_extension(th_phone_read read, const void *text, size_t len, uint16_t grammar, size_t tail_start,
-                          size_t *tail_end, char *ext_digits, uint8_t *ext_len) {
+                          int collapse, size_t *tail_end, char *ext_digits, uint8_t *ext_len) {
     const th_phone_dfa *dfa = dfa_at(grammar);
     uint16_t state = 1;
     char digits[TH_PHONE_MAX_EXTENSION + 1];
@@ -833,6 +876,12 @@ static int walk_extension(th_phone_read read, const void *text, size_t len, uint
     int found = 0;
     for (size_t position = tail_start; position < len; position++) {
         uint32_t code = read(text, position);
+        if (collapse && is_collapsing_space(code)) {
+            while (position + 1 < len && is_collapsing_space(read(text, position + 1))) {
+                position++;
+            }
+            code = ' ';
+        }
         int value = th_phone_digit_value(code);
         state = dfa_step(dfa, state, extension_symbol(code));
         if (state == 0) {
@@ -854,10 +903,11 @@ static int walk_extension(th_phone_read read, const void *text, size_t len, uint
 }
 
 static int segment(th_phone_read read, const void *text, size_t len, uint16_t grammar, size_t left_bound,
-                   size_t digit_pos, run_record *run) {
+                   size_t digit_pos, int collapse, run_record *run) {
     memset(run, 0, sizeof(*run));
     size_t digits_start = digit_pos;
     size_t position = digits_start;
+    size_t width = 0; /* characters of the rendered text since the first digit, a collapsed run counting once */
     int separator_dots = 0;
     int separator_marker = 0;
     for (;;) {
@@ -880,6 +930,7 @@ static int segment(th_phone_read read, const void *text, size_t len, uint16_t gr
             break;
         }
         group->end = position;
+        width += group->count;
         group->separator_is_dots = (uint8_t)separator_dots;
         group->separator_has_extension_marker = (uint8_t)separator_marker;
         run->group_count++;
@@ -893,10 +944,10 @@ static int segment(th_phone_read read, const void *text, size_t len, uint16_t gr
         int cut = 0;
         while (probe < len && punctuation < MAX_LEAD_PUNCTUATION) {
             uint32_t code = read(text, probe);
-            if (!is_punctuation(code)) {
+            if (!is_separator(code, collapse)) {
                 break;
             }
-            if (code == '/' && second_number_start(read, text, len, probe, &run->second_number_cut)) {
+            if (code == '/' && second_number_start(read, text, len, probe, &run->second_number_cut, collapse)) {
                 cut = 1;
                 break;
             }
@@ -904,11 +955,12 @@ static int segment(th_phone_read read, const void *text, size_t len, uint16_t gr
             if (is_extension_marker(code)) {
                 separator_marker = 1;
             }
-            probe++;
+            probe = separator_end(read, text, probe, len, code, collapse);
             punctuation++;
+            width++;
         }
         if (cut || probe == position || probe >= len || th_phone_digit_value(read(text, probe)) < 0 ||
-            probe - digits_start > TH_PHONE_MAX_RUN_CHARS) {
+            width > TH_PHONE_MAX_RUN_CHARS) {
             break;
         }
         separator_dots = next_dots;
@@ -919,11 +971,14 @@ static int segment(th_phone_read read, const void *text, size_t len, uint16_t gr
     }
     run->end = run->groups[run->group_count - 1].end;
     size_t earliest = digits_start > left_bound + MAX_LEAD_CHARS ? digits_start - MAX_LEAD_CHARS : left_bound;
+    if (collapse) {
+        earliest = lead_window(read, text, left_bound, digits_start);
+    }
     /* the bracket rule belongs to parseAndVerify, which read_chunk applies per chunk: a lead whose bracket never
        closes still starts the candidate, and the text before that bracket is the chunk extractInnerMatch offers */
     run->start = digits_start;
     for (size_t candidate = earliest; candidate < digits_start; candidate++) {
-        if (lead_groups_match(read, text, candidate, digits_start)) {
+        if (lead_groups_match(read, text, candidate, digits_start, collapse)) {
             run->start = candidate;
             break;
         }
@@ -937,13 +992,13 @@ static int segment(th_phone_read read, const void *text, size_t len, uint16_t gr
     size_t tail_end;
     char ext_digits[TH_PHONE_MAX_EXTENSION + 1];
     uint8_t ext_len;
-    if (walk_extension(read, text, len, grammar, run->end, &tail_end, ext_digits, &ext_len)) {
+    if (walk_extension(read, text, len, grammar, run->end, collapse, &tail_end, ext_digits, &ext_len)) {
         memcpy(run->extension, ext_digits, ext_len);
         run->extension_len = ext_len;
         run->extension_end = tail_end;
     } else if (run->group_count > 1 && run->groups[run->group_count - 1].separator_has_extension_marker &&
-               walk_extension(read, text, len, grammar, run->groups[run->group_count - 2].end, &tail_end, ext_digits,
-                              &ext_len) &&
+               walk_extension(read, text, len, grammar, run->groups[run->group_count - 2].end, collapse, &tail_end,
+                              ext_digits, &ext_len) &&
                tail_end >= run->end) {
         /* PATTERN reads `x1234` as a punctuation-separated digit block, so a `#` after it stays outside the match */
         run->group_count--;
@@ -985,7 +1040,7 @@ static int is_slash_date(th_phone_read read, const void *text, const run_record 
 /* PhoneNumberMatcher.TIME_STAMPS at the run's end followed by TIME_STAMPS_SUFFIX: eight digits shaped
    [12]ddd[01]d[0-3]d, split only after the year and after the month and only by a single `-` or `/`, then spaces, a
    two-digit hour starting 0-2, and `:MM` right after the run. Returns the count of groups it spans, 0 when none. */
-static size_t timestamp_groups(th_phone_read read, const void *text, size_t len, const run_record *run) {
+static size_t timestamp_groups(th_phone_read read, const void *text, size_t len, const run_record *run, int collapse) {
     if (run->group_count < 2) {
         return 0;
     }
@@ -994,7 +1049,8 @@ static size_t timestamp_groups(th_phone_read read, const void *text, size_t len,
         return 0;
     }
     for (size_t position = run->groups[run->group_count - 2].end; position < hour->start; position++) {
-        if (read(text, position) != ' ') {
+        uint32_t code = read(text, position);
+        if (code != ' ' && !(collapse && is_collapsing_space(code))) {
             return 0;
         }
     }
@@ -1052,16 +1108,17 @@ static void poison_ipv4(run_record *run) {
     }
 }
 
-static int is_space_separator(uint32_t code) {
-    return code == ' ' || code == 0xA0 || code == 0x3000;
+static int is_space_separator(uint32_t code, int collapse) {
+    return code == ' ' || code == 0xA0 || code == 0x3000 || (collapse && is_collapsing_space(code));
 }
 
 /* Does whitespace sit between a group and the one before it? An identifier label reaches over hyphens and dots
    (`Order 650-253-0000`), not over the space that starts a new token (`Order 12345, 650-253-0000`). */
-static int separator_has_space(th_phone_read read, const void *text, const run_record *run, size_t index) {
+static int separator_has_space(th_phone_read read, const void *text, const run_record *run, size_t index,
+                               int collapse) {
     for (size_t position = run->groups[index - 1].end; position < run->groups[index].start; position++) {
         uint32_t code = read(text, position);
-        if (is_space_separator(code)) {
+        if (is_space_separator(code, collapse)) {
             return 1;
         }
     }
@@ -1076,7 +1133,8 @@ static int label_before(th_phone_read read, const void *text, size_t start, cons
     size_t position = start;
     while (position > 0) {
         uint32_t code = read(text, position - 1);
-        if (!is_space_separator(code) && !(code < 0x80 && memchr(marks, (int)code, sizeof marks - 1) != NULL)) {
+        if (!is_space_separator(code, config->collapse_whitespace) &&
+            !(code < 0x80 && memchr(marks, (int)code, sizeof marks - 1) != NULL)) {
             break;
         }
         position--;
@@ -1173,7 +1231,7 @@ static void poison(th_phone_read read, const void *text, size_t len, const th_ph
             run->poison |= 7u << index;
         }
     }
-    size_t stamp = timestamp_groups(read, text, len, run);
+    size_t stamp = timestamp_groups(read, text, len, run, config->collapse_whitespace);
     if (stamp) {
         run->poison |= ((1u << stamp) - 1u) << (run->group_count - stamp);
     }
@@ -1186,7 +1244,7 @@ static void poison(th_phone_read read, const void *text, size_t len, const th_ph
         do {
             run->poison |= 1u << index;
             index++;
-        } while (index < run->group_count && !separator_has_space(read, text, run, index));
+        } while (index < run->group_count && !separator_has_space(read, text, run, index, config->collapse_whitespace));
     }
 }
 
@@ -1222,8 +1280,8 @@ static void push_chunk(chunk_list *chunks, size_t start, size_t end) {
 }
 
 /* A candidate ends on a digit or an extension's last character, not on a separator, so these runs stop inside it. */
-static size_t skip_space_separators(th_phone_read read, const void *text, size_t position) {
-    while (is_space_separator(read(text, position))) {
+static size_t skip_space_separators(th_phone_read read, const void *text, size_t position, int collapse) {
+    while (is_space_separator(read(text, position), collapse)) {
         position++;
     }
     return position;
@@ -1232,7 +1290,8 @@ static size_t skip_space_separators(th_phone_read read, const void *text, size_t
 /* The text ranges parseAndVerify sees for one candidate: the whole, then PhoneNumberMatcher.INNER_MATCHES in its
    order: the part after the first slash run, each bracketed part, the parts around a spaced hyphen, around a wide
    hyphen, between dots, between spaces; each rule first offers the text before its first match. */
-static void enumerate_chunks(th_phone_read read, const void *text, size_t start, size_t end, chunk_list *chunks) {
+static void enumerate_chunks(th_phone_read read, const void *text, size_t start, size_t end, int collapse,
+                             chunk_list *chunks) {
     chunks->count = 0;
     push_chunk(chunks, start, end);
     for (size_t position = start; position < end; position++) {
@@ -1259,16 +1318,17 @@ static void enumerate_chunks(th_phone_read read, const void *text, size_t start,
     for (size_t position = start; position + 1 < end; position++) {
         uint32_t code = read(text, position);
         uint32_t following = read(text, position + 1);
-        if ((is_space_separator(code) && following == '-') || (code == '-' && is_space_separator(following))) {
+        if ((is_space_separator(code, collapse) && following == '-') ||
+            (code == '-' && is_space_separator(following, collapse))) {
             push_chunk(chunks, start, position);
-            push_chunk(chunks, skip_space_separators(read, text, position + (code == '-' ? 1 : 2)), end);
+            push_chunk(chunks, skip_space_separators(read, text, position + (code == '-' ? 1 : 2), collapse), end);
             break;
         }
     }
     for (size_t position = start; position < end; position++) {
         if (is_wide_hyphen(read(text, position))) {
             push_chunk(chunks, start, position);
-            push_chunk(chunks, skip_space_separators(read, text, position + 1), end);
+            push_chunk(chunks, skip_space_separators(read, text, position + 1, collapse), end);
             break;
         }
     }
@@ -1282,7 +1342,7 @@ static void enumerate_chunks(th_phone_read read, const void *text, size_t start,
         while (read(text, position) == '.') {
             position++;
         }
-        chunk_start = skip_space_separators(read, text, position);
+        chunk_start = skip_space_separators(read, text, position, collapse);
         position = chunk_start;
     }
     if (chunk_start != NO_POSITION) {
@@ -1290,12 +1350,12 @@ static void enumerate_chunks(th_phone_read read, const void *text, size_t start,
     }
     chunk_start = NO_POSITION;
     for (size_t position = start; position < end;) {
-        if (!is_space_separator(read(text, position))) {
+        if (!is_space_separator(read(text, position), collapse)) {
             position++;
             continue;
         }
         push_chunk(chunks, chunk_start == NO_POSITION ? start : chunk_start, position);
-        chunk_start = skip_space_separators(read, text, position);
+        chunk_start = skip_space_separators(read, text, position, collapse);
         position = chunk_start;
     }
     if (chunk_start != NO_POSITION) {
@@ -1304,10 +1364,10 @@ static void enumerate_chunks(th_phone_read read, const void *text, size_t start,
 }
 
 /* PhoneNumberMatcher.PUB_PAGES on the chunk: "pages 1-5 (3 pages)", ASCII digits, hyphens, digits, up to four
-   spaces and a bracketed count, is not a number. Its \d and \s are ASCII, and of Java's \s only the space is
-   punctuation a candidate can hold. */
+   spaces and a bracketed count, is not a number. Its \d and \s are ASCII; of Java's \s only the space is
+   punctuation a candidate can hold, and under `collapse_whitespace` the rest of ASCII whitespace joins it. */
 static int is_pub_pages(th_phone_read read, const void *text, const run_record *run, size_t first, size_t last,
-                        size_t chunk_end) {
+                        size_t chunk_end, int collapse) {
     for (size_t index = first; index + 1 < last; index++) {
         const group_record *left = &run->groups[index];
         const group_record *right = &run->groups[index + 1];
@@ -1325,9 +1385,11 @@ static int is_pub_pages(th_phone_read read, const void *text, const run_record *
         if (!hyphens_only || !ascii_digits) {
             continue;
         }
-        /* a separator holds at most four characters, so fewer than the regex's four spaces can precede the bracket */
+        /* a separator holds at most four characters of the rendered text, so fewer than the regex's four spaces
+           can precede the bracket however long the run is */
         size_t probe = right->end;
-        while (probe < chunk_end && read(text, probe) == ' ') {
+        while (probe < chunk_end &&
+               (read(text, probe) == ' ' || (collapse && is_collapsing_space(read(text, probe))))) {
             probe++;
         }
         if (probe + 1 < chunk_end && read(text, probe) == '(' && read(text, probe + 1) < 0x80 &&
@@ -1592,9 +1654,11 @@ static size_t write_country_code(unsigned country_code, char *out) {
 }
 
 /* The candidate as the matcher normalizes it for the grouping checks: every digit an ASCII digit, every other code
-   point kept. A run may reach TH_PHONE_MAX_RUN_CHARS from its first digit and then hold one more group, after its
-   lead characters and before an extension; a chunk that read as a number is far shorter, its digits being a country
-   code, a prefix and a national number. */
+   point kept, and under `collapse_whitespace` a whitespace run written as its first character alone; the checks read
+   the candidate's digit runs, so which separator stands for the run does not reach them. A run may reach
+   TH_PHONE_MAX_RUN_CHARS from its first digit and then hold one more group, after its lead characters and before an
+   extension; a chunk that read as a number is far shorter, its digits being a country code, a prefix and a national
+   number. */
 #define CANDIDATE_CAPACITY (MAX_LEAD_CHARS + TH_PHONE_MAX_RUN_CHARS + TH_PHONE_MAX_GROUP_DIGITS + 128)
 
 typedef struct {
@@ -1602,13 +1666,15 @@ typedef struct {
     size_t len;
 } candidate_text;
 
-static void normalize_candidate(th_phone_read read, const void *text, size_t start, size_t end,
+static void normalize_candidate(th_phone_read read, const void *text, size_t start, size_t end, int collapse,
                                 candidate_text *candidate) {
     candidate->len = 0;
-    for (size_t position = start; position < end; position++) {
+    size_t position = start;
+    while (position < end) {
         uint32_t code = read(text, position);
         int value = th_phone_digit_value(code);
         candidate->data[candidate->len++] = value >= 0 ? (uint32_t)('0' + value) : code;
+        position = separator_end(read, text, position, end, code, collapse);
     }
 }
 
@@ -1788,7 +1854,7 @@ static int grouping_holds(th_phone_read read, const void *text, const th_phone_c
         return 1;
     }
     candidate_text candidate;
-    normalize_candidate(read, text, start, end, &candidate);
+    normalize_candidate(read, text, start, end, config->collapse_whitespace, &candidate);
     if (more_than_one_slash(&candidate, result)) {
         return 0;
     }
@@ -1848,15 +1914,16 @@ static int read_chunk(th_phone_read read, const void *text, size_t len, const th
         size_t tail_end;
         char ext_digits[TH_PHONE_MAX_EXTENSION + 1];
         uint8_t ext_len;
-        if (walk_extension(read, text, len, extension_dfa(config), run->groups[last - 2].end, &tail_end, ext_digits,
-                           &ext_len) &&
+        if (walk_extension(read, text, len, extension_dfa(config), run->groups[last - 2].end,
+                           config->collapse_whitespace, &tail_end, ext_digits, &ext_len) &&
             tail_end >= found->end) {
             memcpy(found->ext, ext_digits, ext_len);
             found->ext_len = ext_len;
             last--;
         }
     }
-    if (!brackets_match(read, text, start, found->end) || is_pub_pages(read, text, run, first, last, found->end) ||
+    if (!brackets_match(read, text, start, found->end) ||
+        is_pub_pages(read, text, run, first, last, found->end, config->collapse_whitespace) ||
         blocked_by_neighbors(read, text, len, config, start, found->end)) {
         return 0;
     }
@@ -1897,7 +1964,12 @@ static int read_chunk(th_phone_read read, const void *text, size_t len, const th
 int th_phone_find(th_phone_read read, const void *text, size_t len, size_t left_bound, size_t digit_pos,
                   const th_phone_config *config, th_phone_match *match, size_t *retry) {
     run_record run;
-    if (!segment(read, text, len, extension_dfa(config), left_bound, digit_pos, &run)) {
+    /* The two calls hand `collapse` in as a constant so the optimizer clones `segment` and folds the collapse tests
+       out of the common clone: the flag costs a branch here, not one per character of every run it walks. */
+    int found_run = config->collapse_whitespace
+                        ? segment(read, text, len, extension_dfa(config), left_bound, digit_pos, 1, &run)
+                        : segment(read, text, len, extension_dfa(config), left_bound, digit_pos, 0, &run);
+    if (!found_run) {
         size_t end = digit_pos;
         while (end < len && th_phone_digit_value(read(text, end)) >= 0) {
             end++;
@@ -1927,7 +1999,13 @@ int th_phone_find(th_phone_read read, const void *text, size_t len, size_t left_
         }
         size_t start = first == 0 ? run.start : run.groups[first].start;
         size_t end = end_group == run.group_count ? run.extension_end : run.groups[end_group - 1].end;
-        enumerate_chunks(read, text, start, end, &chunks);
+        /* split on the flag for the same reason the segment calls do: the common clone folds the collapse tests
+           out of the passes this makes over every candidate */
+        if (config->collapse_whitespace) {
+            enumerate_chunks(read, text, start, end, 1, &chunks);
+        } else {
+            enumerate_chunks(read, text, start, end, 0, &chunks);
+        }
         for (size_t index = 0; index < chunks.count; index++) {
             const text_range *range = &chunks.ranges[index];
             if (!read_chunk(read, text, len, config, &run, first, end_group, range->start, range->end, &found)) {
@@ -2085,7 +2163,7 @@ static int number_to_parse(th_phone_read read, const void *text, size_t start, s
         for (size_t position = first; position < last; position++) {
             uint32_t code = read(text, position);
             size_t cut;
-            if ((code == '/' || code == '\\') && second_number_start(read, text, last, position, &cut)) {
+            if ((code == '/' || code == '\\') && second_number_start(read, text, last, position, &cut, 0)) {
                 last = position;
             }
         }
@@ -2124,8 +2202,8 @@ static size_t viable_number_end(const th_phone_config *config, const candidate_t
     }
     for (size_t position = third_digit; position <= end; position++) {
         size_t tail_end;
-        if (walk_extension(read_candidate, number, number->len, extension_dfa(config), position, &tail_end, ext_digits,
-                           ext_len) &&
+        if (walk_extension(read_candidate, number, number->len, extension_dfa(config), position, 0, &tail_end,
+                           ext_digits, ext_len) &&
             tail_end == number->len) {
             return position;
         }

--- a/src/turbohtml/_c/clean/phone.h
+++ b/src/turbohtml/_c/clean/phone.h
@@ -62,6 +62,7 @@ typedef struct {
     uint8_t require_separators;
     uint8_t skip_card_numbers;
     uint8_t require_national_prefix; /* VALID's isNationalPrefixPresentIfRequired applies */
+    uint8_t collapse_whitespace;     /* th_phone_find reads a run of HTML whitespace as the space it renders as */
     uint8_t grouping;                /* enum th_phone_grouping */
     uint8_t parsing_extensions;      /* also read the auto-dialling extension forms parse accepts (`,,12`, `;12`) */
     uint8_t national_floor;

--- a/src/turbohtml/_c/clean/phone_binding.c
+++ b/src/turbohtml/_c/clean/phone_binding.c
@@ -9,7 +9,7 @@
 
 #include <string.h>
 
-#define SPEC_ITEMS 11
+#define SPEC_ITEMS 12
 #define MAX_LABELS 256
 #define MAX_LABEL_LENGTH 12
 #define TYPE_MEMBERS 12
@@ -262,11 +262,12 @@ static int fill_config(PhoneConfigObject *self, PyObject *spec) {
         parse_flag(PyTuple_GET_ITEM(spec, 2), "require_separators", &config->require_separators) < 0 ||
         parse_flag(PyTuple_GET_ITEM(spec, 3), "skip_card_numbers", &config->skip_card_numbers) < 0 ||
         parse_flag(PyTuple_GET_ITEM(spec, 4), "require_national_prefix", &config->require_national_prefix) < 0 ||
-        parse_grouping(PyTuple_GET_ITEM(spec, 5), config, &config->grouping) < 0 ||
-        parse_type_mask(PyTuple_GET_ITEM(spec, 6), config, &config->type_mask) < 0 ||
-        parse_labels(PyTuple_GET_ITEM(spec, 7), self) < 0 ||
-        parse_classes(PyTuple_GET_ITEM(spec, 8), PyTuple_GET_ITEM(spec, 9), self) < 0 ||
-        parse_flag(PyTuple_GET_ITEM(spec, 10), "parsing_extensions", &config->parsing_extensions) < 0) {
+        parse_flag(PyTuple_GET_ITEM(spec, 5), "collapse_whitespace", &config->collapse_whitespace) < 0 ||
+        parse_grouping(PyTuple_GET_ITEM(spec, 6), config, &config->grouping) < 0 ||
+        parse_type_mask(PyTuple_GET_ITEM(spec, 7), config, &config->type_mask) < 0 ||
+        parse_labels(PyTuple_GET_ITEM(spec, 8), self) < 0 ||
+        parse_classes(PyTuple_GET_ITEM(spec, 9), PyTuple_GET_ITEM(spec, 10), self) < 0 ||
+        parse_flag(PyTuple_GET_ITEM(spec, 11), "parsing_extensions", &config->parsing_extensions) < 0) {
         return -1;
     }
     th_phone_config_floor(config);
@@ -274,8 +275,8 @@ static int fill_config(PhoneConfigObject *self, PyObject *spec) {
 }
 
 /* _phone_config_compile(spec) -> _PhoneConfig, spec = (regions, require_valid, require_separators,
-   skip_card_numbers, require_national_prefix, grouping, type_mask, labels, phone_number_type, phone_types,
-   parsing_extensions). */
+   skip_card_numbers, require_national_prefix, collapse_whitespace, grouping, type_mask, labels, phone_number_type,
+   phone_types, parsing_extensions). */
 PyObject *turbohtml_phone_config_compile(PyObject *module, PyObject *spec) {
     if (!PyTuple_Check(spec) || PyTuple_GET_SIZE(spec) != SPEC_ITEMS) {
         PyErr_Format(PyExc_TypeError, "phone spec must be a tuple of %d items", SPEC_ITEMS);

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -17,6 +17,7 @@ _PhoneSpec: TypeAlias = tuple[
     bool,
     bool,
     bool,
+    bool,
     int,
     int,
     tuple[str, ...],

--- a/src/turbohtml/clean/_linkify.py
+++ b/src/turbohtml/clean/_linkify.py
@@ -155,6 +155,8 @@ class PhoneNumbers:
     :param require_national_prefix: a number written without ``+`` must carry the national prefix its number format
         writes (``20 7946 0958`` is not a British number, ``020 7946 0958`` is); False links it the way people dial
         locally. Applies with ``require_valid``.
+    :param collapse_whitespace: read a run of HTML whitespace (tab, newline, form feed, carriage return, space) as
+        the single space it renders as, so a number a source formatter broke across a line still reads as one.
     :param grouping: how closely the written digit groups must follow the number's format. Needs ``require_valid``.
     :param types: link only numbers of these resolved types; ``None`` links every type. Needs ``require_valid``.
     :param ignore_numbers_after: words that mark the digits right after them as an identifier.
@@ -165,6 +167,7 @@ class PhoneNumbers:
     require_separators: bool
     skip_card_numbers: bool
     require_national_prefix: bool
+    collapse_whitespace: bool
     grouping: PhoneGrouping
     types: frozenset[PhoneType] | None
     ignore_numbers_after: tuple[str, ...]
@@ -178,6 +181,7 @@ class PhoneNumbers:
         require_separators: bool = False,
         skip_card_numbers: bool = True,
         require_national_prefix: bool = True,
+        collapse_whitespace: bool = False,
         grouping: PhoneGrouping = PhoneGrouping.ANY,
         types: Iterable[PhoneType] | None = None,
         ignore_numbers_after: Iterable[str] = DEFAULT_PHONE_LABELS,
@@ -188,6 +192,7 @@ class PhoneNumbers:
             ("require_separators", require_separators),
             ("skip_card_numbers", skip_card_numbers),
             ("require_national_prefix", require_national_prefix),
+            ("collapse_whitespace", collapse_whitespace),
         ):
             if not isinstance(flag, bool):
                 msg = f"{name} must be bool"
@@ -224,6 +229,7 @@ class PhoneNumbers:
         object.__setattr__(self, "require_separators", require_separators)
         object.__setattr__(self, "skip_card_numbers", skip_card_numbers)
         object.__setattr__(self, "require_national_prefix", require_national_prefix)
+        object.__setattr__(self, "collapse_whitespace", collapse_whitespace)
         object.__setattr__(self, "grouping", grouping)
         object.__setattr__(self, "types", wanted)
         object.__setattr__(
@@ -247,6 +253,7 @@ class PhoneNumbers:
             require_separators=self.require_separators,
             skip_card_numbers=self.skip_card_numbers,
             require_national_prefix=self.require_national_prefix,
+            collapse_whitespace=self.collapse_whitespace,
             grouping=self.grouping,
             types=self.types,
             ignore_numbers_after=self.ignore_numbers_after,
@@ -411,6 +418,7 @@ def _compile_settings(phones: PhoneNumbers, number_type: type[PhoneNumber], *, p
         phones.require_separators,
         phones.skip_card_numbers,
         phones.require_national_prefix,
+        phones.collapse_whitespace,
         _PHONE_GROUPINGS.index(phones.grouping),
         _ALL_PHONE_TYPES if phones.types is None else sum(1 << _PHONE_TYPES.index(member) for member in phones.types),
         phones.ignore_numbers_after,

--- a/tests/clean/test_phone_c_api.py
+++ b/tests/clean/test_phone_c_api.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 _SPEC: Final = cast(
     "_PhoneSpec",
-    (("US",), True, False, True, True, 0, 0x7FF, ("order", "ref"), PhoneNumber, _PHONE_TYPES, False),
+    (("US",), True, False, True, True, False, 0, 0x7FF, ("order", "ref"), PhoneNumber, _PHONE_TYPES, False),
 )
 
 
@@ -44,6 +44,7 @@ def _spec(**overrides: object) -> _PhoneSpec:
                         "require_separators",
                         "skip_card_numbers",
                         "require_national_prefix",
+                        "collapse_whitespace",
                         "grouping",
                         "type_mask",
                         "labels",
@@ -70,13 +71,13 @@ def test_compile_returns_an_unconstructible_config() -> None:
     "spec",
     [
         pytest.param(list(_SPEC), id="list"),
-        pytest.param(_SPEC[:10], id="ten-items"),
-        pytest.param((*_SPEC, 0), id="twelve-items"),
+        pytest.param(_SPEC[:11], id="eleven-items"),
+        pytest.param((*_SPEC, 0), id="thirteen-items"),
         pytest.param(None, id="none"),
     ],
 )
 def test_compile_rejects_malformed_specs(spec: object) -> None:
-    with pytest.raises(TypeError, match="tuple of 11 items"):
+    with pytest.raises(TypeError, match="tuple of 12 items"):
         _phone_config_compile(spec)  # ty: ignore[invalid-argument-type]
 
 
@@ -106,6 +107,7 @@ def test_compile_rejects_malformed_specs(spec: object) -> None:
         pytest.param(
             {"require_national_prefix": 1}, TypeError, "require_national_prefix must be bool", id="int-prefix-flag"
         ),
+        pytest.param({"collapse_whitespace": 1}, TypeError, "collapse_whitespace must be bool", id="int-collapse-flag"),
         pytest.param({"grouping": "1"}, TypeError, "grouping must be int", id="str-grouping"),
         pytest.param({"parsing_extensions": 1}, TypeError, "parsing_extensions must be bool", id="int-parsing-flag"),
         pytest.param({"grouping": 3}, ValueError, "grouping must be between 0 and 2", id="grouping-high"),

--- a/tests/clean/test_phone_controls.py
+++ b/tests/clean/test_phone_controls.py
@@ -44,6 +44,7 @@ def test_defaults() -> None:
         require_separators=False,
         skip_card_numbers=True,
         require_national_prefix=True,
+        collapse_whitespace=False,
         grouping=PhoneGrouping.ANY,
         types=None,
         ignore_numbers_after=DEFAULT_PHONE_LABELS,
@@ -132,7 +133,13 @@ def test_regions_reject_unknown_codes(regions: tuple[str, ...], message: str) ->
     "name",
     [
         pytest.param(name, id=name)
-        for name in ("require_valid", "require_separators", "skip_card_numbers", "require_national_prefix")
+        for name in (
+            "require_valid",
+            "require_separators",
+            "skip_card_numbers",
+            "require_national_prefix",
+            "collapse_whitespace",
+        )
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/clean/test_phone_whitespace.py
+++ b/tests/clean/test_phone_whitespace.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import copy
+import pickle  # ruff:ignore[suspicious-pickle-import]  # this test pickles its own values
+import random
+import re
+from typing import Final
+
+import pytest
+
+from turbohtml.clean import LinkDetector, Linkify, PhoneGrouping, PhoneNumbers, linkify
+
+_CH: Final = PhoneNumbers(regions=("CH",))
+_CH_COLLAPSED: Final = PhoneNumbers(regions=("CH",), collapse_whitespace=True)
+_US: Final = PhoneNumbers(regions=("US",))
+_US_COLLAPSED: Final = PhoneNumbers(regions=("US",), collapse_whitespace=True)
+
+
+def _found(phones: PhoneNumbers, text: str) -> list[str]:
+    return [span.url for span in LinkDetector(phones=phones).find(text)]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("+41     79434     3254", id="five-spaces"),
+        pytest.param("+41\n79434\n3254", id="newline"),
+        pytest.param("+41\t79434\t3254", id="tab"),
+        pytest.param("+41\r\n79434\r\n3254", id="carriage-return"),
+        pytest.param("+41\f79434\f3254", id="form-feed"),
+        pytest.param("+41 \n 79434 \n 3254", id="mixed-run"),
+        pytest.param("079\n434\n32\n54", id="national"),
+    ],
+)
+def test_collapse_whitespace_reads_a_run_as_one_space(text: str) -> None:
+    assert _found(_CH_COLLAPSED, text) == ["tel:+41794343254"]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("+41     79434     3254", id="five-spaces"),
+        pytest.param("+41\n79434\n3254", id="newline"),
+        pytest.param("+41\t79434\t3254", id="tab"),
+        pytest.param("079\n434\n32\n54", id="national"),
+    ],
+)
+def test_default_stops_at_the_separator_limit(text: str) -> None:
+    assert _found(_CH, text) == []
+
+
+@pytest.mark.parametrize("separator", [pytest.param("\u00a0", id="nbsp"), pytest.param("\u3000", id="ideographic")])
+def test_collapse_whitespace_leaves_the_spaces_html_keeps(separator: str) -> None:
+    assert _found(_CH_COLLAPSED, f"+41{separator * 5}79434{separator * 5}3254") == []
+    assert _found(_CH_COLLAPSED, f"+41{separator * 4}79434{separator * 4}3254") == ["tel:+41794343254"]
+
+
+def test_collapse_whitespace_leaves_a_vertical_tab() -> None:
+    assert _found(_CH_COLLAPSED, "+41\v79434 3254") == []
+
+
+def test_collapse_whitespace_reaches_a_lead_over_a_run() -> None:
+    text = f"+{' ' * 300}41 79434 3254"
+    assert [(span.text, span.url) for span in LinkDetector(phones=_CH_COLLAPSED).find(text)] == [
+        (text, "tel:+41794343254")
+    ]
+
+
+def test_collapse_whitespace_measures_a_run_as_it_renders() -> None:
+    text = f"+41{' ' * 300}79434 3254"
+    assert [(span.text, span.url) for span in LinkDetector(phones=_CH_COLLAPSED).find(text)] == [
+        (text, "tel:+41794343254")
+    ]
+    assert _found(_CH, text) == []
+
+
+def test_collapse_whitespace_reads_a_broken_extension() -> None:
+    assert _found(_US_COLLAPSED, "650-253-0000\next. 1234") == ["tel:+16502530000;ext=1234"]
+    assert _found(_US, "650-253-0000\next. 1234") == ["tel:+16502530000"]
+
+
+def test_collapse_whitespace_reaches_an_identifier_label_over_a_run() -> None:
+    assert _found(_US_COLLAPSED, "Order\f650-253-0000") == []
+    assert _found(_US, "Order\f650-253-0000") == ["tel:+16502530000"]
+
+
+def test_collapse_whitespace_keeps_a_timestamp_out() -> None:
+    assert _found(_US_COLLAPSED, "20250901\n10:30") == []
+    assert _found(_US_COLLAPSED, "20250901\n10") == ["tel:+12025090110"]
+
+
+def test_collapse_whitespace_groups_across_a_run() -> None:
+    strict = PhoneNumbers(regions=("US",), grouping=PhoneGrouping.EXACT, collapse_whitespace=True)
+    assert _found(strict, "650\n253 0000") == ["tel:+16502530000"]
+    assert _found(PhoneNumbers(regions=("US",), grouping=PhoneGrouping.EXACT), "650\n253 0000") == []
+
+
+def test_collapse_whitespace_links_a_number_a_formatter_wrapped() -> None:
+    assert linkify("<p>Call\n+41 79\n434 32 54\ntoday</p>", Linkify(phones=_CH_COLLAPSED)) == (
+        '<p>Call\n<a href="tel:+41794343254">+41 79\n434 32 54</a>\ntoday</p>'
+    )
+
+
+def test_collapse_whitespace_survives_a_pickle_and_a_copy() -> None:
+    restored = pickle.loads(pickle.dumps(_CH_COLLAPSED))  # ruff:ignore[suspicious-pickle-usage]  # this test's bytes
+    assert restored == _CH_COLLAPSED
+    assert copy.deepcopy(_CH_COLLAPSED) == _CH_COLLAPSED
+
+
+# numbers, dates, an address, an extension and prose, the pieces a run of whitespace can end up gluing together
+_PIECES: Final = (
+    "+41", "79434", "3254", "079", "434", "32", "54", "650", "253", "0000", "(650)", "-", ".", "/", "x12", "Order",
+    "Tel:", "abc", "+1", "20250901", "10:30", "4111", "1111", "pages", "1-5", "(3", "pages)", "2001:db8::8888", "020",
+    "7946", "0958", "#", ",", "]", "ext.", "~", "[", "\u00a0", "\u3000",
+)  # fmt: skip
+_SEPARATORS: Final = (" ", "  ", "     ", "\n", "\t", "\r\n", " \n ", "\f", "")
+_RUNS: Final = re.compile(r"[ \t\n\f\r]+")
+
+
+def _corpus() -> list[str]:
+    """Glue the pieces with every run of whitespace the knob has to read as one space."""
+    rng = random.Random(20260901)  # ruff:ignore[suspicious-non-cryptographic-random-usage]  # a fixed corpus
+    return [
+        "".join(rng.choice(_PIECES) + rng.choice(_SEPARATORS) for _ in range(rng.randint(2, 7))) for _ in range(20_000)
+    ]
+
+
+def test_collapse_whitespace_matches_the_text_as_it_renders() -> None:
+    """The rule the knob promises: a run reads as the one space HTML paints, whatever it holds."""
+    regions = ("CH", "US", "GB")
+    collapsed = LinkDetector(phones=PhoneNumbers(regions=regions, collapse_whitespace=True))
+    rendered = LinkDetector(phones=PhoneNumbers(regions=regions))
+    for text in _corpus():
+        assert [(span.url, _RUNS.sub(" ", span.text)) for span in collapsed.find(text)] == [
+            (span.url, span.text) for span in rendered.find(_RUNS.sub(" ", text))
+        ], text


### PR DESCRIPTION
A separator between two digit groups holds at most four characters, and `\t`, `\n` and `\r` are none of them. So `+41     79434     3254` and `+41 79434\n3254` stay plain text while `+41 79434 3254` links, and the browser paints all of them alike, which leaves a reader with no way to tell why one anchor is there and the others are not. [@Daverball raised it on #758](https://github.com/tox-dev/turbohtml/issues/758#issuecomment-5495575393) from a WYSIWYG editor that hides the extra whitespace. A source formatter or a template that wraps a line lands in the same place.

`PhoneNumbers(collapse_whitespace=True)` measures a run the way the document renders it: a run of `U+0009`, `U+000A`, `U+000C`, `U+000D` and `U+0020` counts as the one space it paints, in the separator, in the lead, in the extension grammar and in the 250-character run budget alike. 📏 `U+00A0` and `U+3000` come through rendering intact, so they stay separators of their own and hold a run apart. The rule holds as an equality: the result on a text equals the result on that text with its whitespace runs collapsed, which is what the property test asserts over a fixed corpus of numbers, dates, addresses and prose. That equality is why this beat raising the separator limit for plain spaces, the other reading [offered on the issue](https://github.com/tox-dev/turbohtml/issues/758#issuecomment-5495734223): it fixes the count and leaves the newline dead.

The knob is off by default, so the default keeps matching `phonenumbers` across the vendored conformance suite. Four rules read whitespace for something other than joining groups, and each had to learn the same reading: the timestamp shape that keeps `20250901 10:30` out, the `PUB_PAGES` shape, the extension grammar, and the lead window that decides how far left of the first digit a `+` or `(` may sit. Those are the parts worth a hard look.
