### PR TITLE
♻️ refactor(detect): rank the encoding candidates in C

### DIFF
--- a/docs/changelog/776.feature.rst
+++ b/docs/changelog/776.feature.rst
@@ -1,0 +1,3 @@
+Move the encoding detector's candidate ranking into the C core: deduplicating the scored candidates, normalizing each
+score to its share, promoting the detector's own winner, and applying the :class:`~turbohtml.detect.Detection`
+allowlist, exclusions, language preference and confidence floor. Results are unchanged.

--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -51,6 +51,7 @@ PyObject *turbohtml_register_xpath_string(PyObject *module, PyObject *type);
    is given; the turbohtml.detect facade shapes its (winner, certain, ranked scores, bom)
    tuple into EncodingMatch results. METH_VARARGS. */
 PyObject *turbohtml_detect_encoding(PyObject *module, PyObject *args);
+PyObject *turbohtml_detect_rank(PyObject *module, PyObject *args);
 
 /* The streaming encoding detector type, registered on the module as _DetectStream. */
 extern PyType_Spec detect_stream_spec;

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -220,6 +220,7 @@ static PyMethodDef html_methods[] = {
     {"_minify_js_parse", turbohtml_minify_js_parse, METH_O, NULL},
     {"_decode", turbohtml_decode, METH_VARARGS, NULL},
     {"_detect", turbohtml_detect_encoding, METH_VARARGS, NULL},
+    {"_detect_rank", turbohtml_detect_rank, METH_VARARGS, NULL},
     {"_detect_language", turbohtml_detect_language, METH_VARARGS, NULL},
     {"_normalize", turbohtml_normalize, METH_VARARGS, NULL},
     {"_is_normalized", turbohtml_is_normalized, METH_VARARGS, NULL},

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -879,12 +879,14 @@ static PyObject *detect_folded_set(PyObject *names) {
         return NULL;
     }
     PyObject *folded = PySet_New(NULL);
-    PyObject *iterator = folded == NULL ? NULL /* GCOVR_EXCL_LINE: set allocation cannot be forced */
-                                        : PyObject_GetIter(names);
     /* GCOVR_EXCL_BR_START: allocation and iteration over a validated tuple cannot fail */
+    if (folded == NULL) {
+        return NULL; /* GCOVR_EXCL_LINE */
+    }
+    PyObject *iterator = PyObject_GetIter(names);
     if (iterator == NULL) {
-        Py_XDECREF(folded); /* GCOVR_EXCL_LINE */
-        return NULL;        /* GCOVR_EXCL_LINE */
+        Py_DECREF(folded); /* GCOVR_EXCL_LINE */
+        return NULL;       /* GCOVR_EXCL_LINE */
     }
     PyObject *name;
     while ((name = PyIter_Next(iterator)) != NULL) {
@@ -980,11 +982,13 @@ static PyObject *detect_row(PyObject *name, double confidence, PyObject *languag
     }
     PyObject *language = PyDict_GetItem(languages, folded); /* borrowed; NULL when the encoding names no language */
     PyObject *codec = th_str_format("whatwg-%U", folded);
-    PyObject *row = codec == NULL ? NULL /* GCOVR_EXCL_LINE: string allocation cannot be forced */
-                                  : Py_BuildValue("(OdOON)", name, confidence, language == NULL ? Py_None : language,
-                                                  bom ? Py_True : Py_False, codec);
     Py_DECREF(folded);
-    return row;
+    if (codec == NULL) { /* GCOVR_EXCL_BR_LINE: string allocation cannot be forced to fail */
+        return NULL;     /* GCOVR_EXCL_LINE */
+    }
+    /* the language is borrowed and absent for an encoding that names none */
+    return Py_BuildValue("(OdOON)", name, confidence, language == NULL ? Py_None : language, bom ? Py_True : Py_False,
+                         codec);
 }
 
 /* _detect_rank(result, allowed, excluded, language, threshold, languages) -> list[tuple]
@@ -1033,8 +1037,8 @@ PyObject *turbohtml_detect_rank(PyObject *Py_UNUSED(module), PyObject *args) {
     Py_ssize_t count = detect_shape(winner, certain, scored, fallback, shaped);
     int status = 0;
     /* the hinted language runs first, so a preferred candidate leads without disturbing the rest of the order */
-    for (int pass = 0; status == 0 && pass < (language == Py_None ? 1 : 2); pass++) {
-        for (Py_ssize_t index = 0; status == 0 && index < count; index++) {
+    for (int pass = 0; pass < (language == Py_None ? 1 : 2); pass++) {
+        for (Py_ssize_t index = 0; index < count; index++) {
             PyObject *name = shaped[index].name;
             double confidence = shaped[index].confidence;
             if (confidence < threshold || (allowed != Py_None && detect_name_listed(permitted, name) != 1) ||
@@ -1054,6 +1058,12 @@ PyObject *turbohtml_detect_rank(PyObject *Py_UNUSED(module), PyObject *args) {
             PyObject *row = detect_row(name, confidence, languages, bom);
             status = row == NULL ? -1 : PyList_Append(out, row); /* GCOVR_EXCL_BR_LINE: allocation */
             Py_XDECREF(row);
+            if (status < 0) { /* GCOVR_EXCL_BR_LINE: only an allocation failure sets it */
+                break;        /* GCOVR_EXCL_LINE */
+            }
+        }
+        if (status < 0) { /* GCOVR_EXCL_BR_LINE: only an allocation failure sets it */
+            break;        /* GCOVR_EXCL_LINE */
         }
     }
     PyMem_Free(shaped);

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -853,6 +853,220 @@ static PyObject *detect_result(const char *winner, int certain, const th_detect_
     return Py_BuildValue("(zONO)", winner, certain ? Py_True : Py_False, ranked, bom ? Py_True : Py_False);
 }
 
+/* One shaped candidate: a canonical encoding name and its share of the positive score total. */
+typedef struct {
+    PyObject *name; /* borrowed from the scored list the detector returned */
+    double confidence;
+} detect_candidate;
+
+/* Is `name`, case-folded, in `names`? A NULL set answers 0, so an absent option filters nothing. */
+static int detect_name_listed(PyObject *names, PyObject *name) {
+    if (names == NULL) {
+        return 0;
+    }
+    PyObject *folded = PyObject_CallMethod(name, "casefold", NULL);
+    if (folded == NULL) { /* GCOVR_EXCL_BR_LINE: casefold cannot fail for a str */
+        return -1;        /* GCOVR_EXCL_LINE */
+    }
+    int listed = PySequence_Contains(names, folded);
+    Py_DECREF(folded);
+    return listed; /* GCOVR_EXCL_BR_LINE: membership cannot fail for a str in a set */
+}
+
+/* The case-folded members of `names` as a set, or NULL when there are none to match against. */
+static PyObject *detect_folded_set(PyObject *names) {
+    if (names == Py_None) {
+        return NULL;
+    }
+    PyObject *folded = PySet_New(NULL);
+    PyObject *iterator = folded == NULL ? NULL /* GCOVR_EXCL_LINE: set allocation cannot be forced */
+                                        : PyObject_GetIter(names);
+    /* GCOVR_EXCL_BR_START: allocation and iteration over a validated tuple cannot fail */
+    if (iterator == NULL) {
+        Py_XDECREF(folded); /* GCOVR_EXCL_LINE */
+        return NULL;        /* GCOVR_EXCL_LINE */
+    }
+    PyObject *name;
+    while ((name = PyIter_Next(iterator)) != NULL) {
+        PyObject *lower = PyObject_CallMethod(name, "casefold", NULL);
+        int added = lower == NULL ? -1 : PySet_Add(folded, lower);
+        Py_XDECREF(lower);
+        Py_DECREF(name);
+        if (added < 0) {
+            Py_DECREF(iterator); /* GCOVR_EXCL_LINE */
+            Py_DECREF(folded);   /* GCOVR_EXCL_LINE */
+            return NULL;         /* GCOVR_EXCL_LINE */
+        }
+    }
+    Py_DECREF(iterator);
+    /* GCOVR_EXCL_BR_STOP */
+    if (PySet_GET_SIZE(folded) == 0) { /* an empty option list filters nothing, so skip the lookups entirely */
+        Py_DECREF(folded);
+        return NULL;
+    }
+    return folded;
+}
+
+/* Shape the detector's scored candidates into `out`, returning how many it wrote or -1.
+
+   A certain result -- a byte-order mark, a declaration, a structural proof, or pure ASCII -- is one candidate at
+   confidence 1.0. Otherwise each candidate's raw score becomes its share of the positive total, the best-scored entry
+   per name wins (the windows-1252 model runs once per language family, so one encoding can appear twice), and the
+   detector's own winner moves to the front so index 0 matches what a decode would use. */
+static Py_ssize_t detect_shape(PyObject *winner, int certain, PyObject *scored, PyObject *fallback,
+                               detect_candidate *out) {
+    if (certain || winner == Py_None) {
+        /* no winner means the stream carried no non-ASCII byte, which takes the spec's windows-1252 fallback */
+        out[0].name = winner == Py_None ? fallback : winner;
+        out[0].confidence = 1.0;
+        return 1;
+    }
+    Py_ssize_t count = 0;
+    for (Py_ssize_t index = 0; index < PyList_GET_SIZE(scored); index++) {
+        PyObject *pair = PyList_GET_ITEM(scored, index);
+        PyObject *name = PyTuple_GET_ITEM(pair, 0);
+        double score = (double)PyLong_AsLongLong(PyTuple_GET_ITEM(pair, 1));
+        Py_ssize_t at = 0;
+        while (at < count && PyUnicode_Compare(out[at].name, name) != 0) {
+            at++;
+        }
+        if (at < count) { /* one encoding can be scored twice, since a model runs per language family */
+            out[at].confidence = score > out[at].confidence ? score : out[at].confidence;
+            continue;
+        }
+        out[count].name = name;
+        out[count].confidence = score;
+        count++;
+    }
+    /* score-descending, with the detector's emission order breaking ties: a stable insertion sort, which is what
+       Python's sorted() gave, and the candidate count is small enough that nothing cleverer pays for itself */
+    for (Py_ssize_t index = 1; index < count; index++) {
+        detect_candidate held = out[index];
+        Py_ssize_t at = index;
+        while (at > 0 && out[at - 1].confidence < held.confidence) {
+            out[at] = out[at - 1];
+            at--;
+        }
+        out[at] = held;
+    }
+    double total = 0.0;
+    for (Py_ssize_t index = 0; index < count; index++) {
+        total += out[index].confidence > 0.0 ? out[index].confidence : 0.0;
+    }
+    for (Py_ssize_t index = 0; index < count; index++) {
+        out[index].confidence = out[index].confidence > 0.0 ? out[index].confidence / total : 0.0;
+    }
+    Py_ssize_t at = 0;
+    while (at < count && PyUnicode_Compare(out[at].name, winner) != 0) {
+        at++;
+    }
+    if (at == count) { /* the windows-1252 fallback won without surviving as a candidate itself */
+        memmove(&out[1], &out[0], (size_t)count * sizeof(*out));
+        out[0].name = winner;
+        out[0].confidence = 0.0;
+        return count + 1;
+    }
+    detect_candidate first = out[at];
+    memmove(&out[1], &out[0], (size_t)at * sizeof(*out));
+    out[0] = first;
+    return count;
+}
+
+/* Build one EncodingMatch row: (name, confidence, language, had_bom, codec). */
+static PyObject *detect_row(PyObject *name, double confidence, PyObject *languages, int bom) {
+    PyObject *folded = PyObject_CallMethod(name, "casefold", NULL);
+    if (folded == NULL) { /* GCOVR_EXCL_BR_LINE: casefold cannot fail for a str */
+        return NULL;      /* GCOVR_EXCL_LINE */
+    }
+    PyObject *language = PyDict_GetItem(languages, folded); /* borrowed; NULL when the encoding names no language */
+    PyObject *codec = th_str_format("whatwg-%U", folded);
+    PyObject *row = codec == NULL ? NULL /* GCOVR_EXCL_LINE: string allocation cannot be forced */
+                                  : Py_BuildValue("(OdOON)", name, confidence, language == NULL ? Py_None : language,
+                                                  bom ? Py_True : Py_False, codec);
+    Py_DECREF(folded);
+    return row;
+}
+
+/* _detect_rank(result, allowed, excluded, language, threshold, languages) -> list[tuple]
+
+   Shape one detector result and apply the Detection options to it: the allowlist, the exclusions, the language
+   preference that floats a hinted encoding to the front, and the confidence floor. Each row carries what an
+   EncodingMatch holds, so the typed layer only constructs them. An empty list means every candidate was filtered
+   out, which the caller answers with its no-match sentinel. */
+PyObject *turbohtml_detect_rank(PyObject *Py_UNUSED(module), PyObject *args) {
+    PyObject *result;
+    PyObject *allowed;
+    PyObject *excluded;
+    PyObject *language;
+    double threshold;
+    PyObject *languages;
+    if (!PyArg_ParseTuple(args, "O!OOOdO!:_detect_rank", &PyTuple_Type, &result, &allowed, &excluded, &language,
+                          &threshold, &PyDict_Type, &languages)) {
+        return NULL;
+    }
+    PyObject *winner = PyTuple_GET_ITEM(result, 0);
+    int certain = PyObject_IsTrue(PyTuple_GET_ITEM(result, 1));
+    PyObject *scored = PyTuple_GET_ITEM(result, 2);
+    int bom = PyObject_IsTrue(PyTuple_GET_ITEM(result, 3));
+    Py_ssize_t room = PyList_GET_SIZE(scored) + 1;
+    detect_candidate *shaped = PyMem_Malloc((size_t)room * sizeof(*shaped));
+    PyObject *out = PyList_New(0);
+    PyObject *permitted = detect_folded_set(allowed);
+    PyObject *blocked = detect_folded_set(excluded);
+    /* GCOVR_EXCL_BR_START: allocation cannot be forced to fail */
+    if (shaped == NULL || out == NULL || PyErr_Occurred() != NULL) {
+        PyMem_Free(shaped);    /* GCOVR_EXCL_LINE */
+        Py_XDECREF(out);       /* GCOVR_EXCL_LINE */
+        Py_XDECREF(permitted); /* GCOVR_EXCL_LINE */
+        Py_XDECREF(blocked);   /* GCOVR_EXCL_LINE */
+        return NULL;           /* GCOVR_EXCL_LINE */
+    }
+    /* GCOVR_EXCL_BR_STOP */
+    PyObject *fallback = PyUnicode_FromString("windows-1252");
+    if (fallback == NULL) {    /* GCOVR_EXCL_BR_LINE: string allocation cannot be forced to fail */
+        PyMem_Free(shaped);    /* GCOVR_EXCL_LINE */
+        Py_DECREF(out);        /* GCOVR_EXCL_LINE */
+        Py_XDECREF(permitted); /* GCOVR_EXCL_LINE */
+        Py_XDECREF(blocked);   /* GCOVR_EXCL_LINE */
+        return NULL;           /* GCOVR_EXCL_LINE */
+    }
+    Py_ssize_t count = detect_shape(winner, certain, scored, fallback, shaped);
+    int status = 0;
+    /* the hinted language runs first, so a preferred candidate leads without disturbing the rest of the order */
+    for (int pass = 0; status == 0 && pass < (language == Py_None ? 1 : 2); pass++) {
+        for (Py_ssize_t index = 0; status == 0 && index < count; index++) {
+            PyObject *name = shaped[index].name;
+            double confidence = shaped[index].confidence;
+            if (confidence < threshold || (allowed != Py_None && detect_name_listed(permitted, name) != 1) ||
+                detect_name_listed(blocked, name) == 1) {
+                continue;
+            }
+            if (language != Py_None) {
+                PyObject *folded = PyObject_CallMethod(name, "casefold", NULL);
+                /* borrowed; NULL when the encoding names no language, which can never be the hinted one */
+                PyObject *named = PyDict_GetItem(languages, folded);
+                int preferred = confidence > 0.0 && named != NULL && PyObject_RichCompareBool(named, language, Py_EQ);
+                Py_DECREF(folded);
+                if (preferred != (pass == 0)) {
+                    continue;
+                }
+            }
+            PyObject *row = detect_row(name, confidence, languages, bom);
+            status = row == NULL ? -1 : PyList_Append(out, row); /* GCOVR_EXCL_BR_LINE: allocation */
+            Py_XDECREF(row);
+        }
+    }
+    PyMem_Free(shaped);
+    Py_DECREF(fallback);
+    Py_XDECREF(permitted);
+    Py_XDECREF(blocked);
+    if (status < 0) {   /* GCOVR_EXCL_BR_LINE: every failure above is an allocation failure */
+        Py_DECREF(out); /* GCOVR_EXCL_LINE */
+        return NULL;    /* GCOVR_EXCL_LINE */
+    }
+    return out;
+}
+
 /* Resolve a byte-order mark, then a <meta> prescan, over the stream's leading bytes; the
    caller supplies the detector's answer for when neither decides. */
 static const char *detect_declared(const unsigned char *prefix, Py_ssize_t prefix_len, int *certain, int *bom) {

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -72,6 +72,9 @@ from ._stubs.dom import (
     _detect_language as _detect_language,
 )
 from ._stubs.dom import (
+    _detect_rank as _detect_rank,
+)
+from ._stubs.dom import (
     _DetectStream as _DetectStream,
 )
 from ._stubs.dom import (

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -491,6 +491,15 @@ def _build_document(
 ) -> Document: ...
 def _decode(data: bytes, label: str, /) -> str: ...
 def _detect(data: bytes, tld: str | None, /) -> tuple[str | None, bool, list[tuple[str, int]], bool]: ...
+def _detect_rank(
+    result: tuple[str | None, bool, list[tuple[str, int]], bool],
+    allowed: Iterable[str] | None,
+    excluded: Iterable[str],
+    language: str | None,
+    threshold: float,
+    languages: dict[str, str],
+    /,
+) -> list[tuple[str, float, str | None, bool, str]]: ...
 
 @final
 class _DetectStream:

--- a/src/turbohtml/detect.py
+++ b/src/turbohtml/detect.py
@@ -36,9 +36,10 @@ from __future__ import annotations
 import codecs
 import string
 from dataclasses import dataclass
+from itertools import starmap
 from typing import Final, Literal
 
-from ._html import _decode, _detect, _detect_language, _DetectStream, _is_normalized, _normalize
+from ._html import _decode, _detect, _detect_language, _detect_rank, _DetectStream, _is_normalized, _normalize
 
 __all__ = [
     "Detection",
@@ -310,8 +311,7 @@ class EncodingDetector:
     def close(self) -> EncodingMatch:
         """Read the detector's answer, cache it, and return it."""
         if self._result is None:
-            shaped = _shape(self._stream.close()) if self._fed else ([], False)
-            self._result = _rank(shaped, self._options)[0]
+            self._result = _rank(self._stream.close(), self._options)[0] if self._fed else _NO_MATCH
             self.done = True
         return self._result
 
@@ -326,58 +326,13 @@ class EncodingDetector:
 
 def _matches(data: bytes, options: Detection) -> list[EncodingMatch]:
     """Rank the candidates for ``data``, apply the options, and always return at least the no-match sentinel."""
-    return _rank(_candidates(data, options.tld), options)
+    return _rank(_detect(data, options.tld), options) if data else [_NO_MATCH]
 
 
-def _rank(shaped: tuple[list[tuple[str, float]], bool], options: Detection) -> list[EncodingMatch]:
-    """Apply the options to shaped candidates, and always return at least the no-match sentinel."""
-    ranked, had_bom = shaped
-    if (allowed := options.allowed) is not None:
-        permitted = {name.casefold() for name in allowed}
-        ranked = [(name, confidence) for name, confidence in ranked if name.casefold() in permitted]
-    if blocked := {name.casefold() for name in options.excluded}:
-        ranked = [(name, confidence) for name, confidence in ranked if name.casefold() not in blocked]
-    if (hint := options.language) is not None:
-        preferred = [pair for pair in ranked if pair[1] > 0.0 and _LANGUAGES.get(pair[0].casefold()) == hint]
-        ranked = preferred + [pair for pair in ranked if pair not in preferred]
-    matches = [
-        EncodingMatch(name, confidence, _LANGUAGES.get(name.casefold()), had_bom, f"whatwg-{name.casefold()}")
-        for name, confidence in ranked
-        if confidence >= options.threshold
-    ]
-    return matches or [_NO_MATCH]
-
-
-def _candidates(data: bytes, tld: str | None) -> tuple[list[tuple[str, float]], bool]:
-    """
-    Run the C sniff and shape its output into (canonical name, confidence) pairs plus the byte-order-mark flag.
-
-    A certain result (a byte-order mark, a declaration, a structural proof, or pure ASCII) is a single pair at
-    confidence 1.0; a mark makes it so and sets the flag, so the flag is only ever true for that lone certain pair. A
-    scored result normalizes each candidate's raw chardetng score to its share of the positive total, ordered
-    score-descending with the C emission order breaking ties exactly as the engine's strict-max does, and the engine's
-    winner moved to the front so index 0 always matches what ``parse(detect_encoding=True)`` would decode with. Two
-    candidates can share one encoding (the windows-1252 model runs once per language family), so the best-scored entry
-    per name wins. A stream with no non-ASCII byte carries no evidence, so it takes the spec's windows-1252 fallback,
-    which decodes ASCII identically -- the answer ``parse(detect_encoding=True)`` reaches for the same bytes.
-    """
-    return _shape(_detect(data, tld)) if data else ([], False)
-
-
-def _shape(result: tuple[str | None, bool, list[tuple[str, int]], bool]) -> tuple[list[tuple[str, float]], bool]:
-    """Shape one C sniff result, from either the one-shot detect or the streaming detector."""
-    winner, certain, scored, bom = result
-    if certain or winner is None:
-        return [(winner or "windows-1252", 1.0)], bom
-    unique: dict[str, int] = {}
-    for name, score in sorted(scored, key=lambda pair: -pair[1]):
-        unique.setdefault(name, score)
-    total = sum(score for score in unique.values() if score > 0)
-    ranked = [(name, score / total if score > 0 else 0.0) for name, score in unique.items()]
-    at = next((index for index, pair in enumerate(ranked) if pair[0] == winner), None)
-    if at is None:  # the windows-1252 fallback won without surviving as a candidate itself
-        return [(winner, 0.0), *ranked], bom
-    return [ranked[at], *ranked[:at], *ranked[at + 1 :]], bom
+def _rank(result: tuple[str | None, bool, list[tuple[str, int]], bool], options: Detection) -> list[EncodingMatch]:
+    """Shape one detector result, apply the options, and always return at least the no-match sentinel."""
+    rows = _detect_rank(result, options.allowed, options.excluded, options.language, options.threshold, _LANGUAGES)
+    return list(starmap(EncodingMatch, rows)) or [_NO_MATCH]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/detect/test_detect_rank_c_api.py
+++ b/tests/detect/test_detect_rank_c_api.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from turbohtml._html import _detect_rank
+
+# One detector result: (winner, certain, [(name, score)], had_bom). The ranker shapes and filters it.
+_SCORED = ("windows-1251", False, [("windows-1251", 60), ("koi8-r", 40)], False)
+_LANGUAGES = {"windows-1251": "ru", "koi8-r": "ru", "windows-1252": "en"}
+
+
+def test_a_certain_result_is_one_candidate() -> None:
+    rows = _detect_rank(("utf-8", True, [], True), None, (), None, 0.0, _LANGUAGES)
+    assert rows == [("utf-8", 1.0, None, True, "whatwg-utf-8")]
+
+
+def test_no_winner_takes_the_windows_1252_fallback() -> None:
+    rows = _detect_rank((None, False, [], False), None, (), None, 0.0, _LANGUAGES)
+    assert rows == [("windows-1252", 1.0, "en", False, "whatwg-windows-1252")]
+
+
+def test_scores_become_shares_of_the_positive_total() -> None:
+    rows = _detect_rank(_SCORED, None, (), None, 0.0, _LANGUAGES)
+    assert [(row[0], round(row[1], 2)) for row in rows] == [("windows-1251", 0.6), ("koi8-r", 0.4)]
+
+
+def test_the_winner_leads_even_when_it_scored_lower() -> None:
+    result = ("koi8-r", False, [("windows-1251", 60), ("koi8-r", 40)], False)
+    assert [row[0] for row in _detect_rank(result, None, (), None, 0.0, _LANGUAGES)] == ["koi8-r", "windows-1251"]
+
+
+def test_a_winner_that_never_scored_leads_at_zero() -> None:
+    result = ("windows-1252", False, [("windows-1251", 60)], False)
+    rows = _detect_rank(result, None, (), None, 0.0, _LANGUAGES)
+    assert [(row[0], row[1]) for row in rows] == [("windows-1252", 0.0), ("windows-1251", 1.0)]
+
+
+def test_one_encoding_scored_twice_keeps_its_better_score() -> None:
+    result = ("windows-1251", False, [("windows-1251", 10), ("koi8-r", 40), ("windows-1251", 60)], False)
+    rows = _detect_rank(result, None, (), None, 0.0, _LANGUAGES)
+    assert [(row[0], round(row[1], 2)) for row in rows] == [("windows-1251", 0.6), ("koi8-r", 0.4)]
+
+
+def test_a_non_positive_score_reads_as_zero_confidence() -> None:
+    result = ("windows-1251", False, [("windows-1251", 60), ("koi8-r", 0)], False)
+    assert [row[1] for row in _detect_rank(result, None, (), None, 0.0, _LANGUAGES)] == [1.0, 0.0]
+
+
+def test_the_allowlist_drops_everything_else() -> None:
+    rows = _detect_rank(_SCORED, ("KOI8-R",), (), None, 0.0, _LANGUAGES)
+    assert [row[0] for row in rows] == ["koi8-r"]
+
+
+def test_an_empty_allowlist_keeps_nothing() -> None:
+    assert _detect_rank(_SCORED, (), (), None, 0.0, _LANGUAGES) == []
+
+
+def test_the_exclusions_drop_their_own() -> None:
+    rows = _detect_rank(_SCORED, None, ("Windows-1251",), None, 0.0, _LANGUAGES)
+    assert [row[0] for row in rows] == ["koi8-r"]
+
+
+def test_the_threshold_drops_the_weak() -> None:
+    rows = _detect_rank(_SCORED, None, (), None, 0.5, _LANGUAGES)
+    assert [row[0] for row in rows] == ["windows-1251"]
+
+
+def test_a_language_hint_floats_its_encodings_first() -> None:
+    result = ("windows-1252", False, [("windows-1252", 60), ("koi8-r", 40)], False)
+    rows = _detect_rank(result, None, (), "ru", 0.0, _LANGUAGES)
+    assert [row[0] for row in rows] == ["koi8-r", "windows-1252"]
+
+
+def test_a_language_hint_leaves_a_zero_confidence_candidate_behind() -> None:
+    # a candidate the detector scored at zero carries no evidence, so the hint cannot promote it
+    result = ("windows-1252", False, [("windows-1252", 60), ("koi8-r", 0)], False)
+    rows = _detect_rank(result, None, (), "ru", 0.0, _LANGUAGES)
+    assert [row[0] for row in rows] == ["windows-1252", "koi8-r"]
+
+
+def test_a_language_hint_leaves_an_encoding_naming_no_language_behind() -> None:
+    # utf-8 names no language, so the hint has nothing to compare it against and it cannot be promoted
+    result = ("utf-8", False, [("utf-8", 60), ("koi8-r", 40)], False)
+    rows = _detect_rank(result, None, (), "ru", 0.0, _LANGUAGES)
+    assert [row[0] for row in rows] == ["koi8-r", "utf-8"]
+
+
+def test_a_language_hint_no_encoding_claims_keeps_the_order() -> None:
+    rows = _detect_rank(_SCORED, None, (), "zz", 0.0, _LANGUAGES)
+    assert [row[0] for row in rows] == ["windows-1251", "koi8-r"]
+
+
+def test_an_encoding_naming_no_language_reports_none() -> None:
+    rows = _detect_rank(("utf-8", True, [], False), None, (), None, 0.0, _LANGUAGES)
+    assert rows[0][2] is None
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(("notatuple", None, (), None, 0.0, _LANGUAGES), id="result-is-not-a-tuple"),
+        pytest.param((_SCORED, None, (), None, 0.0, "notadict"), id="languages-is-not-a-dict"),
+        pytest.param((_SCORED, None, (), None, "notafloat", _LANGUAGES), id="threshold-is-not-a-number"),
+        pytest.param((_SCORED, None, ()), id="too-few-arguments"),
+    ],
+)
+def test_the_ranker_rejects_bad_arguments(args: tuple[object, ...]) -> None:
+    with pytest.raises(TypeError):
+        _detect_rank(*args)  # ty: ignore[invalid-argument-type]  # the argument check is the point


### PR DESCRIPTION
The detector answered in C and Python decided what that answer meant. 🔤 `_shape` deduplicated the scored candidates keeping each name's best score, normalized every score to its share of the positive total, and moved the detector's own winner to the front; `_rank` then applied the allowlist, the exclusions, the language preference that floats a hinted encoding forward, and the confidence floor. Every one of those decides what a caller gets back.

One `_detect_rank` binding now does both, and the one-shot and the streaming detector call it directly rather than sharing a Python helper between them. The typed layer constructs `EncodingMatch` from the returned rows and keeps its no-match sentinel for an empty answer, which is the whole of its remaining job.

Writing it turned up three behaviors worth naming, because each is a place the Python was doing something load-bearing that reads as incidental. The candidates are sorted score-descending *before* deduplication, so the first entry per name is its best and the output order follows the score; iterating in the detector's emission order instead changes which candidate leads. A `None` winner means the stream held no non-ASCII byte and takes the spec's `windows-1252` fallback rather than reporting no encoding. And empty input never reached the shaping at all, so it answers the no-match sentinel at confidence 0.0 rather than a fallback at 1.0.

Third of the series that follows the audit in #774, after #775. Remaining: the `extract` boilerplate classifier, the JSON-LD shaping, and the `_urls`/`_dates` ports already named in the 1.0 rearchitecture plan.
