### PR TITLE
♻️ refactor(extract): classify boilerplate in C

### DIFF
--- a/docs/changelog/777.feature.rst
+++ b/docs/changelog/777.feature.rst
@@ -1,0 +1,3 @@
+Move the boilerplate classifier into the C core: segmenting a page into paragraph units, collapsing each unit's text,
+and deciding which units are article content against the :class:`~turbohtml.extract.Extraction` thresholds. Results are
+unchanged.

--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,7 @@ py.extension_module(
         'src/turbohtml/_c/serialize/markdown.c',
         'src/turbohtml/_c/serialize/text.c',
         'src/turbohtml/_c/extract/readability.c',
+        'src/turbohtml/_c/extract/boilerplate.c',
         'src/turbohtml/_c/js/lexer.c',
         'src/turbohtml/_c/js/ast.c',
         'src/turbohtml/_c/js/parser.c',

--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -50,6 +50,7 @@ PyObject *turbohtml_register_xpath_string(PyObject *module, PyObject *type);
    over a byte buffer without parsing, narrowed by the host's rightmost DNS label when one
    is given; the turbohtml.detect facade shapes its (winner, certain, ranked scores, bom)
    tuple into EncodingMatch results. METH_VARARGS. */
+PyObject *turbohtml_extract_boilerplate(PyObject *module, PyObject *args);
 PyObject *turbohtml_detect_encoding(PyObject *module, PyObject *args);
 PyObject *turbohtml_detect_rank(PyObject *module, PyObject *args);
 

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -229,6 +229,7 @@ static PyMethodDef html_methods[] = {
     {"_minify_js_tokens", turbohtml_minify_js_tokens, METH_O, NULL},
     {"_minify_js_parse", turbohtml_minify_js_parse, METH_O, NULL},
     {"_decode", turbohtml_decode, METH_VARARGS, NULL},
+    {"_boilerplate", turbohtml_extract_boilerplate, METH_VARARGS, NULL},
     {"_detect", turbohtml_detect_encoding, METH_VARARGS, NULL},
     {"_detect_rank", turbohtml_detect_rank, METH_VARARGS, NULL},
     {"_detect_language", turbohtml_detect_language, METH_VARARGS, NULL},

--- a/src/turbohtml/_c/extract/boilerplate.c
+++ b/src/turbohtml/_c/extract/boilerplate.c
@@ -1,0 +1,212 @@
+/* Paragraph segmentation and boilerplate classification behind turbohtml.extract.boilerplate.
+
+   A page segments into units -- the block elements a reader sees as paragraphs -- and each unit is either article
+   text or the navigation, footer and sidebar noise around it. The scoring that finds the content body is
+   th_node_main_content; what remains is deciding which units are paragraphs at all and which of them survive the
+   caller's thresholds, and that decision is what the caller gets back, so it runs here. */
+
+#include "core/common.h"
+#include "dom/tree.h"
+
+/* The block elements a page segments into. A unit holding another unit is a container -- a <li> wrapping a <p>, a
+   <td> wrapping a list -- so the nested units are the real paragraphs and the container is skipped. */
+static int boilerplate_is_unit(const th_node *node) {
+    switch (node->atom) {
+    case TH_TAG_H1:
+    case TH_TAG_H2:
+    case TH_TAG_H3:
+    case TH_TAG_H4:
+    case TH_TAG_H5:
+    case TH_TAG_H6:
+    case TH_TAG_P:
+    case TH_TAG_LI:
+    case TH_TAG_PRE:
+    case TH_TAG_BLOCKQUOTE:
+    case TH_TAG_TD:
+    case TH_TAG_DD:
+    case TH_TAG_DT:
+    case TH_TAG_FIGCAPTION:
+        return node->type == TH_NODE_ELEMENT;
+    default:
+        return 0;
+    }
+}
+
+static int boilerplate_is_heading(const th_node *node) {
+    return node->atom >= TH_TAG_H1 && node->atom <= TH_TAG_H6;
+}
+
+/* Does any descendant of `node` open a unit of its own? */
+static int boilerplate_holds_a_unit(const th_node *node) {
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (boilerplate_is_unit(child) || boilerplate_holds_a_unit(child)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Is `ancestor` above `node`? The content body has to contain a unit for that unit to be article text. */
+static int boilerplate_within(const th_node *node, const th_node *ancestor) {
+    for (const th_node *walk = node->parent; walk != NULL; walk = walk->parent) {
+        if (walk == ancestor) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* The combined length of the unit's text that sits inside an anchor. */
+static Py_ssize_t boilerplate_linked_length(th_tree *tree, th_node *node) {
+    Py_ssize_t linked = 0;
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type != TH_NODE_ELEMENT) {
+            continue;
+        }
+        if (child->atom == TH_TAG_A) {
+            Py_ssize_t length = 0;
+            th_node_text(tree, child, &length);
+            linked += length;
+            continue;
+        }
+        linked += boilerplate_linked_length(tree, child);
+    }
+    return linked;
+}
+
+/* The ASCII whitespace ``str.split`` breaks on. Kept as a table rather than a chain of comparisons so each
+   spelling is one iteration of one branch, which both coverage gates can see the whole of. */
+static int boilerplate_is_space(Py_UCS4 point) {
+    static const Py_UCS4 spaces[] = {' ', '\t', '\n', '\r', '\f', 0x0B};
+    for (size_t index = 0; index < sizeof(spaces) / sizeof(spaces[0]); index++) {
+        if (point == spaces[index]) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Collapse the unit's text the way ``" ".join(text.split())`` does: runs of ASCII whitespace become one space and
+   the edges are trimmed. Returns the collapsed string, or NULL with the error set. */
+static PyObject *boilerplate_collapse(const Py_UCS4 *text, Py_ssize_t length) {
+    Py_UCS4 *packed = PyMem_Malloc((size_t)(length + 1) * sizeof(*packed));
+    if (packed == NULL) {        /* GCOVR_EXCL_BR_LINE: allocation cannot be forced to fail */
+        return PyErr_NoMemory(); /* GCOVR_EXCL_LINE */
+    }
+    Py_ssize_t written = 0;
+    int pending = 0;
+    for (Py_ssize_t index = 0; index < length; index++) {
+        Py_UCS4 point = text[index];
+        if (boilerplate_is_space(point)) {
+            pending = written > 0;
+            continue;
+        }
+        if (pending) {
+            packed[written++] = ' ';
+            pending = 0;
+        }
+        packed[written++] = point;
+    }
+    PyObject *collapsed = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, packed, written);
+    PyMem_Free(packed);
+    return collapsed;
+}
+
+/* Classify one unit: outside the content body, link-dense, or below the length floor is boilerplate. */
+static int boilerplate_classify(th_tree *tree, th_node *unit, const th_node *content, Py_ssize_t collapsed_length,
+                                Py_ssize_t min_length, double max_link_density, int keep_headings) {
+    if (content == NULL || !boilerplate_within(unit, content)) {
+        return 1;
+    }
+    Py_ssize_t length = 0;
+    th_node_text(tree, unit, &length);
+    Py_ssize_t linked = boilerplate_linked_length(tree, unit);
+    if (linked > 0 && (double)linked / (double)length > max_link_density) {
+        return 1;
+    }
+    if (keep_headings && boilerplate_is_heading(unit)) {
+        return 0; /* a heading is short by nature, so the length floor does not apply to it */
+    }
+    return collapsed_length < min_length;
+}
+
+/* Walk the tree in document order, appending one row per non-blank unit. */
+static int boilerplate_walk(th_tree *tree, th_node *node, const th_node *content, Py_ssize_t min_length,
+                            double max_link_density, int keep_headings, PyObject *out) {
+    for (th_node *child = node->first_child; child != NULL; child = child->next_sibling) {
+        if (child->type != TH_NODE_ELEMENT) {
+            continue;
+        }
+        if (!boilerplate_is_unit(child) || boilerplate_holds_a_unit(child)) {
+            /* GCOVR_EXCL_BR_START: only an allocation failure below returns -1 */
+            if (boilerplate_walk(tree, child, content, min_length, max_link_density, keep_headings, out) < 0) {
+                return -1; /* GCOVR_EXCL_LINE */
+            }
+            /* GCOVR_EXCL_BR_STOP */
+            continue;
+        }
+        Py_ssize_t length = 0;
+        const Py_UCS4 *text = th_node_text(tree, child, &length);
+        if (text == NULL) { /* GCOVR_EXCL_BR_LINE: text realization cannot be forced to fail */
+            return -1;      /* GCOVR_EXCL_LINE */
+        }
+        PyObject *collapsed = boilerplate_collapse(text, length);
+        if (collapsed == NULL) { /* GCOVR_EXCL_BR_LINE: allocation cannot be forced to fail */
+            return -1;           /* GCOVR_EXCL_LINE */
+        }
+        Py_ssize_t collapsed_length = PyUnicode_GET_LENGTH(collapsed);
+        if (collapsed_length == 0) { /* a blank unit is not a paragraph */
+            Py_DECREF(collapsed);
+            continue;
+        }
+        int boiler =
+            boilerplate_classify(tree, child, content, collapsed_length, min_length, max_link_density, keep_headings);
+        PyObject *row =
+            PyTuple_Pack(3, collapsed, boiler ? Py_True : Py_False, boilerplate_is_heading(child) ? Py_True : Py_False);
+        Py_DECREF(collapsed);
+        /* GCOVR_EXCL_BR_START: tuple and list allocation cannot be forced to fail */
+        int status = row == NULL ? -1 : PyList_Append(out, row);
+        Py_XDECREF(row);
+        if (status < 0) {
+            return -1; /* GCOVR_EXCL_LINE */
+        }
+        /* GCOVR_EXCL_BR_STOP */
+    }
+    return 0;
+}
+
+/* _boilerplate(root, content, min_length, max_link_density, keep_headings) -> list[(text, is_boilerplate, is_heading)]
+
+   `root` is the parsed document's root and `content` the element th_node_main_content scored as the article body, or
+   None when the page has none. Each row carries what a Paragraph holds, so the typed layer only names the fields. */
+PyObject *turbohtml_extract_boilerplate(PyObject *module, PyObject *args) {
+    PyObject *root;
+    PyObject *content;
+    Py_ssize_t min_length;
+    double max_link_density;
+    int keep_headings;
+    if (!PyArg_ParseTuple(args, "OOndp:_boilerplate", &root, &content, &min_length, &max_link_density,
+                          &keep_headings)) {
+        return NULL;
+    }
+    th_tree *tree;
+    th_node *node;
+    if (turbohtml_node_borrow(module, root, &tree, &node) < 0) {
+        return NULL;
+    }
+    th_tree *content_tree;
+    th_node *body = NULL;
+    if (content != Py_None && turbohtml_node_borrow(module, content, &content_tree, &body) < 0) {
+        return NULL;
+    }
+    PyObject *out = PyList_New(0);
+    if (out == NULL) { /* GCOVR_EXCL_BR_LINE: list allocation cannot be forced to fail */
+        return NULL;   /* GCOVR_EXCL_LINE */
+    }
+    int walked = boilerplate_walk(tree, node, body, min_length, max_link_density, keep_headings, out);
+    if (walked < 0) {   /* GCOVR_EXCL_BR_LINE: allocation */
+        Py_DECREF(out); /* GCOVR_EXCL_LINE */
+        return NULL;    /* GCOVR_EXCL_LINE */
+    }
+    return out;
+}

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -60,6 +60,9 @@ from ._stubs.dom import (
     TreeWalker as TreeWalker,
 )
 from ._stubs.dom import (
+    _boilerplate as _boilerplate,
+)
+from ._stubs.dom import (
     _build_document as _build_document,
 )
 from ._stubs.dom import (

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -500,6 +500,14 @@ def _detect_rank(
     languages: dict[str, str],
     /,
 ) -> list[tuple[str, float, str | None, bool, str]]: ...
+def _boilerplate(
+    root: Element,
+    content: Element | None,
+    min_length: int,
+    max_link_density: float,
+    keep_headings: bool,
+    /,
+) -> list[tuple[str, bool, bool]]: ...
 
 @final
 class _DetectStream:

--- a/src/turbohtml/extract/__init__.py
+++ b/src/turbohtml/extract/__init__.py
@@ -32,9 +32,10 @@ records, the ``feedparser.parse`` entry point over :meth:`turbohtml.Document.fee
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Final, NamedTuple
+from itertools import starmap
+from typing import Final, NamedTuple, cast
 
-from turbohtml._html import Element, parse
+from turbohtml._html import Element, _boilerplate, parse
 
 from ._article import Article
 from ._dates import DateExtraction, PublicationDate, dates
@@ -46,6 +47,7 @@ from ._urls import UrlCleaning, clean_url, extract_links, normalize_url
 __all__ = [
     "Article",
     "DateExtraction",
+    "Element",
     "Entry",
     "Extraction",
     "Feed",
@@ -66,10 +68,6 @@ __all__ = [
     "normalize_url",
     "opengraph",
 ]
-
-_HEADINGS: Final = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
-_UNITS: Final[list[str]] = [*_HEADINGS, "p", "li", "pre", "blockquote", "td", "dd", "dt", "figcaption"]
-"""The block elements a page segments into; a unit holding another unit is a container, not a paragraph."""
 
 
 class Paragraph(NamedTuple):
@@ -191,23 +189,12 @@ def boilerplate(html: str, options: Extraction | None = None, /) -> list[Paragra
     """
     thresholds = options or _DEFAULT
     document = parse(html)
-    content = document.main_content()
-    paragraphs = []
-    for unit in document.find_all(_UNITS):
-        if unit.find(_UNITS) is not None:  # a container whose nested units are the real paragraphs
-            continue
-        if text := " ".join(unit.text.split()):
-            paragraphs.append(Paragraph(text, _is_boilerplate(unit, text, content, thresholds), unit.tag in _HEADINGS))
-    return paragraphs
-
-
-def _is_boilerplate(unit: Element, text: str, content: Element | None, thresholds: Extraction) -> bool:
-    """Classify one non-blank unit: outside the content body, link-dense, or below the length floor is boilerplate."""
-    if content is None or content not in unit.ancestors:
-        return True
-    linked = sum(len(anchor.text) for anchor in unit.find_all("a"))
-    if linked and linked / len(unit.text) > thresholds.max_link_density:
-        return True
-    if unit.tag in _HEADINGS and thresholds.keep_headings:
-        return False
-    return len(text) < thresholds.min_length
+    rows = _boilerplate(
+        # a parsed document always has an <html> root, though the type admits None
+        cast("Element", document.root),
+        document.main_content(),
+        thresholds.min_length,
+        thresholds.max_link_density,
+        thresholds.keep_headings,
+    )
+    return list(starmap(Paragraph, rows))

--- a/tests/extract/test_boilerplate_c_api.py
+++ b/tests/extract/test_boilerplate_c_api.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import pytest
+
+import turbohtml
+from turbohtml._html import _boilerplate
+from turbohtml.extract import Extraction, boilerplate
+
+# Thresholds the binding takes as (min_length, max_link_density, keep_headings). Wide open, so only the segmentation
+# decides the answer; a test that cares about one threshold passes its own.
+_OPEN = (0, 1.0, True)
+_ARTICLE = "<article><h2>brief</h2><p>ordinary prose long enough for this to score as the article body</p></article>"
+
+
+def _classify(
+    markup: str, thresholds: tuple[int, float, bool] = _OPEN, *, content: bool = True
+) -> list[tuple[str, bool, bool]]:
+    """Run the binding over markup, passing the scored content body unless the caller withholds it."""
+    document = turbohtml.parse(markup)
+    root = document.root
+    assert root is not None  # a parsed document always has an <html> root, though the type admits None
+    return _boilerplate(root, document.main_content() if content else None, *thresholds)
+
+
+@pytest.mark.parametrize(
+    ("tag", "wrapper"),
+    [
+        pytest.param("p", "{0}", id="unit-p"),
+        pytest.param("li", "{0}", id="unit-li"),
+        pytest.param("pre", "{0}", id="unit-pre"),
+        pytest.param("blockquote", "{0}", id="unit-blockquote"),
+        # a bare cell is foster-parented out of the tree, so it needs the table it belongs to
+        pytest.param("td", "<table><tr>{0}</tr></table>", id="unit-td"),
+        pytest.param("dd", "<dl>{0}</dl>", id="unit-dd"),
+        pytest.param("dt", "<dl>{0}</dl>", id="unit-dt"),
+        pytest.param("figcaption", "<figure>{0}</figure>", id="unit-figcaption"),
+        pytest.param("h1", "{0}", id="unit-h1"),
+        pytest.param("h3", "{0}", id="unit-h3"),
+        pytest.param("h6", "{0}", id="unit-h6"),
+    ],
+)
+def test_every_unit_tag_becomes_a_paragraph(tag: str, wrapper: str) -> None:
+    markup = wrapper.format(f"<{tag}>text of the unit</{tag}>")
+    assert [row[0] for row in _classify(markup)] == ["text of the unit"]
+
+
+@pytest.mark.parametrize(
+    ("tag", "heading"),
+    [pytest.param("h2", True, id="heading"), pytest.param("p", False, id="not-a-heading")],
+)
+def test_a_unit_reports_whether_it_is_a_heading(tag: str, heading: bool) -> None:  # ruff:ignore[boolean-type-hint-positional-argument]  # a pytest parametrize value, not a boolean-trap call site
+    assert _classify(f"<{tag}>words</{tag}>")[0][2] is heading
+
+
+def test_a_container_yields_its_nested_units_not_itself() -> None:
+    assert [row[0] for row in _classify("<li><p>inner one</p><p>inner two</p></li>")] == ["inner one", "inner two"]
+
+
+def test_a_container_holding_a_unit_below_a_non_unit_is_still_a_container() -> None:
+    # the <li>'s own child is a <div>, which is not a unit but carries one, so the <li> is a container
+    assert [row[0] for row in _classify("<li><div><p>the real paragraph</p></div></li>")] == ["the real paragraph"]
+
+
+def test_a_unit_nested_below_a_non_unit_is_still_found() -> None:
+    assert [row[0] for row in _classify("<div><section><p>buried</p></section></div>")] == ["buried"]
+
+
+def test_a_blank_unit_is_not_a_paragraph() -> None:
+    assert [row[0] for row in _classify("<p>   </p><p>real</p>")] == ["real"]
+
+
+@pytest.mark.parametrize(
+    ("markup", "expected"),
+    [
+        pytest.param("<p>a   b</p>", "a b", id="runs-collapse"),
+        pytest.param("<p>\ta\nb\r</p>", "a b", id="tab-newline-return"),
+        pytest.param("<p>a\x0cb</p>", "a b", id="form-feed"),
+        pytest.param("<p>a\x0bb</p>", "a b", id="vertical-tab"),
+        pytest.param("<p>  edges  </p>", "edges", id="edges-trimmed"),
+    ],
+)
+def test_the_text_is_whitespace_collapsed(markup: str, expected: str) -> None:
+    assert _classify(markup)[0][0] == expected
+
+
+def test_a_unit_outside_the_content_body_is_boilerplate() -> None:
+    assert _classify("<p>orphan</p>", content=False)[0][1] is True
+
+
+def test_a_link_dense_unit_is_boilerplate() -> None:
+    markup = "<article><p><a href='/x'>all of it is a link</a></p></article>"
+    assert _classify(markup, (0, 0.5, True))[0][1] is True
+
+
+def test_an_anchor_nested_below_another_element_still_counts() -> None:
+    markup = "<article><p><span><a href='/x'>all of it is a link</a></span></p></article>"
+    assert _classify(markup, (0, 0.5, True))[0][1] is True
+
+
+def test_a_non_anchor_element_beside_an_anchor_is_not_counted_as_linked() -> None:
+    # the <em> contributes text but no link, so the density stays under the limit and the unit is content
+    markup = "<article><p><em>a good deal of ordinary prose</em> and <a href='/x'>one</a> link</p></article>"
+    assert _classify(markup, (0, 0.5, True))[0][1] is False
+
+
+def test_the_length_floor_drops_a_short_unit() -> None:
+    assert _classify("<article><p>short</p></article>", (25, 1.0, True))[0][1] is True
+
+
+def test_a_kept_heading_escapes_the_length_floor() -> None:
+    assert _classify(_ARTICLE, (25, 1.0, True))[0][1] is False
+
+
+def test_a_heading_faces_the_floor_when_headings_are_not_kept() -> None:
+    assert _classify(_ARTICLE, (25, 1.0, False))[0][1] is True
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param(("notanelement", None, 0, 1.0, True), id="root-is-not-an-element"),
+        pytest.param((None, 0, 1.0, True), id="too-few-arguments"),
+    ],
+)
+def test_the_binding_rejects_bad_arguments(args: tuple[object, ...]) -> None:
+    with pytest.raises(TypeError):
+        _boilerplate(*args)  # ty: ignore[invalid-argument-type]  # the argument check is the point
+
+
+def test_the_binding_rejects_a_content_that_is_not_an_element() -> None:
+    document = turbohtml.parse("<p>x</p>")
+    root = document.root
+    assert root is not None
+    with pytest.raises(TypeError):
+        _boilerplate(root, "notanelement", 0, 1.0, True)  # ruff:ignore[boolean-positional-value-in-call]  # ty: ignore[invalid-argument-type]  # positional-only C binding
+
+
+def test_the_public_entry_point_still_answers_paragraphs() -> None:
+    found = boilerplate("<article><p>a paragraph long enough to clear the default floor</p></article>", Extraction())
+    assert [(unit.text, unit.is_boilerplate, unit.is_heading) for unit in found] == [
+        ("a paragraph long enough to clear the default floor", False, False)
+    ]


### PR DESCRIPTION
Segmenting a page into paragraph units and deciding which of them are article text ran in Python over wrapper objects. 📄 It called `find_all` for every unit tag, a second `find_all` per unit to see whether it was really a container, a third for its anchors, and materialized the unit's whole text twice to measure link density. All of it decides what a caller gets back, which is what the "all logic in C" rule is about.

The walk now runs once over the arena. It recognizes a unit by tag atom, skips one that carries another unit, collapses the whitespace as it reads, and sums anchor text without building a wrapper per anchor. The typed layer parses, asks `main_content()` for the scored body, and names the fields of each row it gets back.

One thing improves beyond the rule: the list of unit tags lived in Python, in a module the C knew nothing about. It is one `switch` now, so the segmentation and the tag set cannot drift apart.

Fourth of the series that follows the audit in #774, after #775 and #776. Remaining: the JSON-LD shaping in `extract/_structured_data.py`, and the `_urls`/`_dates` ports already named in the 1.0 rearchitecture plan.
