### PR TITLE
♻️ refactor(extract): run the date stages in C

### DIFF
--- a/docs/changelog/779.feature.rst
+++ b/docs/changelog/779.feature.rst
@@ -1,0 +1,2 @@
+Move the publication-date stages into the C core: the canonical-URL, ``<meta>``, JSON-LD, ``<time>`` and visible-text
+signals :func:`~turbohtml.extract.dates` reads now run in one walk each. Results are unchanged.

--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -263,12 +263,12 @@ PyObject *turbohtml_date_scan(PyObject *module, PyObject *args);
 PyObject *turbohtml_date_scan_all(PyObject *module, PyObject *args);
 PyObject *turbohtml_date_url(PyObject *module, PyObject *url);
 
-/* Document._date_meta(want, current_year, min_y, min_m, min_d, max_y, max_m, max_d)
-   -> (year, month, day) or None (METH_VARARGS): the <meta> stage of
-   turbohtml.extract.dates, walking the meta elements, classifying each publication
-   or modification date against htmldate's key vocabulary, and returning the winner
-   the shared _pick selection would. Registered on the document method table. */
-PyObject *turbohtml_document_date_meta(PyObject *self, PyObject *args);
+/* Document._dates(want, current_year, min_y, min_m, min_d, max_y, max_m, max_d, extensive)
+   -> (year, month, day, signal) or None. The whole of turbohtml.extract.dates
+   after parsing: the URL, meta, JSON-LD, time and (with extensive) text stages
+   tried in htmldate's order, each fusing its walk with the wanted-role selection,
+   and the first in-window date wins. The shim only formats the tuple. */
+PyObject *turbohtml_document_dates(PyObject *self, PyObject *args);
 
 /* Implemented in tokenizer/tokenizer.c. tokenize() matches METH_VARARGS | METH_KEYWORDS;
    the internal conformance hook _tokenize_states matches METH_VARARGS. */

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -509,7 +509,7 @@ static PyMethodDef document_methods[] = {
      microdata_doc},
     {"rdfa", (PyCFunction)(void (*)(void))turbohtml_document_rdfa, METH_VARARGS | METH_KEYWORDS, rdfa_doc},
     {"dublin_core", turbohtml_document_dublin_core, METH_NOARGS, dublin_core_doc},
-    {"_date_meta", turbohtml_document_date_meta, METH_VARARGS, NULL},
+    {"_dates", turbohtml_document_dates, METH_VARARGS, NULL},
     {"feed", turbohtml_document_feed, METH_NOARGS, feed_doc},
     {NULL, NULL, 0, NULL},
 };

--- a/src/turbohtml/_c/extract/dates.c
+++ b/src/turbohtml/_c/extract/dates.c
@@ -1,29 +1,23 @@
-/* Date-string parsing for turbohtml._dates, the htmldate.find_date counterpart.
+/* Publication-date extraction for turbohtml.extract.dates, the htmldate.find_date counterpart.
 
-   The Python layer walks the parsed DOM -- <meta> tags, JSON-LD, <time> elements,
-   the canonical URL, and (as a last resort) visible text -- and hands each date
-   string here. This file is the pure string parser it delegates instead of the
-   `datetime` module and a stack of `re` patterns; it never touches a tree, so it
-   needs no critical section and is free-threading safe (its only inputs are
-   immutable str objects).
+   The shim parses the page, computes the [min, max] window and hands the tree here; Document._dates runs the
+   signals in htmldate's priority order -- a date in the canonical URL, then publication/modification <meta> tags,
+   then JSON-LD, then <time> elements and date-marked elements, then (as a last resort) the visible text -- and the
+   first stage that yields a date inside the window wins. Within a stage the wanted role (publication for
+   original=True, modification otherwise) or a generic date wins on sight and the first off-role date is the reserve.
 
-   Three surfaces mirror the three Python helpers the shim used:
-     _date_scan(text, year)     -> the first numeric date (ISO 8601, an 8-digit
-                                   stamp, or a day-month-year spelling), or None,
-                                   trying the patterns in that order.
-     _date_scan_all(text, year) -> every ISO, day-month-year, and written-out
-                                   date, in that pattern order, for the text
-                                   stage's frequency scoring.
+   The date-string parser the stages share is also exposed on its own, as the conformance surface for its grammar:
+     _date_scan(text, year)     -> the first numeric date (ISO 8601, an 8-digit stamp, or a day-month-year
+                                   spelling), or None, trying the patterns in that order.
+     _date_scan_all(text, year) -> every ISO, day-month-year, and written-out date, in that pattern order, the
+                                   sweep the text stage's frequency scoring reads.
      _date_url(url)             -> the /YYYY/MM/DD/ date a URL path carries.
-   `year` is the current year, the pivot _correct_year expands a two-digit year
-   against. Each surface returns (year, month, day) int tuples the shim wraps in
-   datetime.date; a calendar-impossible combination (Feb 30, a non-leap Feb 29)
-   is rejected the way date() raises.
+   `year` is the current year, the pivot a two-digit year expands against. Each returns (year, month, day) int
+   tuples; a calendar-impossible combination (Feb 30, a non-leap Feb 29) is rejected the way date() raises.
 
-   Two deliberate narrowings from the Python regexes, both documented and outside
-   any realistic date string: the digit guards and the day-month-year year run
-   read ASCII [0-9] rather than Unicode \d, and the whitespace between written-out
-   date tokens is ASCII [ \t\n\r\f\v] rather than Unicode \s. */
+   Two deliberate narrowings from the regexes the grammar was written from, both outside any realistic date string:
+   the digit guards and the day-month-year year run read ASCII [0-9] rather than Unicode \d, and the whitespace
+   between written-out date tokens is ASCII [ \t\n\r\f\v] rather than Unicode \s. */
 
 #include "core/ascii.h"
 #include "core/common.h"
@@ -36,6 +30,7 @@
 #include <string.h>
 
 #define CP(index) PyUnicode_READ(kind, data, (index))
+#define COUNT_OF(table) (sizeof(table) / sizeof(*(table)))
 
 /* Lowercase for the case-insensitive month vocabulary: the ASCII fold plus the
    Latin-1 uppercase block (0xC0-0xDE minus the 0xD7 multiplication sign), which
@@ -497,16 +492,6 @@ static int text_b(const void *data, int kind, Py_ssize_t len, Py_ssize_t pos, in
     return 0;
 }
 
-static int append_ymd(PyObject *list, int year, int month, int day) {
-    PyObject *item = Py_BuildValue("(iii)", year, month, day);
-    if (item == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
-    int rc = PyList_Append(list, item);
-    Py_DECREF(item);
-    return rc; /* GCOVR_EXCL_BR_LINE: PyList_Append only fails on allocation failure */
-}
-
 /* The first numeric date in the text -- ISO, then the compact stamp, then the
    day-month-year spelling, each tried in turn. ISO and compact fall through to the
    next pattern when their first match is calendar-impossible; day-month-year is the
@@ -562,30 +547,21 @@ PyObject *turbohtml_date_scan(PyObject *Py_UNUSED(module), PyObject *args) {
     Py_RETURN_NONE;
 }
 
-/* _scan_all: every ISO, day-month-year, and written-out date, each pattern swept
-   independently over the whole text and appended in that order. A match whose
-   calendar is impossible is skipped but still advances the scan past its span,
-   the way re.finditer does. */
-PyObject *turbohtml_date_scan_all(PyObject *Py_UNUSED(module), PyObject *args) {
-    PyObject *text;
-    int current_year;
-    if (!PyArg_ParseTuple(args, "Ui:_date_scan_all", &text, &current_year)) {
-        return NULL;
-    }
-    int kind = PyUnicode_KIND(text);
-    const void *data = PyUnicode_DATA(text);
-    Py_ssize_t len = PyUnicode_GET_LENGTH(text);
-    PyObject *found = PyList_New(0);
-    if (found == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
+/* A visitor for scan_every_date: one calendar-valid date, returning -1 to stop the sweep with an error. */
+typedef int (*date_visitor)(void *context, int year, int month, int day);
+
+/* Every ISO, day-month-year, and written-out date in the text, each pattern swept independently over the whole
+   text and reported in that order. A match whose calendar is impossible is skipped but still advances the scan
+   past its span, the way re.finditer does. Returns -1 when the visitor did. */
+static int scan_every_date(const void *data, int kind, Py_ssize_t len, int current_year, date_visitor visit,
+                           void *context) {
     int year, month, day;
     Py_ssize_t end;
     Py_ssize_t pos = 0;
     while (pos < len) {
         if (iso_at(data, kind, len, pos, &year, &month, &day, &end)) {
-            if (ymd_valid(year, month, day) && append_ymd(found, year, month, day) < 0) { /* GCOVR_EXCL_BR_LINE */
-                goto error;                                                               /* GCOVR_EXCL_LINE */
+            if (ymd_valid(year, month, day) && visit(context, year, month, day) < 0) { /* GCOVR_EXCL_BR_LINE */
+                return -1;                                                             /* GCOVR_EXCL_LINE */
             }
             pos = end;
         } else {
@@ -599,8 +575,8 @@ PyObject *turbohtml_date_scan_all(PyObject *Py_UNUSED(module), PyObject *args) {
             dmy_at(data, kind, len, pos, &raw_day, &raw_month, &raw_year, &end)) {
             int resolved_year = correct_year(raw_year, current_year);
             if (dmy_resolve(raw_day, raw_month, resolved_year, &month, &day)) {
-                if (append_ymd(found, resolved_year, month, day) < 0) { /* GCOVR_EXCL_BR_LINE */
-                    goto error;                                         /* GCOVR_EXCL_LINE */
+                if (visit(context, resolved_year, month, day) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+                    return -1;                                       /* GCOVR_EXCL_LINE */
                 }
             }
             pos = end;
@@ -620,15 +596,42 @@ PyObject *turbohtml_date_scan_all(PyObject *Py_UNUSED(module), PyObject *args) {
             pos++;
             continue;
         }
-        if (ymd_valid(year, month, day) && append_ymd(found, year, month, day) < 0) { /* GCOVR_EXCL_BR_LINE */
-            goto error;                                                               /* GCOVR_EXCL_LINE */
+        if (ymd_valid(year, month, day) && visit(context, year, month, day) < 0) { /* GCOVR_EXCL_BR_LINE */
+            return -1;                                                             /* GCOVR_EXCL_LINE */
         }
         pos = end;
     }
+    return 0;
+}
+
+static int append_ymd(void *context, int year, int month, int day) {
+    PyObject *item = Py_BuildValue("(iii)", year, month, day);
+    if (item == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int rc = PyList_Append((PyObject *)context, item);
+    Py_DECREF(item);
+    return rc; /* GCOVR_EXCL_BR_LINE: PyList_Append only fails on allocation failure */
+}
+
+/* _scan_all: every date the sweep reports, or an empty list. */
+PyObject *turbohtml_date_scan_all(PyObject *Py_UNUSED(module), PyObject *args) {
+    PyObject *text;
+    int current_year;
+    if (!PyArg_ParseTuple(args, "Ui:_date_scan_all", &text, &current_year)) {
+        return NULL;
+    }
+    PyObject *found = PyList_New(0);
+    if (found == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return NULL;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int status = scan_every_date(PyUnicode_DATA(text), PyUnicode_KIND(text), PyUnicode_GET_LENGTH(text), current_year,
+                                 append_ymd, found);
+    if (status < 0) {     /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(found); /* GCOVR_EXCL_LINE: allocation-failure path */
+        return NULL;      /* GCOVR_EXCL_LINE */
+    }
     return found;
-error:                /* GCOVR_EXCL_LINE: shared cleanup for the unreachable allocation-failure arms */
-    Py_DECREF(found); /* GCOVR_EXCL_LINE: allocation-failure path */
-    return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
 }
 
 /* A URL date, _URL_DATE = (?<!\d)(YEAR)[/_-](MONTH)[/_-](DAY)(?!\d), starting at
@@ -796,10 +799,10 @@ static int key_role(const Py_UCS4 *value, Py_ssize_t len) {
     if (value == NULL || !fold_key(value, len, folded)) {
         return META_NONE;
     }
-    if (key_in_set(folded, PUBLISHED_KEYS, sizeof(PUBLISHED_KEYS) / sizeof(*PUBLISHED_KEYS))) {
+    if (key_in_set(folded, PUBLISHED_KEYS, COUNT_OF(PUBLISHED_KEYS))) {
         return META_PUBLISHED;
     }
-    if (key_in_set(folded, MODIFIED_KEYS, sizeof(MODIFIED_KEYS) / sizeof(*MODIFIED_KEYS))) {
+    if (key_in_set(folded, MODIFIED_KEYS, COUNT_OF(MODIFIED_KEYS))) {
         return META_MODIFIED;
     }
     return META_NONE;
@@ -823,7 +826,7 @@ static int meta_role(th_tree *tree, th_node *node) {
         find_node_attr(node, TH_ATTR_HTTP_EQUIV),
     };
     int modified = 0;
-    for (size_t index = 0; index < sizeof(keys) / sizeof(*keys); index++) {
+    for (size_t index = 0; index < COUNT_OF(keys); index++) {
         if (keys[index] == NULL) {
             continue;
         }
@@ -876,26 +879,91 @@ static int date_at_least(int year, int month, int day, int min_year, int min_mon
     return day >= min_day;
 }
 
-/* Document._date_meta(want, current_year, min_y, min_m, min_d, max_y, max_m, max_d)
-   -> (year, month, day) or None.
+/* A candidate's role. The meta walk's enum names the two signed roles; a date with no publication or modification
+   marker is generic and satisfies whichever role the caller wanted. */
+enum { DATE_ROLE_GENERIC = 3 };
 
-   The <meta> stage of turbohtml.extract.dates, gathering and selection fused into
-   one walk. want is META_PUBLISHED (original=True) or META_MODIFIED; a candidate
-   whose role matches want wins on sight -- htmldate's _pick returns the first
-   wanted-role hit -- so the walk stops at the first such element instead of scoring
-   the rest. A date outside [min, max] is ignored; the first in-window off-role date
-   is the fallback _pick returns when no wanted-role date appears. */
-PyObject *turbohtml_document_date_meta(PyObject *self, PyObject *args) {
-    int want, current_year, min_year, min_month, min_day, max_year, max_month, max_day;
-    if (!PyArg_ParseTuple(args, "iiiiiiii:_date_meta", &want, &current_year, &min_year, &min_month, &min_day, &max_year,
-                          &max_month, &max_day)) {
+/* Is (year, month, day) inside the inclusive window? */
+static int date_within(int year, int month, int day, const int *low, const int *high) {
+    return date_at_least(year, month, day, low[0], low[1], low[2]) &&
+           date_at_least(high[0], high[1], high[2], year, month, day);
+}
+
+/* One stage's answer: the wanted-role date if the stage found one, else the first off-role date it saw. htmldate
+   returns the first wanted-role hit and falls back to whatever else the stage offered. */
+typedef struct {
+    int wanted;
+    int reserve;
+    int chosen[3];
+    int spare[3];
+} date_pick;
+
+/* Offer a candidate to the pick. Returns 1 once the wanted role is settled and the stage can stop. */
+static int pick_offer(date_pick *pick, int role, int year, int month, int day, int want) {
+    if (role == want || role == DATE_ROLE_GENERIC) {
+        pick->wanted = 1;
+        pick->chosen[0] = year;
+        pick->chosen[1] = month;
+        pick->chosen[2] = day;
+        return 1;
+    }
+    if (!pick->reserve) {
+        pick->reserve = 1;
+        pick->spare[0] = year;
+        pick->spare[1] = month;
+        pick->spare[2] = day;
+    }
+    return 0;
+}
+
+/* The date the pick settled on, or NULL when the stage found nothing in the window. */
+static const int *pick_result(const date_pick *pick) {
+    if (pick->wanted) {
+        return pick->chosen;
+    }
+    return pick->reserve ? pick->spare : NULL;
+}
+
+/* The value of the named attribute as code points, or NULL. A tokenized attribute (class) is joined on the fly by
+   the caller, so this hands back the raw storage. */
+static const Py_UCS4 *attr_text(th_tree *tree, th_node *node, const char *name, Py_ssize_t *out_len) {
+    const th_node_attr *found = named_attr(tree, node, name, (Py_ssize_t)strlen(name));
+    if (found == NULL) {
         return NULL;
     }
-    th_tree *tree = tree_of(self);
-    th_node *root = ((NodeObject *)self)->node;
-    int wanted_hit = 0, wanted_year = 0, wanted_month = 0, wanted_day = 0;
-    int reserve_hit = 0, reserve_year = 0, reserve_month = 0, reserve_day = 0;
-    Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
+    *out_len = found->value_len;
+    return found->value;
+}
+
+/* Does the lowercased attribute text hold `needle`? Used for the class/id/itemprop marker vocabulary, which
+   htmldate matches as a case-insensitive substring rather than a whole token. */
+static int text_holds(const Py_UCS4 *text, Py_ssize_t len, const char *needle) {
+    Py_ssize_t width = (Py_ssize_t)strlen(needle);
+    for (Py_ssize_t start = 0; start + width <= len; start++) {
+        Py_ssize_t offset = 0;
+        while (offset < width && lower_ascii(text[start + offset]) == (Py_UCS4)(unsigned char)needle[offset]) {
+            offset++;
+        }
+        if (offset == width) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Does any of `words` appear in the attribute text? */
+static int text_holds_any(const Py_UCS4 *text, Py_ssize_t len, const char *const *words, size_t count) {
+    for (size_t index = 0; index < count; index++) {
+        if (text_holds(text, len, words[index])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* The <meta> stage: a candidate of the wanted role ends the walk, the first in-window off-role date is the reserve. */
+static void dates_meta_stage(th_tree *tree, th_node *root, const int *low, const int *high, int current_year, int want,
+                             date_pick *pick) {
     for (th_node *node = root->first_child; node != NULL; node = preorder_next(node, root)) {
         if (node->type != TH_NODE_ELEMENT || node->atom != TH_TAG_META) {
             continue;
@@ -910,33 +978,380 @@ PyObject *turbohtml_document_date_meta(PyObject *self, PyObject *args) {
             continue;
         }
         int year, month, day;
-        if (!scan_first_date(text, PyUnicode_4BYTE_KIND, len, current_year, &year, &month, &day)) {
+        if (!scan_first_date(text, PyUnicode_4BYTE_KIND, len, current_year, &year, &month, &day) ||
+            !date_within(year, month, day, low, high)) {
             continue;
         }
-        if (!date_at_least(year, month, day, min_year, min_month, min_day) ||
-            !date_at_least(max_year, max_month, max_day, year, month, day)) {
+        if (pick_offer(pick, role, year, month, day, want)) {
+            return;
+        }
+    }
+}
+
+/* The URL stage: the /YYYY/MM/DD/ a canonical link or og:url carries, the fastest and most trustworthy signal. */
+static void dates_url_stage(th_tree *tree, th_node *root, const int *low, const int *high, int want, date_pick *pick) {
+    for (th_node *node = root->first_child; node != NULL; node = preorder_next(node, root)) {
+        if (node->type != TH_NODE_ELEMENT) {
             continue;
         }
-        if (role == want) {
-            wanted_hit = 1;
-            wanted_year = year;
-            wanted_month = month;
-            wanted_day = day;
+        const Py_UCS4 *url = NULL;
+        Py_ssize_t len = 0;
+        if (node->atom == TH_TAG_LINK) {
+            Py_ssize_t rel_len = 0;
+            const Py_UCS4 *rel = attr_text(tree, node, "rel", &rel_len);
+            if (rel != NULL && text_holds(rel, rel_len, "canonical")) {
+                url = attr_text(tree, node, "href", &len);
+            }
+        } else if (node->atom == TH_TAG_META) {
+            Py_ssize_t key_len = 0;
+            const Py_UCS4 *key = attr_text(tree, node, "property", &key_len);
+            if (key == NULL) {
+                key = attr_text(tree, node, "name", &key_len);
+            }
+            if (key != NULL && key_len == 6 && text_holds(key, key_len, "og:url")) {
+                url = attr_text(tree, node, "content", &len);
+            }
+        }
+        if (url == NULL) {
+            continue;
+        }
+        for (Py_ssize_t pos = 0; pos < len; pos++) {
+            int year, month, day;
+            if (!url_at(url, PyUnicode_4BYTE_KIND, len, pos, &year, &month, &day)) {
+                continue;
+            }
+            if (date_within(year, month, day, low, high)) {
+                pick_offer(pick, DATE_ROLE_GENERIC, year, month, day, want);
+                return;
+            }
             break;
         }
-        if (!reserve_hit) {
-            reserve_hit = 1;
-            reserve_year = year;
-            reserve_month = month;
-            reserve_day = day;
+    }
+}
+
+/* The scan_every_date visitor that keeps the first report: the first date of any spelling in a block of element
+   text, written-out months included. */
+typedef struct {
+    int found;
+    int year;
+    int month;
+    int day;
+} first_date_hit;
+
+static int first_date(void *context, int year, int month, int day) {
+    first_date_hit *hit = context;
+    if (!hit->found) {
+        hit->found = 1;
+        hit->year = year;
+        hit->month = month;
+        hit->day = day;
+    }
+    return 0;
+}
+
+/* The class/id/itemprop vocabulary of the temporal-markup stage, drawn from htmldate's but kept to the
+   high-precision markers (skipping its broad info/author/footer catch-alls, which pull in unrelated dates). Each
+   is matched as a case-insensitive substring of the attribute, the way a [class*=word i] selector reads it. */
+static const char *const CLASS_MARKERS[] = {"date",   "datum",    "publish",    "posted",  "pubdate",  "timestamp",
+                                            "byline", "dateline", "entry-date", "updated", "modified", "created"};
+static const char *const ID_MARKERS[] = {"date", "publish", "posted", "timestamp"};
+static const char *const PUBLISHED_MARKERS[] = {"publish",  "posted",  "pubdate", "entry-date",
+                                                "dateline", "created", "byline"};
+static const char *const MODIFIED_MARKERS[] = {"updated", "modified", "lastmod", "revised"};
+
+typedef struct {
+    const Py_UCS4 *classes;
+    Py_ssize_t class_len;
+    const Py_UCS4 *identity;
+    Py_ssize_t id_len;
+    const Py_UCS4 *prop;
+    Py_ssize_t prop_len;
+} date_markers;
+
+static int markers_temporal(th_node *node, const date_markers *markers) {
+    if (node->atom == TH_TAG_TIME) {
+        return 1;
+    }
+    if (markers->classes != NULL &&
+        text_holds_any(markers->classes, markers->class_len, CLASS_MARKERS, COUNT_OF(CLASS_MARKERS))) {
+        return 1;
+    }
+    if (markers->identity != NULL &&
+        text_holds_any(markers->identity, markers->id_len, ID_MARKERS, COUNT_OF(ID_MARKERS))) {
+        return 1;
+    }
+    return markers->prop != NULL && text_holds(markers->prop, markers->prop_len, "date");
+}
+
+static int markers_hold_any(const date_markers *markers, const char *const *words, size_t count) {
+    if (markers->classes != NULL && text_holds_any(markers->classes, markers->class_len, words, count)) {
+        return 1;
+    }
+    return markers->identity != NULL && text_holds_any(markers->identity, markers->id_len, words, count);
+}
+
+static int markers_role(th_tree *tree, th_node *node, const date_markers *markers) {
+    if (named_attr(tree, node, "pubdate", 7) != NULL) {
+        return META_PUBLISHED;
+    }
+    if (markers_hold_any(markers, PUBLISHED_MARKERS, COUNT_OF(PUBLISHED_MARKERS))) {
+        return META_PUBLISHED;
+    }
+    if (markers_hold_any(markers, MODIFIED_MARKERS, COUNT_OF(MODIFIED_MARKERS))) {
+        return META_MODIFIED;
+    }
+    return DATE_ROLE_GENERIC;
+}
+
+/* The temporal-markup stage: <time> elements, and elements whose class/id/itemprop marks them as a date. A
+   <time datetime> is the canonical spelling, but many pages date an article in a <span class="published"> or
+   <p class="entry-date"> instead. Each element contributes the date in its datetime/title attribute or its first
+   text date. Returns -1 on allocation failure. */
+static int dates_time_stage(th_tree *tree, th_node *root, const int *low, const int *high, int current_year, int want,
+                            date_pick *pick) {
+    for (th_node *node = root->first_child; node != NULL; node = preorder_next(node, root)) {
+        if (node->type != TH_NODE_ELEMENT) {
+            continue;
+        }
+        date_markers markers = {0};
+        markers.classes = attr_text(tree, node, "class", &markers.class_len);
+        markers.identity = attr_text(tree, node, "id", &markers.id_len);
+        markers.prop = attr_text(tree, node, "itemprop", &markers.prop_len);
+        if (!markers_temporal(node, &markers)) {
+            continue;
+        }
+        Py_ssize_t raw_len = 0;
+        const Py_UCS4 *raw = attr_text(tree, node, "datetime", &raw_len);
+        if (raw == NULL) {
+            raw = attr_text(tree, node, "title", &raw_len);
+        }
+        first_date_hit hit = {0};
+        if (raw != NULL) {
+            hit.found =
+                scan_first_date(raw, PyUnicode_4BYTE_KIND, raw_len, current_year, &hit.year, &hit.month, &hit.day);
+        } else {
+            Py_ssize_t text_len = 0;
+            Py_UCS4 *text = th_node_text(tree, node, &text_len);
+            if (text == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            (void)scan_every_date(text, PyUnicode_4BYTE_KIND, text_len, current_year, first_date, &hit);
+            PyMem_Free(text);
+        }
+        if (!hit.found || !date_within(hit.year, hit.month, hit.day, low, high)) {
+            continue;
+        }
+        if (pick_offer(pick, markers_role(tree, node, &markers), hit.year, hit.month, hit.day, want)) {
+            return 0;
         }
     }
+    return 0;
+}
+
+/* Offer the datePublished/dateModified strings of one JSON-LD node to the pick, recursing through @graph, nested
+   objects and lists in the order json.loads produced them. Returns 1 once the wanted role is settled. */
+static int dates_json_node(PyObject *node, const int *low, const int *high, int current_year, int want,
+                           date_pick *pick) {
+    if (PyList_Check(node)) {
+        for (Py_ssize_t index = 0; index < PyList_GET_SIZE(node); index++) {
+            if (dates_json_node(PyList_GET_ITEM(node, index), low, high, current_year, want, pick)) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+    if (!PyDict_Check(node)) {
+        return 0;
+    }
+    static const char *const keys[] = {"datePublished", "dateModified"};
+    static const int roles[] = {META_PUBLISHED, META_MODIFIED};
+    for (size_t index = 0; index < COUNT_OF(keys); index++) {
+        PyObject *value = PyDict_GetItemString(node, keys[index]);
+        if (value == NULL || !PyUnicode_Check(value)) {
+            continue;
+        }
+        int year, month, day;
+        if (scan_first_date(PyUnicode_DATA(value), PyUnicode_KIND(value), PyUnicode_GET_LENGTH(value), current_year,
+                            &year, &month, &day) &&
+            date_within(year, month, day, low, high) && pick_offer(pick, roles[index], year, month, day, want)) {
+            return 1;
+        }
+    }
+    Py_ssize_t position = 0;
+    PyObject *key, *value;
+    while (PyDict_Next(node, &position, &key, &value)) {
+        if ((PyList_Check(value) || PyDict_Check(value)) &&
+            dates_json_node(value, low, high, current_year, want, pick)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* The text stage's tally: how often each in-window date recurs across the visible text, keyed by the ordinal
+   year * 10000 + month * 100 + day so a tie breaks by comparing keys. */
+typedef struct {
+    const int *low;
+    const int *high;
+    int *keys;
+    int *counts;
+    Py_ssize_t size;
+    Py_ssize_t capacity;
+} date_tally;
+
+static int tally_date(void *context, int year, int month, int day) {
+    date_tally *tally = context;
+    if (!date_within(year, month, day, tally->low, tally->high)) {
+        return 0;
+    }
+    int key = year * 10000 + month * 100 + day;
+    for (Py_ssize_t index = 0; index < tally->size; index++) {
+        if (tally->keys[index] == key) {
+            tally->counts[index]++;
+            return 0;
+        }
+    }
+    if (tally->size == tally->capacity) {
+        Py_ssize_t grown = tally->capacity == 0 ? 16 : tally->capacity * 2;
+        int *keys = PyMem_Realloc(tally->keys, (size_t)grown * sizeof(*keys));
+        if (keys == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        tally->keys = keys;
+        int *counts = PyMem_Realloc(tally->counts, (size_t)grown * sizeof(*counts));
+        if (counts == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;        /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        tally->counts = counts;
+        tally->capacity = grown;
+    }
+    tally->keys[tally->size] = key;
+    tally->counts[tally->size] = 1;
+    tally->size++;
+    return 0;
+}
+
+/* Does the tallied date at `index` beat the one at `best`: more occurrences, or as many and earlier when a
+   publication date is wanted, later otherwise? */
+static int tally_prefers(const date_tally *tally, Py_ssize_t index, Py_ssize_t best, int want) {
+    if (tally->counts[index] != tally->counts[best]) {
+        return tally->counts[index] > tally->counts[best];
+    }
+    if (want == META_PUBLISHED) {
+        return tally->keys[index] < tally->keys[best];
+    }
+    return tally->keys[index] > tally->keys[best];
+}
+
+/* The extensive last resort: the date that recurs most across the body's visible text. Boilerplate pages carry no
+   date metadata, so the publication date is only in the prose -- but so is every comment and archive link; the
+   modal date (the byline, a permalink, a caption, the dateline) is the one htmldate's reference scoring settles
+   on. A tie breaks toward the earliest date when a publication date is wanted and the latest otherwise. Returns -1
+   on allocation failure. */
+static int dates_text_stage(th_tree *tree, th_node *root, const int *low, const int *high, int current_year, int want,
+                            date_pick *pick) {
+    date_tally tally = {low, high, NULL, NULL, 0, 0};
+    int status = 0;
+    for (th_node *node = root->first_child; node != NULL; node = preorder_next(node, root)) {
+        if (node->type != TH_NODE_ELEMENT || node->atom != TH_TAG_BODY) {
+            continue;
+        }
+        Py_ssize_t len = 0;
+        Py_UCS4 *text = th_node_text(tree, node, &len);
+        if (text == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            status = -1;    /* GCOVR_EXCL_LINE: allocation-failure path */
+            break;          /* GCOVR_EXCL_LINE */
+        }
+        status = scan_every_date(text, PyUnicode_4BYTE_KIND, len, current_year, tally_date, &tally);
+        PyMem_Free(text);
+        if (status < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            break;        /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    if (status < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        goto done;    /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    if (tally.size > 0) {
+        Py_ssize_t best = 0;
+        for (Py_ssize_t index = 1; index < tally.size; index++) {
+            if (tally_prefers(&tally, index, best, want)) {
+                best = index;
+            }
+        }
+        int key = tally.keys[best];
+        pick_offer(pick, DATE_ROLE_GENERIC, key / 10000, key / 100 % 100, key % 100, want);
+    }
+done:
+    PyMem_Free(tally.keys);
+    PyMem_Free(tally.counts);
+    return status;
+}
+
+/* The markup stages that need the tree: <time> elements, then (with extensive) the visible text. Returns -1 on
+   allocation failure. */
+static int dates_markup_stages(th_tree *tree, th_node *root, const int *low, const int *high, int current_year,
+                               int want, int extensive, date_pick *pick, const char **signal) {
+    *signal = "time";
+    if (dates_time_stage(tree, root, low, high, current_year, want, pick) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+        return -1;                                                               /* GCOVR_EXCL_LINE */
+    }
+    if (pick_result(pick) != NULL || !extensive) {
+        return 0;
+    }
+    *signal = "text";
+    return dates_text_stage(tree, root, low, high, current_year, want, pick);
+}
+
+/* Document._dates(want, current_year, min_y, min_m, min_d, max_y, max_m, max_d, extensive)
+   -> (year, month, day, signal) or None.
+
+   The whole of turbohtml.extract.dates after parsing: the signals tried in htmldate's order -- a date in the
+   canonical URL, then publication/modification <meta> tags, then JSON-LD, then <time> elements, then (with
+   extensive) visible text -- and the first stage that yields a date inside [min, max] wins. want is META_PUBLISHED
+   (original=True) or META_MODIFIED; within a stage a candidate of the wanted or generic role wins on sight and the
+   first off-role one is the reserve. The tree-walking stages run under the document's critical section. */
+PyObject *turbohtml_document_dates(PyObject *self, PyObject *args) {
+    int want, current_year, extensive;
+    int low[3], high[3];
+    if (!PyArg_ParseTuple(args, "iiiiiiiip:_dates", &want, &current_year, &low[0], &low[1], &low[2], &high[0], &high[1],
+                          &high[2], &extensive)) {
+        return NULL;
+    }
+    th_tree *tree = tree_of(self);
+    th_node *root = ((NodeObject *)self)->node;
+    date_pick pick = {0};
+    const char *signal = "url";
+    const int *found;
+    Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
+    dates_url_stage(tree, root, low, high, want, &pick);
+    if ((found = pick_result(&pick)) == NULL) {
+        signal = "meta";
+        dates_meta_stage(tree, root, low, high, current_year, want, &pick);
+        found = pick_result(&pick);
+    }
     Py_END_CRITICAL_SECTION();
-    if (wanted_hit) {
-        return Py_BuildValue("(iii)", wanted_year, wanted_month, wanted_day);
+    if (found == NULL) {
+        signal = "json-ld";
+        PyObject *blocks = turbohtml_document_json_ld(self, NULL); /* runs Python code, so outside the section */
+        if (blocks == NULL) {
+            return NULL;
+        }
+        dates_json_node(blocks, low, high, current_year, want, &pick);
+        Py_DECREF(blocks);
+        found = pick_result(&pick);
     }
-    if (reserve_hit) {
-        return Py_BuildValue("(iii)", reserve_year, reserve_month, reserve_day);
+    if (found == NULL) {
+        int status;
+        Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
+        status = dates_markup_stages(tree, root, low, high, current_year, want, extensive, &pick, &signal);
+        Py_END_CRITICAL_SECTION();
+        if (status < 0) {            /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        found = pick_result(&pick);
     }
-    Py_RETURN_NONE;
+    if (found == NULL) {
+        Py_RETURN_NONE;
+    }
+    return Py_BuildValue("(iiis)", found[0], found[1], found[2], signal);
 }

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -7,6 +7,7 @@ from typing import Literal, TypeAlias, final
 from turbohtml._internal._locations import SourceLocation
 from turbohtml._internal._render import Canonical, Html, Markdown, PlainText
 from turbohtml.extract._article import Article as Article
+from turbohtml.extract._dates import Signal
 from turbohtml.extract._feed import Feed
 from turbohtml.extract._links import Link
 from turbohtml.extract._structured_data import JSONValue, MicrodataItem, OpenGraph, RdfaItem, StructuredData
@@ -351,7 +352,7 @@ class Document(Node):
     def microdata(self, base_url: str | None = None) -> list[MicrodataItem]: ...
     def rdfa(self, base_url: str | None = None) -> list[RdfaItem]: ...
     def dublin_core(self) -> dict[str, str]: ...
-    def _date_meta(
+    def _dates(
         self,
         want: int,
         current_year: int,
@@ -361,8 +362,9 @@ class Document(Node):
         max_year: int,
         max_month: int,
         max_day: int,
+        extensive: bool,
         /,
-    ) -> tuple[int, int, int] | None: ...
+    ) -> tuple[int, int, int, Signal] | None: ...
     def feed(self) -> Feed | None: ...
     @property
     def errors(self) -> list[ParseError]: ...

--- a/src/turbohtml/extract/_dates.py
+++ b/src/turbohtml/extract/_dates.py
@@ -6,19 +6,18 @@ Publication-date extraction for :mod:`turbohtml.extract`, the ``htmldate.find_da
 visible text -- but off the parsed DOM and the :meth:`~turbohtml.Document.structured_data` engine rather than a
 second parse. Each signal is a stage tried in htmldate's priority order; the first stage that yields a bounded date
 wins, and within a stage the :class:`DateExtraction` ``original`` flag routes a publication date against a
-modification date. The date parsing is standard-library only (no ``dateparser`` dependency): ISO 8601, the common
-numeric spellings, an 8-digit stamp, and a compact multilingual month vocabulary.
+modification date. The stages and the date parsing run in C (``Document._dates``); this module holds the options,
+the result record, and the window and output formatting the :mod:`datetime` module owns. The date parsing needs no
+``dateparser``: ISO 8601, the common numeric spellings, an 8-digit stamp, and a compact multilingual month vocabulary.
 """
 
 from __future__ import annotations
 
-from collections import Counter
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from itertools import starmap
 from typing import Final, Literal, NamedTuple
 
-from turbohtml._html import Document, _date_scan, _date_scan_all, _date_url, parse
+from turbohtml._html import parse
 
 __all__ = [
     "DateExtraction",
@@ -28,12 +27,6 @@ __all__ = [
 
 Signal = Literal["url", "meta", "json-ld", "time", "text"]
 """Which engine a :class:`PublicationDate` came from, in htmldate's stage-priority order."""
-
-_Role = Literal["published", "modified", "generic"]
-
-_PUBLISHED: Final[_Role] = "published"
-_MODIFIED: Final[_Role] = "modified"
-_GENERIC: Final[_Role] = "generic"
 
 _EARLIEST: Final = date(1995, 1, 1)
 """The default lower bound, htmldate's ``MIN_DATE``: the web's date metadata does not predate it."""
@@ -84,18 +77,6 @@ class DateExtraction:
 
 _DEFAULT: Final = DateExtraction()
 
-# Elements that tend to carry a date, drawn from htmldate's class/id vocabulary but kept to the high-precision
-# markers (skipping its broad 'info'/'author'/'footer' catch-alls, which pull in unrelated dates).
-_DATE_MARKUP: Final = ", ".join((
-    "time",
-    *(f"[class*={token} i]" for token in ("date", "datum", "publish", "posted", "pubdate", "timestamp", "byline")),
-    *(f"[class*={token} i]" for token in ("dateline", "entry-date", "updated", "modified", "created")),
-    *(f"[id*={token} i]" for token in ("date", "publish", "posted", "timestamp")),
-    "[itemprop*=date i]",
-))
-_PUBLISHED_MARKERS: Final = ("publish", "posted", "pubdate", "entry-date", "dateline", "created", "byline")
-_MODIFIED_MARKERS: Final = ("updated", "modified", "lastmod", "revised")
-
 
 def dates(html: str, options: DateExtraction | None = None, /) -> PublicationDate | None:
     """
@@ -112,202 +93,24 @@ def dates(html: str, options: DateExtraction | None = None, /) -> PublicationDat
     :returns: the date and the signal it came from, or ``None`` when no bounded date is found.
     """
     active = options or _DEFAULT
-    document = parse(html)
     today = _today()
-    window = _Window(active.min_date or _EARLIEST, active.max_date or today)
-    want = _PUBLISHED if active.original else _MODIFIED
-    current_year = today.year
-    if found := _pick(_url_candidates(document), want, window, active.output_format, "url"):
-        return found
-    if found := _meta_date(document, want, window, active.output_format, current_year):
-        return found
-    if found := _pick(_json_candidates(document, current_year), want, window, active.output_format, "json-ld"):
-        return found
-    if found := _pick(_time_candidates(document, current_year), want, window, active.output_format, "time"):
-        return found
-    if active.extensive_search and (
-        found := _pick(
-            _text_candidates(document, window, current_year, original=active.original),
-            want,
-            window,
-            active.output_format,
-            "text",
-        )
-    ):
-        return found
-    return None
-
-
-class _Window(NamedTuple):
-    """The inclusive date bounds a candidate must fall within to be accepted."""
-
-    earliest: date
-    latest: date
-
-    def holds(self, moment: date) -> bool:
-        """Whether the moment lies within the window."""
-        return self.earliest <= moment <= self.latest
-
-
-def _pick(
-    candidates: list[tuple[_Role, date]], want: _Role, window: _Window, output_format: str, signal: Signal
-) -> PublicationDate | None:
-    """Return the wanted-role (or generic) candidate a stage offers, falling back to the first off-role one."""
-    reserve: PublicationDate | None = None
-    for role, moment in candidates:
-        if not window.holds(moment):
-            continue
-        if role in {want, _GENERIC}:
-            return PublicationDate(moment.strftime(output_format), signal)
-        if reserve is None:
-            reserve = PublicationDate(moment.strftime(output_format), signal)
-    return reserve
-
-
-def _url_candidates(document: Document) -> list[tuple[_Role, date]]:
-    """Read a date pattern from the canonical link or ``og:url``, the fastest and most trustworthy signal."""
-    canonical = document.find("link", attrs={"rel": "canonical"})
-    sources = (canonical.attrs.get("href") if canonical else None, _meta_value(document, "og:url"))
-    return [(_GENERIC, moment) for url in sources if isinstance(url, str) and (moment := _url_date(url))]
-
-
-def _url_date(url: str) -> date | None:
-    """Extract the ``/YYYY/MM/DD/`` date a URL path often carries."""
-    parts = _date_url(url)
-    return date(*parts) if parts else None
-
-
-def _meta_date(
-    document: Document, want: _Role, window: _Window, output_format: str, current_year: int
-) -> PublicationDate | None:
-    """
-    Return the ``<meta>`` stage's date, keyed by name/property/itemprop/http-equiv/pubdate as htmldate reads them.
-
-    The walk that classifies each meta element against htmldate's key vocabulary and returns the winner :func:`_pick`
-    would runs in C (:meth:`Document._date_meta`); this shim passes the window and the wanted role and formats the
-    (year, month, day) the walk returns.
-    """
-    parts = document._date_meta(  # ruff:ignore[private-member-access]  # the Document type's private C entry point
-        1 if want == _PUBLISHED else 2,
-        current_year,
-        window.earliest.year,
-        window.earliest.month,
-        window.earliest.day,
-        window.latest.year,
-        window.latest.month,
-        window.latest.day,
+    earliest = active.min_date or _EARLIEST
+    latest = active.max_date or today
+    found = parse(html)._dates(  # ruff:ignore[private-member-access]  # the Document type's private C entry point
+        1 if active.original else 2,
+        today.year,
+        earliest.year,
+        earliest.month,
+        earliest.day,
+        latest.year,
+        latest.month,
+        latest.day,
+        active.extensive_search,
     )
-    return PublicationDate(date(*parts).strftime(output_format), "meta") if parts else None
-
-
-def _json_candidates(document: Document, current_year: int) -> list[tuple[_Role, date]]:
-    """JSON-LD ``datePublished``/``dateModified`` values, from the structured-data engine's decoded blocks."""
-    found: list[tuple[_Role, date]] = []
-    for block in document.structured_data().json_ld:
-        _walk_json(block, found, current_year)
-    return found
-
-
-def _time_candidates(document: Document, current_year: int) -> list[tuple[_Role, date]]:
-    """
-    Dates in temporal HTML markup: ``<time>`` elements and elements whose class/id/itemprop marks them as a date.
-
-    A ``<time datetime>`` is the canonical spelling, but many pages date an article in a ``<span class="published">``
-    or ``<p class="entry-date">`` instead, the class/id vocabulary ``htmldate`` scans. Each element contributes the
-    date in its ``datetime``/``title`` attribute or its first text date, with a publication/modification role read
-    from a ``pubdate`` attribute or an ``updated``/``modified`` marker in its class.
-    """
-    found: list[tuple[_Role, date]] = []
-    for element in document.select(_DATE_MARKUP):
-        attributes = element.attrs
-        raw = attributes.get("datetime") or attributes.get("title")
-        moment = _scan(raw, current_year) if isinstance(raw, str) else _first_date(element.text, current_year)
-        if moment is None:
-            continue
-        marker = (
-            f"{_token(attributes.get('class'))} {_token(attributes.get('id'))} {_token(attributes.get('itemprop'))}"
-        )
-        if "pubdate" in attributes or any(word in marker for word in _PUBLISHED_MARKERS):
-            found.append((_PUBLISHED, moment))
-        elif any(word in marker for word in _MODIFIED_MARKERS):
-            found.append((_MODIFIED, moment))
-        else:
-            found.append((_GENERIC, moment))
-    return found
-
-
-def _text_candidates(
-    document: Document, window: _Window, current_year: int, *, original: bool
-) -> list[tuple[_Role, date]]:
-    """
-    Recover the extensive last resort: the date that recurs most across the page's visible text.
-
-    Boilerplate pages carry no date metadata, so the publication date is only in the prose -- but so is every comment
-    and archive link. The scan reads the whole body and takes the date that repeats most (in the byline, a permalink,
-    a caption, the article dateline), the modal reasoning ``htmldate``'s reference scoring rests on. Ties break toward
-    the earliest date for ``original`` and the latest otherwise, the publication-vs-modification preference the
-    structured stages apply.
-    """
-    counts = Counter(
-        moment
-        for body in document.find_all("body")
-        for moment in _scan_all(body.text, current_year)
-        if window.holds(moment)
-    )
-    if not counts:
-        return []
-    peak = max(counts.values())
-    finalists = [moment for moment, count in counts.items() if count == peak]
-    return [(_GENERIC, min(finalists) if original else max(finalists))]
-
-
-def _walk_json(node: object, found: list[tuple[_Role, date]], current_year: int) -> None:
-    """Collect datePublished/dateModified from a JSON-LD node, recursing through @graph and nested objects."""
-    if isinstance(node, list):
-        for item in node:
-            _walk_json(item, found, current_year)
-    elif isinstance(node, dict):
-        for role, key in ((_PUBLISHED, "datePublished"), (_MODIFIED, "dateModified")):
-            value = node.get(key)
-            if isinstance(value, str) and (moment := _scan(value, current_year)):
-                found.append((role, moment))
-        for value in node.values():
-            if isinstance(value, (list, dict)):
-                _walk_json(value, found, current_year)
-
-
-def _meta_value(document: Document, key: str) -> str | None:
-    """Return the content of the first ``<meta>`` whose name or property equals key."""
-    for name in ("property", "name"):
-        if (element := document.find("meta", attrs={name: key})) and isinstance(
-            content := element.attrs.get("content"), str
-        ):
-            return content
-    return None
-
-
-def _token(value: str | list[str] | None) -> str:
-    """Return the lowercased text of a class/id/itemprop attribute, joining a multi-valued class list."""
-    if isinstance(value, list):
-        return " ".join(value).lower()
-    return value.lower() if isinstance(value, str) else ""
-
-
-def _first_date(text: str, current_year: int) -> date | None:
-    """Return the first date of any spelling in a block of element text, written-out months included."""
-    parts = _date_scan_all(text, current_year)
-    return date(*parts[0]) if parts else None
-
-
-def _scan(text: str, current_year: int) -> date | None:
-    """Parse the first numeric date in a metadata string: ISO, an 8-digit stamp, or a day-month-year spelling."""
-    parts = _date_scan(text, current_year)
-    return date(*parts) if parts else None
-
-
-def _scan_all(text: str, current_year: int) -> list[date]:
-    """Every ISO, day-month-year, and written-out date in a block of visible text, for frequency scoring."""
-    return list(starmap(date, _date_scan_all(text, current_year)))
+    if found is None:
+        return None
+    year, month, day, signal = found
+    return PublicationDate(date(year, month, day).strftime(active.output_format), signal)
 
 
 def _today() -> date:

--- a/tests/extract/test_extract_dates_c_api.py
+++ b/tests/extract/test_extract_dates_c_api.py
@@ -1,0 +1,159 @@
+"""The Document._dates C entry point: the stage order, the signal it names, and the argument contract."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from turbohtml import parse
+from turbohtml.extract import DateExtraction, PublicationDate, dates
+
+_WINDOW = (1995, 1, 1, 2100, 1, 1)
+
+
+def _run(html: str, *, extensive: bool = True) -> tuple[int, int, int, str] | None:
+    """Call the entry point wanting a modification date, in the fixed window, from a 2026 vantage point."""
+    return parse(html)._dates(2, 2026, *_WINDOW, extensive)
+
+
+def test_the_entry_point_names_the_winning_signal() -> None:
+    assert _run('<link rel="canonical" href="http://x.com/2016/12/23/a.html">') == (2016, 12, 23, "url")
+
+
+def test_the_entry_point_answers_none_without_a_date() -> None:
+    assert _run("<p>nothing</p>") is None
+
+
+def test_extensive_off_skips_the_text_stage() -> None:
+    assert _run("<p>2016-12-23</p>", extensive=False) is None
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param((2, 2026, 1995, 1, 1, 2100, 1), id="too-few"),
+        pytest.param((2, 2026, 1995, 1, 1, 2100, 1, 1, True, 0), id="too-many"),
+        pytest.param((2.5, 2026, 1995, 1, 1, 2100, 1, 1, True), id="want-is-a-float"),
+    ],
+)
+def test_the_entry_point_rejects_bad_arguments(args: tuple[object, ...]) -> None:
+    with pytest.raises(TypeError):
+        parse("")._dates(*args)  # ty: ignore[invalid-argument-type]  # the argument check is the point
+
+
+def test_a_json_ld_block_too_deep_to_decode_propagates() -> None:
+    # malformed JSON is skipped, but a block that overflows the decoder's recursion budget is an error the caller
+    # sees; the depth is well past every interpreter's budget so the error is the same everywhere
+    html = '<script type="application/ld+json">' + "[" * 1_000_000 + "</script>"
+    with pytest.raises(RecursionError):
+        dates(html)
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param('<link rel="canonical">', None, id="canonical-without-href"),
+        pytest.param('<link href="/2016/12/23/">', None, id="link-without-rel"),
+        pytest.param('<link rel="stylesheet" href="/2016/12/23/a.css">', None, id="not-canonical"),
+        pytest.param('<meta name="og:url" content="http://x.com/2016/12/23/">', "2016-12-23", id="og-url-by-name"),
+        pytest.param('<meta property="og:title" content="/2016/12/23/">', None, id="another-og-key"),
+        pytest.param('<meta property="og:url" content="/story">', None, id="og-url-without-a-date"),
+        pytest.param(
+            '<link rel="canonical" href="/1990/01/01/"><meta name="date" content="2011-11-11">',
+            "2011-11-11",
+            id="url-date-out-of-window-falls-through",
+        ),
+    ],
+)
+def test_the_url_stage_reads_only_a_canonical_or_og_url(html: str, expected: str | None) -> None:
+    found = dates(html, DateExtraction(extensive_search=False))
+    assert (found.date if found else None) == expected
+
+
+@pytest.mark.parametrize(
+    ("block", "expected"),
+    [
+        pytest.param('{"datePublished": 20160101}', None, id="a-number-is-not-a-date"),
+        pytest.param('{"datePublished": "soon"}', None, id="a-string-without-a-date"),
+        pytest.param('{"datePublished": "1990-01-01"}', None, id="out-of-window"),
+        pytest.param('{"@graph": [{"dateModified": "2016-01-02"}]}', "2016-01-02", id="inside-a-graph"),
+        pytest.param(
+            '{"name": "x", "author": {"name": "y"}, "@graph": [{"dateModified": "2016-01-03"}]}',
+            "2016-01-03",
+            id="after-a-scalar-and-a-dateless-object",
+        ),
+        pytest.param('[1, "two", {"dateModified": "2016-01-04"}]', "2016-01-04", id="after-list-scalars"),
+    ],
+)
+def test_the_json_ld_stage_walks_the_decoded_blocks(block: str, expected: str | None) -> None:
+    found = dates(f'<script type="application/ld+json">{block}</script>', DateExtraction(extensive_search=False))
+    assert (found.date if found else None) == expected
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param('<span id="post-date">2016-01-05</span>', PublicationDate("2016-01-05", "time"), id="id-marker"),
+        pytest.param(
+            '<span itemprop="dateCreated">2016-01-06</span>',
+            PublicationDate("2016-01-06", "time"),
+            id="itemprop-marker",
+        ),
+        pytest.param(
+            '<time datetime="soon">2016-01-07</time>', None, id="datetime-without-a-date-is-not-read-from-text"
+        ),
+        pytest.param(
+            '<time pubdate datetime="2016-01-08">x</time>',
+            PublicationDate("2016-01-08", "time"),
+            id="pubdate-attribute",
+        ),
+        pytest.param('<span id="revised-on">2016-01-09</span>', None, id="id-with-a-role-word-but-no-marker"),
+        pytest.param(
+            '<span id="date" class="modified">2016-01-10</span>',
+            PublicationDate("2016-01-10", "time"),
+            id="class-modified",
+        ),
+        pytest.param('<span class="posted">1990-01-10</span>', None, id="out-of-window"),
+        pytest.param(
+            '<p class="intro" id="main" itemprop="name">2016-01-11</p>', None, id="attributes-without-a-marker"
+        ),
+        pytest.param(
+            "<time>2016-01-15 then 2016-01-16</time>", PublicationDate("2016-01-15", "time"), id="first-text-date-wins"
+        ),
+        pytest.param(
+            '<span id="date-updated">2016-01-17</span>', PublicationDate("2016-01-17", "time"), id="id-modified"
+        ),
+    ],
+)
+def test_the_time_stage_reads_marked_elements(html: str, expected: PublicationDate | None) -> None:
+    assert dates(html, DateExtraction(extensive_search=False)) == expected
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        pytest.param('<span class="posted">2016-01-11</span><span class="updated">2016-01-12</span>', id="class"),
+        pytest.param('<span id="posted-on">2016-01-11</span><span id="date-updated">2016-01-12</span>', id="id"),
+    ],
+)
+def test_a_published_marker_is_the_reserve_when_a_modification_is_wanted(html: str) -> None:
+    assert dates(html) == PublicationDate("2016-01-12", "time")
+    assert dates(html, DateExtraction(original=True)) == PublicationDate("2016-01-11", "time")
+
+
+def test_a_text_tie_breaks_the_same_way_whichever_date_comes_first() -> None:
+    html = "<body><p>Seen 2018-01-01 once and 2014-01-01 once.</p></body>"
+    assert dates(html, DateExtraction(original=True)) == PublicationDate("2014-01-01", "text")
+    assert dates(html) == PublicationDate("2018-01-01", "text")
+
+
+def test_the_text_stage_tallies_more_dates_than_its_first_allocation() -> None:
+    days = [date(2016, 1, day).isoformat() for day in range(1, 21)]
+    html = "<body>" + " ".join(days) + " " + days[7] + "</body>"
+    assert dates(html) == PublicationDate("2016-01-08", "text")
+
+
+def test_the_text_stage_ignores_dates_outside_the_window() -> None:
+    html = "<body>1990-01-01 1990-01-01 2016-01-13</body>"
+    assert dates(html) == PublicationDate("2016-01-13", "text")

--- a/tests/extract/test_extract_dates_meta.py
+++ b/tests/extract/test_extract_dates_meta.py
@@ -1,6 +1,6 @@
 """The <meta> date stage's C walk: key classification, the pubdate flag, and the window boundary.
 
-These exercise the branches the C _date_meta walk adds -- an over-long or non-ASCII key, a valueless key, the
+These exercise the branches the C meta stage adds -- an over-long or non-ASCII key, a valueless key, the
 publication-wins-over-modification precedence, the pubdate="pubdate" flag's spellings, and the inclusive window
 edges -- through the public dates() API.
 """
@@ -54,10 +54,11 @@ def test_pubdate_flag_only_marks_the_literal_value(pubdate: str, expected: Publi
     assert dates(f'<meta {pubdate} content="2014-03-08">{_GOOD}') == expected
 
 
-def test_date_meta_rejects_a_non_integer_argument() -> None:
-    # the private C entry point takes eight ints; a wrong type must fail the argument parse, not read the tree
+def test_dates_rejects_a_non_integer_argument() -> None:
+    # the private C entry point takes eight ints and a flag; a wrong type must fail the parse, not read the tree
+    extensive = True
     with pytest.raises(TypeError):
-        parse("")._date_meta("published", 2016, 1, 1, 1, 2100, 1, 1)  # ty: ignore[invalid-argument-type]  # bad type
+        parse("")._dates("published", 2016, 1, 1, 1, 2100, 1, 1, extensive)  # ty: ignore[invalid-argument-type]  # bad type
 
 
 def test_http_equiv_last_modified_is_a_modification_key() -> None:


### PR DESCRIPTION
`turbohtml.extract.dates` ran four of its five stages in Python. The canonical-URL, JSON-LD, `<time>` and visible-text stages were loops over the DOM around three C string-parser hooks, and the wanted-role selection over each stage's candidates was a Python function too. Each of those loops decides which date a caller gets back, so under the project rule that the Python layer only configures, calls and wraps, they belong in the core alongside the `<meta>` stage that already lived there. This is the sixth area of that series, after #774, #775, #776, #777 and #778.

🧭 One entry point, `Document._dates`, now runs the stages in htmldate's order under the document's critical section and returns the winning date together with the signal that produced it. Each stage fuses its walk with the selection: a candidate of the wanted role ends the walk, and the first in-window off-role date is the reserve. The text stage tallies the body's dates in a small array keyed by the date ordinal, so the modal date and its earliest-or-latest tie-break need no `Counter`. Decoding the JSON-LD blocks still goes through the registered Python parser, so that stage runs outside the critical section and a decoder error, such as a block nested past the interpreter's recursion budget, reaches the caller. The old `_date_meta` binding folds into the new entry point; the three string-parser hooks stay as the grammar's conformance surface and share one sweep with the stages.

The results do not change. The shim keeps what the `datetime` module owns, the window bounds and `strftime` output formatting, and the `Signal` literal now types the tuple the C returns.
