### PR TITLE
♻️ refactor(extract): run the URL cleaner in C

### DIFF
--- a/docs/changelog/780.feature.rst
+++ b/docs/changelog/780.feature.rst
@@ -1,0 +1,3 @@
+Move the URL cleaning pipeline into the C core: :func:`~turbohtml.extract.normalize_url`,
+:func:`~turbohtml.extract.clean_url` and :func:`~turbohtml.extract.extract_links` now run their normalization, gates and
+anchor walk in one C call each. Results are unchanged.

--- a/docs/changelog/788.bugfix.rst
+++ b/docs/changelog/788.bugfix.rst
@@ -1,0 +1,3 @@
+A ``<script type="application/ld+json">`` block that the decoder cannot process for a reason other than malformed JSON,
+such as nesting past the interpreter's recursion budget, now raises from :meth:`~turbohtml.Document.json_ld` and
+:func:`~turbohtml.extract.dates` instead of being skipped.

--- a/meson.build
+++ b/meson.build
@@ -93,6 +93,7 @@ py.extension_module(
         'src/turbohtml/_c/clean/phone_binding.c',
         'src/turbohtml/_c/extract/links.c',
         'src/turbohtml/_c/url/url.c',
+        'src/turbohtml/_c/url/clean.c',
         'src/turbohtml/_c/url/idna.c',
         'src/turbohtml/_c/unicode/normalize.c',
         'src/turbohtml/_c/url/registrable.c',

--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -151,6 +151,15 @@ PyObject *turbohtml_url_scrub(PyObject *module, PyObject *arg);
 /* _url_variant_key(url): the scheme-and-trailing-slash-collapsed dedup key extract_links compares links by. METH_O. */
 PyObject *turbohtml_url_variant_key(PyObject *module, PyObject *arg);
 
+/* Implemented in url/clean.c, the crawl-oriented cleaning pipeline behind turbohtml.extract.clean_url, normalize_url
+   and extract_links. _url_normalize(url, strict, trailing_slash, strip_fragment, allow, deny, content,
+   language_params) returns the canonical spelling; _url_clean adds language and iso_639_1 and returns the cleaned
+   web URL or None; Document._extract_links(base_url, external_only, ...the same knobs) returns the cleaned,
+   deduplicated anchor set. */
+PyObject *turbohtml_url_normalize(PyObject *module, PyObject *args);
+PyObject *turbohtml_url_clean(PyObject *module, PyObject *args);
+PyObject *turbohtml_document_extract_links(PyObject *self, PyObject *args);
+
 /* _url_normalize_query(query, allow, deny, strict, content, language): drop denied, tracker, or non-allowlisted query
    parameters, encode the survivors, and sort them, the crawl cleaner's per-pair loop. Matches METH_VARARGS. */
 PyObject *turbohtml_url_normalize_query(PyObject *module, PyObject *args);

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -263,6 +263,8 @@ static PyMethodDef html_methods[] = {
     {"_url_normalize_query", turbohtml_url_normalize_query, METH_VARARGS, NULL},
     {"_url_language_matches", turbohtml_url_language_matches, METH_VARARGS, NULL},
     {"_url_to_ascii", turbohtml_url_to_ascii, METH_O, NULL},
+    {"_url_normalize", turbohtml_url_normalize, METH_VARARGS, NULL},
+    {"_url_clean", turbohtml_url_clean, METH_VARARGS, NULL},
     {"_sanitize", turbohtml_sanitize, METH_VARARGS, NULL},
     {"_grow_probe", turbohtml_grow_probe, METH_VARARGS, NULL},
     {"_schema_compile", turbohtml_schema_compile, METH_VARARGS, NULL},

--- a/src/turbohtml/_c/dom/document.c
+++ b/src/turbohtml/_c/dom/document.c
@@ -510,6 +510,7 @@ static PyMethodDef document_methods[] = {
     {"rdfa", (PyCFunction)(void (*)(void))turbohtml_document_rdfa, METH_VARARGS | METH_KEYWORDS, rdfa_doc},
     {"dublin_core", turbohtml_document_dublin_core, METH_NOARGS, dublin_core_doc},
     {"_dates", turbohtml_document_dates, METH_VARARGS, NULL},
+    {"_extract_links", turbohtml_document_extract_links, METH_VARARGS, NULL},
     {"feed", turbohtml_document_feed, METH_NOARGS, feed_doc},
     {NULL, NULL, 0, NULL},
 };

--- a/src/turbohtml/_c/extract/structured_data.c
+++ b/src/turbohtml/_c/extract/structured_data.c
@@ -1558,8 +1558,12 @@ PyObject *turbohtml_document_json_ld(PyObject *self, PyObject *Py_UNUSED(ignored
     for (Py_ssize_t index = 0; index < PyList_GET_SIZE(texts); index++) {
         PyObject *value = PyObject_CallOneArg(decoder, PyList_GET_ITEM(texts, index));
         if (value == NULL) {
-            /* not JSON at all, which is a block to skip rather than an error to raise */
-            PyErr_Clear();
+            if (!PyErr_ExceptionMatches(PyExc_ValueError)) {
+                Py_DECREF(texts);  /* a decoder failure that is not malformed JSON, such as a nesting depth past */
+                Py_DECREF(parsed); /* the interpreter's recursion budget, reaches the caller */
+                return NULL;
+            }
+            PyErr_Clear(); /* not JSON at all, which is a block to skip rather than an error to raise */
             continue;
         }
         int carries = PyDict_Check(value) || PyList_Check(value);

--- a/src/turbohtml/_c/url/clean.c
+++ b/src/turbohtml/_c/url/clean.c
@@ -1,0 +1,744 @@
+/* The crawl-oriented URL cleaner behind turbohtml.extract.clean_url, normalize_url and extract_links.
+
+   url.c holds the WHATWG primitives (split, percent-encode, dot-segment removal, relative join, the query and language
+   filters); this unit is the pipeline that runs them in the order the spec and courlan/w3lib users expect, and the
+   page walk that feeds anchors into it. The shim keeps only the option record: the knobs arrive here as plain flags
+   and name sets, and every decision about what a caller gets back -- which URLs survive, in which spelling, and which
+   anchors count -- is made here.
+
+   Normalization: lowercase scheme and host, domain-to-ASCII for a registered name (host parsing, URL standard 3.5),
+   default-port removal (port state), dot-segment resolution (path state), the component percent-encode sets (1.3), the
+   empty-path-to-"/" serialization of a special URL (4.5), then the beyond-spec query sort and tracker removal and the
+   fragment scrub. Cleaning wraps that in the scrub of markup damage and the web-scheme, host and language gates.
+   Extraction walks the anchors, resolves each against the document base, cleans it, and deduplicates the http/https
+   and trailing-slash twins, first in document order winning. */
+
+#include "core/common.h"
+#include "dom/nodes.h"
+#include "tokenizer/binding.h" /* Py_BEGIN_CRITICAL_SECTION shim for the GIL/pre-3.13 build */
+#include "url/url.h"
+
+#include <string.h>
+
+/* The knobs of turbohtml.extract.UrlCleaning, plus the two vocabularies the shim holds as configuration. `allow` is a
+   lowercased name set or None, `deny` a lowercased name set; `language` is an ISO 639-1 code or None. */
+typedef struct {
+    int strict;
+    int trailing_slash;
+    int strip_fragment;
+    PyObject *allow;
+    PyObject *deny;
+    PyObject *content;
+    PyObject *language_params;
+    PyObject *language;
+    PyObject *iso_639_1;
+} clean_options;
+
+/* A new set holding the lowercased spelling of every name in `names`, or None when `names` is None: the query filter
+   compares decoded, lowercased parameter names, so the caller's allow and deny lists fold once per call. */
+static PyObject *lowered_names(PyObject *names) {
+    if (names == Py_None) {
+        return Py_NewRef(Py_None);
+    }
+    PyObject *iterator = PyObject_GetIter(names);
+    if (iterator == NULL) {
+        return NULL;
+    }
+    PyObject *lowered = PySet_New(NULL);
+    if (lowered == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(iterator); /* GCOVR_EXCL_LINE: allocation-failure path */
+        return NULL;         /* GCOVR_EXCL_LINE */
+    }
+    PyObject *name;
+    while ((name = PyIter_Next(iterator)) != NULL) {
+        if (!PyUnicode_Check(name)) {
+            PyErr_Format(PyExc_TypeError, "query parameter names must be str, got %s", Py_TYPE(name)->tp_name);
+            Py_DECREF(name);
+            break;
+        }
+        PyObject *folded = PyObject_CallMethod(name, "lower", NULL);
+        Py_DECREF(name);
+        if (folded == NULL) { /* GCOVR_EXCL_BR_LINE: str.lower only fails on allocation failure */
+            break;            /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        int added = PySet_Add(lowered, folded);
+        Py_DECREF(folded);
+        if (added < 0) { /* GCOVR_EXCL_BR_LINE: a str insert only fails on allocation failure */
+            break;       /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    Py_DECREF(iterator);
+    if (PyErr_Occurred()) {
+        Py_DECREF(lowered);
+        return NULL;
+    }
+    return lowered;
+}
+
+/* Fill the options from the trailing arguments every entry point shares; returns -1 with an error set. `allow` and
+   `deny` are owned by the options afterwards, so clean_options_clear must run. */
+static int clean_options_take(clean_options *options, PyObject *allow, PyObject *deny) {
+    options->allow = lowered_names(allow);
+    if (options->allow == NULL) {
+        return -1;
+    }
+    options->deny = lowered_names(deny);
+    return options->deny == NULL ? -1 : 0;
+}
+
+static void clean_options_clear(clean_options *options) {
+    Py_XDECREF(options->allow);
+    Py_XDECREF(options->deny);
+}
+
+static int str_equals(PyObject *text, const char *literal) {
+    return PyUnicode_CompareWithASCIIString(text, literal) == 0;
+}
+
+/* Whether `text` starts with `literal`, without materializing a str for the literal. */
+static int str_has_prefix(PyObject *text, const char *literal) {
+    Py_ssize_t width = (Py_ssize_t)strlen(literal);
+    if (PyUnicode_GET_LENGTH(text) < width) {
+        return 0;
+    }
+    int kind = PyUnicode_KIND(text);
+    const void *data = PyUnicode_DATA(text);
+    for (Py_ssize_t index = 0; index < width; index++) {
+        if (PyUnicode_READ(kind, data, index) != (Py_UCS4)(unsigned char)literal[index]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int str_holds(PyObject *text, Py_UCS4 needle) {
+    return PyUnicode_FindChar(text, needle, 0, PyUnicode_GET_LENGTH(text), 1) >= 0;
+}
+
+static int str_is_ascii(PyObject *text) {
+    if (PyUnicode_KIND(text) != PyUnicode_1BYTE_KIND) {
+        return 0;
+    }
+    const unsigned char *data = PyUnicode_1BYTE_DATA(text);
+    for (Py_ssize_t index = 0; index < PyUnicode_GET_LENGTH(text); index++) {
+        if (data[index] >= 0x80) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/* The ASCII (punycode) form of a registered name the way the URL standard's host parser produces it (spec 3.5): the
+   lowercased host when it is already ASCII, else UTS #46 ToASCII in C; a label punycode cannot encode (an unpaired
+   surrogate) leaves the lowercased host as it is, which the later encode step then rejects. */
+static PyObject *ascii_host(PyObject *host) {
+    PyObject *lowered = PyObject_CallMethod(host, "lower", NULL);
+    if (lowered == NULL) { /* GCOVR_EXCL_BR_LINE: str.lower cannot fail on a host */
+        return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    if (str_is_ascii(lowered)) {
+        return lowered;
+    }
+    PyObject *encoded = th_url_to_ascii(lowered);
+    if (encoded != NULL) {
+        Py_DECREF(lowered);
+        return encoded;
+    }
+    if (!PyErr_ExceptionMatches(PyExc_ValueError)) { /* GCOVR_EXCL_BR_LINE: ToASCII raises nothing else */
+        Py_DECREF(lowered);                          /* GCOVR_EXCL_LINE: allocation-failure path */
+        return NULL;                                 /* GCOVR_EXCL_LINE */
+    }
+    PyErr_Clear();
+    return lowered;
+}
+
+/* The ":port" suffix, or "" for an absent, empty, or scheme-default port (port state, URL standard 4.4). A port of
+   digits is read as the integer it spells, so leading zeros fall away and "0080" is the http default. */
+static PyObject *port_suffix(const th_url_parts *parts) {
+    PyObject *port = parts->part[TH_URL_PORT];
+    Py_ssize_t len = PyUnicode_GET_LENGTH(port);
+    if (!parts->has_port || len == 0) {
+        return PyUnicode_FromString("");
+    }
+    int kind = PyUnicode_KIND(port);
+    const void *data = PyUnicode_DATA(port);
+    for (Py_ssize_t index = 0; index < len; index++) {
+        if (!Py_UNICODE_ISDIGIT(PyUnicode_READ(kind, data, index))) {
+            return th_str_format(":%U", port);
+        }
+    }
+    PyObject *number = PyLong_FromUnicodeObject(port, 10);
+    if (number == NULL) { /* GCOVR_EXCL_BR_LINE: a digit-only string always parses */
+        return NULL;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    static const struct {
+        const char *scheme;
+        long port;
+    } defaults[] = {{"ftp", 21}, {"http", 80}, {"ws", 80}, {"https", 443}, {"wss", 443}};
+    int overflow;
+    long value = PyLong_AsLongAndOverflow(number, &overflow);
+    PyObject *scheme = parts->part[TH_URL_SCHEME];
+    for (size_t index = 0; index < sizeof(defaults) / sizeof(*defaults); index++) {
+        if (!overflow && value == defaults[index].port && str_equals(scheme, defaults[index].scheme)) {
+            Py_DECREF(number);
+            return PyUnicode_FromString("");
+        }
+    }
+    PyObject *suffix = th_str_format(":%S", number);
+    Py_DECREF(number);
+    return suffix;
+}
+
+/* The authority rebuilt from its normalized host and port, keeping userinfo verbatim: a registered name goes through
+   domain-to-ASCII, an IPv4/IPv6 literal is already ASCII and only lowercases (IPv6 keeping its brackets). */
+static PyObject *normalize_netloc(const th_url_parts *parts) {
+    PyObject *host;
+    if (parts->kind == TH_HOST_REGNAME) {
+        host = ascii_host(parts->part[TH_URL_HOST]);
+    } else {
+        PyObject *lowered = PyObject_CallMethod(parts->part[TH_URL_HOST], "lower", NULL);
+        if (lowered == NULL) { /* GCOVR_EXCL_BR_LINE: str.lower cannot fail on a host */
+            return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        host = parts->kind == TH_HOST_IPV6 ? th_str_format("[%U]", lowered) : Py_NewRef(lowered);
+        Py_DECREF(lowered);
+    }
+    if (host == NULL) { /* GCOVR_EXCL_BR_LINE: the host fold only fails on allocation failure */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *suffix = port_suffix(parts);
+    if (suffix == NULL) { /* GCOVR_EXCL_BR_LINE: the suffix only fails on allocation failure */
+        Py_DECREF(host);  /* GCOVR_EXCL_LINE: allocation-failure path */
+        return NULL;      /* GCOVR_EXCL_LINE */
+    }
+    PyObject *userinfo = parts->part[TH_URL_USERINFO];
+    PyObject *netloc = PyUnicode_GET_LENGTH(userinfo) > 0 ? th_str_format("%U@%U%U", userinfo, host, suffix)
+                                                          : th_str_format("%U%U", host, suffix);
+    Py_DECREF(host);
+    Py_DECREF(suffix);
+    return netloc;
+}
+
+/* The query with denied, tracker, or non-allowlisted parameters dropped and the rest sorted. */
+static PyObject *normalize_query(PyObject *query, const clean_options *options) {
+    return th_url_normalize_query(query, options->allow, options->deny, options->strict, options->content,
+                                  options->language_params);
+}
+
+/* The fragment percent-encoded, after scrubbing one shaped like a query string the way the query is: a `&`-joined
+   list goes through the query filter, a lone `key=value` is dropped when the key is a tracker. */
+static PyObject *normalize_fragment(PyObject *fragment, const clean_options *options) {
+    if (!str_holds(fragment, '=')) {
+        return th_url_encode_component(fragment, TH_URL_SET_FRAGMENT);
+    }
+    if (str_holds(fragment, '&')) {
+        return normalize_query(fragment, options);
+    }
+    Py_ssize_t equals = PyUnicode_FindChar(fragment, '=', 0, PyUnicode_GET_LENGTH(fragment), 1);
+    PyObject *key = PyUnicode_Substring(fragment, 0, equals);
+    if (key == NULL) { /* GCOVR_EXCL_BR_LINE: a substring only fails on allocation failure */
+        return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *decoded = th_url_percent_decode_obj(key);
+    Py_DECREF(key);
+    if (decoded == NULL) { /* GCOVR_EXCL_BR_LINE: the decode only fails on allocation failure */
+        return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *lowered = PyObject_CallMethod(decoded, "lower", NULL);
+    Py_DECREF(decoded);
+    if (lowered == NULL) { /* GCOVR_EXCL_BR_LINE: str.lower only fails on allocation failure */
+        return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int tracker = th_url_is_tracker_obj(lowered);
+    Py_DECREF(lowered);
+    if (tracker < 0) { /* a key holding a lone surrogate has no UTF-8 form, the encoder's UnicodeEncodeError */
+        return NULL;
+    }
+    return tracker ? PyUnicode_FromString("") : th_url_encode_component(fragment, TH_URL_SET_FRAGMENT);
+}
+
+/* The schemes urllib.parse.uses_netloc lists, the ones whose serialization always carries the "//" authority marker
+   before an absolute path even when the authority is empty. */
+static const char *const NETLOC_SCHEMES[] = {"ftp",   "http",    "gopher", "nntp",  "telnet",       "imap",     "wais",
+                                             "file",  "mms",     "https",  "shttp", "snews",        "prospero", "rtsp",
+                                             "rtsps", "rtspu",   "rsync",  "svn",   "svn+ssh",      "sftp",     "nfs",
+                                             "git",   "git+ssh", "ws",     "wss",   "itms-services"};
+
+static int scheme_uses_netloc(PyObject *scheme) {
+    for (size_t index = 0; index < sizeof(NETLOC_SCHEMES) / sizeof(*NETLOC_SCHEMES); index++) {
+        if (str_equals(scheme, NETLOC_SCHEMES[index])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Reassemble the components the way urllib.parse.urlunsplit does: an authority (or, for a netloc scheme, an empty
+   one before an absolute path) is introduced by "//"; an empty query or fragment is dropped with its delimiter. The
+   split never leaves a relative path behind an authority, so the path needs no leading slash added. */
+static PyObject *unsplit(PyObject *scheme, PyObject *netloc, PyObject *path, PyObject *query, PyObject *fragment) {
+    int has_scheme = PyUnicode_GET_LENGTH(scheme) > 0;
+    int has_netloc = PyUnicode_GET_LENGTH(netloc) > 0;
+    if (!has_netloc && has_scheme && scheme_uses_netloc(scheme) &&
+        (PyUnicode_GET_LENGTH(path) == 0 || str_has_prefix(path, "/"))) {
+        has_netloc = 1;
+    }
+    const char *marker = has_netloc || str_has_prefix(path, "//") ? "//" : "";
+    return th_str_format("%U%s%s%U%U%s%U%s%U", scheme, has_scheme ? ":" : "", marker, netloc, path,
+                         PyUnicode_GET_LENGTH(query) > 0 ? "?" : "", query,
+                         PyUnicode_GET_LENGTH(fragment) > 0 ? "#" : "", fragment);
+}
+
+/* The path with a trailing slash run trimmed (any path but the root, and only without a query), the fold of
+   "/dir/" and "/dir" into one form that trailing_slash=False asks for. */
+static PyObject *trim_trailing_slash(PyObject *path) {
+    Py_ssize_t end = PyUnicode_GET_LENGTH(path);
+    while (end > 0 && PyUnicode_READ_CHAR(path, end - 1) == '/') {
+        end--;
+    }
+    return PyUnicode_Substring(path, 0, end);
+}
+
+/* Rebuild the URL from spec-normalized components plus the beyond-spec query/fragment canonicalization. Returns NULL
+   with a ValueError when a component cannot be percent-encoded (a lone surrogate). */
+static PyObject *normalize_parts(const th_url_parts *parts, const clean_options *options) {
+    PyObject *scheme = parts->part[TH_URL_SCHEME];
+    int has_netloc = PyUnicode_GET_LENGTH(parts->part[TH_URL_NETLOC]) > 0;
+    PyObject *netloc = has_netloc ? normalize_netloc(parts) : PyUnicode_FromString("");
+    PyObject *path = NULL;
+    PyObject *query = NULL;
+    PyObject *fragment = NULL;
+    PyObject *result = NULL;
+    if (netloc == NULL) { /* GCOVR_EXCL_BR_LINE: the authority rebuild only fails on allocation failure */
+        goto done;        /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    path = th_url_encode_component(parts->part[TH_URL_PATH], TH_URL_SET_PATH);
+    if (path == NULL) {
+        goto done;
+    }
+    if (has_netloc) {
+        Py_SETREF(path, turbohtml_url_remove_dot_segments(NULL, path));
+        if (path == NULL) { /* GCOVR_EXCL_BR_LINE: dot-segment removal only fails on allocation failure */
+            goto done;      /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    query = normalize_query(parts->part[TH_URL_QUERY], options);
+    if (query == NULL) {
+        goto done;
+    }
+    int web = str_equals(scheme, "http") || str_equals(scheme, "https");
+    if (has_netloc && web && PyUnicode_GET_LENGTH(path) == 0) {
+        Py_SETREF(path, PyUnicode_FromString("/")); /* a special URL with a host never serializes an empty path */
+    }
+    if (!options->trailing_slash && PyUnicode_GET_LENGTH(query) == 0 && PyUnicode_GET_LENGTH(path) > 1 &&
+        PyUnicode_READ_CHAR(path, PyUnicode_GET_LENGTH(path) - 1) == '/') {
+        Py_SETREF(path, trim_trailing_slash(path));
+    }
+    if (path == NULL) { /* GCOVR_EXCL_BR_LINE: the path rewrites only fail on allocation failure */
+        goto done;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    fragment = options->strict || options->strip_fragment ? PyUnicode_FromString("")
+                                                          : normalize_fragment(parts->part[TH_URL_FRAGMENT], options);
+    if (fragment == NULL) {
+        goto done;
+    }
+    result = unsplit(scheme, netloc, path, query, fragment);
+done:
+    Py_XDECREF(netloc);
+    Py_XDECREF(path);
+    Py_XDECREF(query);
+    Py_XDECREF(fragment);
+    return result;
+}
+
+/* Reject anything but a str with the message the shim raised. */
+static int require_str(PyObject *url) {
+    if (PyUnicode_Check(url)) {
+        return 0;
+    }
+    PyErr_Format(PyExc_TypeError, "url must be a str, got %s", Py_TYPE(url)->tp_name);
+    return -1;
+}
+
+/* _url_normalize(url, strict, trailing_slash, strip_fragment, allow, deny, content, language_params) -> str: the
+   canonical form of a URL, so that two spellings of the same resource compare equal. Raises TypeError for a non-str
+   and ValueError when the URL cannot be split or a component cannot be percent-encoded. */
+PyObject *turbohtml_url_normalize(PyObject *Py_UNUSED(module), PyObject *args) {
+    PyObject *url, *allow, *deny;
+    clean_options options = {0};
+    if (!PyArg_ParseTuple(args, "OpppOOOO:_url_normalize", &url, &options.strict, &options.trailing_slash,
+                          &options.strip_fragment, &allow, &deny, &options.content, &options.language_params)) {
+        return NULL;
+    }
+    th_url_parts parts;
+    if (require_str(url) < 0 || th_url_split(url, &parts) < 0) {
+        return NULL;
+    }
+    PyObject *result = NULL;
+    if (clean_options_take(&options, allow, deny) == 0) {
+        result = normalize_parts(&parts, &options);
+    }
+    clean_options_clear(&options);
+    th_url_parts_clear(&parts);
+    return result;
+}
+
+/* Whether the scrubbed, split URL is a fetchable web address: an http/https scheme and a host that is either dotted
+   or carries a port, the shape gate clean_url applies before the language filter and normalization. */
+static int is_web_url(const th_url_parts *parts, PyObject *host) {
+    PyObject *scheme = parts->part[TH_URL_SCHEME];
+    if (!str_equals(scheme, "http") && !str_equals(scheme, "https")) {
+        return 0;
+    }
+    if (PyUnicode_GET_LENGTH(host) == 0) {
+        return 0;
+    }
+    return str_holds(host, '.') || str_holds(parts->part[TH_URL_NETLOC], ':');
+}
+
+/* clean_url's pipeline over one str: scrub, split, the web gate, the language gate, then normalization. Returns the
+   cleaned URL, None for anything that is not a fetchable web URL, or NULL on an error that is not a rejection. */
+static PyObject *clean(PyObject *url, const clean_options *options) {
+    PyObject *scrubbed = turbohtml_url_scrub(NULL, url);
+    if (scrubbed == NULL) { /* GCOVR_EXCL_BR_LINE: the scrub of a str only fails on allocation failure */
+        return NULL;        /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    th_url_parts parts;
+    int split = th_url_split(scrubbed, &parts);
+    Py_DECREF(scrubbed);
+    if (split < 0) {
+        if (!PyErr_ExceptionMatches(PyExc_ValueError)) { /* GCOVR_EXCL_BR_LINE: the split raises nothing else */
+            return NULL;                                 /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        PyErr_Clear();
+        Py_RETURN_NONE;
+    }
+    PyObject *host = PyObject_CallMethod(parts.part[TH_URL_HOST], "lower", NULL);
+    PyObject *result = NULL;
+    if (host == NULL) { /* GCOVR_EXCL_BR_LINE: str.lower cannot fail on a host */
+        goto done;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    if (!is_web_url(&parts, host)) {
+        result = Py_NewRef(Py_None);
+        goto done;
+    }
+    if (options->language != Py_None) {
+        int matches =
+            th_url_language_matches(parts.part[TH_URL_QUERY], parts.part[TH_URL_PATH], host, options->language,
+                                    options->strict, options->language_params, options->iso_639_1);
+        if (matches < 0) { /* GCOVR_EXCL_BR_LINE: the language filter only fails on allocation failure */
+            goto done;     /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        if (!matches) {
+            result = Py_NewRef(Py_None);
+            goto done;
+        }
+    }
+    result = normalize_parts(&parts, options);
+    if (result == NULL) {
+        if (!PyErr_ExceptionMatches(PyExc_ValueError)) { /* GCOVR_EXCL_BR_LINE: normalization raises nothing else */
+            goto done;                                   /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        /* an unencodable component (a lone surrogate) is not a fetchable URL, as courlan also decides */
+        PyErr_Clear();
+        result = Py_NewRef(Py_None);
+    }
+done:
+    Py_XDECREF(host);
+    th_url_parts_clear(&parts);
+    return result;
+}
+
+/* _url_clean(url, strict, trailing_slash, strip_fragment, allow, deny, content, language_params, language, iso_639_1)
+   -> str | None: scrub a URL scraped from markup and normalize it, or None when nothing usable remains. */
+PyObject *turbohtml_url_clean(PyObject *Py_UNUSED(module), PyObject *args) {
+    PyObject *url, *allow, *deny;
+    clean_options options = {0};
+    if (!PyArg_ParseTuple(args, "OpppOOOOOO:_url_clean", &url, &options.strict, &options.trailing_slash,
+                          &options.strip_fragment, &allow, &deny, &options.content, &options.language_params,
+                          &options.language, &options.iso_639_1)) {
+        return NULL;
+    }
+    if (require_str(url) < 0) {
+        return NULL;
+    }
+    PyObject *result = NULL;
+    if (clean_options_take(&options, allow, deny) == 0) {
+        result = clean(url, &options);
+    }
+    clean_options_clear(&options);
+    return result;
+}
+
+/* The registrable domain (eTLD+1) that defines a URL's external_only site, or "" for no host. The host is punycoded
+   first so a Unicode base compares against the ASCII hosts clean emits. Raises ValueError when the URL cannot be
+   split. */
+static PyObject *site_of(PyObject *url) {
+    th_url_parts parts;
+    if (th_url_split(url, &parts) < 0) {
+        return NULL;
+    }
+    PyObject *host = ascii_host(parts.part[TH_URL_HOST]);
+    th_url_parts_clear(&parts);
+    if (host == NULL) { /* GCOVR_EXCL_BR_LINE: the host fold only fails on allocation failure */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *site = turbohtml_registrable_domain(NULL, host);
+    Py_DECREF(host);
+    return site;
+}
+
+/* The whitespace str.split() splits on: Unicode White_Space, not only the ASCII set. Kept out of line so the
+   macro's ASCII fast path is one branch site rather than one per scanning loop. */
+static int rel_space(Py_UCS4 ch) {
+    return Py_UNICODE_ISSPACE(ch) != 0;
+}
+
+/* Whether a rel attribute carries the nofollow token: the value split on whitespace the way str.split() does, each
+   token compared to "nofollow" without regard to ASCII case. */
+static int rel_has_nofollow(const Py_UCS4 *value, Py_ssize_t len) {
+    Py_ssize_t pos = 0;
+    while (pos < len) {
+        while (pos < len && rel_space(value[pos])) {
+            pos++;
+        }
+        Py_ssize_t start = pos;
+        while (pos < len && !rel_space(value[pos])) {
+            pos++;
+        }
+        if (pos - start != 8) {
+            continue;
+        }
+        int matched = 1;
+        for (Py_ssize_t offset = 0; offset < 8; offset++) {
+            if (lower_ascii(value[start + offset]) != (Py_UCS4)(unsigned char)"nofollow"[offset]) {
+                matched = 0;
+            }
+        }
+        if (matched) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* Whether an anchor's hreflang names the target language: a missing or empty value always does, so does x-default,
+   otherwise the primary subtag (before the first '-') must equal the code. Returns -1 on allocation failure. */
+static int hreflang_matches(const Py_UCS4 *value, Py_ssize_t len, PyObject *language) {
+    if (value == NULL) {
+        return 1; /* absent, or empty: the parser stores an empty value as no value */
+    }
+    PyObject *raw = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, value, len);
+    if (raw == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *code = PyObject_CallMethod(raw, "lower", NULL);
+    Py_DECREF(raw);
+    if (code == NULL) { /* GCOVR_EXCL_BR_LINE: str.lower only fails on allocation failure */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int matches = str_equals(code, "x-default");
+    if (!matches) {
+        Py_ssize_t dash = PyUnicode_FindChar(code, '-', 0, PyUnicode_GET_LENGTH(code), 1);
+        Py_ssize_t primary_len = dash < 0 ? PyUnicode_GET_LENGTH(code) : dash;
+        matches = primary_len == PyUnicode_GET_LENGTH(language) &&
+                  PyUnicode_Tailmatch(code, language, 0, primary_len, -1) == 1;
+    }
+    Py_DECREF(code);
+    return matches;
+}
+
+/* The value of a by-name attribute, or NULL when the element has none (or it is valueless). */
+static const Py_UCS4 *anchor_attr(th_tree *tree, th_node *node, const char *name, Py_ssize_t *out_len) {
+    Py_ssize_t index = th_node_attr_find(tree, node, name, (Py_ssize_t)strlen(name));
+    if (index < 0 || node->attrs[index].value == NULL) {
+        *out_len = 0;
+        return NULL;
+    }
+    *out_len = node->attrs[index].value_len;
+    return node->attrs[index].value;
+}
+
+/* Collect the href of every <a>/<area> that is neither rel=nofollow nor, under a language filter, hreflang'd to
+   another language, in document order, trimmed the way Node.links() reports a URL attribute. Pure tree reads plus
+   str allocation, so it runs under the document's critical section. Returns -1 on allocation failure. */
+static int collect_hrefs(th_tree *tree, th_node *root, PyObject *language, PyObject *hrefs) {
+    for (th_node *node = root->first_child; node != NULL; node = preorder_next(node, root)) {
+        if (node->type != TH_NODE_ELEMENT || (node->atom != TH_TAG_A && node->atom != TH_TAG_AREA)) {
+            continue;
+        }
+        Py_ssize_t len = 0;
+        const Py_UCS4 *href = anchor_attr(tree, node, "href", &len);
+        Py_ssize_t start = 0;
+        Py_ssize_t end = len;
+        while (start < end && is_space(href[start])) {
+            start++;
+        }
+        while (end > start && is_space(href[end - 1])) {
+            end--;
+        }
+        if (end == start) {
+            continue;
+        }
+        Py_ssize_t rel_len = 0;
+        const Py_UCS4 *rel = anchor_attr(tree, node, "rel", &rel_len);
+        if (rel != NULL && rel_has_nofollow(rel, rel_len)) {
+            continue;
+        }
+        if (language != Py_None) {
+            Py_ssize_t hreflang_len = 0;
+            const Py_UCS4 *hreflang = anchor_attr(tree, node, "hreflang", &hreflang_len);
+            int matches = hreflang_matches(hreflang, hreflang_len, language);
+            if (matches < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+                return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+            }
+            if (!matches) {
+                continue;
+            }
+        }
+        PyObject *url = PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, href + start, end - start);
+        if (url == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+        int appended = PyList_Append(hrefs, url);
+        Py_DECREF(url);
+        if (appended < 0) { /* GCOVR_EXCL_BR_LINE: a list append only fails on allocation failure */
+            return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
+        }
+    }
+    return 0;
+}
+
+/* The cleaned form of one href, resolved against `base` when it is relative, memoized in `cleaned_of` because pages
+   repeat hrefs (navigation, pagination). A borrowed reference into the memo, or NULL on error. */
+static PyObject *cleaned_href(PyObject *href, PyObject *base, const clean_options *options, PyObject *cleaned_of) {
+    PyObject *cached = PyDict_GetItemWithError(cleaned_of, href);
+    if (cached != NULL || PyErr_Occurred()) { /* GCOVR_EXCL_BR_LINE: a str key lookup cannot raise */
+        return cached;
+    }
+    PyObject *candidate;
+    if (base == Py_None || str_has_prefix(href, "http://") || str_has_prefix(href, "https://")) {
+        candidate = Py_NewRef(href);
+    } else {
+        candidate = th_url_join(base, href);
+        if (candidate == NULL) {
+            return NULL; /* the document base cannot be split (an unbalanced IPv6 bracket) */
+        }
+    }
+    PyObject *cleaned = clean(candidate, options);
+    Py_DECREF(candidate);
+    if (cleaned == NULL) { /* GCOVR_EXCL_BR_LINE: cleaning a joined URL only fails on allocation failure */
+        return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    int stored = PyDict_SetItem(cleaned_of, href, cleaned);
+    Py_DECREF(cleaned);
+    return stored < 0 ? NULL : cleaned; /* GCOVR_EXCL_BR_LINE: a dict insert only fails on allocation failure */
+}
+
+/* Document._extract_links(base_url, external_only, strict, trailing_slash, strip_fragment, allow, deny, content,
+   language_params, language, iso_639_1) -> set[str]: the cleaned page links, the courlan.extract_links counterpart.
+   Each anchor href resolves against the document base (a <base href> wins over base_url, HTML spec 4.2.3), is cleaned,
+   and is deduplicated across the http/https and trailing-slash twins, the first in document order winning. With
+   external_only only links leaving base_url's registrable domain survive. */
+PyObject *turbohtml_document_extract_links(PyObject *self, PyObject *args) {
+    PyObject *base_url, *allow, *deny;
+    int external_only;
+    clean_options options = {0};
+    if (!PyArg_ParseTuple(args, "OppppOOOOOO:_extract_links", &base_url, &external_only, &options.strict,
+                          &options.trailing_slash, &options.strip_fragment, &allow, &deny, &options.content,
+                          &options.language_params, &options.language, &options.iso_639_1)) {
+        return NULL;
+    }
+    if (external_only && base_url == Py_None) {
+        PyErr_SetString(PyExc_ValueError, "external_only requires a base_url to compare hosts against");
+        return NULL;
+    }
+    PyObject *site = base_url == Py_None ? PyUnicode_FromString("") : site_of(base_url);
+    if (site == NULL) {
+        return NULL;
+    }
+    PyObject *fallback = base_url == Py_None ? PyUnicode_FromString("") : Py_NewRef(base_url);
+    PyObject *base = th_document_base_url(self, fallback);
+    Py_DECREF(fallback);
+    PyObject *hrefs = NULL;
+    PyObject *found = NULL;
+    PyObject *seen = NULL;
+    PyObject *cleaned_of = NULL;
+    if (base == NULL) {
+        goto done; /* the <base href> cannot be resolved against base_url */
+    }
+    hrefs = PyList_New(0);
+    if (hrefs == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        goto done;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    if (PyUnicode_GET_LENGTH(base) == 0) {
+        Py_SETREF(base, Py_NewRef(Py_None)); /* no fetch URL and no <base href>: relative links cannot resolve */
+    }
+    int collected;
+    Py_BEGIN_CRITICAL_SECTION(((NodeObject *)self)->handle);
+    collected = collect_hrefs(tree_of(self), ((NodeObject *)self)->node, options.language, hrefs);
+    Py_END_CRITICAL_SECTION();
+    if (collected < 0) { /* GCOVR_EXCL_BR_LINE: the walk only fails on allocation failure */
+        goto done;       /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    if (clean_options_take(&options, allow, deny) < 0) {
+        goto done;
+    }
+    PyObject *links = PySet_New(NULL);
+    seen = PySet_New(NULL);
+    cleaned_of = PyDict_New();
+    if (links == NULL || seen == NULL || cleaned_of == NULL) { /* GCOVR_EXCL_BR_LINE: allocation cannot be forced */
+        Py_XDECREF(links);                                     /* GCOVR_EXCL_LINE: allocation-failure path */
+        goto done;                                             /* GCOVR_EXCL_LINE */
+    }
+    for (Py_ssize_t index = 0; index < PyList_GET_SIZE(hrefs); index++) {
+        PyObject *cleaned = cleaned_href(PyList_GET_ITEM(hrefs, index), base, &options, cleaned_of);
+        if (cleaned == NULL) { /* the base cannot be split, or a parameter name is not a str */
+            Py_DECREF(links);
+            goto done;
+        }
+        if (cleaned == Py_None) {
+            continue;
+        }
+        if (external_only) {
+            PyObject *link_site = site_of(cleaned);
+            if (link_site == NULL) { /* GCOVR_EXCL_BR_LINE: a cleaned URL always splits */
+                Py_DECREF(links);    /* GCOVR_EXCL_LINE: allocation-failure path */
+                goto done;           /* GCOVR_EXCL_LINE */
+            }
+            int internal = PyUnicode_Compare(link_site, site) == 0;
+            Py_DECREF(link_site);
+            if (internal) {
+                continue;
+            }
+        }
+        PyObject *key = turbohtml_url_variant_key(NULL, cleaned);
+        if (key == NULL) {    /* GCOVR_EXCL_BR_LINE: the key of a str only fails on allocation failure */
+            Py_DECREF(links); /* GCOVR_EXCL_LINE: allocation-failure path */
+            goto done;        /* GCOVR_EXCL_LINE */
+        }
+        Py_ssize_t before = PySet_GET_SIZE(seen);
+        int added = PySet_Add(seen, key);
+        Py_DECREF(key);
+        if (added < 0) {      /* GCOVR_EXCL_BR_LINE: a str insert only fails on allocation failure */
+            Py_DECREF(links); /* GCOVR_EXCL_LINE: allocation-failure path */
+            goto done;        /* GCOVR_EXCL_LINE */
+        }
+        if (PySet_GET_SIZE(seen) == before) {
+            continue; /* a scheme or trailing-slash twin of a link already kept */
+        }
+        if (PySet_Add(links, cleaned) < 0) { /* GCOVR_EXCL_BR_LINE: a str insert only fails on allocation failure */
+            Py_DECREF(links);                /* GCOVR_EXCL_LINE: allocation-failure path */
+            goto done;                       /* GCOVR_EXCL_LINE */
+        }
+    }
+    found = links;
+done:
+    clean_options_clear(&options);
+    Py_XDECREF(cleaned_of);
+    Py_XDECREF(seen);
+    Py_XDECREF(hrefs);
+    Py_XDECREF(base);
+    Py_DECREF(site);
+    return found;
+}

--- a/src/turbohtml/_c/url/url.c
+++ b/src/turbohtml/_c/url/url.c
@@ -61,7 +61,7 @@ Py_ssize_t th_url_encode_span(char *out, Py_ssize_t at, const char *bytes, Py_ss
    encoding, so this raises the UnicodeEncodeError PyUnicode_AsUTF8AndSize sets), then rewrites an existing %XX to
    uppercase hex and percent-encodes every byte outside the set. Since '%' stays in every keep set, a valid escape
    survives; a stray '%' or a truncated %X is a literal byte the set keeps. */
-static PyObject *th_url_percent_encode_obj(PyObject *text, int set_id) {
+PyObject *th_url_percent_encode_obj(PyObject *text, int set_id) {
     Py_ssize_t len;
     const char *bytes = PyUnicode_AsUTF8AndSize(text, &len);
     if (bytes == NULL) {
@@ -136,7 +136,7 @@ static int decode_flush(const unsigned char *run, Py_ssize_t run_len, Py_UCS4 *o
    and keeping any other ASCII char or non-ASCII code point verbatim, then UTF-8 decodes each ASCII byte run with U+FFFD
    replacement. A non-ASCII input char ends the current run, matching the ascii/non-ascii split unquote makes, so a raw
    code point (even a lone surrogate) survives unencoded. */
-static PyObject *th_url_percent_decode_obj(PyObject *arg) {
+PyObject *th_url_percent_decode_obj(PyObject *arg) {
     Py_ssize_t len = PyUnicode_GET_LENGTH(arg);
     int kind = PyUnicode_KIND(arg);
     const void *data = PyUnicode_DATA(arg);
@@ -272,13 +272,14 @@ void th_url_authority(const Py_UCS4 *work, Py_ssize_t start, Py_ssize_t end, th_
    lowercased; the host is the bracket-stripped ASCII span; every other component is the verbatim slice. Raises
    ValueError on an authority with an unbalanced '['/']' pair. The shim guarantees a str argument, as the other _html
    entry points assume. */
-PyObject *turbohtml_url_split(PyObject *Py_UNUSED(module), PyObject *arg) {
+int th_url_split(PyObject *arg, th_url_parts *out) {
     Py_ssize_t raw_len = PyUnicode_GET_LENGTH(arg);
     int kind = PyUnicode_KIND(arg);
     const void *data = PyUnicode_DATA(arg);
     Py_UCS4 *work = PyMem_Malloc((size_t)(raw_len + 1) * sizeof(Py_UCS4));
-    if (work == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
-        return PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+    if (work == NULL) {   /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        PyErr_NoMemory(); /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;        /* GCOVR_EXCL_LINE */
     }
     Py_ssize_t read = 0;
     while (read < raw_len && input_char(kind, data, read) <= 0x20) {
@@ -334,7 +335,7 @@ PyObject *turbohtml_url_split(PyObject *Py_UNUSED(module), PyObject *arg) {
         if (has_open != has_close) {
             PyMem_Free(work);
             PyErr_SetString(PyExc_ValueError, "Invalid IPv6 URL");
-            return NULL;
+            return -1;
         }
     }
     Py_ssize_t hash = -1;
@@ -367,20 +368,37 @@ PyObject *turbohtml_url_split(PyObject *Py_UNUSED(module), PyObject *arg) {
         {auth.host_start, auth.host_end},
         {auth.port_start, auth.port_end},
     };
-    PyObject *parts[8];
-    for (int index = 0; index < 8; index++) {
-        parts[index] = span_str(work, spans[index][0], spans[index][1]);
-        if (parts[index] == NULL) {      /* GCOVR_EXCL_BR_LINE: only span_str allocation can fail */
-            while (index-- > 0) {        /* GCOVR_EXCL_LINE: allocation-failure unwind */
-                Py_DECREF(parts[index]); /* GCOVR_EXCL_LINE */
+    for (int index = 0; index < TH_URL_PART_COUNT; index++) {
+        out->part[index] = span_str(work, spans[index][0], spans[index][1]);
+        if (out->part[index] == NULL) {      /* GCOVR_EXCL_BR_LINE: only span_str allocation can fail */
+            while (index-- > 0) {            /* GCOVR_EXCL_LINE: allocation-failure unwind */
+                Py_DECREF(out->part[index]); /* GCOVR_EXCL_LINE */
             } /* GCOVR_EXCL_LINE */
             PyMem_Free(work); /* GCOVR_EXCL_LINE */
-            return NULL;      /* GCOVR_EXCL_LINE */
+            return -1;        /* GCOVR_EXCL_LINE */
         }
     }
-    PyObject *result = Py_BuildValue("(NNNNNNNNNi)", parts[0], parts[1], parts[2], parts[3], parts[4], parts[5],
-                                     parts[6], parts[7], PyBool_FromLong(auth.has_port), auth.kind);
+    out->has_port = auth.has_port;
+    out->kind = auth.kind;
     PyMem_Free(work);
+    return 0;
+}
+
+void th_url_parts_clear(th_url_parts *parts) {
+    for (int index = 0; index < TH_URL_PART_COUNT; index++) {
+        Py_DECREF(parts->part[index]);
+    }
+}
+
+PyObject *turbohtml_url_split(PyObject *Py_UNUSED(module), PyObject *arg) {
+    th_url_parts parts;
+    if (th_url_split(arg, &parts) < 0) {
+        return NULL;
+    }
+    PyObject *result =
+        Py_BuildValue("(OOOOOOOONi)", parts.part[0], parts.part[1], parts.part[2], parts.part[3], parts.part[4],
+                      parts.part[5], parts.part[6], parts.part[7], PyBool_FromLong(parts.has_port), parts.kind);
+    th_url_parts_clear(&parts);
     return result;
 }
 
@@ -867,7 +885,7 @@ static int tracker_word_at(const char *key, size_t start, size_t end) {
    returns 1 for a tracker, 0 otherwise, and -1 with a UnicodeEncodeError set when the key carries a lone surrogate (a
    raw surrogate the caller's URL held, which has no UTF-8 form). Exposed so the query normalizer decides a pair without
    materializing a Py_True/Py_False per key. */
-static int th_url_is_tracker_obj(PyObject *key_obj) {
+int th_url_is_tracker_obj(PyObject *key_obj) {
     Py_ssize_t size;
     const char *key = PyUnicode_AsUTF8AndSize(key_obj, &size);
     if (key == NULL) {
@@ -1141,16 +1159,11 @@ PyObject *turbohtml_url_variant_key(PyObject *Py_UNUSED(module), PyObject *arg) 
     return PyUnicode_Substring(arg, start, end);
 }
 
-/* Percent-encode the query pair query[start:end) for the query set, rewrapping the encoder's UnicodeEncodeError as the
-   ValueError the Python _encode raised, so a lone surrogate reports the same "cannot be percent-encoded" message. */
-static PyObject *normalize_query_encode_pair(PyObject *query, Py_ssize_t start, Py_ssize_t end) {
-    PyObject *pair = PyUnicode_Substring(query, start, end);
-    if (pair == NULL) { /* GCOVR_EXCL_BR_LINE: substring of an existing string cannot fail here */
-        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
-    }
-    PyObject *encoded = th_url_percent_encode_obj(pair, TH_URL_SET_QUERY);
+/* Percent-encode one component for its set, rewrapping the encoder's UnicodeEncodeError as the ValueError
+   normalize_url raises, so a lone surrogate reports the "cannot be percent-encoded" message with the component. */
+PyObject *th_url_encode_component(PyObject *text, int set_id) {
+    PyObject *encoded = th_url_percent_encode_obj(text, set_id);
     if (encoded != NULL) {
-        Py_DECREF(pair);
         return encoded;
     }
     PyObject *type;
@@ -1159,13 +1172,23 @@ static PyObject *normalize_query_encode_pair(PyObject *query, Py_ssize_t start, 
     PyErr_Fetch(&type, &value, &traceback);
     PyErr_NormalizeException(&type, &value, &traceback);
     PyObject *reason = PyObject_GetAttrString(value, "reason"); /* UnicodeEncodeError always carries a reason str */
-    PyErr_Format(PyExc_ValueError, "URL component %R has a character that cannot be percent-encoded: %U", pair, reason);
+    PyErr_Format(PyExc_ValueError, "URL component %R has a character that cannot be percent-encoded: %U", text, reason);
     Py_XDECREF(reason);
     Py_DECREF(type);
     Py_DECREF(value);
     Py_XDECREF(traceback);
-    Py_DECREF(pair);
     return NULL;
+}
+
+/* Percent-encode the query pair query[start:end) for the query set. */
+static PyObject *encode_pair(PyObject *query, Py_ssize_t start, Py_ssize_t end) {
+    PyObject *pair = PyUnicode_Substring(query, start, end);
+    if (pair == NULL) { /* GCOVR_EXCL_BR_LINE: substring of an existing string cannot fail here */
+        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    PyObject *encoded = th_url_encode_component(pair, TH_URL_SET_QUERY);
+    Py_DECREF(pair);
+    return encoded;
 }
 
 /* _url_normalize_query(query, allow, deny, strict, content, language): drop denied, tracker, or non-allowlisted query
@@ -1183,6 +1206,11 @@ PyObject *turbohtml_url_normalize_query(PyObject *Py_UNUSED(module), PyObject *a
     if (!PyArg_ParseTuple(args, "UOOpOO", &query, &allow, &deny, &strict, &content, &language)) {
         return NULL;
     }
+    return th_url_normalize_query(query, allow, deny, strict, content, language);
+}
+
+PyObject *th_url_normalize_query(PyObject *query, PyObject *allow, PyObject *deny, int strict, PyObject *content,
+                                 PyObject *language) {
     Py_ssize_t len = PyUnicode_GET_LENGTH(query);
     int kind = PyUnicode_KIND(query);
     const void *data = PyUnicode_DATA(query);
@@ -1232,7 +1260,7 @@ PyObject *turbohtml_url_normalize_query(PyObject *Py_UNUSED(module), PyObject *a
             goto error;
         }
         if (drop == 0) {
-            PyObject *encoded = normalize_query_encode_pair(query, pair_start, index);
+            PyObject *encoded = encode_pair(query, pair_start, index);
             if (encoded == NULL) {
                 Py_DECREF(key);
                 goto error;
@@ -1406,16 +1434,25 @@ PyObject *turbohtml_url_language_matches(PyObject *Py_UNUSED(module), PyObject *
                           &iso_639_1)) {
         return NULL;
     }
+    int matches = th_url_language_matches(query, path, hostname, language, strict, language_params, iso_639_1);
+    if (matches < 0) { /* GCOVR_EXCL_BR_LINE: the filter only fails on the excluded alloc paths */
+        return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
+    }
+    return PyBool_FromLong(matches);
+}
+
+int th_url_language_matches(PyObject *query, PyObject *path, PyObject *hostname, PyObject *language, int strict,
+                            PyObject *language_params, PyObject *iso_639_1) {
     int rejected = language_query_rejects(query, language, language_params);
     if (rejected < 0) { /* GCOVR_EXCL_BR_LINE: the decode/lower/membership steps only fail on the excluded alloc path */
-        return NULL;    /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;      /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     if (rejected) {
-        Py_RETURN_FALSE;
+        return 0;
     }
     PyObject *lowered = PyObject_CallMethod(path, "lower", NULL);
     if (lowered == NULL) { /* GCOVR_EXCL_BR_LINE: str.lower cannot fail on a path component */
-        return NULL;       /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;         /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     Py_ssize_t len = PyUnicode_GET_LENGTH(lowered);
     int kind = PyUnicode_KIND(lowered);
@@ -1442,10 +1479,10 @@ PyObject *turbohtml_url_language_matches(PyObject *Py_UNUSED(module), PyObject *
     }
     Py_DECREF(lowered);
     if (rejects < 0) { /* GCOVR_EXCL_BR_LINE: building a two-letter code and testing membership cannot error */
-        return NULL;   /* GCOVR_EXCL_LINE: allocation-failure path */
+        return -1;     /* GCOVR_EXCL_LINE: allocation-failure path */
     }
     if (rejects) {
-        Py_RETURN_FALSE;
+        return 0;
     }
     if (strict) {
         Py_ssize_t host_len = PyUnicode_GET_LENGTH(hostname);
@@ -1460,12 +1497,12 @@ PyObject *turbohtml_url_language_matches(PyObject *Py_UNUSED(module), PyObject *
             code[1] = PyUnicode_READ(host_kind, host_data, 1);
             int label_rejects = language_code_rejects(code, language, iso_639_1);
             if (label_rejects < 0) { /* GCOVR_EXCL_BR_LINE: a two-letter code test cannot error */
-                return NULL;         /* GCOVR_EXCL_LINE: membership-failure path */
+                return -1;           /* GCOVR_EXCL_LINE: membership-failure path */
             }
             if (label_rejects) {
-                Py_RETURN_FALSE;
+                return 0;
             }
         }
     }
-    Py_RETURN_TRUE;
+    return 1;
 }

--- a/src/turbohtml/_c/url/url.h
+++ b/src/turbohtml/_c/url/url.h
@@ -66,4 +66,45 @@ typedef struct {
    authority (after "scheme://" or "//", before the path/query/fragment) and owns the buffer. */
 void th_url_authority(const Py_UCS4 *work, Py_ssize_t start, Py_ssize_t end, th_authority *out);
 
+/* The components url split reports, each a new str reference: the eight spans of urllib's SplitResult plus userinfo,
+   host and port, with the port presence flag and the TH_HOST_* kind of the host. th_url_parts_clear releases them. */
+enum {
+    TH_URL_SCHEME = 0,
+    TH_URL_NETLOC = 1,
+    TH_URL_PATH = 2,
+    TH_URL_QUERY = 3,
+    TH_URL_FRAGMENT = 4,
+    TH_URL_USERINFO = 5,
+    TH_URL_HOST = 6,
+    TH_URL_PORT = 7,
+    TH_URL_PART_COUNT = 8
+};
+
+typedef struct {
+    PyObject *part[TH_URL_PART_COUNT];
+    int has_port;
+    int kind;
+} th_url_parts;
+
+/* Split `url` (a str) into its components the way urllib.parse.urlsplit does, lowercasing the scheme and dropping the
+   tab and newline bytes the WHATWG parser removes. Returns -1 with a ValueError set for an unbalanced IPv6 bracket. */
+int th_url_split(PyObject *url, th_url_parts *out);
+void th_url_parts_clear(th_url_parts *parts);
+
+/* The per-component encoder and decoder bodies, and the tracker-name test, shared with the cleaning pipeline in
+   clean.c. th_url_encode_component rewraps the encoder's UnicodeEncodeError as the ValueError normalize_url raises for
+   a lone surrogate. th_url_is_tracker_obj returns 1 for a tracker, 0 otherwise, -1 with an error set. */
+PyObject *th_url_percent_encode_obj(PyObject *text, int set_id);
+PyObject *th_url_encode_component(PyObject *text, int set_id);
+PyObject *th_url_percent_decode_obj(PyObject *text);
+int th_url_is_tracker_obj(PyObject *key);
+
+/* The query filter and the language filter, the bodies behind _url_normalize_query and _url_language_matches, taken
+   as borrowed objects so the cleaning pipeline runs them without an argument tuple. th_url_language_matches returns 1
+   to keep, 0 to reject, -1 with an error set. */
+PyObject *th_url_normalize_query(PyObject *query, PyObject *allow, PyObject *deny, int strict, PyObject *content,
+                                 PyObject *language);
+int th_url_language_matches(PyObject *query, PyObject *path, PyObject *hostname, PyObject *language, int strict,
+                            PyObject *language_params, PyObject *iso_639_1);
+
 #endif /* TURBOHTML_URL_H */

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -189,6 +189,9 @@ from ._stubs.features import (
     _sanitize as _sanitize,
 )
 from ._stubs.features import (
+    _url_clean as _url_clean,
+)
+from ._stubs.features import (
     _url_is_tracker as _url_is_tracker,
 )
 from ._stubs.features import (
@@ -196,6 +199,9 @@ from ._stubs.features import (
 )
 from ._stubs.features import (
     _url_language_matches as _url_language_matches,
+)
+from ._stubs.features import (
+    _url_normalize as _url_normalize,
 )
 from ._stubs.features import (
     _url_normalize_query as _url_normalize_query,

--- a/src/turbohtml/_stubs/dom.pyi
+++ b/src/turbohtml/_stubs/dom.pyi
@@ -365,6 +365,21 @@ class Document(Node):
         extensive: bool,
         /,
     ) -> tuple[int, int, int, Signal] | None: ...
+    def _extract_links(
+        self,
+        base_url: str | None,
+        external_only: bool,
+        strict: bool,
+        trailing_slash: bool,
+        strip_fragment: bool,
+        allow: frozenset[str] | None,
+        deny: frozenset[str],
+        content: frozenset[str],
+        language_params: frozenset[str],
+        language: str | None,
+        iso_639_1: frozenset[str],
+        /,
+    ) -> set[str]: ...
     def feed(self) -> Feed | None: ...
     @property
     def errors(self) -> list[ParseError]: ...

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -108,6 +108,30 @@ def _url_language_matches(
     /,
 ) -> bool: ...
 def _url_to_ascii(host: str, /) -> str: ...
+def _url_normalize(
+    url: str,
+    strict: bool,
+    trailing_slash: bool,
+    strip_fragment: bool,
+    allow: frozenset[str] | None,
+    deny: frozenset[str],
+    content: frozenset[str],
+    language_params: frozenset[str],
+    /,
+) -> str: ...
+def _url_clean(
+    url: str,
+    strict: bool,
+    trailing_slash: bool,
+    strip_fragment: bool,
+    allow: frozenset[str] | None,
+    deny: frozenset[str],
+    content: frozenset[str],
+    language_params: frozenset[str],
+    language: str | None,
+    iso_639_1: frozenset[str],
+    /,
+) -> str | None: ...
 def _register_links(link_type: type, /) -> None: ...
 def _microdata_as_dict(item: MicrodataItem, /) -> dict[str, JSONValue]: ...
 def _register_structured_data(

--- a/src/turbohtml/extract/_urls.py
+++ b/src/turbohtml/extract/_urls.py
@@ -8,30 +8,16 @@ domain-to-ASCII (host parsing, spec 3.5), default-port removal (port state), dot
 the path/query/fragment percent-encode sets (percent-encoded bytes, spec 1.3). On top of that sits the crawl-oriented
 canonicalization ``courlan`` and ``w3lib`` users expect -- query-parameter sorting, tracking-parameter removal, an
 optional strict parameter allowlist, and a URL-based language filter -- each documented where it goes beyond the spec.
+The pipeline runs in C (``_url_clean``, ``_url_normalize`` and ``Document._extract_links``); this module holds the
+option record and the two vocabularies it hands over.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import lru_cache
-from typing import Final, NamedTuple
-from urllib.parse import urlunsplit
+from typing import Final
 
-from turbohtml._html import (
-    _registrable_domain,
-    _url_is_tracker,
-    _url_join,
-    _url_language_matches,
-    _url_normalize_query,
-    _url_percent_decode,
-    _url_percent_encode,
-    _url_remove_dot_segments,
-    _url_scrub,
-    _url_split,
-    _url_to_ascii,
-    _url_variant_key,
-    parse,
-)
+from turbohtml._html import _url_clean, _url_normalize, parse
 
 __all__ = [
     "UrlCleaning",
@@ -74,46 +60,6 @@ _CONTENT_PARAMS: Final[frozenset[str]] = frozenset({
 """The content-identifying query parameters strict mode keeps; everything else is presumed decorative."""
 
 _LANGUAGE_PARAMS: Final[frozenset[str]] = frozenset({"lang", "language"})
-
-# The WHATWG component percent-encode set (spec 1.3) each _encode call applies in C, mirroring the TH_URL_SET_* enum in
-# _c/url/url.h. The C encoder keeps the set's raw characters, UTF-8 percent-encodes the rest, and uppercases existing
-# %XX escapes, so a component that is already clean passes through unchanged.
-_SET_PATH: Final = 0
-_SET_FRAGMENT: Final = 2
-
-_DEFAULT_PORTS: Final[dict[str, int]] = {"ftp": 21, "http": 80, "ws": 80, "https": 443, "wss": 443}
-_WEB_SCHEMES: Final = ("http", "https")
-_WEB_PREFIXES: Final = ("http://", "https://")
-
-# The host kinds _url_split tags an authority with, mirroring the TH_HOST_* enum in _c/url/url.h: a registered name
-# reaches the domain-to-ASCII step, while an IPv4 or IPv6 literal is already ASCII and only needs lowercasing.
-_HOST_REGNAME: Final = 0
-_HOST_IPV6: Final = 2
-
-
-class _Split(NamedTuple):
-    """The components :func:`_url_split` reports for a URL, the fields the normalize and clean passes read."""
-
-    scheme: str
-    netloc: str
-    path: str
-    query: str
-    fragment: str
-    userinfo: str
-    host: str
-    port: str
-    has_port: bool
-    host_kind: int
-
-    @property
-    def hostname(self) -> str:
-        """The lowercased, bracket-stripped host that urllib's ``SplitResult.hostname`` returned, ``""`` for none."""
-        return self.host.lower()
-
-
-def _split(url: str) -> _Split:
-    """Split a URL into its components in C, the ``urllib.parse.urlsplit`` replacement; raises on an unbalanced host."""
-    return _Split(*_url_split(url))
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,24 +124,8 @@ def clean_url(url: str, options: UrlCleaning | None = None, /) -> str | None:
     :returns: the cleaned, normalized URL, or ``None`` for anything that is not a fetchable web URL.
     :raises TypeError: if ``url`` is not a ``str``.
     """
-    if not isinstance(url, str):
-        msg = f"url must be a str, got {type(url).__name__}"
-        raise TypeError(msg)
     active = options or _DEFAULT
-    scrubbed = _url_scrub(url)
-    try:
-        parts = _split(scrubbed)
-    except ValueError:
-        return None
-    host = parts.hostname
-    if parts.scheme not in _WEB_SCHEMES or not host or ("." not in host and ":" not in parts.netloc):
-        return None
-    if active.language is not None and not _language_matches(parts, active.language, strict=active.strict):
-        return None
-    try:
-        return _normalize(parts, active)
-    except ValueError:
-        return None  # an unencodable component (a lone surrogate) is not a fetchable URL, as courlan also decides
+    return _url_clean(url, *_knobs(active), active.language, _ISO_639_1)
 
 
 def normalize_url(url: str, options: UrlCleaning | None = None, /) -> str:
@@ -218,10 +148,7 @@ def normalize_url(url: str, options: UrlCleaning | None = None, /) -> str:
     :raises ValueError: if the URL cannot be split into components (e.g. an unclosed IPv6 bracket) or carries a
         character that cannot be percent-encoded (a lone surrogate).
     """
-    if not isinstance(url, str):
-        msg = f"url must be a str, got {type(url).__name__}"
-        raise TypeError(msg)
-    return _normalize(_split(url), options or _DEFAULT)
+    return _url_normalize(url, *_knobs(options or _DEFAULT))
 
 
 def extract_links(
@@ -253,145 +180,21 @@ def extract_links(
     :raises ValueError: if ``external_only`` is set without a ``base_url`` to define what external means.
     """
     active = options or _DEFAULT
-    if external_only and base_url is None:
-        msg = "external_only requires a base_url to compare hosts against"
-        raise ValueError(msg)
-    site = _site_of(base_url) if base_url is not None else ""
-    document = parse(html)
-    base = document.base_url(base_url or "") or None  # honor a <base href>, the document base URL (HTML spec 4.2.3)
-    found: set[str] = set()
-    seen: set[str] = set()
-    cleaned_of: dict[str, str | None] = {}  # pages repeat hrefs (navigation, pagination); clean each spelling once
-    for link in document.links():
-        if link.attribute != "href" or link.element.tag not in {"a", "area"}:
-            continue
-        attributes = link.element.attrs
-        if _has_nofollow(attributes.get("rel")):
-            continue
-        if active.language is not None and not _hreflang_matches(attributes.get("hreflang"), active.language):
-            continue
-        if link.url in cleaned_of:
-            cleaned = cleaned_of[link.url]
-        else:
-            candidate = link.url if base is None or link.url.startswith(_WEB_PREFIXES) else _url_join(base, link.url)
-            cleaned = cleaned_of[link.url] = clean_url(candidate, active)
-        if cleaned is None or (external_only and _site_of(cleaned) == site):
-            continue
-        if (key := _url_variant_key(cleaned)) not in seen:
-            seen.add(key)
-            found.add(cleaned)
-    return found
-
-
-def _language_matches(parts: _Split, language: str, *, strict: bool) -> bool:
-    """
-    Judge the URL's own language markers against the target language in C.
-
-    Three URL-based heuristics (content-based detection is out of scope): a ``lang``/``language`` query parameter
-    whose value does not start with the code, a leading path segment that is an ISO 639-1 tag of another language
-    (``/de/``, ``/en-us/``), and -- in strict mode -- a two-letter language subdomain (``de.example.org``).
-    """
-    return _url_language_matches(
-        parts.query, parts.path, parts.hostname, language, strict, _LANGUAGE_PARAMS, _ISO_639_1
+    return parse(html)._extract_links(  # ruff:ignore[private-member-access]  # the Document type's private C entry point
+        base_url, external_only, *_knobs(active), active.language, _ISO_639_1
     )
 
 
-def _normalize(parts: _Split, options: UrlCleaning) -> str:
-    """Rebuild the URL from spec-normalized components plus the beyond-spec query/fragment canonicalization."""
-    scheme = parts.scheme
-    netloc = _normalize_netloc(parts, scheme) if parts.netloc else ""
-    path = _encode(parts.path, _SET_PATH)
-    if netloc:
-        path = _url_remove_dot_segments(path)
-    query = _normalize_query(parts.query, options)
-    if netloc and scheme in _WEB_SCHEMES and not path:
-        path = "/"  # a special URL with a host never serializes an empty path (URL serializing, spec 4.5)
-    if not options.trailing_slash and not query and path.endswith("/") and path != "/":
-        path = path.rstrip("/")
-    fragment = "" if options.strict or options.strip_fragment else _normalize_fragment(parts.fragment, options)
-    return urlunsplit((scheme, netloc, path, query, fragment))
-
-
-def _normalize_netloc(parts: _Split, scheme: str) -> str:
-    """Lowercase the host into its ASCII form and drop an empty or scheme-default port, keeping userinfo verbatim."""
-    if parts.host_kind == _HOST_REGNAME:
-        host = _ascii_host(parts.host)
-    else:  # an IPv4/IPv6 literal is already ASCII, so it only needs lowercasing, and IPv6 keeps its brackets
-        host = f"[{parts.hostname}]" if parts.host_kind == _HOST_IPV6 else parts.hostname
-    prefix = f"{parts.userinfo}@" if parts.userinfo else ""
-    return f"{prefix}{host}{_port_suffix(parts, scheme)}"
-
-
-def _port_suffix(parts: _Split, scheme: str) -> str:
-    """Return ``:port``, or nothing for an empty or scheme-default port (port state, spec 4.4)."""
-    if not parts.has_port or not parts.port:
-        return ""
-    if not parts.port.isdigit():
-        return f":{parts.port}"
-    port = int(parts.port)
-    return "" if port == _DEFAULT_PORTS.get(scheme) else f":{port}"
-
-
-@lru_cache(maxsize=1024)  # a crawl resolves the same hosts over and over, and domain-to-ASCII is the pass's hot spot
-def _ascii_host(host: str) -> str:
-    """Convert a Unicode host to its ASCII (punycode) form the way the URL standard's host parser does (spec 3.5)."""
-    lowered = host.lower()
-    if lowered.isascii():
-        return lowered
-    try:
-        # UTS #46 ToASCII (Transitional_Processing=false) in C, the spec's domain-to-ASCII, not the IDNA-2003 idna codec
-        return _url_to_ascii(lowered)
-    except ValueError:  # a label carries a code point punycode cannot encode (an unpaired surrogate)
-        return lowered
-
-
-def _encode(text: str, url_set: int) -> str:
-    """Percent-encode a component's out-of-set characters in C, uppercasing existing escape hex (RFC 3986 6.2.2.1)."""
-    try:
-        return _url_percent_encode(text, url_set)
-    except UnicodeEncodeError as exc:
-        # the C encoder UTF-8-encodes the component; a lone surrogate has no encoding, so the URL is not serializable
-        msg = f"URL component {text!r} has a character that cannot be percent-encoded: {exc.reason}"
-        raise ValueError(msg) from exc
-
-
-def _normalize_query(query: str, options: UrlCleaning) -> str:
-    """Drop denied, tracker, or non-allowlisted parameters and sort the rest in C, keeping each pair's raw encoding."""
-    allow = {name.lower() for name in options.query_allow} if options.query_allow is not None else None
-    deny = {name.lower() for name in options.query_deny}
-    return _url_normalize_query(query, allow, deny, options.strict, _CONTENT_PARAMS, _LANGUAGE_PARAMS)
-
-
-def _normalize_fragment(fragment: str, options: UrlCleaning) -> str:
-    """Percent-encode the fragment, first scrubbing trackers from one shaped like a query string."""
-    if "=" in fragment:
-        if "&" in fragment:
-            return _normalize_query(fragment, options)
-        if _url_is_tracker(_url_percent_decode(fragment.partition("=")[0]).lower()):
-            return ""
-    return _encode(fragment, _SET_FRAGMENT)
-
-
-def _has_nofollow(rel: str | list[str] | None) -> bool:
-    """Whether a ``rel`` attribute value carries the ``nofollow`` token."""
-    tokens = rel.lower().split() if isinstance(rel, str) else [token.lower() for token in rel or []]
-    return "nofollow" in tokens
-
-
-def _hreflang_matches(hreflang: str | list[str] | None, language: str) -> bool:
-    """Whether an anchor's ``hreflang`` names the target language; a missing value or ``x-default`` always does."""
-    if not isinstance(hreflang, str) or not hreflang:
-        return True
-    code = hreflang.lower()
-    return code == "x-default" or code.partition("-")[0] == language
-
-
-def _site_of(url: str) -> str:
-    """
-    Return the registrable domain (eTLD+1) that defines a URL's ``external_only`` site, or ``""`` for no host.
-
-    The host is punycoded first so a Unicode ``base_url`` compares against the ASCII hosts :func:`clean_url` emits; the
-    eTLD+1 is then read in C from the shipped IANA and Public Suffix List tables (``www.example.com`` and
-    ``blog.example.com`` both collapse to ``example.com``, ``a.co.uk`` and ``b.co.uk`` stay distinct).
-    """
-    return _registrable_domain(_ascii_host(_split(url).hostname))
+def _knobs(
+    options: UrlCleaning,
+) -> tuple[bool, bool, bool, frozenset[str] | None, frozenset[str], frozenset[str], frozenset[str]]:
+    """Return the option fields and vocabularies every C entry point takes, in its argument order."""
+    return (
+        options.strict,
+        options.trailing_slash,
+        options.strip_fragment,
+        options.query_allow,
+        options.query_deny,
+        _CONTENT_PARAMS,
+        _LANGUAGE_PARAMS,
+    )

--- a/tests/extract/test_extract_urls_c_api.py
+++ b/tests/extract/test_extract_urls_c_api.py
@@ -1,0 +1,128 @@
+"""The URL cleaner's C entry points: the argument contract and the paths the public options do not reach."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+import pytest
+
+from turbohtml import parse
+from turbohtml._html import _url_clean, _url_normalize
+from turbohtml.extract import UrlCleaning, clean_url, extract_links, normalize_url
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_KNOBS: Final = (False, True, False, None, frozenset(), frozenset({"id"}), frozenset({"lang"}))
+
+
+@pytest.mark.parametrize(
+    ("entry", "args"),
+    [
+        pytest.param(_url_normalize, ("http://x.com", *_KNOBS[:-1]), id="normalize-too-few"),
+        pytest.param(_url_clean, ("http://x.com", *_KNOBS), id="clean-too-few"),
+        pytest.param(_url_normalize, ("http://x.com", *_KNOBS[:3], 5, *_KNOBS[4:]), id="allow-not-iterable"),
+        pytest.param(_url_normalize, ("http://x.com", *_KNOBS[:3], {1}, *_KNOBS[4:]), id="allow-holds-an-int"),
+        pytest.param(_url_normalize, ("http://x.com", *_KNOBS[:4], {1}, *_KNOBS[5:]), id="deny-holds-an-int"),
+        pytest.param(
+            _url_clean,
+            ("http://x.com", *_KNOBS[:3], {1}, *_KNOBS[4:], None, frozenset()),
+            id="clean-allow-holds-an-int",
+        ),
+    ],
+)
+def test_the_entry_points_reject_bad_arguments(entry: Callable[..., object], args: tuple[object, ...]) -> None:
+    with pytest.raises(TypeError):
+        entry(*args)
+
+
+def test_extract_links_rejects_a_parameter_name_that_is_not_a_str() -> None:
+    with pytest.raises(TypeError, match="query parameter names must be str"):
+        extract_links("", "https://a.com/", UrlCleaning(query_deny=frozenset({1})))  # ty: ignore[invalid-argument-type]
+
+
+def test_the_document_entry_point_rejects_too_few_arguments() -> None:
+    external_only = False
+    with pytest.raises(TypeError):
+        parse("")._extract_links(None, external_only)  # ty: ignore[missing-argument]  # the arity check is the point
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        pytest.param("http://x.com:443/", "http://x.com:443/", id="another-scheme-default-is-kept"),
+        pytest.param(
+            "http://x.com:99999999999999999999/", "http://x.com:99999999999999999999/", id="an-overflowing-port"
+        ),
+        pytest.param("http://x.com:0080/", "http://x.com/", id="leading-zeros-read-as-the-default"),
+        pytest.param("http://x.com:0081/", "http://x.com:81/", id="leading-zeros-fall-away"),
+        pytest.param("ftp://x.com", "ftp://x.com", id="a-non-web-scheme-keeps-its-empty-path"),
+        pytest.param("http:/x", "http:///x", id="a-netloc-scheme-without-an-authority-gets-the-marker"),
+        pytest.param("http:x", "http:x", id="a-netloc-scheme-with-a-relative-path-keeps-its-shape"),
+        pytest.param("http:", "http://", id="a-netloc-scheme-alone-gets-the-marker"),
+        pytest.param("mailto:x@y.com", "mailto:x@y.com", id="an-opaque-scheme"),
+        pytest.param("/a/b?utm_source=x#top", "/a/b#top", id="a-relative-reference"),
+        pytest.param("////x", "////x", id="an-empty-authority-before-a-double-slash-path"),
+    ],
+)
+def test_normalize_reassembles_every_shape(url: str, expected: str) -> None:
+    assert normalize_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        pytest.param("http://x.com//", "http://x.com", id="a-slash-run-is-trimmed-whole"),
+        pytest.param("http://x.com/", "http://x.com/", id="the-root-stays"),
+        pytest.param("http://x.com/a", "http://x.com/a", id="no-slash-to-trim"),
+    ],
+)
+def test_trailing_slash_off(url: str, expected: str) -> None:
+    assert normalize_url(url, UrlCleaning(trailing_slash=False)) == expected
+
+
+def test_a_fragment_key_with_a_lone_surrogate_cannot_be_encoded() -> None:
+    with pytest.raises(UnicodeEncodeError):
+        normalize_url("http://x.com/#\ud800=1")
+
+
+def test_clean_drops_a_fragment_key_with_a_lone_surrogate() -> None:
+    assert clean_url("http://x.com/#\ud800=1") is None
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        pytest.param('<a href=" https://test.com/a\t">x</a>', {"https://test.com/a"}, id="href-is-trimmed"),
+        pytest.param(
+            '<a href="https://test.com/a" rel="noopener">x</a>', {"https://test.com/a"}, id="an-eight-letter-rel"
+        ),
+        pytest.param(
+            '<a href="https://test.com/a" rel="\xa0nofollow\xa0\xfcgc ">x</a>', set(), id="unicode-spaced-nofollow"
+        ),
+        pytest.param('<a href="https://test.com/a" rel="ugc\tNOFOLLOW">x</a>', set(), id="tab-separated-nofollow"),
+        pytest.param('<a href="https://test.com/a" rel="ugc ">x</a>', {"https://test.com/a"}, id="rel-ends-in-a-space"),
+    ],
+)
+def test_anchor_attributes_are_read_the_way_html_defines_them(html: str, expected: set[str]) -> None:
+    assert extract_links(html, "https://test.com/") == expected
+
+
+def test_a_longer_hreflang_subtag_is_another_language() -> None:
+    html = '<a href="https://test.com/a" hreflang="deu">x</a>'
+    assert extract_links(html, "https://test.com/", UrlCleaning(language="de")) == set()
+
+
+def test_an_unsplittable_base_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid IPv6 URL"):
+        extract_links('<a href="https://a.example/">x</a>', "http://[::1", external_only=True)
+
+
+def test_a_base_element_that_cannot_resolve_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid IPv6 URL"):
+        extract_links('<base href="http://[::1"><a href="p">x</a>', "https://a.com/")
+
+
+def test_a_relative_href_against_an_unsplittable_base_element_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid IPv6 URL"):
+        extract_links('<base href="http://[::1"><a href="p">x</a>')

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -944,7 +944,7 @@ def escape_identifier(idents: tuple[str, ...]) -> None:
 
 
 def idna(urls: tuple[str, ...]) -> None:
-    """Overflow the 1,024-entry cache so each IDNA conversion runs."""
+    """Run the domain-to-ASCII conversion over a batch of distinct Unicode hosts."""
     for url in urls:
         _normalize_url(url)
 

--- a/tools/fuzz/_targets.py
+++ b/tools/fuzz/_targets.py
@@ -30,7 +30,7 @@ import turbohtml
 from turbohtml import clean
 
 # the harness targets the private URL/IDNA C bindings (th_url_split/join/percent, th_url_to_ascii) by design
-from turbohtml.extract._urls import (  # ruff:ignore[import-private-name]
+from turbohtml._html import (  # ruff:ignore[import-private-name]
     _url_join,
     _url_percent_decode,
     _url_percent_encode,


### PR DESCRIPTION
`turbohtml.extract` cleaned URLs in Python around a dozen C hooks: the split, the percent-encoders, the join, the query and language filters each ran in C, but the pipeline over them, which decides what a caller gets back, was a Python module of 400 lines. Rebuilding the authority with punycode and default-port removal, the dot-segment and trailing-slash rules, the fragment scrub, the `urlunsplit` reassembly, the web-scheme and host gate of `clean_url`, and the anchor walk, resolution, memoization and twin deduplication of `extract_links` all ran there. Under the project rule that the Python layer only configures, calls and wraps, they belong in the core. This is the seventh area of the series after #774, #775, #776, #777, #778 and #779, and the last one the audit listed.

🧭 A new `url/clean.c` unit holds the pipeline and three entry points: `_url_normalize`, `_url_clean` and `Document._extract_links`. The split, the encoders, the tracker test and the two filters in `url.c` gain object-level C signatures so the pipeline calls them without argument tuples; their Python bindings stay as the conformance surface of each primitive. The reassembly follows the current `urllib.parse.urlunsplit`, so a scheme with no authority and a relative path keeps its shape on each supported interpreter instead of depending on the `urllib` it ships. `extract_links` reads the anchors off the tree under the document's critical section in one pure walk and cleans the collected hrefs afterwards, so the walk never re-derives the structure across allocations. The per-process `lru_cache` over domain-to-ASCII goes away with the module. An ASCII host skips the conversion, and the IDNA benchmark measures the cache-miss path.

The results do not change. A query allow or deny entry that is not a `str` now raises `TypeError` naming the parameter instead of an `AttributeError` from `str.lower`. The shim keeps the `UrlCleaning` record, its validation, and the two vocabularies it hands to C.
