### PR TITLE
♻️ refactor(clean): compile the sanitizer's policy in C

### DIFF
--- a/docs/changelog/785.feature.rst
+++ b/docs/changelog/785.feature.rst
@@ -1,0 +1,2 @@
+Move the sanitizer's policy compilation into the C core: the ``rel`` value, the value allowlists, the style patterns and
+the transform rules a :class:`~turbohtml.clean.Sanitizer` indexes are built there. Results are unchanged.

--- a/src/turbohtml/_c/clean/sanitize.c
+++ b/src/turbohtml/_c/clean/sanitize.c
@@ -2114,6 +2114,243 @@ static int require_prefixes(PyObject *prefixes) {
    sanitized snapshot; sanitizer.py serializes it. A str is parsed into the private output tree; an Element is
    copied under its tree lock before callbacks run. `removed` is a list the walk appends (tag, attr_or_None) records to,
    or None to skip the audit. */
+/* A fresh dict holding a mapping's items, the dict(mapping) copy the walk indexes. */
+static PyObject *policy_dict(PyObject *mapping) {
+    return PyObject_CallOneArg((PyObject *)&PyDict_Type, mapping);
+}
+
+/* The rel value add_link_rel asks for: its tokens sorted and space-joined, or None when there are none. */
+static PyObject *policy_link_rel(PyObject *tokens) {
+    PyObject *sorted_tokens = PySequence_List(tokens);
+    if (sorted_tokens == NULL || PyList_Sort(sorted_tokens) < 0) {
+        Py_XDECREF(sorted_tokens);
+        return NULL;
+    }
+    if (PyList_GET_SIZE(sorted_tokens) == 0) {
+        Py_DECREF(sorted_tokens);
+        Py_RETURN_NONE;
+    }
+    PyObject *space = PyUnicode_FromString(" ");
+    if (space == NULL) {          /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(sorted_tokens); /* GCOVR_EXCL_LINE */
+        return NULL;              /* GCOVR_EXCL_LINE */
+    }
+    PyObject *joined = PyUnicode_Join(space, sorted_tokens);
+    Py_DECREF(space);
+    Py_DECREF(sorted_tokens);
+    return joined;
+}
+
+/* Rebuild a two-level mapping {tag: {name: value}} with `inner` applied to each leaf value. */
+static PyObject *policy_nested(PyObject *mapping, PyObject *(*inner)(PyObject *value, module_state *state),
+                               module_state *state) {
+    PyObject *items = PyMapping_Items(mapping);
+    if (items == NULL) {
+        return NULL;
+    }
+    PyObject *out = PyDict_New();
+    if (out == NULL) {    /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(items); /* GCOVR_EXCL_LINE */
+        return NULL;      /* GCOVR_EXCL_LINE */
+    }
+    for (Py_ssize_t index = 0; index < PyList_GET_SIZE(items); index++) {
+        PyObject *pair = PyList_GET_ITEM(items, index);
+        PyObject *leaves = PyMapping_Items(PyTuple_GET_ITEM(pair, 1));
+        PyObject *rebuilt = leaves == NULL ? NULL : PyDict_New();
+        int failed = rebuilt == NULL;
+        for (Py_ssize_t leaf = 0; !failed && leaf < PyList_GET_SIZE(leaves); leaf++) {
+            PyObject *entry = PyList_GET_ITEM(leaves, leaf);
+            PyObject *value = inner(PyTuple_GET_ITEM(entry, 1), state);
+            if (value == NULL) {
+                failed = 1;
+                break;
+            }
+            failed = PyDict_SetItem(rebuilt, PyTuple_GET_ITEM(entry, 0), value) < 0; /* GCOVR_EXCL_BR_LINE: alloc */
+            Py_DECREF(value);
+        }
+        if (!failed && PyDict_SetItem(out, PyTuple_GET_ITEM(pair, 0), rebuilt) < 0) { /* GCOVR_EXCL_BR_LINE: alloc */
+            failed = 1;                                                               /* GCOVR_EXCL_LINE */
+        } /* GCOVR_EXCL_LINE: llvm attributes the unexecuted fall-through to this brace */
+        Py_XDECREF(leaves);
+        Py_XDECREF(rebuilt);
+        if (failed) {
+            Py_DECREF(out);
+            Py_DECREF(items);
+            return NULL;
+        }
+    }
+    Py_DECREF(items);
+    return out;
+}
+
+static PyObject *policy_str_leaf(PyObject *value, module_state *Py_UNUSED(state)) {
+    return Py_NewRef(value);
+}
+
+static PyObject *policy_frozenset_leaf(PyObject *value, module_state *Py_UNUSED(state)) {
+    return PyFrozenSet_New(value);
+}
+
+/* The compiled patterns an allowed_styles property lists: a compiled pattern is kept as is, a str is compiled. The
+   tuple is built fresh rather than patched in place: a tuple handed back by the sequence conversion is not a fresh
+   allocation on every interpreter, and only a fresh one takes PyTuple_SET_ITEM. */
+static PyObject *policy_patterns_leaf(PyObject *value, module_state *state) {
+    PyObject *listed = PySequence_Tuple(value);
+    if (listed == NULL) {
+        return NULL;
+    }
+    Py_ssize_t count = PyTuple_GET_SIZE(listed);
+    PyObject *patterns = PyTuple_New(count);
+    if (patterns == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(listed);  /* GCOVR_EXCL_LINE */
+        return NULL;        /* GCOVR_EXCL_LINE */
+    }
+    for (Py_ssize_t index = 0; index < count; index++) {
+        PyObject *pattern = PyTuple_GET_ITEM(listed, index);
+        PyObject *compiled = PyObject_TypeCheck(pattern, (PyTypeObject *)state->pattern_type)
+                                 ? Py_NewRef(pattern)
+                                 : PyObject_CallOneArg(state->re_compile, pattern);
+        if (compiled == NULL) {
+            Py_DECREF(listed);
+            Py_DECREF(patterns);
+            return NULL;
+        }
+        PyTuple_SET_ITEM(patterns, index, compiled);
+    }
+    Py_DECREF(listed);
+    return patterns;
+}
+
+/* allowed_styles with each property name lowercased, the spelling the walk looks a declaration up by. */
+static PyObject *policy_styles(PyObject *mapping, module_state *state) {
+    PyObject *nested = policy_nested(mapping, policy_patterns_leaf, state);
+    if (nested == NULL) {
+        return NULL;
+    }
+    PyObject *out = PyDict_New();
+    if (out == NULL) {     /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(nested); /* GCOVR_EXCL_LINE */
+        return NULL;       /* GCOVR_EXCL_LINE */
+    }
+    Py_ssize_t position = 0;
+    PyObject *tag, *props;
+    int failed = 0;
+    while (!failed && PyDict_Next(nested, &position, &tag, &props)) {
+        PyObject *lowered = PyDict_New();
+        if (lowered == NULL) { /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+            failed = 1;        /* GCOVR_EXCL_LINE */
+            break;             /* GCOVR_EXCL_LINE */
+        }
+        Py_ssize_t inner = 0;
+        PyObject *prop, *patterns;
+        while (PyDict_Next(props, &inner, &prop, &patterns)) {
+            PyObject *name = PyObject_CallMethod(prop, "lower", NULL);
+            if (name == NULL) {
+                failed = 1; /* a property name that is not a str */
+                break;
+            }
+            failed = PyDict_SetItem(lowered, name, patterns) < 0; /* GCOVR_EXCL_BR_LINE: a str key only fails on OOM */
+            Py_DECREF(name);
+        }
+        if (!failed && PyDict_SetItem(out, tag, lowered) < 0) { /* GCOVR_EXCL_BR_LINE: allocation failure */
+            failed = 1;                                         /* GCOVR_EXCL_LINE */
+        } /* GCOVR_EXCL_LINE: llvm attributes the unexecuted fall-through to this brace */
+        Py_XDECREF(lowered);
+    }
+    Py_DECREF(nested);
+    if (failed) {
+        Py_DECREF(out);
+        return NULL;
+    }
+    return out;
+}
+
+/* transform_tags normalized to {source: (target_tag, added_attributes)}: a bare str renames, a Transform renames and
+   adds attributes, anything else is a TypeError and an empty target tag a ValueError. */
+static PyObject *policy_transforms(PyObject *mapping, PyObject *transform_type) {
+    PyObject *items = PyMapping_Items(mapping);
+    if (items == NULL) {
+        return NULL;
+    }
+    PyObject *out = PyDict_New();
+    if (out == NULL) {    /* GCOVR_EXCL_BR_LINE: allocation failure cannot be forced from a test */
+        Py_DECREF(items); /* GCOVR_EXCL_LINE */
+        return NULL;      /* GCOVR_EXCL_LINE */
+    }
+    for (Py_ssize_t index = 0; index < PyList_GET_SIZE(items); index++) {
+        PyObject *source = PyTuple_GET_ITEM(PyList_GET_ITEM(items, index), 0);
+        PyObject *target = PyTuple_GET_ITEM(PyList_GET_ITEM(items, index), 1);
+        PyObject *name;
+        PyObject *attributes;
+        if (PyUnicode_Check(target)) {
+            name = Py_NewRef(target);
+            attributes = PyDict_New();
+        } else if (PyObject_IsInstance(target, transform_type) == 1) {
+            name = PyObject_GetAttrString(target, "tag");
+            PyObject *added = name == NULL ? NULL : PyObject_GetAttrString(target, "attributes");
+            attributes = added == NULL ? NULL : policy_dict(added);
+            Py_XDECREF(added);
+        } else {
+            PyErr_Format(PyExc_TypeError, "transform_tags[%R] must be a str or Transform, got %s", source,
+                         Py_TYPE(target)->tp_name);
+            name = NULL;
+            attributes = NULL;
+        }
+        int failed = name == NULL || attributes == NULL; /* GCOVR_EXCL_BR_LINE: a Transform's fields always read */
+        if (!failed && (!PyUnicode_Check(name) || PyUnicode_GET_LENGTH(name) == 0)) {
+            PyErr_Format(PyExc_ValueError, "transform_tags[%R] target tag must be a non-empty string", source);
+            failed = 1;
+        }
+        PyObject *rule = failed ? NULL : PyTuple_Pack(2, name, attributes);
+        failed = rule == NULL || PyDict_SetItem(out, source, rule) < 0; /* GCOVR_EXCL_BR_LINE: allocation */
+        Py_XDECREF(rule);
+        Py_XDECREF(name);
+        Py_XDECREF(attributes);
+        if (failed) {
+            Py_DECREF(out);
+            Py_DECREF(items);
+            return NULL;
+        }
+    }
+    Py_DECREF(items);
+    return out;
+}
+
+/* _sanitize_policy(attributes, add_link_rel, set_attributes, attribute_values, allowed_styles, transform_tags,
+   transform_type) -> (attributes, link_rel, set_attributes, attribute_values, allowed_styles, transform_tags): the
+   forms of a Policy the walk indexes, compiled once per Sanitizer. */
+PyObject *turbohtml_sanitize_policy(PyObject *module, PyObject *args) {
+    PyObject *attributes, *add_link_rel, *set_attributes, *attribute_values, *allowed_styles, *transform_tags,
+        *transform_type;
+    if (!PyArg_ParseTuple(args, "OOOOOOO:_sanitize_policy", &attributes, &add_link_rel, &set_attributes,
+                          &attribute_values, &allowed_styles, &transform_tags, &transform_type)) {
+        return NULL;
+    }
+    module_state *state = PyModule_GetState(module);
+    PyObject *parts[6] = {policy_dict(attributes), NULL, NULL, NULL, NULL, NULL};
+    if (parts[0] != NULL) {
+        parts[1] = policy_link_rel(add_link_rel);
+    }
+    if (parts[1] != NULL) {
+        parts[2] = policy_nested(set_attributes, policy_str_leaf, state);
+    }
+    if (parts[2] != NULL) {
+        parts[3] = policy_nested(attribute_values, policy_frozenset_leaf, state);
+    }
+    if (parts[3] != NULL) {
+        parts[4] = policy_styles(allowed_styles, state);
+    }
+    if (parts[4] != NULL) {
+        parts[5] = policy_transforms(transform_tags, transform_type);
+    }
+    PyObject *compiled =
+        parts[5] == NULL ? NULL : PyTuple_Pack(6, parts[0], parts[1], parts[2], parts[3], parts[4], parts[5]);
+    for (size_t index = 0; index < 6; index++) {
+        Py_XDECREF(parts[index]);
+    }
+    return compiled;
+}
+
 /* The attribute filter a bleach predicate table compiles to: `predicates` is {tag: callable}, the tag's own entry
    winning and the "*" entry applying otherwise, so a wildcard callable never fails open. The predicate's truth
    keeps the value, anything else drops it. */

--- a/src/turbohtml/_c/core/common.h
+++ b/src/turbohtml/_c/core/common.h
@@ -207,6 +207,12 @@ int turbohtml_node_borrow(PyObject *module, PyObject *obj, struct th_tree **tree
 /* _bleach_attributes(attributes, mapping_type) translates bleach's flat, per-tag, or callable `attributes` into
    a Policy name allowlist and an optional attribute filter bound to the per-tag predicates (METH_VARARGS). */
 PyObject *turbohtml_bleach_attributes(PyObject *module, PyObject *args);
+
+/* _sanitize_policy(attributes, add_link_rel, set_attributes, attribute_values, allowed_styles, transform_tags,
+   transform_type) compiles a Policy's mappings into the forms _sanitize indexes: the rel value, the frozen value
+   sets, the lowercased style properties with their compiled patterns, and the normalized transform rules
+   (METH_VARARGS). */
+PyObject *turbohtml_sanitize_policy(PyObject *module, PyObject *args);
 PyObject *turbohtml_sanitize(PyObject *module, PyObject *args);
 
 /* Implemented in annotation.c, the inscriptis annotation output processors over

--- a/src/turbohtml/_c/core/module.c
+++ b/src/turbohtml/_c/core/module.c
@@ -274,6 +274,8 @@ static PyMethodDef html_methods[] = {
     {"_url_clean", turbohtml_url_clean, METH_VARARGS, NULL},
     {"_sanitize", turbohtml_sanitize, METH_VARARGS, NULL},
     {"_bleach_attributes", turbohtml_bleach_attributes, METH_VARARGS, NULL},
+
+    {"_sanitize_policy", turbohtml_sanitize_policy, METH_VARARGS, NULL},
     {"_grow_probe", turbohtml_grow_probe, METH_VARARGS, NULL},
     {"_schema_compile", turbohtml_schema_compile, METH_VARARGS, NULL},
     {"_schema_validate", turbohtml_schema_validate, METH_VARARGS, NULL},

--- a/src/turbohtml/_html.pyi
+++ b/src/turbohtml/_html.pyi
@@ -207,6 +207,9 @@ from ._stubs.features import (
     _sanitize as _sanitize,
 )
 from ._stubs.features import (
+    _sanitize_policy as _sanitize_policy,
+)
+from ._stubs.features import (
     _url_clean as _url_clean,
 )
 from ._stubs.features import (

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -3,7 +3,7 @@ import re
 from collections.abc import Callable, Iterable, Mapping
 from typing import TypeAlias
 
-from turbohtml.clean import LinkCandidate, PhoneNumber, PhoneType
+from turbohtml.clean import LinkCandidate, PhoneNumber, PhoneType, Transform
 from turbohtml.extract._feed import Entry, Feed
 from turbohtml.extract._structured_data import JSONValue, MicrodataItem, OpenGraph, RdfaItem, StructuredData
 
@@ -151,6 +151,23 @@ def _register_locations(location_type: type, span_type: type, /) -> None: ...
 def _bleach_attributes(
     attributes: object, mapping_type: type, /
 ) -> tuple[dict[str, frozenset[str]], Callable[[str, str, str], str | None] | None]: ...
+def _sanitize_policy(
+    attributes: Mapping[str, frozenset[str]],
+    add_link_rel: Iterable[str],
+    set_attributes: Mapping[str, Mapping[str, str]],
+    attribute_values: Mapping[str, Mapping[str, Iterable[str]]],
+    allowed_styles: Mapping[str, Mapping[str, Iterable[str | re.Pattern[str]]]],
+    transform_tags: Mapping[str, str | Transform],
+    transform_type: type[Transform],
+    /,
+) -> tuple[
+    dict[str, frozenset[str]],
+    str | None,
+    dict[str, dict[str, str]],
+    dict[str, dict[str, frozenset[str]]],
+    dict[str, dict[str, tuple[re.Pattern[str], ...]]],
+    dict[str, tuple[str, dict[str, str]]],
+]: ...
 def _sanitize(
     source: str | Element,
     tags: frozenset[str],

--- a/src/turbohtml/clean/_sanitizer.py
+++ b/src/turbohtml/clean/_sanitizer.py
@@ -14,16 +14,16 @@ This module is the policy facade only; the walk that keeps, escapes, strips, or 
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
 from enum import Enum
 from itertools import starmap
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Final
 
-from turbohtml._html import _sanitize
+from turbohtml._html import _sanitize, _sanitize_policy
 
 if TYPE_CHECKING:
+    import re
     from collections.abc import Callable, Mapping, Sequence
 
     from turbohtml._html import Element
@@ -282,36 +282,22 @@ class Sanitizer:
     def __init__(self, options: Policy | None = None) -> None:
         """Compile a policy into the form the C walk consumes."""
         self.policy = options if options is not None else Policy()
-        self._attributes = dict(self.policy.attributes)
-        self._link_rel = " ".join(sorted(self.policy.add_link_rel)) or None
-        self._set_attributes = {tag: dict(values) for tag, values in self.policy.set_attributes.items()}
-        self._attribute_values = {
-            tag: {attr: frozenset(values) for attr, values in attrs.items()}
-            for tag, attrs in self.policy.attribute_values.items()
-        }
-        self._allowed_styles = {
-            tag: {
-                prop.lower(): tuple(p if isinstance(p, re.Pattern) else re.compile(p) for p in patterns)
-                for prop, patterns in props.items()
-            }
-            for tag, props in self.policy.allowed_styles.items()
-        }
-        self._transform_tags = dict(starmap(self._compile_transform, self.policy.transform_tags.items()))
-
-    @staticmethod
-    def _compile_transform(source: str, target: Transform | str) -> tuple[str, tuple[str, dict[str, str]]]:
-        """Normalize one transform rule into ``(source, (target_tag, added_attributes))`` for the C walk."""
-        if isinstance(target, str):
-            name, attributes = target, {}
-        elif isinstance(target, Transform):
-            name, attributes = target.tag, dict(target.attributes)
-        else:
-            msg = f"transform_tags[{source!r}] must be a str or Transform, got {type(target).__name__}"
-            raise TypeError(msg)
-        if not name:
-            msg = f"transform_tags[{source!r}] target tag must be a non-empty string"
-            raise ValueError(msg)
-        return source, (name, attributes)
+        (
+            self._attributes,
+            self._link_rel,
+            self._set_attributes,
+            self._attribute_values,
+            self._allowed_styles,
+            self._transform_tags,
+        ) = _sanitize_policy(
+            self.policy.attributes,
+            self.policy.add_link_rel,
+            self.policy.set_attributes,
+            self.policy.attribute_values,
+            self.policy.allowed_styles,
+            self.policy.transform_tags,
+            Transform,
+        )
 
     def sanitize(self, html: str) -> str:
         """

--- a/tests/clean/test_sanitizer_policy_c_api.py
+++ b/tests/clean/test_sanitizer_policy_c_api.py
@@ -1,0 +1,170 @@
+"""The sanitizer's policy compiler in C: the rel value, the style patterns and the transform rules it produces."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from turbohtml._html import _sanitize_policy
+from turbohtml.clean import Policy, Sanitizer, Transform
+
+_EMPTY = ({}, frozenset(), {}, {}, {}, {}, Transform)
+
+
+_Compiled = tuple[
+    dict[str, frozenset[str]],
+    str | None,
+    dict[str, dict[str, str]],
+    dict[str, dict[str, frozenset[str]]],
+    dict[str, dict[str, tuple[re.Pattern[str], ...]]],
+    dict[str, tuple[str, dict[str, str]]],
+]
+
+
+def _compile(**fields: object) -> _Compiled:
+    """Compile a policy built from the given fields, returning the six compiled forms."""
+    policy = Policy(**fields)  # ty: ignore[invalid-argument-type]  # each test passes a valid field
+    return _sanitize_policy(
+        policy.attributes,
+        policy.add_link_rel,
+        policy.set_attributes,
+        policy.attribute_values,
+        policy.allowed_styles,
+        policy.transform_tags,
+        Transform,
+    )
+
+
+def test_the_rel_value_is_sorted_and_space_joined() -> None:
+    assert _compile(add_link_rel=frozenset({"noreferrer", "noopener"}))[1] == "noopener noreferrer"
+
+
+def test_no_rel_tokens_is_none() -> None:
+    assert _compile(add_link_rel=frozenset())[1] is None
+
+
+def test_the_attributes_are_copied_into_a_dict() -> None:
+    copied = _compile(attributes={"a": frozenset({"href"})})[0]
+    assert copied == {"a": frozenset({"href"})}
+    assert isinstance(copied, dict)
+
+
+def test_value_sets_are_frozen_per_attribute() -> None:
+    assert _compile(attribute_values={"a": {"rel": ["nofollow", "ugc"]}})[3] == {
+        "a": {"rel": frozenset({"nofollow", "ugc"})}
+    }
+
+
+def test_set_attributes_are_copied_per_tag() -> None:
+    assert _compile(set_attributes={"a": {"target": "_blank"}})[2] == {"a": {"target": "_blank"}}
+
+
+def test_style_properties_are_lowercased_and_patterns_compiled() -> None:
+    styles = _compile(allowed_styles={"*": {"Color": ["^red$"]}})[4]
+    assert list(styles["*"]) == ["color"]
+    (pattern,) = styles["*"]["color"]
+    assert pattern.pattern == "^red$"
+
+
+def test_a_precompiled_pattern_is_kept_as_it_is() -> None:
+    ready = re.compile(r"^blue$")
+    assert _compile(allowed_styles={"p": {"color": [ready]}})[4]["p"]["color"] == (ready,)
+
+
+def test_a_bad_pattern_raises_the_regex_error() -> None:
+    with pytest.raises(re.error):
+        _compile(allowed_styles={"p": {"color": ["("]}})
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        pytest.param("em", ("em", {}), id="a-bare-rename"),
+        pytest.param(Transform("div", {"class": "c"}), ("div", {"class": "c"}), id="a-transform-with-attributes"),
+    ],
+)
+def test_transform_rules_normalize(target: str | Transform, expected: tuple[str, dict[str, str]]) -> None:
+    assert _compile(transform_tags={"i": target})[5] == {"i": expected}
+
+
+def test_a_transform_target_must_be_a_str_or_transform() -> None:
+    with pytest.raises(TypeError, match="transform_tags\\['i'\\] must be a str or Transform, got int"):
+        Sanitizer(Policy(transform_tags={"i": 5}))  # ty: ignore[invalid-argument-type]  # the check is the point
+
+
+@pytest.mark.parametrize(
+    "target", [pytest.param("", id="empty-str"), pytest.param(Transform(""), id="empty-transform")]
+)
+def test_a_transform_target_tag_must_be_non_empty(target: str | Transform) -> None:
+    with pytest.raises(ValueError, match="target tag must be a non-empty string"):
+        Sanitizer(Policy(transform_tags={"i": target}))
+
+
+def test_the_compiler_rejects_a_non_mapping() -> None:
+    with pytest.raises(TypeError):
+        _sanitize_policy(5, *_EMPTY[1:])  # ty: ignore[invalid-argument-type]  # the argument check is the point
+
+
+def test_the_compiler_rejects_a_non_mapping_nest() -> None:
+    with pytest.raises(AttributeError, match="items"):
+        _sanitize_policy({}, frozenset(), {"a": 5}, {}, {}, {}, Transform)  # ty: ignore[invalid-argument-type]
+
+
+def test_the_compiler_rejects_a_non_mapping_table() -> None:
+    with pytest.raises(AttributeError, match="items"):
+        _sanitize_policy({}, frozenset(), 5, {}, {}, {}, Transform)  # ty: ignore[invalid-argument-type]
+
+
+def test_the_compiler_rejects_a_non_iterable_rel() -> None:
+    with pytest.raises(TypeError):
+        _sanitize_policy({}, 5, {}, {}, {}, {}, Transform)  # ty: ignore[invalid-argument-type]
+
+
+def test_rel_tokens_of_mixed_types_cannot_be_sorted() -> None:
+    with pytest.raises(TypeError):
+        _sanitize_policy({}, {"a", 1}, {}, {}, {}, {}, Transform)  # ty: ignore[invalid-argument-type]
+
+
+def test_a_style_pattern_list_must_be_iterable() -> None:
+    with pytest.raises(TypeError):
+        _compile(allowed_styles={"p": {"color": 5}})
+
+
+def test_a_style_property_must_be_a_str() -> None:
+    with pytest.raises(AttributeError, match="lower"):
+        _compile(allowed_styles={"p": {5: []}})
+
+
+def test_a_transform_table_must_be_a_mapping() -> None:
+    with pytest.raises(AttributeError, match="items"):
+        _sanitize_policy({}, frozenset(), {}, {}, {}, 5, Transform)  # ty: ignore[invalid-argument-type]
+
+
+class _TagOnly:
+    """A transform-like object carrying a tag but no attributes, the way a caller's own record might."""
+
+    tag = "em"
+
+
+class _Bare:
+    """A transform-like object carrying neither field."""
+
+
+@pytest.mark.parametrize(
+    ("target", "missing"),
+    [pytest.param(_TagOnly(), "attributes", id="no-attributes"), pytest.param(_Bare(), "tag", id="no-tag")],
+)
+def test_a_transform_type_must_carry_both_fields(target: object, missing: str) -> None:
+    with pytest.raises(AttributeError, match=missing):
+        _sanitize_policy({}, frozenset(), {}, {}, {}, {"i": target}, type(target))  # ty: ignore[invalid-argument-type]
+
+
+def test_a_transform_tag_that_is_not_a_str_is_rejected() -> None:
+    with pytest.raises(ValueError, match="target tag must be a non-empty string"):
+        Sanitizer(Policy(transform_tags={"i": Transform(5)}))  # ty: ignore[invalid-argument-type]
+
+
+def test_the_compiler_rejects_too_few_arguments() -> None:
+    with pytest.raises(TypeError):
+        _sanitize_policy({}, frozenset())  # ty: ignore[missing-argument]  # the arity check is the point


### PR DESCRIPTION
`turbohtml.clean.Sanitizer` ran its walk in C but compiled its `Policy` in Python first: the `rel` value was sorted and joined, the attribute value allowlists frozen, every `allowed_styles` property lowercased and its `str` patterns compiled with `re.compile`, and each `transform_tags` rule validated and reshaped. Each step decides what the walk keeps or emits, so under the project rule that the Python layer only configures, calls and wraps, they belong in the core. This continues the series after #774 to #784.

🧭 A `_sanitize_policy` entry point takes the policy's mappings and returns the six forms `_sanitize` indexes. Patterns compile through the module's own `re.compile` reference and a precompiled `re.Pattern` is kept as it is, so the matching itself is unchanged. `Sanitizer.__init__` is now one call and an unpack.

The results do not change. A transform target that is not a `str` or `Transform` still raises `TypeError` with the old message and an empty target tag still raises `ValueError`; a `Transform` whose tag is not a `str` now raises that same `ValueError` instead of reaching the walk.
