### PR TITLE
🐛 fix(extract): let a decoder error escape json_ld

### DIFF
--- a/docs/changelog/788.bugfix.rst
+++ b/docs/changelog/788.bugfix.rst
@@ -1,0 +1,3 @@
+A ``<script type="application/ld+json">`` block that the decoder cannot process for a reason other than malformed JSON,
+such as nesting past the interpreter's recursion budget, now raises from :meth:`~turbohtml.Document.json_ld` and
+:func:`~turbohtml.extract.dates` instead of being skipped.

--- a/src/turbohtml/_c/extract/structured_data.c
+++ b/src/turbohtml/_c/extract/structured_data.c
@@ -1558,8 +1558,12 @@ PyObject *turbohtml_document_json_ld(PyObject *self, PyObject *Py_UNUSED(ignored
     for (Py_ssize_t index = 0; index < PyList_GET_SIZE(texts); index++) {
         PyObject *value = PyObject_CallOneArg(decoder, PyList_GET_ITEM(texts, index));
         if (value == NULL) {
-            /* not JSON at all, which is a block to skip rather than an error to raise */
-            PyErr_Clear();
+            if (!PyErr_ExceptionMatches(PyExc_ValueError)) {
+                Py_DECREF(texts);  /* a decoder failure that is not malformed JSON, such as a nesting depth past */
+                Py_DECREF(parsed); /* the interpreter's recursion budget, reaches the caller */
+                return NULL;
+            }
+            PyErr_Clear(); /* not JSON at all, which is a block to skip rather than an error to raise */
             continue;
         }
         int carries = PyDict_Check(value) || PyList_Check(value);


### PR DESCRIPTION
`main` is red on one test since #778 and #779 merged next to each other: the JSON-LD walk from #778 clears every decoder error to skip a malformed block, so a block whose nesting exhausts the interpreter's recursion budget vanishes silently too, while the date stage's test from #779 expects that error to reach the caller.

🐛 Only a `ValueError`, the malformed-JSON case `json.loads` raises, is skipped now; anything else the decoder raises propagates from `Document.json_ld` and `turbohtml.extract.dates`. The existing deep-nesting test covers the propagating path and the existing malformed-block tests cover the skip.
