### PR TITLE
✨ feat(clean): sanitize an already parsed tree

### DIFF
--- a/docs/changelog/793.feature.rst
+++ b/docs/changelog/793.feature.rst
@@ -1,0 +1,3 @@
+Add :func:`~turbohtml.clean.sanitize_node` and :func:`~turbohtml.clean.sanitize_report_node`, the tree-to-tree sanitizer
+for a pipeline that parses once and serializes once; :func:`~turbohtml.clean.sanitize` and
+:func:`~turbohtml.clean.sanitize_report` also accept a parsed node.

--- a/docs/explanation/sanitizing.rst
+++ b/docs/explanation/sanitizing.rst
@@ -100,6 +100,11 @@ sanitizer keeps its parse-once-serialize-once shape: the tree the walk cleared i
 trip for a mutation-XSS vector to re-enter through. Every DOMPurify corpus vector, serialized this way, reparses through
 :func:`turbohtml.parse_xml` without error.
 
+**A tree in, a tree out.** The walk never needed a string: :func:`~turbohtml.clean.sanitize` parses one, and
+:func:`~turbohtml.clean.sanitize_node` takes a parsed node instead and returns the sanitized copy as a tree, in its own
+tree and with the source untouched. That is what lets sanitizing sit in a pipeline with linkifying and a minifying
+serialization without a parse and a serialization between each step.
+
 **Validated against DOMPurify.** ``tests/conformance/test_sanitizer_dompurify_conformance.py`` runs DOMPurify's own
 corpus (its ``test/fixtures/expect.mjs``, ~219 XSS vectors, vendored as a pinned submodule) through the sanitizer under
 every config, and diffs against a live DOMPurify Node build. The absolute result holds across the whole corpus and every

--- a/docs/how-to/sanitizing.rst
+++ b/docs/how-to/sanitizing.rst
@@ -220,3 +220,32 @@ in the order the walk reached it, so a policy can be tuned against evidence inst
 .. testoutput::
 
     [Removed(tag='p', attribute='onmouseover'), Removed(tag='b', attribute='onclick')]
+
+*********************************
+ Sanitize an already parsed tree
+*********************************
+
+When the HTML is already a tree -- because the same document goes through :func:`~turbohtml.clean.linkify`, a custom
+edit, or a minifying serialization afterwards -- :func:`turbohtml.clean.sanitize_node` sanitizes the node and returns
+the sanitized copy as a tree, the way DOMPurify's ``RETURN_DOM`` hands back a DOM instead of a string. The node passed
+in is the kept context, like the fragment root of :func:`~turbohtml.clean.sanitize`: the policy applies to its
+descendants and never to the node itself, so pass the ``body`` to clean what a page holds. The source is left as it was.
+
+.. testcode::
+
+    from turbohtml import Html, parse
+    from turbohtml.clean import Minify, Policy, sanitize_node
+
+    document = parse("<p onclick='x'>Hi <b>there</b></p><script>evil()</script>")
+    body = document.find("body")
+    clean = sanitize_node(body, Policy.relaxed())
+    print(clean.serialize(Html(layout=Minify())))
+
+.. testoutput::
+
+    <body><p>Hi <b>there</b></p>&lt;script&gt;evil()&lt;/script&gt;</body>
+
+Passing a :class:`~turbohtml.Document` makes the policy judge the ``html`` element itself, so a policy meant for whole
+documents lists ``html``, ``head`` and ``body``; a ``bleach``-style fragment allowlist would strip them.
+:func:`~turbohtml.clean.sanitize_report_node` pairs the copy with the :class:`~turbohtml.clean.Removed` records, and the
+string forms accept a node as well when a string is wanted at the end.

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -18,10 +18,18 @@ element or stripped attribute, the way DOMPurify populates ``DOMPurify.removed``
 
 .. autofunction:: sanitize_report
 
+:func:`sanitize_node` and :func:`sanitize_report_node` take an already parsed node and hand back the sanitized copy as a
+tree, so a pipeline of transforms parses once and serializes once; :func:`sanitize` and :func:`sanitize_report` accept a
+node too when a string is wanted at the end.
+
+.. autofunction:: sanitize_node
+
+.. autofunction:: sanitize_report_node
+
 .. autoclass:: Removed
 
 .. autoclass:: Sanitizer
-    :members: sanitize, sanitize_report
+    :members: sanitize, sanitize_report, sanitize_node, sanitize_report_node
 
 .. autoclass:: Policy
     :members: strict, basic, relaxed

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -7,7 +7,7 @@ from turbohtml.clean import LinkCandidate, PhoneNumber, PhoneType, Transform
 from turbohtml.extract._feed import Entry, Feed
 from turbohtml.extract._structured_data import JSONValue, MicrodataItem, OpenGraph, RdfaItem, StructuredData
 
-from .dom import Element
+from .dom import Element, Node
 
 # (start, end, kind, href, phone): the scanner builds the href for every kind and sets the phone for kind 4
 _Span: TypeAlias = tuple[int, int, int, str, PhoneNumber | None, bool]
@@ -169,7 +169,7 @@ def _sanitize_policy(
     dict[str, tuple[str, dict[str, str]]],
 ]: ...
 def _sanitize(
-    source: str | Element,
+    source: str | Node,
     tags: frozenset[str],
     attributes: Mapping[str, frozenset[str]],
     url_schemes: frozenset[str],
@@ -196,6 +196,6 @@ def _sanitize(
     allow_svg: bool,
     allow_mathml: bool,
     /,
-) -> Element: ...
+) -> Node: ...
 def annotation_surface(text: str, spans: Iterable[tuple[int, int, str]], /) -> dict[str, list[str]]: ...
 def annotation_tags(text: str, spans: Iterable[tuple[int, int, str]], /) -> str: ...

--- a/src/turbohtml/clean/__init__.py
+++ b/src/turbohtml/clean/__init__.py
@@ -44,7 +44,9 @@ from ._sanitizer import (
     Sanitizer,
     Transform,
     sanitize,
+    sanitize_node,
     sanitize_report,
+    sanitize_report_node,
 )
 
 __all__ = [
@@ -80,6 +82,8 @@ __all__ = [
     "minify_js",
     "nofollow",
     "sanitize",
+    "sanitize_node",
     "sanitize_report",
+    "sanitize_report_node",
     "target_blank",
 ]

--- a/src/turbohtml/clean/_sanitizer.py
+++ b/src/turbohtml/clean/_sanitizer.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     import re
     from collections.abc import Callable, Mapping, Sequence
 
-    from turbohtml._html import Element
+    from turbohtml._html import Node
 
 
 @dataclass(frozen=True, slots=True)
@@ -299,11 +299,12 @@ class Sanitizer:
             Transform,
         )
 
-    def sanitize(self, html: str) -> str:
+    def sanitize(self, html: str | Node) -> str:
         """
         Sanitize an HTML fragment.
 
-        :param html: the untrusted HTML fragment.
+        :param html: the untrusted HTML fragment, or an already parsed node whose subtree to sanitize (see
+            :meth:`sanitize_node`), which skips the parse.
         :returns: the sanitized, safe HTML.
         :raises TypeError: if a set-typed policy field (``tags``, ``url_schemes``, ``remove_with_content``,
             ``css_properties``, ``attribute_prefixes``, ``media_hosts``) holds a value that is not a set or frozenset,
@@ -312,7 +313,7 @@ class Sanitizer:
         """
         return self._render(self._filter(html, None))
 
-    def sanitize_report(self, html: str) -> tuple[str, list[Removed]]:
+    def sanitize_report(self, html: str | Node) -> tuple[str, list[Removed]]:
         """
         Sanitize a fragment and report what the policy dropped, the way DOMPurify populates ``DOMPurify.removed``.
 
@@ -320,7 +321,7 @@ class Sanitizer:
         :class:`Removed` record, in the order the walk reached it, so a caller can log or tune a policy against
         evidence instead of guessing.
 
-        :param html: the untrusted HTML fragment.
+        :param html: the untrusted HTML fragment, or an already parsed node (see :meth:`sanitize_node`).
         :returns: the sanitized HTML paired with the list of dropped items.
         :raises TypeError: like :meth:`sanitize`, on a mistyped set-valued policy field.
         :raises ValueError: like :meth:`sanitize`, on an empty ``attribute_prefixes`` entry.
@@ -329,12 +330,46 @@ class Sanitizer:
         html_out = self._render(self._filter(html, removed))
         return html_out, list(starmap(Removed, removed))
 
-    def _render(self, root: Element) -> str:
+    def sanitize_node(self, node: Node) -> Node:
+        """
+        Sanitize an already parsed subtree and return the sanitized copy as a tree.
+
+        This is the tree-to-tree form for a pipeline that parses once, runs several transforms, and serializes once,
+        the way DOMPurify's ``RETURN_DOM`` hands back a DOM instead of a string. The node itself is the kept context,
+        like the fragment root of :meth:`sanitize`: the policy applies to its descendants, never to the node. So pass
+        the ``body`` of a document to clean what it holds, or a ``Document`` to have the policy judge the ``html``
+        element itself (a ``bleach``-style allowlist then needs ``html``, ``head`` and ``body`` listed). The copy lives
+        in its own tree and inherits the source's XML flag; the source is left untouched.
+
+        :param node: the element or document whose subtree to sanitize.
+        :returns: a new node of the same kind holding the sanitized subtree.
+        :raises TypeError: if ``node`` is not a node, or on a mistyped set-valued policy field.
+        :raises ValueError: like :meth:`sanitize`, on an empty ``attribute_prefixes`` entry.
+        """
+        return self._filter(_node_only(node), None)
+
+    def sanitize_report_node(self, node: Node) -> tuple[Node, list[Removed]]:
+        """
+        Sanitize an already parsed subtree and report what the policy dropped.
+
+        :meth:`sanitize_node` and :meth:`sanitize_report` combined: the copy comes back as a tree, the drops as
+        records.
+
+        :param node: the element or document whose subtree to sanitize.
+        :returns: the sanitized copy paired with one :class:`Removed` record per dropped element or attribute.
+        :raises TypeError: if ``node`` is not a node, or on a mistyped set-valued policy field.
+        :raises ValueError: like :meth:`sanitize`, on an empty ``attribute_prefixes`` entry.
+        """
+        removed: list[tuple[str, str | None]] = []
+        copy = self._filter(_node_only(node), removed)
+        return copy, list(starmap(Removed, removed))
+
+    def _render(self, root: Node) -> str:
         """Serialize the sanitized root's children as XML when the policy asks, else as HTML."""
         return root.inner_xml if self.policy.xml else root.inner_html
 
-    def _filter(self, html: str, removed: list[tuple[str, str | None]] | None) -> Element:
-        """Run the C walk over a freshly parsed fragment, appending drops to ``removed`` when it is not None."""
+    def _filter(self, html: str | Node, removed: list[tuple[str, str | None]] | None) -> Node:
+        """Run the C walk over a freshly parsed fragment or a copy of a node, appending drops to ``removed``."""
         policy = self.policy
         return _sanitize(
             html,
@@ -366,11 +401,20 @@ class Sanitizer:
         )
 
 
-def sanitize(html: str, options: Policy | None = None) -> str:
+def _node_only(node: Node) -> Node:
+    """Reject a str where a parsed node is required, so a caller who meant the string form gets told which one."""
+    if isinstance(node, str):
+        msg = "sanitize_node takes a parsed node; pass a str to sanitize instead"
+        raise TypeError(msg)
+    return node
+
+
+def sanitize(html: str | Node, options: Policy | None = None) -> str:
     """
     Sanitize an HTML fragment against a policy.
 
-    :param html: the untrusted HTML fragment.
+    :param html: the untrusted HTML fragment, or an already parsed node whose subtree to sanitize (see
+        :func:`sanitize_node`), which skips the parse.
     :param options: the policy to enforce; None uses bleach's default allowlist.
     :returns: the sanitized, safe HTML.
     :raises TypeError: if a set-typed policy field (``tags``, ``url_schemes``, ``remove_with_content``,
@@ -381,17 +425,46 @@ def sanitize(html: str, options: Policy | None = None) -> str:
     return Sanitizer(options).sanitize(html)
 
 
-def sanitize_report(html: str, options: Policy | None = None) -> tuple[str, list[Removed]]:
+def sanitize_report(html: str | Node, options: Policy | None = None) -> tuple[str, list[Removed]]:
     """
     Sanitize a fragment and report what the policy dropped, like DOMPurify's ``DOMPurify.removed``.
 
-    :param html: the untrusted HTML fragment.
+    :param html: the untrusted HTML fragment, or an already parsed node (see :func:`sanitize_node`).
     :param options: the policy to enforce; None uses bleach's default allowlist.
     :returns: the sanitized HTML paired with one :class:`Removed` record per dropped element or attribute.
     :raises TypeError: like :func:`sanitize`, on a mistyped set-valued policy field.
     :raises ValueError: like :func:`sanitize`, on an empty ``attribute_prefixes`` entry.
     """
     return Sanitizer(options).sanitize_report(html)
+
+
+def sanitize_node(node: Node, options: Policy | None = None) -> Node:
+    """
+    Sanitize an already parsed subtree against a policy and return the sanitized copy as a tree.
+
+    The tree-to-tree form for a pipeline that parses once and serializes once; see
+    :meth:`Sanitizer.sanitize_node` for what the node means and what comes back.
+
+    :param node: the element or document whose subtree to sanitize.
+    :param options: the policy to enforce; None uses bleach's default allowlist.
+    :returns: a new node of the same kind holding the sanitized subtree.
+    :raises TypeError: if ``node`` is not a node, or on a mistyped set-valued policy field.
+    :raises ValueError: like :func:`sanitize`, on an empty ``attribute_prefixes`` entry.
+    """
+    return Sanitizer(options).sanitize_node(node)
+
+
+def sanitize_report_node(node: Node, options: Policy | None = None) -> tuple[Node, list[Removed]]:
+    """
+    Sanitize an already parsed subtree and report what the policy dropped.
+
+    :param node: the element or document whose subtree to sanitize.
+    :param options: the policy to enforce; None uses bleach's default allowlist.
+    :returns: the sanitized copy paired with one :class:`Removed` record per dropped element or attribute.
+    :raises TypeError: if ``node`` is not a node, or on a mistyped set-valued policy field.
+    :raises ValueError: like :func:`sanitize`, on an empty ``attribute_prefixes`` entry.
+    """
+    return Sanitizer(options).sanitize_report_node(node)
 
 
 __all__ = [
@@ -405,5 +478,7 @@ __all__ = [
     "Sanitizer",
     "Transform",
     "sanitize",
+    "sanitize_node",
     "sanitize_report",
+    "sanitize_report_node",
 ]

--- a/tests/clean/test_sanitizer_nodes.py
+++ b/tests/clean/test_sanitizer_nodes.py
@@ -1,0 +1,92 @@
+"""sanitize_node and friends: sanitizing an already parsed tree and getting a tree back."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Document, Element, parse, parse_fragment, parse_xml
+from turbohtml.clean import (
+    OnDisallowed,
+    Policy,
+    Removed,
+    Sanitizer,
+    sanitize,
+    sanitize_node,
+    sanitize_report,
+    sanitize_report_node,
+)
+
+_POST = "<p onclick='x'>Hi <b>there</b> <script>evil()</script></p>"
+
+
+def test_node_form_returns_a_sanitized_copy_of_the_same_kind() -> None:
+    root = parse_fragment(_POST)
+    clean = sanitize_node(root, Policy.relaxed())
+    assert isinstance(clean, Element)
+    assert clean.inner_html == sanitize(_POST, Policy.relaxed())
+
+
+def test_the_source_is_left_untouched() -> None:
+    root = parse_fragment(_POST)
+    before = root.inner_html
+    sanitize_node(root, Policy.relaxed())
+    assert root.inner_html == before
+
+
+def test_the_node_itself_is_the_kept_context() -> None:
+    # the policy never judges the node passed in, only its descendants, like the fragment root of the string form
+    script = parse_fragment("<script>evil()</script>").select_one("script")
+    assert script is not None
+    clean = sanitize_node(script, Policy.relaxed())
+    assert isinstance(clean, Element)
+    assert clean.tag == "script"
+
+
+def test_a_document_has_its_html_element_judged() -> None:
+    document = parse("<p onclick='x'>hi</p>")
+    clean = sanitize_node(document, Policy(tags=frozenset({"html", "head", "body", "p"})))
+    assert isinstance(clean, Document)
+    assert clean.serialize() == "<html><head></head><body><p>hi</p></body></html>"
+
+
+def test_a_document_under_a_fragment_policy_loses_its_shell() -> None:
+    clean = sanitize_node(parse("<p>hi</p>"), Policy(tags=frozenset({"p"}), on_disallowed_tag=OnDisallowed.STRIP))
+    assert clean.serialize() == "<p>hi</p>"
+
+
+def test_the_copy_inherits_the_xml_flag() -> None:
+    root = parse_xml("<r><b/><script>x</script></r>").root
+    assert root is not None
+    clean = sanitize_node(root, Policy(tags=frozenset({"b"}), on_disallowed_tag=OnDisallowed.STRIP))
+    assert clean.inner_xml == "<b/>x"
+
+
+def test_the_string_forms_accept_a_node() -> None:
+    root = parse_fragment(_POST)
+    assert sanitize(root, Policy.relaxed()) == sanitize(_POST, Policy.relaxed())
+    assert sanitize_report(root, Policy.relaxed()) == sanitize_report(_POST, Policy.relaxed())
+
+
+def test_the_report_form_pairs_the_copy_with_the_drops() -> None:
+    clean, removed = sanitize_report_node(parse_fragment(_POST), Policy.relaxed())
+    assert clean.inner_html == "<p>Hi <b>there</b> &lt;script&gt;evil()&lt;/script&gt;</p>"
+    assert removed == [Removed(tag="p", attribute="onclick"), Removed(tag="script", attribute=None)]
+
+
+def test_a_reusable_sanitizer_offers_both_node_forms() -> None:
+    sanitizer = Sanitizer(Policy.relaxed())
+    root = parse_fragment(_POST)
+    assert sanitizer.sanitize_node(root).inner_html == sanitizer.sanitize(_POST)
+    assert sanitizer.sanitize_report_node(root)[1] == sanitizer.sanitize_report(_POST)[1]
+
+
+@pytest.mark.parametrize("entry", [sanitize_node, sanitize_report_node], ids=["sanitize_node", "sanitize_report_node"])
+def test_the_node_forms_refuse_a_str(entry: object) -> None:
+    with pytest.raises(TypeError, match="pass a str to sanitize instead"):
+        entry(_POST)  # ty: ignore[call-non-callable]  # the argument check is the point
+
+
+@pytest.mark.parametrize("entry", [sanitize, sanitize_node], ids=["sanitize", "sanitize_node"])
+def test_a_foreign_object_is_rejected(entry: object) -> None:
+    with pytest.raises(TypeError):
+        entry(42)  # ty: ignore[call-non-callable]  # the argument check is the point

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Final
 from bench import corpus
 from bench.core import OPERATIONS
 from bench.operations import INPUTS
+from turbohtml import parse
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
@@ -138,6 +139,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "sanitize-custom-elements": ("sanitize-custom-elements-spec", _spec),
     "sanitize-xml": ("sanitize-xml-spec", _spec),
     "linkify": ("linkify-spec", _spec),
+    "sanitize-node": ("sanitize-node-spec", lambda: parse(_spec()).find("body")),
     "markdown-google": ("markdown-google-parse-spec", _spec),
     "article": ("article-parse-spec", _spec),
     "boilerplate": ("boilerplate-spec", _spec),

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -50,6 +50,8 @@ from turbohtml.validate import XMLSchema as _XMLSchema
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from turbohtml import Node
+
 _SANITIZER = _clean.Sanitizer(_clean.Policy.relaxed())
 _SANITIZER_TEMPLATES = _clean.Sanitizer(replace(_clean.Policy.relaxed(), strip_template_markers=True))
 _SANITIZER_STYLES = _clean.Sanitizer(
@@ -493,6 +495,11 @@ def sanitize_named_props(text: str) -> None:
 def sanitize_report(text: str) -> None:
     """Sanitize with the audit trail on, exercising the removed-node collection."""
     _SANITIZER.sanitize_report(text)
+
+
+def sanitize_node(node: Node) -> None:
+    """Sanitize an already parsed subtree with the relaxed policy, the parse-once pipeline's step."""
+    _SANITIZER.sanitize_node(node)
 
 
 def sanitize_styles(text: str) -> None:
@@ -1037,6 +1044,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "sanitize-templates": (sanitize_templates, "turbohtml"),
     "sanitize-named-props": (sanitize_named_props, "turbohtml"),
     "sanitize-report": (sanitize_report, "turbohtml"),
+    "sanitize-node": (sanitize_node, "turbohtml"),
     "sanitize-styles": (sanitize_styles, "turbohtml"),
     "sanitize-transform": (sanitize_transform, "turbohtml"),
     "sanitize-custom-elements": (sanitize_custom_elements, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -16,6 +16,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Final
 
 from bench import corpus
+from turbohtml import parse_fragment
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -326,6 +327,7 @@ OPERATIONS: dict[str, Operation] = {
     "sanitize-templates": Operation("sanitize (template-safe)", "us"),
     "sanitize-named-props": Operation("sanitize (named-prop isolation)", "us"),
     "sanitize-report": Operation("sanitize with audit trail", "us"),
+    "sanitize-node": Operation("sanitize a parsed tree", "us"),
     "sanitize-styles": Operation("sanitize (style allowlist)", "us"),
     "sanitize-transform": Operation("sanitize (tag transform)", "us"),
     "sanitize-custom-elements": Operation("sanitize (custom elements)", "us"),
@@ -1025,6 +1027,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
     "sanitize-templates": lambda: (("templated 4 KiB", _SANITIZE_TEMPLATES * 20),),
     "sanitize-named-props": lambda: (("clobbering 4 KiB", _SANITIZE_NAMED * 11),),
     "sanitize-report": lambda: (("post 4 KiB", _SANITIZE_POST * 20),),
+    "sanitize-node": lambda: (("post 4 KiB", parse_fragment(_SANITIZE_POST * 20)),),
     "sanitize-styles": lambda: (("styled 4 KiB", _SANITIZE_STYLES * 20),),
     "sanitize-transform": lambda: (("legacy 4 KiB", _SANITIZE_LEGACY * 13),),
     "sanitize-custom-elements": lambda: (("custom 4 KiB", _SANITIZE_CUSTOM * 11),),


### PR DESCRIPTION
Chaining `sanitize` with `linkify` or a minifying serialization parsed and serialized the document at every step, the round trips #791 describes, because the sanitizer's public entry points took only a string although the C walk already accepted a node and copied it into its private tree. This is the first of three PRs from that issue: sanitize on a tree, linkify on a tree, then the pipeline how-to and `minify` on a tree.

🌳 `sanitize_node` and `sanitize_report_node` take a parsed node and return the sanitized copy as a tree, the way DOMPurify's `RETURN_DOM` hands back a DOM instead of a string. The node passed in is the kept context, as the fragment root is for the string form: the policy judges its descendants and never the node itself, so passing a `body` sanitizes what a page holds, and passing a `Document` has the `html` element judged (a `bleach`-style allowlist then needs `html`, `head` and `body` listed). The copy lives in its own tree, inherits the source's XML flag, and leaves the source untouched. `sanitize`, `sanitize_report` and the `Sanitizer` methods accept a node too, for a caller who wants a string at the end without the reparse.

No C changes: the facade only widens what it forwards. A `sanitize-node` benchmark gates the tree form over the same spec corpus as `sanitize`, the reference and explanation pages describe the tree form, and the sanitizing how-to gains a section showing a parse-once chain into a minifying serialization.
