### PR TITLE
✨ feat(clean): linkify an already parsed tree

### DIFF
--- a/docs/changelog/794.feature.rst
+++ b/docs/changelog/794.feature.rst
@@ -1,0 +1,2 @@
+Add :func:`~turbohtml.clean.linkify_node`, which links URLs, email addresses and phone numbers in an already parsed tree
+in place; :func:`~turbohtml.clean.linkify` also accepts a parsed node.

--- a/docs/how-to/links.rst
+++ b/docs/how-to/links.rst
@@ -112,6 +112,31 @@ The native walk collects target references in document order. It copies each tar
 lock, releases the lock, then invokes Python. One :class:`~turbohtml.clean.Linker` can serve concurrent calls; candidate
 mutations remain local to each call.
 
+*****************************
+ Link an already parsed tree
+*****************************
+
+When the HTML is already a tree -- sanitized on the tree, edited, or about to be serialized with a minifying layout --
+:func:`turbohtml.clean.linkify_node` links its text runs in place and returns the node, so a pipeline parses once and
+serializes once. The walk is the one :func:`~turbohtml.clean.linkify` runs after parsing, so an existing ``<a>``, a
+raw-text element and ``Linkify.skip_tags`` are skipped the same way.
+
+.. testcode::
+
+    from turbohtml import Html, parse
+    from turbohtml.clean import Minify, linkify_node
+
+    document = parse("<p>See https://example.com for details.</p>")
+    body = document.find("body")
+    linkify_node(body)
+    print(body.serialize(Html(layout=Minify())))
+
+.. testoutput::
+
+    <body><p>See <a href=https://example.com rel=nofollow>https://example.com</a> for details.</body>
+
+The string form accepts a node as well; it links a copy and hands back the HTML, leaving the node as it was.
+
 **************************
  Find links in plain text
 **************************

--- a/docs/reference/clean.rst
+++ b/docs/reference/clean.rst
@@ -200,11 +200,16 @@ to the built-in ``http``/``https``/``ftp`` set, so a typo scheme or a ``javascri
 
 .. autofunction:: linkify
 
+:func:`linkify_node` takes an already parsed node and links its text runs in place, so a pipeline of transforms parses
+once and serializes once; :func:`linkify` accepts a node too when a string is wanted at the end.
+
+.. autofunction:: linkify_node
+
 .. autoclass:: Linkify
     :members:
 
 .. autoclass:: Linker
-    :members: linkify
+    :members: linkify, linkify_node
 
 .. autoclass:: LinkCandidate
 

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -7,7 +7,7 @@ from turbohtml.clean import LinkCandidate, PhoneNumber, PhoneType, Transform
 from turbohtml.extract._feed import Entry, Feed
 from turbohtml.extract._structured_data import JSONValue, MicrodataItem, OpenGraph, RdfaItem, StructuredData
 
-from .dom import Element, Node
+from .dom import Node
 
 # (start, end, kind, href, phone): the scanner builds the href for every kind and sets the phone for kind 4
 _Span: TypeAlias = tuple[int, int, int, str, PhoneNumber | None, bool]

--- a/src/turbohtml/_stubs/features.pyi
+++ b/src/turbohtml/_stubs/features.pyi
@@ -61,7 +61,7 @@ def _linkify_has(
     /,
 ) -> bool: ...
 def _linkify_apply(
-    root: Element,
+    root: Node,
     callbacks: tuple[Callable[..., object], ...],
     parse_email: bool,
     extra_tlds: tuple[str, ...],

--- a/src/turbohtml/clean/__init__.py
+++ b/src/turbohtml/clean/__init__.py
@@ -30,6 +30,7 @@ from ._linkify import (
     PhoneNumbers,
     PhoneType,
     linkify,
+    linkify_node,
     nofollow,
     target_blank,
 )
@@ -76,6 +77,7 @@ __all__ = [
     "Sanitizer",
     "Transform",
     "linkify",
+    "linkify_node",
     "minify",
     "minify_css",
     "minify_css_inline",

--- a/src/turbohtml/clean/_linkify.py
+++ b/src/turbohtml/clean/_linkify.py
@@ -9,6 +9,7 @@ an existing ``<a>``, a raw-text element (``<script>``/``<style>``), or a caller'
 
 from __future__ import annotations
 
+import copy
 import functools
 from collections.abc import Mapping
 from collections.abc import Set as AbstractSet
@@ -37,7 +38,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    from turbohtml._html import _PhoneConfig
+    from turbohtml._html import Node, _PhoneConfig
 
 # The ``scheme://host`` schemes autolinked when a config registers none: the fixed set linkify-it recognizes, so a typo
 # scheme or a ``javascript://`` payload stays plain text. A ``Linkify.schemes`` restricts to its own set (bleach), while
@@ -528,16 +529,35 @@ class Linker:
         self.phones = config.phones
         self._phone_config = _compile_phones(config.phones)
 
-    def linkify(self, text: str) -> str:
+    def linkify(self, text: str | Node) -> str:
         """
         Linkify HTML, leaving everything but eligible text runs untouched.
 
-        :param text: the HTML to linkify.
+        :param text: the HTML to linkify, or an already parsed node (see :meth:`linkify_node`), which skips the parse
+            and links a copy so the node is left as it was.
         :returns: the linkified HTML.
         """
-        root = parse_fragment(text)
+        root = parse_fragment(text) if isinstance(text, str) else copy.deepcopy(text)
+        return self.linkify_node(root).inner_html
+
+    def linkify_node(self, node: Node) -> Node:
+        """
+        Linkify an already parsed subtree in place and return the node, so it chains.
+
+        This is the tree form for a pipeline that parses once, runs several transforms, and serializes once. The
+        walk is the one :meth:`linkify` runs after parsing: it links only in text the reader sees, never inside an
+        existing ``<a>``, a raw-text element, or a tag in ``Linkify.skip_tags``, and it rewrites the tree under the
+        document's lock on the free-threaded build.
+
+        :param node: the element or document whose text runs to link.
+        :returns: the same node, now holding the links.
+        :raises TypeError: if ``node`` is not a node.
+        """
+        if isinstance(node, str):
+            msg = "linkify_node takes a parsed node; pass a str to linkify instead"
+            raise TypeError(msg)
         _linkify_apply(
-            root,
+            node,
             self.callbacks,
             self.parse_email,
             self.extra_tlds,
@@ -547,20 +567,35 @@ class Linker:
             LinkCandidate,
             self._phone_config,
         )
-        return root.inner_html
+        return node
 
 
-def linkify(text: str, options: Linkify | None = None) -> str:
+def linkify(text: str | Node, options: Linkify | None = None) -> str:
     """
     Find URLs, email addresses and phone numbers in HTML and wrap them in ``<a>`` links.
 
     Existing markup is left untouched.
 
-    :param text: the HTML to linkify.
+    :param text: the HTML to linkify, or an already parsed node (see :func:`linkify_node`), which skips the parse and
+        links a copy so the node is left as it was.
     :param options: the configuration to apply; None uses ``DEFAULT_CALLBACKS`` and detects nothing else.
     :returns: the linkified HTML.
     """
     return Linker(options).linkify(text)
+
+
+def linkify_node(node: Node, options: Linkify | None = None) -> Node:
+    """
+    Find URLs, email addresses and phone numbers in an already parsed subtree and wrap them in ``<a>`` links, in place.
+
+    The tree form for a pipeline that parses once and serializes once; see :meth:`Linker.linkify_node`.
+
+    :param node: the element or document whose text runs to link.
+    :param options: the configuration to apply; None uses ``DEFAULT_CALLBACKS`` and detects nothing else.
+    :returns: the same node, now holding the links.
+    :raises TypeError: if ``node`` is not a node.
+    """
+    return Linker(options).linkify_node(node)
 
 
 class LinkSpan:
@@ -732,6 +767,7 @@ __all__ = [
     "PhoneNumbers",
     "PhoneType",
     "linkify",
+    "linkify_node",
     "nofollow",
     "target_blank",
 ]

--- a/tests/clean/test_linkify_nodes.py
+++ b/tests/clean/test_linkify_nodes.py
@@ -1,0 +1,53 @@
+"""linkify_node: linking an already parsed tree in place, and the string form over a node."""
+
+from __future__ import annotations
+
+import pytest
+
+from turbohtml import Document, parse, parse_fragment
+from turbohtml.clean import Linker, Linkify, linkify, linkify_node
+
+_TEXT = "<p>See https://example.com and <a href='/x'>kept</a></p>"
+
+
+def test_node_form_links_in_place_and_returns_the_node() -> None:
+    root = parse_fragment(_TEXT)
+    assert linkify_node(root) is root
+    assert root.inner_html == linkify(_TEXT)
+
+
+def test_a_document_links_its_body_text() -> None:
+    document = parse(_TEXT)
+    linked = linkify_node(document)
+    assert isinstance(linked, Document)
+    assert linked.serialize().count("<a ") == 2
+
+
+def test_the_string_form_over_a_node_leaves_it_untouched() -> None:
+    root = parse_fragment(_TEXT)
+    before = root.inner_html
+    assert linkify(root) == linkify(_TEXT)
+    assert root.inner_html == before
+
+
+def test_options_apply_to_the_node_form() -> None:
+    root = parse_fragment("<p>mail bob@example.com</p>")
+    linkify_node(root, Linkify(parse_email=True))
+    assert 'href="mailto:bob@example.com"' in root.inner_html
+
+
+def test_a_reusable_linker_offers_the_node_form() -> None:
+    linker = Linker()
+    root = parse_fragment(_TEXT)
+    assert linker.linkify_node(root).inner_html == linker.linkify(_TEXT)
+
+
+def test_the_node_form_refuses_a_str() -> None:
+    with pytest.raises(TypeError, match="pass a str to linkify instead"):
+        linkify_node(_TEXT)  # ty: ignore[invalid-argument-type]  # the argument check is the point
+
+
+@pytest.mark.parametrize("entry", [linkify, linkify_node], ids=["linkify", "linkify_node"])
+def test_a_foreign_object_is_rejected(entry: object) -> None:
+    with pytest.raises(TypeError):
+        entry(42)  # ty: ignore[call-non-callable]  # the argument check is the point

--- a/tools/bench/ci.py
+++ b/tools/bench/ci.py
@@ -140,6 +140,7 @@ _RESIZED: dict[str, tuple[str, Callable[[], object]]] = {
     "sanitize-xml": ("sanitize-xml-spec", _spec),
     "linkify": ("linkify-spec", _spec),
     "sanitize-node": ("sanitize-node-spec", lambda: parse(_spec()).find("body")),
+    "linkify-node": ("linkify-node-spec", lambda: parse(_spec()).find("body")),
     "markdown-google": ("markdown-google-parse-spec", _spec),
     "article": ("article-parse-spec", _spec),
     "boilerplate": ("boilerplate-spec", _spec),

--- a/tools/bench/core.py
+++ b/tools/bench/core.py
@@ -7,6 +7,7 @@ maps each operation to ``(timing function, label)``; the function takes the same
 
 from __future__ import annotations
 
+import copy
 import functools
 import re
 from dataclasses import replace
@@ -555,6 +556,11 @@ def linkify(text: str) -> None:
     _linkify(text)
 
 
+def linkify_node(node: Node) -> None:
+    """Linkify an already parsed subtree in place; each call links a fresh copy, since a linked tree offers nothing."""
+    _LINKER.linkify_node(copy.deepcopy(node))
+
+
 def linkify_traversal(case: tuple[str, str]) -> None:
     """Reuse compiled options so the benchmark isolates traversal."""
     kind, text = case
@@ -1052,6 +1058,7 @@ OPERATIONS: dict[str, tuple[object, str]] = {
     "markup": (markup, "turbohtml"),
     "markup-op": (markup_op, "turbohtml"),
     "linkify": (linkify, "turbohtml"),
+    "linkify-node": (linkify_node, "turbohtml"),
     "linkify-traversal": (linkify_traversal, "turbohtml"),
     "detect": (detect, "turbohtml"),
     "phone": (phone, "turbohtml"),

--- a/tools/bench/operations.py
+++ b/tools/bench/operations.py
@@ -335,6 +335,7 @@ OPERATIONS: dict[str, Operation] = {
     "markup": Operation("markupsafe-compatible escape", "ns"),
     "markup-op": Operation("Markup operations", "ns"),
     "linkify": Operation("linkify HTML", "us"),
+    "linkify-node": Operation("linkify a parsed tree", "us"),
     "linkify-traversal": Operation("linkify with native tree traversal", "us"),
     "detect": Operation("detect links in text", "us"),
     "phone": Operation("detect phone numbers in text", "us"),
@@ -1040,6 +1041,7 @@ INPUTS: dict[str, Callable[[], tuple[tuple[str, object], ...]]] = {
         ("join (escapes operands)", ("join", _MARKUP_JOIN_PARTS)),
     ),
     "linkify": lambda: _LINKIFY_CASES,
+    "linkify-node": lambda: (("markup (4 KiB)", parse_fragment(_LINKIFY_CASES[2][1])),),
     "linkify-traversal": lambda: _LINKIFY_TRAVERSAL_CASES,
     "detect": lambda: (
         ("find comment (1 link, 1 email)", ("find", _LINKIFY_CASES[0][1])),


### PR DESCRIPTION
Chaining `linkify` with a sanitizer or a minifying serialization parsed and serialized the document at every step, the round trips #791 describes, because `linkify` took only a string although the C walk already ran in place on any node. This is the second of the three PRs from that issue, after #793 (sanitize on a tree); the pipeline how-to and `minify` on a tree follow.

🔗 `linkify_node` links the text runs of a parsed node in place and returns the node, so it chains; the walk is the one `linkify` runs after parsing, so an existing `<a>`, a raw-text element and `Linkify.skip_tags` are skipped the same way, under the document's lock on the free-threaded build. `linkify` and `Linker.linkify` accept a node too and link a copy, leaving the node as it was, for a caller who wants a string at the end without the reparse.

No C changes: the facade only widens what it forwards. A `linkify-node` benchmark gates the tree form over the same spec corpus as `linkify`, linking a fresh copy per call since a linked tree offers nothing to link; the reference page describes the tree form and the links how-to gains a section showing it feeding a minifying serialization.
